### PR TITLE
Add deterministic spec-alignment CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,25 @@ jobs:
 
       - name: Validate PR body sections
         run: bash scripts/ci/pr_body_check.sh /tmp/pr-body.md
+
+  spec-alignment:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Save PR body
+        run: |
+          cat <<'EOF' > /tmp/pr-body.md
+          ${{ github.event.pull_request.body }}
+          EOF
+
+      - name: Run spec alignment check
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/ci/spec_alignment_check.sh /tmp/pr-body.md

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -41,6 +41,10 @@ Pull requests should include:
 - validation evidence
 - ADR reference, if required
 
+Implementation pull requests must declare their governing specs in the PR body under a `## Governing Spec` section. Those declarations are validated against:
+
+- `specs/governance/approved-specs.json`
+
 ## Board Discipline
 
 Recommended categories for task tracking:

--- a/docs/quality-standards.md
+++ b/docs/quality-standards.md
@@ -38,6 +38,12 @@ The default validation flow should include:
 - coverage checks for core logic
 - dependency/security checks
 
+Spec-alignment gate implementation:
+
+- approved spec registry: `specs/governance/approved-specs.json`
+- workflow job: `spec-alignment`
+- script: `scripts/ci/spec_alignment_check.sh`
+
 ## Coverage Standard
 
 Required:

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -23,6 +23,9 @@ required_files=(
   "specs/001-foundation-v0-1/plan.md"
   "specs/001-foundation-v0-1/research.md"
   "specs/001-foundation-v0-1/data-model.md"
+  "specs/004-spec-alignment-gate/spec.md"
+  "specs/004-spec-alignment-gate/data-model.md"
+  "specs/governance/approved-specs.json"
 )
 
 for file in "${required_files[@]}"; do
@@ -44,5 +47,8 @@ grep -q "Enterprise Quality Standards" .specify/memory/constitution.md
 grep -q "Non-Functional Requirements" specs/001-foundation-v0-1/spec.md
 grep -q "Non-Negotiable Quality Standards" specs/001-foundation-v0-1/spec.md
 grep -q "AI Review Process" docs/ai-review-process.md
+grep -q '"schema_version": "1.0.0"' specs/governance/approved-specs.json
+grep -q "Spec-alignment gate implementation" docs/quality-standards.md
+grep -q "## Governing Spec" .github/pull_request_template.md
 
 echo "Repository checks passed."

