### PR TITLE
Specify workflow registry and deterministic traversal

### DIFF
--- a/docs/planning-board.md
+++ b/docs/planning-board.md
@@ -17,6 +17,16 @@ Status meanings:
   - status: merged in PR [#5](https://github.com/enricopiovesan/cogolo/pull/5)
   - notes: protected at `100%` line coverage
 
+- `006-runtime-request-execution`
+  - scope: runtime request parsing, deterministic local execution, ambiguity handling, state events, and runtime trace output
+  - status: merged in PR [#20](https://github.com/enricopiovesan/cogolo/pull/20)
+  - notes: protected at `100%` line coverage
+
+- `005-capability-registry`
+  - scope: capability registry storage, immutable publication, overlay lookup, compatibility checks, and discovery index
+  - status: merged in PR [#18](https://github.com/enricopiovesan/cogolo/pull/18)
+  - notes: protected at `100%` line coverage
+
 ## Next Core Tasks
 
 ### `Ready`
@@ -25,27 +35,20 @@ Status meanings:
   - issue: [#6](https://github.com/enricopiovesan/cogolo/issues/6)
   - suggested id: `003-event-contracts`
   - outcome: event artifact shape, lifecycle, ownership, versioning, publisher/subscriber metadata, validation rules
+  - status: merged in PR [#15](https://github.com/enricopiovesan/cogolo/pull/15)
 
 - Spec-alignment CI gate design
   - issue: [#7](https://github.com/enricopiovesan/cogolo/issues/7)
   - outcome: first deterministic check that maps implementation slices to governing spec ids and fails when required spec artifacts are missing or unapproved
-
-### `Needs Spec`
-
-- Capability registry implementation
-  - issue: [#8](https://github.com/enricopiovesan/cogolo/issues/8)
-  - target area: `crates/cogolo-registry`
-  - missing first: dedicated registry slice for file layout, duplicate rules, indexing behavior, and evidence handling
-
-- Runtime request and execution model
-  - issue: [#9](https://github.com/enricopiovesan/cogolo/issues/9)
-  - target area: `crates/cogolo-runtime`
-  - missing first: dedicated runtime execution slice covering request schema, local WASM execution boundary, ambiguity behavior, and trace shape
+  - status: merged in PR [#16](https://github.com/enricopiovesan/cogolo/pull/16)
 
 - Workflow registry and deterministic traversal
   - issue: [#10](https://github.com/enricopiovesan/cogolo/issues/10)
   - target area: `crates/cogolo-registry`, `crates/cogolo-runtime`
-  - missing first: dedicated workflow spec slice
+  - status: spec drafting in progress under `007-workflow-registry-traversal`
+  - outcome: deterministic workflow artifact shape, workflow registry metadata, traversal rules, workflow-backed composed capability semantics
+
+### `Needs Spec`
 
 - Event-driven composition
   - target area: `crates/cogolo-runtime`
@@ -85,12 +88,12 @@ Status meanings:
 
 ## Recommended Sequence
 
-1. Review and merge `003-event-contracts`
-2. Design the spec-alignment CI gate
-3. Write registry slice for capability and event registration
-4. Implement `cogolo-registry`
-5. Write runtime request/execution slice
-6. Implement local runtime execution and trace skeleton
+1. Review and merge `007-workflow-registry-traversal`
+2. Implement workflow registry storage and deterministic traversal
+3. Write the event-driven composition slice for runtime event flow
+4. Implement event-driven workflow execution on top of the workflow slice
+5. Lock the first five capabilities and the first canonical workflow
+6. Move into browser-facing runtime subscription work
 
 ## Project 1 Sync
 

--- a/specs/007-workflow-registry-traversal/data-model.md
+++ b/specs/007-workflow-registry-traversal/data-model.md
@@ -1,0 +1,400 @@
+# Data Model: Workflow Registry and Deterministic Traversal
+
+## Purpose
+
+This document defines the implementation-tight workflow artifacts for the `007-workflow-registry-traversal` slice.
+
+It focuses on deterministic workflow registration, workflow discovery metadata, and workflow traversal evidence for `Foundation v0.1`.
+
+## 1. Workflow Definition
+
+Represents one authoritative workflow artifact.
+
+### Required Fields
+
+- `kind`
+- `schema_version`
+- `id`
+- `name`
+- `version`
+- `lifecycle`
+- `owner`
+- `summary`
+- `inputs`
+- `outputs`
+- `nodes`
+- `edges`
+- `start_node`
+- `terminal_nodes`
+- `tags`
+- `governing_spec`
+
+### Shape
+
+```json
+{
+  "kind": "workflow_definition",
+  "schema_version": "1.0.0",
+  "id": "content.comments.publish-comment",
+  "name": "publish-comment",
+  "version": "1.0.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "comments",
+    "contact": "comments@example.com"
+  },
+  "summary": "Create, validate, and publish a comment deterministically.",
+  "inputs": {
+    "schema": {
+      "type": "object"
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object"
+    }
+  },
+  "nodes": [],
+  "edges": [],
+  "start_node": "create_draft",
+  "terminal_nodes": [
+    "persist_comment"
+  ],
+  "tags": [
+    "comments",
+    "foundation"
+  ],
+  "governing_spec": "007-workflow-registry-traversal"
+}
+```
+
+### Rules
+
+- `kind` must equal `workflow_definition`
+- `schema_version` must equal `1.0.0`
+- `version` must be valid semver
+- `start_node` must identify exactly one declared node
+- `terminal_nodes` must not be empty
+
+## 2. Workflow Owner
+
+Represents workflow ownership metadata.
+
+### Required Fields
+
+- `team`
+- `contact`
+
+### Rules
+
+- both fields must be non-empty
+
+## 3. Workflow Node
+
+Represents one workflow step backed by a capability contract.
+
+### Required Fields
+
+- `node_id`
+- `capability_id`
+- `capability_version`
+- `input`
+- `output`
+
+### Shape
+
+```json
+{
+  "node_id": "create_draft",
+  "capability_id": "content.comments.create-comment-draft",
+  "capability_version": "1.0.0",
+  "input": {
+    "from_workflow_input": [
+      "comment_text",
+      "resource_id"
+    ]
+  },
+  "output": {
+    "to_workflow_state": [
+      "draft_id"
+    ]
+  }
+}
+```
+
+### Rules
+
+- `node_id` values must be unique within one workflow definition
+- `capability_id` + `capability_version` must resolve to one registered capability
+
+## 4. Workflow Edge
+
+Represents one deterministic transition between nodes.
+
+### Required Fields
+
+- `edge_id`
+- `from`
+- `to`
+- `trigger`
+
+### Optional Fields
+
+- `event`
+
+### Shape
+
+```json
+{
+  "edge_id": "draft_to_validate",
+  "from": "create_draft",
+  "to": "validate_comment",
+  "trigger": "direct"
+}
+```
+
+### Event Shape
+
+```json
+{
+  "event_id": "content.comments.draft-created",
+  "version": "1.0.0"
+}
+```
+
+### Rules
+
+- `trigger` values:
+  - `direct`
+  - `event`
+- `event` is required only when `trigger = event`
+- `from` and `to` must reference declared node ids
+
+## 5. Deterministic Traversal Rules
+
+Traversal order for this slice is:
+
+1. enter `start_node`
+2. execute the current node
+3. collect all edges whose `from` matches the current node
+4. if there is one valid direct edge, take it
+5. if there is one valid event edge whose required event was emitted, take it
+6. if there is no valid next edge and the current node is terminal, complete successfully
+7. otherwise fail traversal explicitly
+
+### Rules
+
+- multiple valid next edges are not allowed in this slice
+- deterministic traversal must fail rather than guess
+- cycles are invalid for `v0.1`
+
+## 6. Workflow Registry Record
+
+Represents stored workflow registration metadata.
+
+### Required Fields
+
+- `scope`
+- `id`
+- `version`
+- `lifecycle`
+- `owner`
+- `workflow_path`
+- `workflow_digest`
+- `registered_at`
+- `governing_spec`
+- `validator_version`
+- `evidence`
+
+### Rules
+
+- uniqueness is per `(scope, id, version)`
+- published workflow versions are immutable within their scope
+- `scope` values:
+  - `public`
+  - `private`
+
+## 7. Workflow Discovery Index Entry
+
+Represents workflow metadata exposed for discovery.
+
+### Required Fields
+
+- `scope`
+- `id`
+- `version`
+- `lifecycle`
+- `owner`
+- `summary`
+- `tags`
+- `participating_capabilities`
+- `events_used`
+- `start_node`
+- `terminal_nodes`
+- `registered_at`
+
+### Rules
+
+- `participating_capabilities` must be a deduplicated list of capability ids
+- `events_used` must be a deduplicated list of `event_id@version`
+
+## 8. Workflow Registration Evidence
+
+Represents workflow registration validation output.
+
+### Required Fields
+
+- `evidence_id`
+- `workflow_id`
+- `workflow_version`
+- `scope`
+- `governing_spec`
+- `validator_version`
+- `produced_at`
+- `result`
+
+### Enum Values
+
+`result`:
+
+- `passed`
+
+## 9. Workflow Validation Error
+
+Represents one workflow registration or traversal validation failure.
+
+### Required Fields
+
+- `code`
+- `message`
+- `path`
+- `severity`
+
+### Error Codes
+
+- `missing_required_field`
+- `invalid_literal`
+- `invalid_semver`
+- `duplicate_item`
+- `missing_reference`
+- `invalid_start_node`
+- `invalid_terminal_node`
+- `invalid_edge_reference`
+- `invalid_event_edge`
+- `deterministic_cycle_not_allowed`
+- `immutable_version_conflict`
+
+### Severity Values
+
+- `error`
+
+## 10. Workflow Traversal Request
+
+Represents one deterministic workflow invocation artifact.
+
+### Required Fields
+
+- `kind`
+- `schema_version`
+- `request_id`
+- `workflow_id`
+- `workflow_version`
+- `scope`
+- `input`
+- `governing_spec`
+
+### Rules
+
+- `kind` must equal `workflow_execution_request`
+- `scope` values:
+  - `public_only`
+  - `prefer_private`
+
+## 11. Workflow Traversal Step Record
+
+Represents one visited node during traversal.
+
+### Required Fields
+
+- `step_index`
+- `node_id`
+- `capability_id`
+- `capability_version`
+- `status`
+
+### Enum Values
+
+`status`:
+
+- `entered`
+- `completed`
+- `failed`
+
+## 12. Workflow Traversal Edge Record
+
+Represents one traversed edge.
+
+### Required Fields
+
+- `edge_id`
+- `from`
+- `to`
+- `trigger`
+
+### Optional Fields
+
+- `event`
+
+## 13. Workflow Traversal Evidence
+
+Represents the structured traversal artifact for one workflow run.
+
+### Required Fields
+
+- `kind`
+- `schema_version`
+- `trace_id`
+- `request_id`
+- `workflow_id`
+- `workflow_version`
+- `governing_spec`
+- `visited_nodes`
+- `traversed_edges`
+- `emitted_events`
+- `result`
+
+### Result Shape
+
+- `status`
+- `failure_reason`
+
+### Result Status Values
+
+- `completed`
+- `error`
+
+### Failure Reasons
+
+- `workflow_not_found`
+- `workflow_invalid`
+- `ambiguous_next_edge`
+- `missing_required_event`
+- `terminal_node_not_reached`
+- `step_execution_failed`
+
+## 14. Workflow-backed Capability Linkage
+
+Represents the relationship between a composed capability and its workflow implementation.
+
+### Required Fields
+
+- `capability_id`
+- `capability_version`
+- `workflow_id`
+- `workflow_version`
+
+### Rules
+
+- a workflow-backed capability must point to one registered workflow definition
+- capability semver and workflow semver remain separate artifacts
+- compatibility checks may consider both the capability contract and the linked workflow definition

--- a/specs/007-workflow-registry-traversal/spec.md
+++ b/specs/007-workflow-registry-traversal/spec.md
@@ -1,0 +1,142 @@
+# Feature Specification: Workflow Registry and Deterministic Traversal
+
+**Feature Branch**: `007-workflow-registry-traversal`  
+**Created**: 2026-03-27  
+**Status**: Draft  
+**Input**: Foundation workflow slice for deterministic workflow registration, workflow metadata, and runtime traversal over registered capabilities and event edges.
+
+## Purpose
+
+This spec defines the first implementation-governing workflow slice for Cogolo.
+
+It narrows the broader `Foundation v0.1` workflow intent into a concrete, testable model for:
+
+- registering deterministic workflow definitions
+- storing workflow metadata alongside governed workflow artifacts
+- validating workflow references against capability and event contracts
+- traversing one deterministic workflow path without planner heuristics
+- representing a composed capability as a workflow-backed capability boundary
+- producing structured traversal evidence suitable for later runtime traces and UI consumers
+
+This slice does **not** define AI planning, dynamic path optimization, retries, or distributed workflow execution. It is intentionally limited to deterministic traversal over an approved workflow definition.
+
+## User Scenarios and Testing
+
+### User Story 1 - Register a Deterministic Workflow Definition (Priority: P1)
+
+As a platform developer, I want to register a workflow definition with metadata and governed references so that workflows are first-class artifacts rather than hidden implementation glue.
+
+**Why this priority**: Cogolo’s composition model depends on workflows being governed artifacts in the same way capabilities and events are governed.
+
+**Independent Test**: Register a valid workflow definition referencing existing capability and event contracts, then verify the workflow registry stores the workflow artifact, metadata, and deterministic traversal order.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid workflow definition and valid referenced artifacts, **When** the workflow is registered, **Then** the workflow registry stores the workflow record, derived discovery metadata, and validation evidence.
+2. **Given** a workflow definition that references a missing capability or event version, **When** registration is attempted, **Then** the workflow is rejected with explicit validation feedback.
+3. **Given** a workflow definition whose published version already exists in the same scope, **When** the governed content differs, **Then** the registry rejects the republishing attempt as an immutable version conflict.
+
+### User Story 2 - Traverse One Workflow Deterministically (Priority: P1)
+
+As a platform developer, I want the runtime to traverse a registered workflow in deterministic order so that composed behavior remains explainable and stable.
+
+**Why this priority**: Cogolo’s workflow value depends on composition being explicit and replayable, not hidden behind heuristics.
+
+**Independent Test**: Execute a registered workflow with a valid workflow input and verify the runtime traverses the expected nodes and edges in deterministic order.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workflow with direct sequential edges, **When** traversal begins, **Then** the runtime visits nodes in the declared deterministic order and records the visited node sequence.
+2. **Given** a workflow with event-triggered edges, **When** a node emits the declared event, **Then** the runtime advances only to the nodes allowed by that event edge.
+3. **Given** a workflow with no valid next step from the current node, **When** traversal cannot continue, **Then** the workflow run fails explicitly with structured traversal evidence.
+
+### User Story 3 - Represent a Composed Capability Cleanly (Priority: P2)
+
+As a developer or future agent, I want composed capabilities to be backed by workflow definitions so that higher-level business actions remain discoverable and reusable.
+
+**Why this priority**: A composed capability is one of the main ways Cogolo turns graph traversal into stable business boundaries.
+
+**Independent Test**: Register a workflow-backed composed capability and verify its implementation reference points to the workflow definition while preserving capability identity and versioning.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workflow-backed composed capability, **When** it is registered, **Then** the registry records it as a capability with `implementation_kind = workflow` and a workflow reference.
+2. **Given** a workflow-backed composed capability, **When** it is discovered, **Then** downstream consumers can inspect both capability metadata and the linked workflow identity.
+3. **Given** a breaking workflow contract change for a composed capability, **When** a too-small semver bump is attempted, **Then** the compatibility check fails.
+
+## Edge Cases
+
+- What happens when a workflow references a capability that is present but not runtime-eligible?
+- What happens when two nodes declare the same identifier?
+- What happens when a workflow has more than one declared start node?
+- What happens when an event edge references an event contract that the source node cannot emit?
+- What happens when a direct edge would create a cycle in a deterministic `v0.1` traversal?
+- What happens when a workflow-backed composed capability points to a workflow version that is missing from the workflow registry?
+
+## Functional Requirements
+
+- **FR-001**: The system MUST accept a machine-readable workflow definition artifact as the registration boundary for workflows.
+- **FR-002**: A workflow definition MUST include stable identity, semver version, lifecycle, owner metadata, summary, tags, and governing spec metadata.
+- **FR-003**: A workflow definition MUST declare nodes, edges, start nodes, and terminal nodes explicitly.
+- **FR-004**: Each workflow node MUST reference one registered capability id and version.
+- **FR-005**: Each workflow edge MUST declare its traversal trigger as either `direct` or `event`.
+- **FR-006**: Event-triggered edges MUST reference one registered event contract id and version.
+- **FR-007**: Workflow registration MUST fail when any referenced capability or event contract version is missing.
+- **FR-008**: Workflow registration MUST fail when node identifiers are not unique.
+- **FR-009**: Workflow registration MUST fail when there is not exactly one declared start node for this slice.
+- **FR-010**: Workflow registration MUST fail when traversal edges create an invalid deterministic cycle for `v0.1`.
+- **FR-011**: The workflow registry MUST preserve immutable publication semantics per `(scope, id, version)`.
+- **FR-012**: The workflow registry MUST store both the authoritative workflow artifact and a derived discovery/index record.
+- **FR-013**: The workflow registry MUST expose participating capability ids, event ids, workflow tags, lifecycle, and owner metadata for discovery.
+- **FR-014**: The runtime MUST traverse a registered workflow using deterministic ordering and declared start/edge semantics only.
+- **FR-015**: Deterministic traversal MUST NOT use planner heuristics or implicit best-path selection in this slice.
+- **FR-016**: For direct edges, the runtime MUST advance only along the explicitly declared next node relation.
+- **FR-017**: For event edges, the runtime MUST advance only when the required event reference is emitted by the source node.
+- **FR-018**: The runtime MUST record visited nodes, traversed edges, and emitted events as structured traversal evidence.
+- **FR-019**: The runtime MUST fail explicitly when a workflow cannot reach a valid next node or terminal node under the declared rules.
+- **FR-020**: A composed capability MUST be representable as a first-class capability whose implementation reference points to a workflow definition.
+- **FR-021**: Workflow-backed composed capabilities MUST remain subject to capability semver, immutability, and compatibility rules.
+- **FR-022**: The workflow slice MUST keep workflow artifacts, derived registry entries, and traversal evidence machine-readable for future UI, MCP, and agent use.
+
+## Non-Functional Requirements
+
+- **NFR-001 Determinism**: Registration validation, start-node resolution, edge ordering, and runtime traversal order MUST be deterministic for the same registry state and workflow definition.
+- **NFR-002 Explainability**: Workflow traversal MUST produce structured evidence that explains visited nodes, traversed edges, emitted events, and terminal outcome.
+- **NFR-003 Portability**: Workflow definitions MUST describe orchestration semantics without assuming a specific UI, cloud, or host environment.
+- **NFR-004 Testability**: Core workflow registry and traversal logic MUST remain separable enough to achieve 100% automated line coverage once implemented.
+- **NFR-005 Compatibility**: Workflow identity and versioning MUST support semver discipline and immutable publication semantics.
+- **NFR-006 Maintainability**: Workflow validation, registry storage, traversal planning, and traversal execution evidence MUST remain clearly separated in the implementation.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: Workflow traversal MUST remain deterministic and MUST NOT silently choose among multiple valid paths without an approved rule.
+- **QG-002**: Workflow registration MUST reject missing, incompatible, or undeclared references instead of repairing them implicitly.
+- **QG-003**: Workflow-backed composed capabilities MUST remain discoverable as capabilities and MUST NOT be hidden as undocumented workflow-only artifacts.
+- **QG-004**: Core workflow registry and traversal logic MUST reach 100% automated line coverage when implemented.
+- **QG-005**: Workflow registry and traversal behavior MUST align with the governing spec and fail merge validation when drift occurs.
+
+## Key Entities
+
+- **Workflow Definition**: The authoritative machine-readable artifact describing nodes, edges, start node, terminal nodes, tags, and workflow metadata.
+- **Workflow Registry Record**: The stored workflow artifact plus derived metadata, evidence, and immutable publication identity.
+- **Workflow Node**: A workflow step that references one capability contract version and declares input/output mapping behavior.
+- **Workflow Edge**: A deterministic transition between nodes, triggered either directly or by an event contract.
+- **Workflow Traversal Evidence**: The structured artifact describing node visitation order, traversed edges, emitted events, and terminal traversal status.
+- **Workflow-backed Capability**: A composed capability whose implementation reference points to a workflow definition rather than a direct executable artifact.
+
+## Success Criteria
+
+- **SC-001**: A valid workflow definition can be registered, indexed, and discovered with metadata derived from its governed artifact.
+- **SC-002**: A workflow definition referencing missing or incompatible capability/event versions is rejected predictably with structured validation evidence.
+- **SC-003**: One deterministic workflow can be traversed in declared node order without planner heuristics.
+- **SC-004**: Workflow traversal produces structured evidence capturing visited nodes, traversed edges, and terminal status.
+- **SC-005**: Workflow-backed composed capabilities remain discoverable as first-class capabilities linked to workflow definitions.
+
+## Out of Scope
+
+- AI planning or dynamic workflow generation
+- multi-path optimization
+- distributed workflow execution
+- retries, backoff, compensation, or saga management
+- browser runtime subscription behavior
+- full metadata graph query model beyond workflow-local traversal semantics


### PR DESCRIPTION
## Summary
- define the deterministic workflow registry and traversal slice as `007-workflow-registry-traversal`
- add the implementation-tight workflow data model for workflow artifacts, edges, traversal evidence, and workflow-backed capability linkage
- refresh the local planning board so it matches the current merged state and next sequence

## Governing Spec
- 001-foundation-v0-1

## Project Item
- Closes #10

## Validation
- `bash scripts/ci/repository_checks.sh`
