### PR TITLE
Implement capability contract validation foundation

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,4 +1,4 @@
-# Cogollo Constitution
+# Cogolo Constitution
 
 ## Core Principles
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,11 @@ version = "0.1.0"
 [[package]]
 name = "cogolo-contracts"
 version = "0.1.0"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "cogolo-mcp"
@@ -21,3 +26,105 @@ version = "0.1.0"
 [[package]]
 name = "cogolo-runtime"
 version = "0.1.0"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/ci/coverage-targets.txt
+++ b/ci/coverage-targets.txt
@@ -5,3 +5,4 @@
 #
 # Example:
 # cogolo-runtime 100
+cogolo-contracts 100

--- a/crates/cogolo-contracts/Cargo.toml
+++ b/crates/cogolo-contracts/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+semver = "1.0.27"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 
 [lints]
 workspace = true

--- a/crates/cogolo-contracts/src/lib.rs
+++ b/crates/cogolo-contracts/src/lib.rs
@@ -1,15 +1,743 @@
-//! Core contract types for Cogolo.
+//! Capability contract parsing and validation for Cogolo.
 
-/// Returns the crate purpose as a stable placeholder.
-#[must_use]
-pub fn crate_name() -> &'static str {
-    "cogolo-contracts"
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeSet, HashSet};
+
+const CAPABILITY_CONTRACT_KIND: &str = "capability_contract";
+const SUPPORTED_SCHEMA_VERSION: &str = "1.0.0";
+const GOVERNED_CONTENT_VERSION: &str = "0.1.0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityContract {
+    pub kind: String,
+    pub schema_version: String,
+    pub id: String,
+    pub namespace: String,
+    pub name: String,
+    pub version: String,
+    pub lifecycle: Lifecycle,
+    pub owner: Owner,
+    pub summary: String,
+    pub description: String,
+    pub inputs: SchemaContainer,
+    pub outputs: SchemaContainer,
+    pub preconditions: Vec<Condition>,
+    pub postconditions: Vec<Condition>,
+    pub side_effects: Vec<SideEffect>,
+    pub emits: Vec<EventReference>,
+    pub consumes: Vec<EventReference>,
+    pub permissions: Vec<IdReference>,
+    pub execution: Execution,
+    pub policies: Vec<IdReference>,
+    pub dependencies: Vec<DependencyReference>,
+    pub provenance: Provenance,
+    pub evidence: Vec<ValidationEvidence>,
 }
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn exposes_crate_name() {
-        assert_eq!(super::crate_name(), "cogolo-contracts");
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Lifecycle {
+    Draft,
+    Active,
+    Deprecated,
+    Retired,
+    Archived,
+}
+
+impl Lifecycle {
+    #[must_use]
+    pub fn is_runtime_eligible(&self) -> bool {
+        matches!(self, Self::Active | Self::Deprecated)
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Owner {
+    pub team: String,
+    pub contact: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SchemaContainer {
+    pub schema: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Condition {
+    pub id: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SideEffect {
+    pub kind: SideEffectKind,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SideEffectKind {
+    None,
+    MemoryOnly,
+    EventEmission,
+    ExternalCall,
+    StateChange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EventReference {
+    pub event_id: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdReference {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Execution {
+    pub binary_format: BinaryFormat,
+    pub entrypoint: Entrypoint,
+    pub preferred_targets: Vec<ExecutionTarget>,
+    pub constraints: ExecutionConstraints,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BinaryFormat {
+    Wasm,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Entrypoint {
+    pub kind: EntrypointKind,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum EntrypointKind {
+    WasiCommand,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionTarget {
+    Local,
+    Browser,
+    Edge,
+    Cloud,
+    Worker,
+    Device,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionConstraints {
+    pub host_api_access: HostApiAccess,
+    pub network_access: NetworkAccess,
+    pub filesystem_access: FilesystemAccess,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostApiAccess {
+    None,
+    ExceptionRequired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkAccess {
+    Forbidden,
+    Required,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FilesystemAccess {
+    None,
+    SandboxOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DependencyReference {
+    pub artifact_type: DependencyArtifactType,
+    pub id: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DependencyArtifactType {
+    Capability,
+    Event,
+    Policy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Provenance {
+    pub source: ProvenanceSource,
+    pub author: String,
+    pub created_at: String,
+    #[serde(default)]
+    pub spec_ref: Option<String>,
+    #[serde(default)]
+    pub adr_refs: Vec<String>,
+    #[serde(default)]
+    pub exception_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProvenanceSource {
+    Greenfield,
+    BrownfieldExtracted,
+    AiGenerated,
+    AiAssisted,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationEvidence {
+    pub evidence_id: String,
+    #[serde(rename = "type")]
+    pub evidence_type: EvidenceType,
+    pub status: EvidenceStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceType {
+    SpecAlignment,
+    ContractValidation,
+    Compatibility,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceStatus {
+    Passed,
+    Failed,
+    Superseded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublishedContractRecord {
+    pub id: String,
+    pub version: String,
+    pub governed_content_digest: String,
+    pub lifecycle: Lifecycle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationContext<'a> {
+    pub governing_spec: &'a str,
+    pub validator_version: &'a str,
+    pub existing_published: Option<&'a PublishedContractRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationResult {
+    pub normalized: CapabilityContract,
+    pub evidence: ProducedValidationEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProducedValidationEvidence {
+    pub artifact_id: String,
+    pub artifact_version: String,
+    pub governing_spec: String,
+    pub validator_version: String,
+    pub status: EvidenceStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationFailure {
+    pub errors: Vec<ValidationError>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationError {
+    pub code: ValidationErrorCode,
+    pub message: String,
+    pub path: String,
+    pub severity: ErrorSeverity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationErrorCode {
+    MissingRequiredField,
+    InvalidLiteral,
+    InvalidFormat,
+    InvalidSemver,
+    InconsistentIdentity,
+    DuplicateItem,
+    InvalidCapabilityBoundary,
+    UnsupportedBinaryFormat,
+    UnsupportedEntrypoint,
+    PortabilityExceptionRequired,
+    ImmutableVersionConflict,
+    InvalidDependencyRef,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorSeverity {
+    Error,
+}
+
+/// Parses a capability contract from raw JSON text.
+///
+/// # Errors
+///
+/// Returns [`ValidationFailure`] when the JSON payload cannot be deserialized
+/// into the capability contract model.
+pub fn parse_contract(json: &str) -> Result<CapabilityContract, ValidationFailure> {
+    serde_json::from_str::<CapabilityContract>(json).map_err(|error| ValidationFailure {
+        errors: vec![ValidationError {
+            code: ValidationErrorCode::InvalidFormat,
+            message: error.to_string(),
+            path: "$".to_string(),
+            severity: ErrorSeverity::Error,
+        }],
+    })
+}
+
+/// Validates a parsed capability contract against the governed `v0.1` rules.
+///
+/// # Errors
+///
+/// Returns [`ValidationFailure`] when structural or semantic validation fails.
+pub fn validate_contract(
+    mut contract: CapabilityContract,
+    context: &ValidationContext<'_>,
+) -> Result<ValidationResult, ValidationFailure> {
+    let mut errors = Vec::new();
+
+    validate_kind(&contract, &mut errors);
+    validate_schema_version(&contract, &mut errors);
+    validate_identity(&contract, &mut errors);
+    validate_semver(&contract.version, "$.version", &mut errors);
+    validate_owner(&contract.owner, &mut errors);
+    validate_summary(&contract.summary, "$.summary", &mut errors);
+    validate_description(&contract.description, "$.description", &mut errors);
+    validate_schema_container(&contract.inputs, "$.inputs.schema", &mut errors);
+    validate_schema_container(&contract.outputs, "$.outputs.schema", &mut errors);
+    validate_conditions(&contract.preconditions, "$.preconditions", &mut errors);
+    validate_conditions(&contract.postconditions, "$.postconditions", &mut errors);
+    validate_side_effects(&contract.side_effects, &mut errors);
+    validate_event_references(&contract.emits, "$.emits", &mut errors);
+    validate_event_references(&contract.consumes, "$.consumes", &mut errors);
+    validate_id_references(&contract.permissions, "$.permissions", &mut errors);
+    validate_execution(&contract.execution, &contract.provenance, &mut errors);
+    validate_id_references(&contract.policies, "$.policies", &mut errors);
+    validate_dependencies(&contract.dependencies, &mut errors);
+    validate_provenance(&contract.provenance, &mut errors);
+    validate_evidence(&contract.evidence, &mut errors);
+    validate_boundary(&contract, &mut errors);
+    validate_published_record(&contract, context.existing_published, &mut errors);
+
+    if !errors.is_empty() {
+        return Err(ValidationFailure { errors });
+    }
+
+    contract.evidence.clear();
+
+    Ok(ValidationResult {
+        evidence: ProducedValidationEvidence {
+            artifact_id: contract.id.clone(),
+            artifact_version: contract.version.clone(),
+            governing_spec: context.governing_spec.to_string(),
+            validator_version: context.validator_version.to_string(),
+            status: EvidenceStatus::Passed,
+        },
+        normalized: contract,
+    })
+}
+
+#[must_use]
+pub fn governed_content_digest(contract: &CapabilityContract) -> String {
+    let mut clone = contract.clone();
+    clone.evidence.clear();
+    let json = format!("{clone:?}");
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in json.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0001_0000_01b3);
+    }
+    format!("{GOVERNED_CONTENT_VERSION}:{hash:016x}")
+}
+
+fn validate_kind(contract: &CapabilityContract, errors: &mut Vec<ValidationError>) {
+    if contract.kind != CAPABILITY_CONTRACT_KIND {
+        errors.push(error(
+            ValidationErrorCode::InvalidLiteral,
+            "$.kind",
+            "kind must equal capability_contract",
+        ));
+    }
+}
+
+fn validate_schema_version(contract: &CapabilityContract, errors: &mut Vec<ValidationError>) {
+    if contract.schema_version != SUPPORTED_SCHEMA_VERSION {
+        errors.push(error(
+            ValidationErrorCode::InvalidLiteral,
+            "$.schema_version",
+            "schema_version must equal 1.0.0",
+        ));
+    }
+}
+
+fn validate_identity(contract: &CapabilityContract, errors: &mut Vec<ValidationError>) {
+    if !is_valid_namespace(&contract.namespace) {
+        errors.push(error(
+            ValidationErrorCode::InvalidFormat,
+            "$.namespace",
+            "namespace must be dot-separated lowercase kebab-case segments",
+        ));
+    }
+
+    if !is_valid_name(&contract.name) {
+        errors.push(error(
+            ValidationErrorCode::InvalidFormat,
+            "$.name",
+            "name must be lowercase kebab-case",
+        ));
+    }
+
+    let expected_id = format!("{}.{}", contract.namespace, contract.name);
+    if contract.id != expected_id {
+        errors.push(error(
+            ValidationErrorCode::InconsistentIdentity,
+            "$.id",
+            "id must equal namespace.name",
+        ));
+    }
+}
+
+fn validate_semver(value: &str, path: &str, errors: &mut Vec<ValidationError>) {
+    if Version::parse(value).is_err() {
+        errors.push(error(
+            ValidationErrorCode::InvalidSemver,
+            path,
+            "version must match MAJOR.MINOR.PATCH",
+        ));
+    }
+}
+
+fn validate_owner(owner: &Owner, errors: &mut Vec<ValidationError>) {
+    validate_non_empty(&owner.team, "$.owner.team", errors);
+    validate_non_empty(&owner.contact, "$.owner.contact", errors);
+}
+
+fn validate_summary(summary: &str, path: &str, errors: &mut Vec<ValidationError>) {
+    if summary.trim().len() < 10 || summary.len() > 200 {
+        errors.push(error(
+            ValidationErrorCode::InvalidFormat,
+            path,
+            "summary length must be between 10 and 200 characters",
+        ));
+    }
+}
+
+fn validate_description(description: &str, path: &str, errors: &mut Vec<ValidationError>) {
+    if description.trim().len() < 20 {
+        errors.push(error(
+            ValidationErrorCode::InvalidFormat,
+            path,
+            "description must be at least 20 characters",
+        ));
+    }
+}
+
+fn validate_schema_container(
+    container: &SchemaContainer,
+    path: &str,
+    errors: &mut Vec<ValidationError>,
+) {
+    if !container.schema.is_object() {
+        errors.push(error(
+            ValidationErrorCode::InvalidFormat,
+            path,
+            "schema must be a JSON object",
+        ));
+    }
+}
+
+fn validate_conditions(conditions: &[Condition], path: &str, errors: &mut Vec<ValidationError>) {
+    let mut seen = HashSet::new();
+    for (index, condition) in conditions.iter().enumerate() {
+        let id_path = format!("{path}[{index}].id");
+        let description_path = format!("{path}[{index}].description");
+        validate_non_empty(&condition.id, &id_path, errors);
+        validate_non_empty(&condition.description, &description_path, errors);
+        if !seen.insert(condition.id.clone()) {
+            errors.push(error(
+                ValidationErrorCode::DuplicateItem,
+                &id_path,
+                "condition ids must be unique",
+            ));
+        }
+    }
+}
+
+fn validate_side_effects(side_effects: &[SideEffect], errors: &mut Vec<ValidationError>) {
+    if side_effects.is_empty() {
+        errors.push(error(
+            ValidationErrorCode::MissingRequiredField,
+            "$.side_effects",
+            "side_effects must contain at least one item",
+        ));
+    }
+
+    for (index, side_effect) in side_effects.iter().enumerate() {
+        validate_non_empty(
+            &side_effect.description,
+            &format!("$.side_effects[{index}].description"),
+            errors,
+        );
+    }
+}
+
+fn validate_event_references(
+    references: &[EventReference],
+    path: &str,
+    errors: &mut Vec<ValidationError>,
+) {
+    let mut seen = HashSet::new();
+    for (index, item) in references.iter().enumerate() {
+        let event_path = format!("{path}[{index}].event_id");
+        let version_path = format!("{path}[{index}].version");
+        validate_non_empty(&item.event_id, &event_path, errors);
+        validate_semver(&item.version, &version_path, errors);
+        if !seen.insert((item.event_id.clone(), item.version.clone())) {
+            errors.push(error(
+                ValidationErrorCode::DuplicateItem,
+                &event_path,
+                "event references must be unique by id and version",
+            ));
+        }
+    }
+}
+
+fn validate_id_references(items: &[IdReference], path: &str, errors: &mut Vec<ValidationError>) {
+    let mut seen = HashSet::new();
+    for (index, item) in items.iter().enumerate() {
+        let item_path = format!("{path}[{index}].id");
+        validate_non_empty(&item.id, &item_path, errors);
+        if !seen.insert(item.id.clone()) {
+            errors.push(error(
+                ValidationErrorCode::DuplicateItem,
+                &item_path,
+                "ids must be unique",
+            ));
+        }
+    }
+}
+
+fn validate_execution(
+    execution: &Execution,
+    provenance: &Provenance,
+    errors: &mut Vec<ValidationError>,
+) {
+    match execution.binary_format {
+        BinaryFormat::Wasm => {}
+    }
+
+    match execution.entrypoint.kind {
+        EntrypointKind::WasiCommand => {}
+    }
+
+    validate_non_empty(
+        &execution.entrypoint.command,
+        "$.execution.entrypoint.command",
+        errors,
+    );
+
+    if execution.preferred_targets.is_empty() {
+        errors.push(error(
+            ValidationErrorCode::MissingRequiredField,
+            "$.execution.preferred_targets",
+            "preferred_targets must contain at least one item",
+        ));
+    }
+
+    let unique_targets: BTreeSet<_> = execution.preferred_targets.iter().cloned().collect();
+    if unique_targets.len() != execution.preferred_targets.len() {
+        errors.push(error(
+            ValidationErrorCode::DuplicateItem,
+            "$.execution.preferred_targets",
+            "preferred_targets must be unique",
+        ));
+    }
+
+    if matches!(
+        execution.constraints.host_api_access,
+        HostApiAccess::ExceptionRequired
+    ) && provenance.exception_refs.is_empty()
+    {
+        errors.push(error(
+            ValidationErrorCode::PortabilityExceptionRequired,
+            "$.execution.constraints.host_api_access",
+            "host_api_access=exception_required requires provenance.exception_refs",
+        ));
+    }
+}
+
+fn validate_dependencies(dependencies: &[DependencyReference], errors: &mut Vec<ValidationError>) {
+    let mut seen = HashSet::new();
+    for (index, dependency) in dependencies.iter().enumerate() {
+        let id_path = format!("$.dependencies[{index}].id");
+        let version_path = format!("$.dependencies[{index}].version");
+        validate_non_empty(&dependency.id, &id_path, errors);
+        validate_semver(&dependency.version, &version_path, errors);
+        if !seen.insert((
+            dependency.artifact_type.clone(),
+            dependency.id.clone(),
+            dependency.version.clone(),
+        )) {
+            errors.push(error(
+                ValidationErrorCode::DuplicateItem,
+                &id_path,
+                "dependencies must be unique by artifact_type, id, and version",
+            ));
+        }
+    }
+}
+
+fn validate_provenance(provenance: &Provenance, errors: &mut Vec<ValidationError>) {
+    validate_non_empty(&provenance.author, "$.provenance.author", errors);
+    validate_non_empty(&provenance.created_at, "$.provenance.created_at", errors);
+
+    if let Some(spec_ref) = &provenance.spec_ref {
+        validate_non_empty(spec_ref, "$.provenance.spec_ref", errors);
+    }
+
+    validate_unique_strings(
+        &provenance.adr_refs,
+        "$.provenance.adr_refs",
+        "adr_refs must be unique",
+        errors,
+    );
+    validate_unique_strings(
+        &provenance.exception_refs,
+        "$.provenance.exception_refs",
+        "exception_refs must be unique",
+        errors,
+    );
+}
+
+fn validate_evidence(evidence: &[ValidationEvidence], errors: &mut Vec<ValidationError>) {
+    let mut seen = HashSet::new();
+    for (index, item) in evidence.iter().enumerate() {
+        let id_path = format!("$.evidence[{index}].evidence_id");
+        validate_non_empty(&item.evidence_id, &id_path, errors);
+        if !seen.insert(item.evidence_id.clone()) {
+            errors.push(error(
+                ValidationErrorCode::DuplicateItem,
+                &id_path,
+                "evidence_id values must be unique",
+            ));
+        }
+    }
+}
+
+fn validate_boundary(contract: &CapabilityContract, errors: &mut Vec<ValidationError>) {
+    let summary = contract.summary.to_ascii_lowercase();
+    let description = contract.description.to_ascii_lowercase();
+    let combined = format!("{summary} {description}");
+    let banned_terms = [
+        "utility function",
+        "helper function",
+        "crud wrapper",
+        "transport handler",
+        "database insert",
+        "full application",
+        "subsystem",
+    ];
+
+    if banned_terms.iter().any(|term| combined.contains(term)) {
+        errors.push(error(
+            ValidationErrorCode::InvalidCapabilityBoundary,
+            "$.summary",
+            "capability must represent one meaningful business action",
+        ));
+    }
+}
+
+fn validate_published_record(
+    contract: &CapabilityContract,
+    published: Option<&PublishedContractRecord>,
+    errors: &mut Vec<ValidationError>,
+) {
+    let Some(published) = published else {
+        return;
+    };
+
+    if published.id != contract.id || published.version != contract.version {
+        return;
+    }
+
+    let digest = governed_content_digest(contract);
+    if published.governed_content_digest != digest {
+        errors.push(error(
+            ValidationErrorCode::ImmutableVersionConflict,
+            "$.version",
+            "published contract versions are immutable",
+        ));
+    }
+}
+
+fn validate_non_empty(value: &str, path: &str, errors: &mut Vec<ValidationError>) {
+    if value.trim().is_empty() {
+        errors.push(error(
+            ValidationErrorCode::MissingRequiredField,
+            path,
+            "value must be non-empty",
+        ));
+    }
+}
+
+fn validate_unique_strings(
+    values: &[String],
+    path: &str,
+    message: &str,
+    errors: &mut Vec<ValidationError>,
+) {
+    let mut seen = HashSet::new();
+    for value in values {
+        if !seen.insert(value.clone()) {
+            errors.push(error(ValidationErrorCode::DuplicateItem, path, message));
+            break;
+        }
+    }
+}
+
+fn error(code: ValidationErrorCode, path: &str, message: &str) -> ValidationError {
+    ValidationError {
+        code,
+        message: message.to_string(),
+        path: path.to_string(),
+        severity: ErrorSeverity::Error,
+    }
+}
+
+fn is_valid_name(name: &str) -> bool {
+    let mut parts = name.split('-');
+    let first = parts.next().unwrap_or_default();
+    is_valid_segment(first) && parts.all(is_valid_segment)
+}
+
+fn is_valid_namespace(namespace: &str) -> bool {
+    let mut parts = namespace.split('.');
+    let first = parts.next().unwrap_or_default();
+    is_valid_name(first) && parts.all(is_valid_name)
+}
+
+fn is_valid_segment(segment: &str) -> bool {
+    !segment.is_empty()
+        && segment
+            .chars()
+            .all(|character| character.is_ascii_lowercase() || character.is_ascii_digit())
 }

--- a/crates/cogolo-contracts/tests/validation.rs
+++ b/crates/cogolo-contracts/tests/validation.rs
@@ -1,0 +1,562 @@
+use cogolo_contracts::{
+    BinaryFormat, CapabilityContract, Condition, DependencyArtifactType, DependencyReference,
+    Entrypoint, EntrypointKind, EventReference, EvidenceStatus, EvidenceType, Execution,
+    ExecutionConstraints, ExecutionTarget, FilesystemAccess, HostApiAccess, IdReference, Lifecycle,
+    NetworkAccess, Owner, ProducedValidationEvidence, Provenance, ProvenanceSource,
+    PublishedContractRecord, SchemaContainer, SideEffect, SideEffectKind, ValidationContext,
+    ValidationErrorCode, ValidationEvidence, ValidationFailure, ValidationResult,
+    governed_content_digest, parse_contract, validate_contract,
+};
+
+const GOVERNING_SPEC: &str = "002-capability-contracts@0.1.0";
+const VALIDATOR_VERSION: &str = "0.1.0";
+
+#[test]
+fn parses_and_validates_a_contract() -> Result<(), String> {
+    let parsed = parse_contract(&valid_contract_json()).map_err(|error| format!("{error:?}"))?;
+    let result = validate_contract(
+        parsed.clone(),
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    )
+    .map_err(|error| format!("{error:?}"))?;
+
+    assert_eq!(
+        result.normalized.id,
+        "content.comments.create-comment-draft"
+    );
+    assert_eq!(
+        result.normalized.execution.binary_format,
+        BinaryFormat::Wasm
+    );
+    assert_eq!(result.evidence.governing_spec, GOVERNING_SPEC);
+    assert_eq!(result.evidence.status, EvidenceStatus::Passed);
+    assert_eq!(parsed.lifecycle, Lifecycle::Draft);
+    Ok(())
+}
+
+#[test]
+fn rejects_invalid_identity_and_semver() {
+    let mut contract = valid_contract();
+    contract.id = "wrong.id".to_string();
+    contract.version = "not-semver".to_string();
+
+    let errors: Vec<_> = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))
+    .into_iter()
+    .collect();
+    assert_eq!(errors.len(), 1);
+    let error = errors[0].clone();
+
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.code == ValidationErrorCode::InconsistentIdentity)
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.code == ValidationErrorCode::InvalidSemver)
+    );
+}
+
+#[test]
+fn rejects_duplicate_references_and_missing_exception_metadata() {
+    let mut contract = valid_contract();
+    contract.permissions.push(IdReference {
+        id: "comments.create".to_string(),
+    });
+    contract
+        .execution
+        .preferred_targets
+        .push(ExecutionTarget::Local);
+    contract.execution.constraints.host_api_access = HostApiAccess::ExceptionRequired;
+
+    let errors: Vec<_> = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))
+    .into_iter()
+    .collect();
+    assert_eq!(errors.len(), 1);
+    let error = errors[0].clone();
+
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.code == ValidationErrorCode::DuplicateItem)
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.code == ValidationErrorCode::PortabilityExceptionRequired)
+    );
+}
+
+#[test]
+fn rejects_invalid_boundary_language() {
+    let mut contract = valid_contract();
+    contract.summary = "utility function for JSON reshaping".to_string();
+
+    let errors: Vec<_> = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))
+    .into_iter()
+    .collect();
+    assert_eq!(errors.len(), 1);
+    let error = errors[0].clone();
+
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.code == ValidationErrorCode::InvalidCapabilityBoundary)
+    );
+}
+
+#[test]
+fn rejects_immutable_published_version_conflicts() {
+    let contract = valid_contract();
+    let published = PublishedContractRecord {
+        id: contract.id.clone(),
+        version: contract.version.clone(),
+        governed_content_digest: "0.1.0:deadbeefdeadbeef".to_string(),
+        lifecycle: Lifecycle::Active,
+    };
+
+    let errors: Vec<_> = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: Some(&published),
+        },
+    ))
+    .into_iter()
+    .collect();
+    assert_eq!(errors.len(), 1);
+    let error = errors[0].clone();
+
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.code == ValidationErrorCode::ImmutableVersionConflict)
+    );
+}
+
+#[test]
+fn governed_content_digest_ignores_evidence() {
+    let contract = valid_contract();
+    let mut with_evidence = contract.clone();
+    with_evidence.evidence.push(ValidationEvidence {
+        evidence_id: "evd_123".to_string(),
+        evidence_type: EvidenceType::ContractValidation,
+        status: EvidenceStatus::Passed,
+    });
+
+    assert_eq!(
+        governed_content_digest(&contract),
+        governed_content_digest(&with_evidence)
+    );
+}
+
+#[test]
+fn lifecycle_runtime_eligibility_matches_spec() {
+    assert!(!Lifecycle::Draft.is_runtime_eligible());
+    assert!(Lifecycle::Active.is_runtime_eligible());
+    assert!(Lifecycle::Deprecated.is_runtime_eligible());
+    assert!(!Lifecycle::Retired.is_runtime_eligible());
+    assert!(!Lifecycle::Archived.is_runtime_eligible());
+}
+
+#[test]
+fn rejects_invalid_json() {
+    let errors: Vec<_> = parse_contract("{").err().into_iter().collect();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].errors[0].code, ValidationErrorCode::InvalidFormat);
+}
+
+#[test]
+fn rejects_invalid_metadata_and_structure() {
+    let mut contract = valid_contract();
+    contract.kind = "wrong".to_string();
+    contract.schema_version = "9.9.9".to_string();
+    contract.namespace = "Content.Comments".to_string();
+    contract.name = "Invalid Name".to_string();
+    contract.summary = "short".to_string();
+    contract.description = "too short".to_string();
+    contract.inputs.schema = serde_json::json!(["not", "an", "object"]);
+    contract.outputs.schema = serde_json::json!(["still", "wrong"]);
+    contract.owner.team.clear();
+    contract.owner.contact.clear();
+
+    let errors: Vec<_> = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))
+    .into_iter()
+    .collect();
+    assert_eq!(errors.len(), 1);
+    let error = errors[0].clone();
+
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.code == ValidationErrorCode::InvalidLiteral)
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.code == ValidationErrorCode::InconsistentIdentity)
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.code == ValidationErrorCode::MissingRequiredField)
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.inputs.schema")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.outputs.schema")
+    );
+}
+
+#[test]
+fn rejects_invalid_conditions_side_effects_and_events() {
+    let mut contract = valid_contract();
+    contract.preconditions.push(Condition {
+        id: "request-authenticated".to_string(),
+        description: String::new(),
+    });
+    contract.postconditions.push(Condition {
+        id: String::new(),
+        description: "duplicate and empty".to_string(),
+    });
+    contract.side_effects.clear();
+    contract.emits.push(EventReference {
+        event_id: "content.comments.comment-draft-created".to_string(),
+        version: "0.1.0".to_string(),
+    });
+    contract.consumes.push(EventReference {
+        event_id: String::new(),
+        version: "bad".to_string(),
+    });
+
+    let errors: Vec<_> = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))
+    .into_iter()
+    .collect();
+    assert_eq!(errors.len(), 1);
+    let error = errors[0].clone();
+
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.preconditions[1].id")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.preconditions[1].description")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.postconditions[1].id")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.side_effects")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.emits[1].event_id")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.consumes[0].version")
+    );
+}
+
+#[test]
+fn rejects_invalid_execution_dependencies_and_evidence() {
+    let mut contract = valid_contract();
+    contract.execution.entrypoint.command.clear();
+    contract.execution.preferred_targets.clear();
+    contract.dependencies = vec![
+        DependencyReference {
+            artifact_type: DependencyArtifactType::Capability,
+            id: "content.comments.create-comment-draft".to_string(),
+            version: "0.1.0".to_string(),
+        },
+        DependencyReference {
+            artifact_type: DependencyArtifactType::Capability,
+            id: "content.comments.create-comment-draft".to_string(),
+            version: "0.1.0".to_string(),
+        },
+    ];
+    contract.evidence = vec![
+        ValidationEvidence {
+            evidence_id: "evd_dup".to_string(),
+            evidence_type: EvidenceType::ContractValidation,
+            status: EvidenceStatus::Passed,
+        },
+        ValidationEvidence {
+            evidence_id: "evd_dup".to_string(),
+            evidence_type: EvidenceType::Compatibility,
+            status: EvidenceStatus::Superseded,
+        },
+    ];
+
+    let errors: Vec<_> = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))
+    .into_iter()
+    .collect();
+    assert_eq!(errors.len(), 1);
+    let error = errors[0].clone();
+
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.execution.entrypoint.command")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.execution.preferred_targets")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.dependencies[1].id")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.evidence[1].evidence_id")
+    );
+}
+
+#[test]
+fn rejects_duplicate_provenance_references() {
+    let mut contract = valid_contract();
+    contract.provenance.spec_ref = Some(String::new());
+    contract.provenance.adr_refs = vec!["adr-1".to_string(), "adr-1".to_string()];
+    contract.provenance.exception_refs = vec!["ex-1".to_string(), "ex-1".to_string()];
+
+    let errors: Vec<_> = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))
+    .into_iter()
+    .collect();
+    assert_eq!(errors.len(), 1);
+    let error = errors[0].clone();
+
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.provenance.spec_ref")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.provenance.adr_refs")
+    );
+    assert!(
+        error
+            .errors
+            .iter()
+            .any(|item| item.path == "$.provenance.exception_refs")
+    );
+}
+
+#[test]
+fn allows_published_records_for_other_versions() {
+    let contract = valid_contract();
+    let published = PublishedContractRecord {
+        id: contract.id.clone(),
+        version: "9.9.9".to_string(),
+        governed_content_digest: "different".to_string(),
+        lifecycle: Lifecycle::Active,
+    };
+
+    let result = validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: Some(&published),
+        },
+    );
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn expect_validation_failure_rejects_success_results() {
+    let result = expect_validation_failure(Ok(ValidationResult {
+        normalized: valid_contract(),
+        evidence: ProducedValidationEvidence {
+            artifact_id: "x".to_string(),
+            artifact_version: "0.1.0".to_string(),
+            governing_spec: GOVERNING_SPEC.to_string(),
+            validator_version: VALIDATOR_VERSION.to_string(),
+            status: EvidenceStatus::Passed,
+        },
+    }));
+
+    assert!(result.is_err());
+}
+
+fn valid_contract_json() -> String {
+    serde_json::to_string(&valid_contract()).unwrap_or_default()
+}
+
+fn expect_validation_failure(
+    result: Result<ValidationResult, ValidationFailure>,
+) -> Result<ValidationFailure, String> {
+    match result {
+        Ok(_) => Err("validation unexpectedly succeeded".to_string()),
+        Err(error) => Ok(error),
+    }
+}
+
+fn valid_contract() -> CapabilityContract {
+    CapabilityContract {
+        kind: "capability_contract".to_string(),
+        schema_version: "1.0.0".to_string(),
+        id: "content.comments.create-comment-draft".to_string(),
+        namespace: "content.comments".to_string(),
+        name: "create-comment-draft".to_string(),
+        version: "0.1.0".to_string(),
+        lifecycle: Lifecycle::Draft,
+        owner: Owner {
+            team: "cogolo-core".to_string(),
+            contact: "enrico.piovesan10@gmail.com".to_string(),
+        },
+        summary: "Create a draft comment from validated request input.".to_string(),
+        description: "Portable capability for creating a comment draft before persistence."
+            .to_string(),
+        inputs: SchemaContainer {
+            schema: serde_json::json!({ "type": "object" }),
+        },
+        outputs: SchemaContainer {
+            schema: serde_json::json!({ "type": "object" }),
+        },
+        preconditions: vec![Condition {
+            id: "request-authenticated".to_string(),
+            description: "Caller identity is already established.".to_string(),
+        }],
+        postconditions: vec![Condition {
+            id: "draft-created".to_string(),
+            description: "A draft payload is returned.".to_string(),
+        }],
+        side_effects: vec![SideEffect {
+            kind: SideEffectKind::MemoryOnly,
+            description: "No durable side effect occurs in this capability.".to_string(),
+        }],
+        emits: vec![EventReference {
+            event_id: "content.comments.comment-draft-created".to_string(),
+            version: "0.1.0".to_string(),
+        }],
+        consumes: Vec::new(),
+        permissions: vec![IdReference {
+            id: "comments.create".to_string(),
+        }],
+        execution: Execution {
+            binary_format: BinaryFormat::Wasm,
+            entrypoint: Entrypoint {
+                kind: EntrypointKind::WasiCommand,
+                command: "run".to_string(),
+            },
+            preferred_targets: vec![ExecutionTarget::Local],
+            constraints: ExecutionConstraints {
+                host_api_access: HostApiAccess::None,
+                network_access: NetworkAccess::Forbidden,
+                filesystem_access: FilesystemAccess::None,
+            },
+        },
+        policies: vec![IdReference {
+            id: "default-comment-safety".to_string(),
+        }],
+        dependencies: Vec::new(),
+        provenance: Provenance {
+            source: ProvenanceSource::Greenfield,
+            author: "enricopiovesan".to_string(),
+            created_at: "2026-03-26T00:00:00Z".to_string(),
+            spec_ref: Some(GOVERNING_SPEC.to_string()),
+            adr_refs: vec!["0001-rust-wasm-foundation".to_string()],
+            exception_refs: Vec::new(),
+        },
+        evidence: Vec::new(),
+    }
+}