--- a/scripts/ci/spec_alignment_check.sh
+++ b/scripts/ci/spec_alignment_check.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly APPROVED_SPECS_FILE="specs/governance/approved-specs.json"
+readonly PR_BODY_FILE="${1:-}"
+readonly BASE_SHA="${BASE_SHA:-${GITHUB_BASE_SHA:-}}"
+readonly HEAD_SHA="${HEAD_SHA:-${GITHUB_HEAD_SHA:-HEAD}}"
+
+if [[ -z "${PR_BODY_FILE}" ]]; then
+  echo "Usage: $0 <pr-body-file>" >&2
+  exit 1
+fi
+
+if [[ ! -f "${APPROVED_SPECS_FILE}" ]]; then
+  echo "Missing approved spec registry: ${APPROVED_SPECS_FILE}" >&2
+  exit 1
+fi
+
+if [[ ! -s "${PR_BODY_FILE}" ]]; then
+  echo "PR body file is missing or empty: ${PR_BODY_FILE}" >&2
+  exit 1
+fi
+
+if [[ -z "${BASE_SHA}" ]]; then
+  echo "BASE_SHA or GITHUB_BASE_SHA must be set for spec alignment checks." >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify "${BASE_SHA}^{commit}" >/dev/null 2>&1; then
+  echo "Base commit not available locally: ${BASE_SHA}" >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify "${HEAD_SHA}^{commit}" >/dev/null 2>&1; then
+  echo "Head commit not available locally: ${HEAD_SHA}" >&2
+  exit 1
+fi
+
+tmp_json="$(mktemp)"
+trap 'rm -f "${tmp_json}"' EXIT
+
+python3 - "${APPROVED_SPECS_FILE}" "${PR_BODY_FILE}" "${BASE_SHA}" "${HEAD_SHA}" > "${tmp_json}" <<'PY'
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+approved_specs_file = Path(sys.argv[1])
+pr_body_file = Path(sys.argv[2])
+base_sha = sys.argv[3]
+head_sha = sys.argv[4]
+
+failures = []
+
+try:
+    registry = json.loads(approved_specs_file.read_text())
+except Exception as exc:
+    failures.append(
+        {
+            "code": "registry.invalid_json",
+            "path": str(approved_specs_file),
+            "message": f"Unable to parse approved spec registry: {exc}",
+        }
+    )
+    print(json.dumps({"status": "failed", "failures": failures}))
+    sys.exit(0)
+
+if registry.get("schema_version") != "1.0.0":
+    failures.append(
+        {
+            "code": "registry.schema_version_invalid",
+            "path": str(approved_specs_file),
+            "message": "Approved spec registry schema_version must be 1.0.0.",
+        }
+    )
+
+specs = registry.get("specs")
+if not isinstance(specs, list) or not specs:
+    failures.append(
+        {
+            "code": "registry.specs_missing",
+            "path": str(approved_specs_file),
+            "message": "Approved spec registry must contain at least one spec record.",
+        }
+    )
+    print(json.dumps({"status": "failed", "failures": failures}))
+    sys.exit(0)
+
+by_id = {}
+paths_seen = set()
+
+for spec in specs:
+    spec_id = spec.get("id")
+    spec_path = spec.get("path")
+
+    if not spec_id:
+        failures.append(
+            {
+                "code": "registry.spec_id_missing",
+                "path": str(approved_specs_file),
+                "message": "Spec record is missing id.",
+            }
+        )
+        continue
+
+    if spec_id in by_id:
+        failures.append(
+            {
+                "code": "registry.spec_id_duplicate",
+                "path": str(approved_specs_file),
+                "message": f"Duplicate approved spec id: {spec_id}",
+            }
+        )
+        continue
+
+    by_id[spec_id] = spec
+
+    if not spec_path:
+        failures.append(
+            {
+                "code": "registry.spec_path_missing",
+                "path": str(approved_specs_file),
+                "message": f"Approved spec {spec_id} is missing path.",
+            }
+        )
+    elif spec_path in paths_seen:
+        failures.append(
+            {
+                "code": "registry.spec_path_duplicate",
+                "path": str(approved_specs_file),
+                "message": f"Duplicate approved spec path: {spec_path}",
+            }
+        )
+    else:
+        paths_seen.add(spec_path)
+        if not Path(spec_path).is_file():
+            failures.append(
+                {
+                    "code": "registry.spec_path_missing_on_disk",
+                    "path": spec_path,
+                    "message": f"Approved spec path does not exist: {spec_path}",
+                }
+            )
+
+    if spec.get("status") != "approved":
+        failures.append(
+            {
+                "code": "registry.spec_not_approved",
+                "path": str(approved_specs_file),
+                "message": f"Approved spec registry entry {spec_id} must have status=approved.",
+            }
+        )
+
+    if spec.get("immutable") is not True:
+        failures.append(
+            {
+                "code": "registry.spec_not_immutable",
+                "path": str(approved_specs_file),
+                "message": f"Approved spec registry entry {spec_id} must have immutable=true.",
+            }
+        )
+
+    governs = spec.get("governs")
+    if not isinstance(governs, list) or not governs:
+        failures.append(
+            {
+                "code": "registry.governs_missing",
+                "path": str(approved_specs_file),
+                "message": f"Approved spec {spec_id} must declare at least one governed path prefix.",
+            }
+        )
+
+try:
+    pr_body = pr_body_file.read_text()
+except Exception as exc:
+    failures.append(
+        {
+            "code": "input.pr_body_unreadable",
+            "path": str(pr_body_file),
+            "message": f"Unable to read PR body file: {exc}",
+        }
+    )
+    print(json.dumps({"status": "failed", "failures": failures}))
+    sys.exit(0)
+
+declared_spec_ids = []
+in_section = False
+for raw_line in pr_body.splitlines():
+    line = raw_line.rstrip()
+    if line == "## Governing Spec":
+        in_section = True
+        continue
+    if in_section and line.startswith("## "):
+        break
+    if in_section:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("- "):
+            declared_spec_ids.append(stripped[2:].strip())
+
+if not in_section:
+    failures.append(
+        {
+            "code": "input.pr_governing_spec_section_missing",
+            "path": str(pr_body_file),
+            "message": "PR body must include a ## Governing Spec section.",
+        }
+    )
+
+declared_spec_ids = list(dict.fromkeys(declared_spec_ids))
+
+for spec_id in declared_spec_ids:
+    spec = by_id.get(spec_id)
+    if spec is None:
+        failures.append(
+            {
+                "code": "registry.spec_missing",
+                "path": str(pr_body_file),
+                "message": f"Declared governing spec is not in the approved registry: {spec_id}",
+            }
+        )
+        continue
+    if spec.get("status") != "approved":
+        failures.append(
+            {
+                "code": "registry.spec_not_approved",
+                "path": str(pr_body_file),
+                "message": f"Declared governing spec is not approved: {spec_id}",
+            }
+        )
+    if spec.get("immutable") is not True:
+        failures.append(
+            {
+                "code": "registry.spec_not_immutable",
+                "path": str(pr_body_file),
+                "message": f"Declared governing spec is not immutable: {spec_id}",
+            }
+        )
+
+changed_files = subprocess.check_output(
+    ["git", "diff", "--name-only", f"{base_sha}...{head_sha}"],
+    text=True,
+).splitlines()
+changed_files = [path.strip() for path in changed_files if path.strip()]
+
+governed_files = []
+required_spec_ids = set()
+
+for path in changed_files:
+    matching_spec_ids = []
+    for spec_id, spec in by_id.items():
+        for prefix in spec.get("governs", []):
+            if path.startswith(prefix):
+                matching_spec_ids.append(spec_id)
+    if matching_spec_ids:
+        governed_files.append(path)
+        required_spec_ids.update(matching_spec_ids)
+    elif path.startswith(("crates/", "scripts/ci/", ".github/workflows/", "specs/governance/")):
+        failures.append(
+            {
+                "code": "coverage.file_unmapped",
+                "path": path,
+                "message": f"Governed file is not covered by an approved spec record: {path}",
+            }
+        )
+
+for spec_id in sorted(required_spec_ids):
+    if spec_id not in declared_spec_ids:
+        failures.append(
+            {
+                "code": "coverage.spec_not_declared",
+                "path": str(pr_body_file),
+                "message": f"Changed governed files require governing spec {spec_id}, but it was not declared in the PR body.",
+            }
+        )
+
+status = "passed" if not failures else "failed"
+
+print(
+    json.dumps(
+        {
+            "status": status,
+            "changed_files": changed_files,
+            "governed_files": governed_files,
+            "required_spec_ids": sorted(required_spec_ids),
+            "declared_spec_ids": declared_spec_ids,
+            "failures": failures,
+        }
+    )
+)
+PY
+
+status="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["status"])' "${tmp_json}")"
+
+echo "Spec alignment evaluation:"
+python3 - "${tmp_json}" <<'PY'
+import json
+import sys
+
+result = json.load(open(sys.argv[1]))
+print(f"  status: {result['status']}")
+print(f"  declared specs: {', '.join(result.get('declared_spec_ids', [])) or '(none)'}")
+print(f"  required specs: {', '.join(result.get('required_spec_ids', [])) or '(none)'}")
+if result.get("governed_files"):
+    print("  governed files:")
+    for path in result["governed_files"]:
+        print(f"    - {path}")
+if result.get("failures"):
+    print("  failures:")
+    for failure in result["failures"]:
+        print(f"    - [{failure['code']}] {failure['message']}")
+PY
+
+if [[ "${status}" != "passed" ]]; then
+  exit 1
+fi
+
+echo "Spec alignment check passed."

--- a/specs/004-spec-alignment-gate/data-model.md
+++ b/specs/004-spec-alignment-gate/data-model.md
@@ -1,0 +1,206 @@
+# Data Model: Cogolo Spec-Alignment CI Gate
+
+## Purpose
+
+This document defines the exact `v0.1` data model for the first deterministic spec-alignment merge gate.
+
+It is intentionally narrow. The model covers approved spec records, declared PR spec references, governed path coverage, and gate outputs.
+
+## Approved Spec Registry
+
+Location:
+
+- `specs/governance/approved-specs.json`
+
+Top-level shape:
+
+```json
+{
+  "schema_version": "1.0.0",
+  "specs": [
+    {
+      "id": "002-capability-contracts",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/002-capability-contracts/spec.md",
+      "governs": [
+        "crates/cogolo-contracts/"
+      ]
+    }
+  ]
+}
+```
+
+## Registry Field Definitions
+
+### `schema_version`
+
+- type: string
+- required: yes
+- allowed value in `v0.1`: `1.0.0`
+
+### `specs`
+
+- type: array
+- required: yes
+- minimum items: 1
+
+Rules:
+
+- each `id` MUST be unique
+- each `path` MUST be unique
+
+## Approved Spec Record
+
+Required fields:
+
+- `id`
+- `version`
+- `status`
+- `immutable`
+- `path`
+- `governs`
+
+### `id`
+
+- type: string
+- required: yes
+- format: numeric-prefixed kebab-case spec id
+
+Examples:
+
+- `001-foundation-v0-1`
+- `002-capability-contracts`
+- `004-spec-alignment-gate`
+
+### `version`
+
+- type: string
+- required: yes
+- format: semantic version `MAJOR.MINOR.PATCH`
+
+### `status`
+
+- type: string
+- required: yes
+- allowed values in `v0.1`:
+  - `approved`
+
+Rule:
+
+- only `approved` specs may appear in the approved spec registry
+
+### `immutable`
+
+- type: boolean
+- required: yes
+- required value in `v0.1`: `true`
+
+### `path`
+
+- type: string
+- required: yes
+
+Rules:
+
+- MUST point to an existing `spec.md`
+- MUST match the canonical spec directory for the given `id`
+
+### `governs`
+
+- type: array
+- required: yes
+- minimum items: 1
+
+Rules:
+
+- each item MUST be a repository-relative path prefix
+- values MUST be unique
+- values SHOULD end with `/` when representing a directory prefix
+
+## PR Governing Spec Declaration
+
+Input source:
+
+- PR body markdown under the `## Governing Spec` section
+
+Allowed shape:
+
+```md
+## Governing Spec
+- 001-foundation-v0-1
+- 004-spec-alignment-gate
+```
+
+Rules:
+
+- each declaration line MUST begin with `- `
+- declared ids MUST be unique after normalization
+- blank lines inside the section are allowed
+- parsing ends at the next markdown heading of the form `## `
+
+## Governed Path Matching
+
+Given a changed file path:
+
+- if it starts with one or more configured `governs` prefixes, it is a governed file
+- the required governing spec set for the PR is the union of all approved spec ids that govern any changed file
+
+Rules:
+
+- matching is prefix-based and case-sensitive
+- if a governed file matches no approved spec record, the gate MUST fail
+- if multiple approved specs govern the same changed file, the PR MUST declare all of them in `v0.1`
+
+## Spec Alignment Result
+
+The gate must be able to report:
+
+- `status`
+- `changed_files`
+- `governed_files`
+- `required_spec_ids`
+- `declared_spec_ids`
+- `failures`
+
+### `status`
+
+- type: string
+- allowed values:
+  - `passed`
+  - `failed`
+
+### `failures`
+
+- type: array
+
+Each failure record must contain:
+
+- `code`
+- `path`
+- `message`
+
+Allowed failure code families:
+
+- `input.*`
+- `registry.*`
+- `pr.*`
+- `coverage.*`
+
+Examples:
+
+- `input.pr_body_missing`
+- `registry.spec_missing`
+- `registry.spec_not_approved`
+- `registry.spec_not_immutable`
+- `coverage.file_unmapped`
+- `coverage.spec_not_declared`
+
+## Semantic Rules
+
+- The approved spec registry is the machine-readable source of truth for merge gating.
+- Specs not present in the approved spec registry are not valid governing references for CI gating.
+- A PR body declaration alone is never sufficient without registry coverage.
+- A governed file diff must be fully covered by approved immutable specs or the gate fails.
+- Non-governed changes should not require unnecessary spec declarations.