--- a/scripts/ci/coverage_gate.sh
+++ b/scripts/ci/coverage_gate.sh
@@ -39,7 +39,7 @@ for entry in "${targets[@]}"; do
   echo "Measuring line coverage for ${crate_name} with threshold ${minimum_percent}%"
   coverage_output="$(cargo llvm-cov --package "${crate_name}" --summary-only)"
   line_percent="$(
-    awk '/^TOTAL/ {gsub(/%/, "", $NF); print $NF}' <<<"${coverage_output}" | tail -n 1
+    awk '/^TOTAL/ {gsub(/%/, "", $(NF-3)); print $(NF-3)}' <<<"${coverage_output}" | tail -n 1
   )"
 
   if [[ -z "${line_percent}" ]]; then

--- a/specs/001-foundation-v0-1/plan.md
+++ b/specs/001-foundation-v0-1/plan.md
@@ -53,22 +53,22 @@ specs/001-foundation-v0-1/
 
 ```text
 crates/
-├── cogollo-contracts/
+├── cogolo-contracts/
 │   ├── src/
 │   └── tests/
-├── cogollo-registry/
+├── cogolo-registry/
 │   ├── src/
 │   └── tests/
-├── cogollo-runtime/
+├── cogolo-runtime/
 │   ├── src/
 │   └── tests/
-├── cogollo-mcp/
+├── cogolo-mcp/
 │   ├── src/
 │   └── tests/
-├── cogollo-cli/
+├── cogolo-cli/
 │   ├── src/
 │   └── tests/
-└── cogollo-capabilities/
+└── cogolo-capabilities/
     ├── comment-draft/
     ├── permissions/
     ├── text-improve/
@@ -185,7 +185,7 @@ Outputs:
 
 ## Module Responsibilities
 
-### `cogollo-contracts`
+### `cogolo-contracts`
 
 Responsible for:
 
@@ -197,7 +197,7 @@ Responsible for:
 
 Must have full coverage because it is core logic.
 
-### `cogollo-registry`
+### `cogolo-registry`
 
 Responsible for:
 
@@ -208,7 +208,7 @@ Responsible for:
 
 Must have full coverage for registry behavior and duplicate handling.
 
-### `cogollo-runtime`
+### `cogolo-runtime`
 
 Responsible for:
 
@@ -224,7 +224,7 @@ Responsible for:
 
 Must have full coverage for decision, state, workflow traversal, and trace behavior.
 
-### `cogollo-mcp`
+### `cogolo-mcp`
 
 Responsible for:
 
@@ -233,7 +233,7 @@ Responsible for:
 
 Must remain narrow in `v0.1`, but stable enough to semver and validate.
 
-### `cogollo-cli`
+### `cogolo-cli`
 
 Responsible for:
 
@@ -245,7 +245,7 @@ Responsible for:
 
 CLI glue should be well tested, with full coverage where logic is nontrivial.
 
-### `cogollo-capabilities`
+### `cogolo-capabilities`
 
 Responsible for:
 

--- a/specs/001-foundation-v0-1/research.md
+++ b/specs/001-foundation-v0-1/research.md
@@ -20,11 +20,11 @@ The goal is not to explore every possible architecture. It is to choose the smal
 
 Use a Rust workspace with multiple focused crates:
 
-- `cogollo-contracts`
-- `cogollo-registry`
-- `cogollo-runtime`
-- `cogollo-mcp`
-- `cogollo-cli`
+- `cogolo-contracts`
+- `cogolo-registry`
+- `cogolo-runtime`
+- `cogolo-mcp`
+- `cogolo-cli`
 - example capability crates
 
 ### Rationale

--- a/specs/002-capability-contracts/data-model.md
+++ b/specs/002-capability-contracts/data-model.md
@@ -1,0 +1,574 @@
+# Data Model: Cogolo Capability Contracts
+
+## Purpose
+
+This document defines the exact `v0.1` capability contract data model and validation rules required by `002-capability-contracts`.
+
+It is intentionally implementation-tight so the first `cogolo-contracts` code can be written without inventing contract semantics during implementation.
+
+## Artifact Identity
+
+### Artifact Kind
+
+`kind` MUST equal:
+
+- `capability_contract`
+
+### Schema Version
+
+`schema_version` identifies the contract schema version, not the capability version.
+
+For `v0.1`, supported value:
+
+- `1.0.0`
+
+### Capability Identity Rule
+
+The capability identity fields are:
+
+- `namespace`
+- `name`
+- `id`
+
+Rules:
+
+- `namespace` MUST be lowercase kebab-case segments separated by `.`
+- `name` MUST be lowercase kebab-case
+- `id` MUST equal `namespace.name`
+
+Examples:
+
+- namespace: `content.comments`
+- name: `create-comment-draft`
+- id: `content.comments.create-comment-draft`
+
+## Top-Level Shape
+
+```json
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "content.comments.create-comment-draft",
+  "namespace": "content.comments",
+  "name": "create-comment-draft",
+  "version": "0.1.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "cogolo-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Create a draft comment from validated request input.",
+  "description": "Portable capability for creating a comment draft before persistence.",
+  "inputs": {
+    "schema": {
+      "type": "object"
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object"
+    }
+  },
+  "preconditions": [
+    {
+      "id": "request-authenticated",
+      "description": "Caller identity is already established."
+    }
+  ],
+  "postconditions": [
+    {
+      "id": "draft-created",
+      "description": "A draft payload is returned."
+    }
+  ],
+  "side_effects": [
+    {
+      "kind": "memory_only",
+      "description": "No durable side effect occurs in this capability."
+    }
+  ],
+  "emits": [
+    {
+      "event_id": "content.comments.comment-draft-created",
+      "version": "0.1.0"
+    }
+  ],
+  "consumes": [],
+  "permissions": [
+    {
+      "id": "comments.create"
+    }
+  ],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [
+    {
+      "id": "default-comment-safety"
+    }
+  ],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-26T00:00:00Z"
+  },
+  "evidence": []
+}
+```
+
+## Field Definitions
+
+### `kind`
+
+- type: string
+- required: yes
+- allowed value: `capability_contract`
+
+### `schema_version`
+
+- type: string
+- required: yes
+- allowed value in `v0.1`: `1.0.0`
+
+### `id`
+
+- type: string
+- required: yes
+- computed rule: MUST equal `namespace.name`
+
+### `namespace`
+
+- type: string
+- required: yes
+- format: dot-separated lowercase kebab-case segments
+- regex: `^[a-z0-9]+(?:-[a-z0-9]+)*(?:\.[a-z0-9]+(?:-[a-z0-9]+)*)*$`
+
+### `name`
+
+- type: string
+- required: yes
+- format: lowercase kebab-case
+- regex: `^[a-z0-9]+(?:-[a-z0-9]+)*$`
+
+### `version`
+
+- type: string
+- required: yes
+- format: semantic version `MAJOR.MINOR.PATCH`
+- regex: `^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$`
+
+### `lifecycle`
+
+- type: string
+- required: yes
+- enum:
+  - `draft`
+  - `active`
+  - `deprecated`
+  - `retired`
+  - `archived`
+
+### `owner`
+
+- type: object
+- required: yes
+- required fields:
+  - `team`
+  - `contact`
+
+Rules:
+
+- `team` MUST be a stable ownership identifier
+- `contact` MUST be a non-empty contact string
+
+### `summary`
+
+- type: string
+- required: yes
+- min length: 10
+- max length: 200
+
+Rule:
+
+- MUST describe one meaningful business action
+
+### `description`
+
+- type: string
+- required: yes
+- min length: 20
+
+### `inputs`
+
+- type: object
+- required: yes
+- required fields:
+  - `schema`
+
+Rule:
+
+- `schema` MUST be a JSON-schema-like object shape suitable for machine validation
+
+### `outputs`
+
+- same rules as `inputs`
+
+### `preconditions`
+
+- type: array
+- required: yes
+- each item required fields:
+  - `id`
+  - `description`
+
+Rules:
+
+- item `id` values MUST be unique
+
+### `postconditions`
+
+- same rules as `preconditions`
+
+### `side_effects`
+
+- type: array
+- required: yes
+- minimum items: 1
+
+Each item required fields:
+
+- `kind`
+- `description`
+
+Allowed `kind` values in `v0.1`:
+
+- `none`
+- `memory_only`
+- `event_emission`
+- `external_call`
+- `state_change`
+
+### `emits`
+
+- type: array
+- required: yes
+
+Each item required fields:
+
+- `event_id`
+- `version`
+
+Rules:
+
+- `(event_id, version)` pairs MUST be unique
+- `version` MUST match semver format
+
+### `consumes`
+
+- same structure and uniqueness rules as `emits`
+
+### `permissions`
+
+- type: array
+- required: yes
+
+Each item required fields:
+
+- `id`
+
+Rules:
+
+- permission `id` values MUST be unique
+
+### `execution`
+
+- type: object
+- required: yes
+
+Required fields:
+
+- `binary_format`
+- `entrypoint`
+- `preferred_targets`
+- `constraints`
+
+#### `execution.binary_format`
+
+- type: string
+- required: yes
+- allowed value in `v0.1`: `wasm`
+
+#### `execution.entrypoint`
+
+- type: object
+- required: yes
+
+Required fields:
+
+- `kind`
+- `command`
+
+Allowed `kind` values in `v0.1`:
+
+- `wasi-command`
+
+Rules:
+
+- `command` MUST be non-empty
+
+#### `execution.preferred_targets`
+
+- type: array
+- required: yes
+- minimum items: 1
+
+Allowed values in `v0.1`:
+
+- `local`
+- `browser`
+- `edge`
+- `cloud`
+- `worker`
+- `device`
+
+Rules:
+
+- values MUST be unique
+- validation MUST not reject non-`local` values
+- runtime support in `v0.1` remains limited to `local`
+
+#### `execution.constraints`
+
+- type: object
+- required: yes
+
+Required fields:
+
+- `host_api_access`
+- `network_access`
+- `filesystem_access`
+
+Allowed values:
+
+- `host_api_access`: `none`, `exception_required`
+- `network_access`: `forbidden`, `required`
+- `filesystem_access`: `none`, `sandbox_only`
+
+Rules:
+
+- if `host_api_access` equals `exception_required`, an approved portability exception reference MUST exist in `provenance`
+
+### `policies`
+
+- type: array
+- required: yes
+
+Each item required fields:
+
+- `id`
+
+Rules:
+
+- policy `id` values MUST be unique
+
+### `dependencies`
+
+- type: array
+- required: yes
+
+Each item required fields:
+
+- `artifact_type`
+- `id`
+- `version`
+
+Allowed `artifact_type` values:
+
+- `capability`
+- `event`
+- `policy`
+
+Rules:
+
+- `(artifact_type, id, version)` tuples MUST be unique
+- `version` MUST match semver format
+
+### `provenance`
+
+- type: object
+- required: yes
+
+Required fields:
+
+- `source`
+- `author`
+- `created_at`
+
+Optional fields:
+
+- `spec_ref`
+- `adr_refs`
+- `exception_refs`
+
+Allowed `source` values:
+
+- `greenfield`
+- `brownfield-extracted`
+- `ai-generated`
+- `ai-assisted`
+
+Rules:
+
+- `spec_ref`, when present, MUST identify the governing implementation spec
+- `exception_refs`, when present, MUST contain unique identifiers
+
+### `evidence`
+
+- type: array
+- required: yes
+
+Each item required fields:
+
+- `evidence_id`
+- `type`
+- `status`
+
+Allowed `type` values:
+
+- `spec_alignment`
+- `contract_validation`
+- `compatibility`
+
+Allowed `status` values:
+
+- `passed`
+- `failed`
+- `superseded`
+
+## Semantic Validation Rules
+
+### Capability Boundary Rules
+
+Validation MUST reject a contract when:
+
+- `summary` or `description` indicates only a utility/helper concern
+- the capability represents only CRUD storage mechanics with no business action
+- the capability is described as a full application or subsystem instead of one business action
+- `inputs`, `outputs`, and `side_effects` together do not form a meaningful business boundary
+
+### Portability Rules
+
+Validation MUST reject a contract when:
+
+- `binary_format` is not `wasm`
+- `execution.entrypoint.kind` is unsupported
+- host-specific access is implied without exception metadata
+- portability-sensitive execution constraints are missing
+
+### Version and Immutability Rules
+
+Validation against an existing published record MUST reject when:
+
+- the same `id` and `version` already exist with different governed content
+- the same `id` and `version` already exist and the lifecycle regression is not explicitly allowed by governance tooling
+
+For `v0.1`, the governed content digest MUST be computed over all top-level fields except:
+
+- `evidence`
+
+### Lifecycle Rules
+
+Allowed lifecycle meanings:
+
+- `draft`: not publishable for runtime use
+- `active`: eligible for runtime use
+- `deprecated`: still valid but discouraged for new composition
+- `retired`: no longer eligible for new runtime selection
+- `archived`: retained as historical record only
+
+For `v0.1` validation:
+
+- new contracts may be authored in any lifecycle state
+- only `active` and `deprecated` should be considered runtime-eligible downstream
+
+## Validation Error Model
+
+Each validation failure MUST produce:
+
+- `code`
+- `message`
+- `path`
+- `severity`
+
+### Error Shape
+
+```json
+{
+  "code": "invalid_semver",
+  "message": "version must match MAJOR.MINOR.PATCH",
+  "path": "$.version",
+  "severity": "error"
+}
+```
+
+### Initial Error Codes
+
+- `missing_required_field`
+- `invalid_literal`
+- `invalid_format`
+- `invalid_semver`
+- `inconsistent_identity`
+- `duplicate_item`
+- `invalid_lifecycle`
+- `invalid_capability_boundary`
+- `unsupported_binary_format`
+- `unsupported_entrypoint`
+- `portability_exception_required`
+- `immutable_version_conflict`
+- `invalid_dependency_ref`
+
+## Validation Evidence Model
+
+Successful validation MUST produce:
+
+- `evidence_id`
+- `artifact_id`
+- `artifact_version`
+- `governing_spec`
+- `validator_version`
+- `status`
+- `produced_at`
+
+### Evidence Shape
+
+```json
+{
+  "evidence_id": "evd_01HXYZ",
+  "artifact_id": "content.comments.create-comment-draft",
+  "artifact_version": "0.1.0",
+  "governing_spec": "002-capability-contracts@0.1.0",
+  "validator_version": "0.1.0",
+  "status": "passed",
+  "produced_at": "2026-03-26T00:00:00Z"
+}
+```
+
+## Open Items Deferred from This Spec
+
+- exact event contract schema
+- exact workflow definition schema
+- contract file hashing algorithm and canonical JSON normalization strategy
+- registry persistence layout for published contract records

--- a/specs/002-capability-contracts/spec.md
+++ b/specs/002-capability-contracts/spec.md
@@ -1,0 +1,200 @@
+# Feature Specification: Cogolo Capability Contracts
+
+**Feature Branch**: `002-capability-contracts`  
+**Created**: 2026-03-26  
+**Status**: Draft  
+**Input**: Existing Cogolo foundation specification, data model, constitution, and project source material derived from UMA, ECCA, and C-DAD.
+
+## Purpose
+
+This specification defines the first implementation-tight contract slice for Cogolo:
+
+- the capability contract artifact
+- capability contract validation behavior
+- capability contract lifecycle and versioning rules
+- capability contract validation evidence and error behavior
+
+This spec governs work in `cogolo-contracts` before broader runtime, registry, or workflow implementation proceeds.
+
+## User Scenarios & Testing
+
+### User Story 1 - Author a Valid Capability Contract (Priority: P1)
+
+As a platform developer, I want to author a machine-readable capability contract that fully describes a portable business capability so that the contract can become the governing source of truth for validation, registration, runtime execution, and AI-assisted development.
+
+**Why this priority**: Cogolo depends on contracts as the primary boundary. If the capability contract is underspecified or ambiguous, registries, runtime behavior, and validation all drift.
+
+**Independent Test**: A developer can create a `contract.json`, validate it through the contracts crate or CLI, and receive a canonical parsed contract object plus no validation errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `contract.json` that includes all required fields and valid values, **When** the contract is parsed and validated, **Then** the system accepts it as a valid capability contract artifact.
+2. **Given** a valid capability contract, **When** the contract is loaded, **Then** the system exposes normalized identity, version, lifecycle, contract boundary, event references, execution metadata, and provenance metadata.
+3. **Given** a valid capability contract with an optional companion `README.md`, **When** validation occurs, **Then** validation treats the JSON contract as authoritative and the Markdown as non-governing documentation.
+
+---
+
+### User Story 2 - Reject Invalid or Unsafe Capability Contracts (Priority: P1)
+
+As a platform developer, I want invalid capability contracts to fail with precise and actionable validation errors so that unsafe, ambiguous, or non-portable capabilities cannot enter the governed system.
+
+**Why this priority**: The contract engine is the first merge and runtime safety boundary.
+
+**Independent Test**: A suite of malformed and semantically invalid contracts can be validated and each one fails with a stable error code, path, and explanation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contract missing a required field, **When** validation runs, **Then** validation fails with the missing field path and error code.
+2. **Given** a contract with an invalid lifecycle transition, malformed semantic version, duplicate event reference, or invalid portability declaration, **When** validation runs, **Then** validation fails with field-specific errors.
+3. **Given** a contract that attempts to represent a utility function, CRUD wrapper, or host-specific implementation disguised as a capability, **When** semantic validation runs, **Then** validation rejects it as an invalid capability boundary or portability violation.
+
+---
+
+### User Story 3 - Treat Published Capability Contracts as Versioned Governed Records (Priority: P2)
+
+As a platform steward, I want capability contracts to be semantic-versioned, lifecycle-aware, and immutable once published so that capabilities can evolve safely without hidden drift.
+
+**Why this priority**: C-DAD and the project constitution both require versioned, governed, immutable artifacts.
+
+**Independent Test**: Given existing registered contract metadata, the system can determine whether a new contract version is valid, duplicate, incompatible, or lifecycle-invalid.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new capability contract version for an existing capability identity, **When** validation runs against the prior published record, **Then** the system validates semver format and lifecycle compatibility.
+2. **Given** a contract with the same identity and version but different governed content, **When** duplicate-version validation runs, **Then** validation fails because published contracts are immutable.
+3. **Given** a contract whose lifecycle is `deprecated`, `retired`, or `archived`, **When** the runtime or registry later consumes it, **Then** downstream systems can rely on the lifecycle state being explicit and machine-readable.
+
+## Scope
+
+In scope:
+
+- capability contract artifact shape
+- exact required and optional fields
+- JSON field-level validation rules
+- semantic validation rules
+- lifecycle states
+- semver rules for capability contract versions
+- portability-related contract declarations
+- error and evidence model for contract validation
+
+Out of scope:
+
+- event contract implementation details beyond reference validation shape
+- workflow definition semantics
+- runtime execution behavior
+- registry persistence behavior
+- browser/demo behavior
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: A capability contract MUST be authored as a `contract.json` artifact.
+- **FR-002**: The capability contract artifact MUST be the governing machine-readable source of truth for capability boundary semantics.
+- **FR-003**: The system MUST support an optional non-governing companion `README.md` for human-readable rationale or explanation.
+- **FR-004**: A capability contract MUST include identity, version, lifecycle, owner, summary, inputs, outputs, side effects, emitted events, consumed events, permissions, execution metadata, policy references, dependency references, and provenance metadata.
+- **FR-005**: The system MUST validate capability contracts in two stages:
+  - structural validation of JSON shape and value presence
+  - semantic validation of business boundary, portability, versioning, and governance rules
+- **FR-006**: Capability contract versions MUST be semantic versions using `MAJOR.MINOR.PATCH`.
+- **FR-007**: Capability contracts MUST expose lifecycle states from a controlled enum.
+- **FR-008**: Capability contract execution metadata MUST explicitly declare the portable binary format and runtime entry metadata.
+- **FR-009**: Capability contracts for `v0.1` MUST declare `wasm` as the binary format.
+- **FR-010**: Capability contracts for `v0.1` MUST support placement-facing execution declarations even though only `local` execution exists in the runtime.
+- **FR-011**: Capability contracts MUST declare emitted and consumed event references as versioned artifact references rather than free-text labels.
+- **FR-012**: Capability contracts MUST support explicit permission references and policy references even if their full evaluation is deferred.
+- **FR-013**: Capability contracts MUST carry provenance metadata sufficient to identify authoring source, approval/governance context, and validation evidence linkage.
+- **FR-014**: Validation MUST reject contracts that omit required fields, contain invalid enumerations, contain malformed semver values, or use inconsistent identity metadata.
+- **FR-015**: Validation MUST reject contracts that declare unsupported binary formats, unsupported `v0.1` portability models, or target-specific API dependence without an approved exception reference.
+- **FR-016**: Validation MUST reject duplicate items where uniqueness is required, including duplicated emitted event references, consumed event references, permission references, dependency references, and preferred execution targets.
+- **FR-017**: Validation MUST reject contracts whose `id` is inconsistent with `namespace` plus `name`.
+- **FR-018**: Validation MUST reject contracts whose published identity and version match an existing published record but whose governed content differs.
+- **FR-019**: Validation MUST produce stable machine-readable error records with error code, JSON path, severity, and human-readable explanation.
+- **FR-020**: Successful validation MUST produce machine-readable validation evidence linked to the contract identity, version, and governing spec.
+- **FR-021**: The contracts crate MUST expose normalized domain types suitable for registry, runtime, and CLI consumers without requiring those downstream systems to re-interpret raw JSON.
+- **FR-022**: The capability contract MUST support explicit boundary assertions for:
+  - preconditions
+  - postconditions
+  - side effects
+- **FR-023**: The capability contract MUST support declaring at least one meaningful business action summary and MUST NOT be treated as valid if it is only a transport, storage, or utility wrapper.
+- **FR-024**: Approved implementation under this spec MUST be validated against this spec before merge.
+
+### Capability Contract Fields
+
+The contract MUST model these top-level fields:
+
+- `kind`
+- `schema_version`
+- `id`
+- `namespace`
+- `name`
+- `version`
+- `lifecycle`
+- `owner`
+- `summary`
+- `description`
+- `inputs`
+- `outputs`
+- `preconditions`
+- `postconditions`
+- `side_effects`
+- `emits`
+- `consumes`
+- `permissions`
+- `execution`
+- `policies`
+- `dependencies`
+- `provenance`
+- `evidence`
+
+### Lifecycle Enum
+
+Allowed `lifecycle` values:
+
+- `draft`
+- `active`
+- `deprecated`
+- `retired`
+- `archived`
+
+### Key Entities
+
+- **Capability Contract**: The governed machine-readable artifact that defines one portable business capability.
+- **Capability Artifact Reference**: A normalized identifier for a versioned contract or dependency target.
+- **Capability Validation Error**: A stable machine-readable error produced when structural or semantic validation fails.
+- **Capability Validation Evidence**: A stable machine-readable record proving a contract passed validation against the governing spec.
+
+## Non-Functional Requirements
+
+- **NFR-001 Determinism**: Parsing, normalization, and validation of the same contract input MUST produce the same results and error ordering.
+- **NFR-002 Explainability**: Validation failures MUST be actionable without requiring source inspection of the validator implementation.
+- **NFR-003 Portability**: The contract model MUST preserve portability-first design and MUST NOT require host-specific declarations as normal behavior.
+- **NFR-004 Maintainability**: The contract types and validator logic MUST be separable into clear modules suitable for full automated test coverage.
+- **NFR-005 Compatibility Discipline**: Contract version interpretation MUST be explicit and predictable.
+- **NFR-006 Testability**: Core validation logic under this spec MUST be structured for 100% automated coverage.
+
+## Non-Negotiable Quality Gates
+
+- **QG-001**: No capability contract implementation may merge unless it is aligned with this spec and the governing foundation spec.
+- **QG-002**: Structural validation, semantic validation, normalization, and duplicate-version behavior MUST have full automated coverage once implemented.
+- **QG-003**: Validation errors and evidence formats MUST be stable enough for CLI, registry, and CI consumers.
+- **QG-004**: The validator MUST reject host-coupled or non-portable declarations unless an approved exception path exists.
+
+## Success Criteria
+
+- **SC-001**: A valid `contract.json` can be parsed into normalized Rust domain types without ambiguity.
+- **SC-002**: Invalid contracts fail with stable error records covering field path, code, and explanation.
+- **SC-003**: Duplicate published version misuse is rejected deterministically.
+- **SC-004**: Lifecycle, semver, and portability rules are all validated automatically.
+- **SC-005**: The implementation of this spec can be added to the protected coverage target list and held to 100% coverage.
+
+## Governing Relationship
+
+This specification is governed by:
+
+- `001-foundation-v0-1`
+- constitution version `1.2.0`
+
+This specification, once approved, is intended to govern the first real implementation slice in:
+
+- `crates/cogolo-contracts`


### PR DESCRIPTION
## Summary

Implements the first real governed core slice for Cogolo: capability contract parsing, normalization, validation, immutability checks, and validation evidence, with protected 100% coverage for the contracts crate.

## Governing Spec

Primary governing slice:
- `002-capability-contracts`

Foundation relationship:
- `001-foundation-v0-1`

## Project Item

Tracked in the Cogolo project board:

- https://github.com/users/enricopiovesan/projects/1/

## What Changed

- Contracts changed: Added the first implementation-tight capability contract spec and data model, then implemented those rules in `cogolo-contracts`.
- Runtime behavior changed: No runtime execution changes yet.
- Compatibility impact: Additive only.
- ADR needed or linked: Existing ADR remains applicable; no new ADR introduced in this slice.

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing
- [x] Core coverage preserved
- [x] Required validation gates passing

## Notes

This PR also fixes remaining Cogolo naming drift in planning docs and corrects the coverage gate parser so protected core-crate line coverage is enforced correctly. `cogolo-contracts` is now held to the repository standard at `100.00%` line coverage.