--- a/specs/004-spec-alignment-gate/spec.md
+++ b/specs/004-spec-alignment-gate/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: Cogolo Spec-Alignment CI Gate
+
+**Feature Branch**: `004-spec-alignment-gate`  
+**Created**: 2026-03-27  
+**Status**: Draft  
+**Input**: Existing Cogolo foundation specification, constitution, quality standards, and issue `#7` for deterministic spec-alignment enforcement.
+
+## Purpose
+
+This specification defines the first deterministic spec-alignment gate for Cogolo pull requests.
+
+The gate exists to make the governance rule enforceable:
+
+- approved specs are versioned and immutable
+- governed implementation must align with an approved spec
+- pull requests that change governed implementation without approved spec coverage must fail
+
+This first version is intentionally narrow. It focuses on deterministic mapping between changed governed paths and approved spec records instead of attempting full semantic validation of every requirement.
+
+## User Scenarios & Testing
+
+### User Story 1 - Fail PRs That Change Governed Code Without Approved Spec Coverage (Priority: P1)
+
+As a maintainer, I want the CI pipeline to fail when a pull request changes governed implementation without an approved governing spec so that code cannot drift ahead of the documented source of truth.
+
+**Why this priority**: This is the core constitutional rule. Without it, the repo only documents spec alignment rather than enforcing it.
+
+**Independent Test**: A pull request that changes a governed file under a protected path without a matching approved spec record fails the spec-alignment job with an actionable explanation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a pull request that changes a governed file under `crates/` or another protected path, **When** no approved spec record governs that file, **Then** the spec-alignment job fails with the unmatched file path.
+2. **Given** a pull request that changes governed files covered by approved spec records, **When** the PR body declares those governing specs, **Then** the spec-alignment job passes.
+3. **Given** a pull request that only changes non-governed docs or community files, **When** the spec-alignment job runs, **Then** the job passes without requiring a governing spec declaration.
+
+---
+
+### User Story 2 - Fail PRs That Reference Missing or Unapproved Specs (Priority: P1)
+
+As a maintainer, I want the CI pipeline to fail when a pull request references specs that are unknown, non-immutable, or not approved for implementation so that the governing-spec mechanism stays trustworthy.
+
+**Why this priority**: Spec references are only meaningful if they point to explicit approved artifacts.
+
+**Independent Test**: A pull request whose `## Governing Spec` section references a missing, draft, mutable, or mismatched spec record fails the spec-alignment job.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR body that references a spec id not present in the approved spec registry, **When** validation runs, **Then** the spec-alignment job fails.
+2. **Given** a PR body that references a spec record with `status != approved` or `immutable != true`, **When** validation runs, **Then** the spec-alignment job fails.
+3. **Given** a PR body that references an approved immutable spec record, **When** validation runs, **Then** the gate accepts that reference.
+
+---
+
+### User Story 3 - Provide Deterministic Merge-Safe Evidence (Priority: P2)
+
+As a maintainer, I want the spec-alignment gate to produce deterministic, actionable output so that developers can understand exactly why a PR passed or failed and CI results remain stable.
+
+**Why this priority**: A merge gate that is noisy or ambiguous will be bypassed or ignored.
+
+**Independent Test**: Re-running the gate on the same PR content and diff produces the same pass or fail result and the same failure categories.
+
+**Acceptance Scenarios**:
+
+1. **Given** the same approved spec registry, PR body, and file diff, **When** the job runs multiple times, **Then** it produces the same result deterministically.
+2. **Given** a failing PR, **When** the job reports failure, **Then** the output identifies the missing or invalid spec mapping clearly enough to fix the PR.
+3. **Given** a passing PR, **When** the job completes, **Then** the output identifies the governing spec ids that justified the change set.
+
+## Scope
+
+In scope:
+
+- approved spec registry format
+- deterministic mapping from governed path prefixes to approved spec records
+- PR-body governing-spec validation
+- CI enforcement job for pull requests
+- actionable pass/fail output
+
+Out of scope:
+
+- semantic verification that every code change fully implements every requirement in a spec
+- automatic approval workflow for specs
+- runtime contract-to-spec semantic comparison
+- workflow or registry behavioral validation beyond path-based coverage
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The repository MUST define a machine-readable approved spec registry.
+- **FR-002**: Each approved spec registry entry MUST include spec identity, version, status, immutable flag, canonical path, and governed path prefixes.
+- **FR-003**: The spec-alignment gate MUST evaluate pull requests using changed file paths and the PR body as inputs.
+- **FR-004**: The gate MUST treat only configured governed path prefixes as requiring approved spec coverage.
+- **FR-005**: The gate MUST fail when a changed governed file is not covered by any approved immutable spec record.
+- **FR-006**: The gate MUST fail when the PR body lacks a `## Governing Spec` section.
+- **FR-007**: The gate MUST fail when the PR body references a spec id that is missing from the approved spec registry.
+- **FR-008**: The gate MUST fail when the PR body references a spec whose registry record is not `approved` or not immutable.
+- **FR-009**: The gate MUST fail when a changed governed file is covered by an approved spec record but that governing spec id is not declared in the PR body.
+- **FR-010**: The gate MUST ignore changes outside configured governed path prefixes.
+- **FR-011**: The gate MUST produce deterministic, machine-readable, and human-readable output that identifies:
+  - changed governed files
+  - governing spec ids required by the diff
+  - governing spec ids declared by the PR
+  - failure reasons
+- **FR-012**: The gate MUST support multiple governing spec ids in a single pull request.
+- **FR-013**: The gate MUST pass when no governed files changed.
+- **FR-014**: The CI workflow MUST run the spec-alignment gate on pull requests.
+- **FR-015**: The repository documentation MUST describe the approved spec registry and the default spec-alignment workflow.
+- **FR-016**: Approved implementation under this spec MUST itself be validated against this governing spec before merge.
+
+### Key Entities
+
+- **Approved Spec Record**: The machine-readable record for an approved immutable spec and the governed paths it covers.
+- **Governed Path Prefix**: A repository path prefix that requires approved spec coverage when changed.
+- **Declared Governing Spec Id**: A spec id listed in a PR body under `## Governing Spec`.
+- **Spec Alignment Result**: The pass/fail evaluation artifact for one pull request diff.
+
+## Non-Functional Requirements
+
+- **NFR-001 Determinism**: The gate MUST produce the same result for the same approved spec registry, PR body, and changed file list.
+- **NFR-002 Explainability**: Failure output MUST identify the specific missing or invalid mapping rather than failing silently.
+- **NFR-003 Maintainability**: The first implementation MUST stay simple enough to evolve as the spec model matures.
+- **NFR-004 Merge Safety**: The gate MUST be reliable enough to become a required protected check.
+- **NFR-005 Testability**: The core gate logic MUST be structured for full automated coverage once implemented as protected core logic.
+
+## Non-Negotiable Quality Gates
+
+- **QG-001**: No governed implementation change may merge unless it is covered by an approved immutable spec record.
+- **QG-002**: The approved spec registry MUST remain the machine-readable source of truth for merge gating.
+- **QG-003**: The PR body governing-spec declaration MUST not be treated as sufficient without registry validation.
+- **QG-004**: The gate MUST fail closed for invalid registry format, missing registry file, or unreadable required inputs.
+
+## Success Criteria
+
+- **SC-001**: A PR that changes governed implementation without approved spec coverage fails deterministically.
+- **SC-002**: A PR that changes governed implementation and declares the correct approved immutable specs passes the alignment gate.
+- **SC-003**: A PR that changes only non-governed files passes without unnecessary friction.
+- **SC-004**: The new CI job can become a required branch-protection check.
+
+## Governing Relationship
+
+This specification is governed by:
+
+- `001-foundation-v0-1`
+- constitution version `1.2.0`
+
+This specification, once approved, is intended to govern implementation in:
+
+- `scripts/ci/spec_alignment_check.sh`
+- `.github/workflows/ci.yml`
+- `specs/governance/approved-specs.json`

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "1.0.0",
+  "specs": [
+    {
+      "id": "001-foundation-v0-1",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/001-foundation-v0-1/spec.md",
+      "governs": [
+        "README.md",
+        ".specify/memory/constitution.md",
+        "docs/quality-standards.md",
+        "docs/compatibility-policy.md",
+        "docs/exception-process.md"
+      ]
+    },
+    {
+      "id": "002-capability-contracts",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/002-capability-contracts/spec.md",
+      "governs": [
+        "crates/cogolo-contracts/"
+      ]
+    },
+    {
+      "id": "003-event-contracts",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/003-event-contracts/spec.md",
+      "governs": [
+        "crates/cogolo-contracts/"
+      ]
+    },
+    {
+      "id": "004-spec-alignment-gate",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/004-spec-alignment-gate/spec.md",
+      "governs": [
+        ".github/workflows/ci.yml",
+        "scripts/ci/",
+        "specs/governance/"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add the governing spec and data model for the first deterministic spec-alignment gate
- add the approved spec registry and CI spec-alignment check script
- wire the new spec-alignment job into CI and document the workflow

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate

## Project Item
- Closes #7
- Tracked in Project 1

## Validation
- bash scripts/ci/repository_checks.sh
- BASE_SHA=$(git merge-base main HEAD) HEAD_SHA=HEAD bash scripts/ci/spec_alignment_check.sh /tmp/pr-body.md