### PR TITLE
Implement workflow registry and deterministic traversal foundation

### DIFF
--- a/crates/cogolo-registry/Cargo.toml
+++ b/crates/cogolo-registry/Cargo.toml
@@ -9,9 +9,8 @@ rust-version.workspace = true
 [dependencies]
 cogolo-contracts = { path = "../cogolo-contracts" }
 semver = "1.0.27"
-
-[dev-dependencies]
 serde_json = "1.0.145"
 
+[dev-dependencies]
 [lints]
 workspace = true

--- a/crates/cogolo-registry/src/lib.rs
+++ b/crates/cogolo-registry/src/lib.rs
@@ -1,5 +1,8 @@
 //! Capability registry support for Cogolo.
 
+mod workflows;
+pub use workflows::*;
+
 use cogolo_contracts::{
     CapabilityContract, ErrorSeverity, EventReference, IdReference, Lifecycle, Owner,
     PublishedContractRecord, ValidationContext, ValidationFailure, governed_content_digest,

--- a/crates/cogolo-registry/src/workflows.rs
+++ b/crates/cogolo-registry/src/workflows.rs
@@ -1,0 +1,1690 @@
+use crate::{
+    CapabilityArtifactRecord, CapabilityRegistry, ImplementationKind, LookupScope, RegistryScope,
+    WorkflowReference,
+};
+use cogolo_contracts::{ErrorSeverity, EventReference, Lifecycle, Owner, SchemaContainer};
+use semver::Version;
+use serde_json::{Map, Value, json};
+use std::collections::{BTreeMap, BTreeSet};
+
+const WORKFLOW_KIND: &str = "workflow_definition";
+const WORKFLOW_SCHEMA_VERSION: &str = "1.0.0";
+const WORKFLOW_GOVERNING_SPEC: &str = "007-workflow-registry-traversal";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowDefinition {
+    pub kind: String,
+    pub schema_version: String,
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub lifecycle: Lifecycle,
+    pub owner: Owner,
+    pub summary: String,
+    pub inputs: SchemaContainer,
+    pub outputs: SchemaContainer,
+    pub nodes: Vec<WorkflowNode>,
+    pub edges: Vec<WorkflowEdge>,
+    pub start_node: String,
+    pub terminal_nodes: Vec<String>,
+    pub tags: Vec<String>,
+    pub governing_spec: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowNode {
+    pub node_id: String,
+    pub capability_id: String,
+    pub capability_version: String,
+    pub input: WorkflowNodeInput,
+    pub output: WorkflowNodeOutput,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowNodeInput {
+    pub from_workflow_input: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowNodeOutput {
+    pub to_workflow_state: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowEdge {
+    pub edge_id: String,
+    pub from: String,
+    pub to: String,
+    pub trigger: WorkflowEdgeTrigger,
+    pub event: Option<EventReference>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowEdgeTrigger {
+    Direct,
+    Event,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowRegistration {
+    pub scope: RegistryScope,
+    pub definition: WorkflowDefinition,
+    pub workflow_path: String,
+    pub registered_at: String,
+    pub validator_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowRegistryRecord {
+    pub scope: RegistryScope,
+    pub id: String,
+    pub version: String,
+    pub lifecycle: Lifecycle,
+    pub owner: Owner,
+    pub workflow_path: String,
+    pub workflow_digest: String,
+    pub registered_at: String,
+    pub governing_spec: String,
+    pub validator_version: String,
+    pub evidence: WorkflowRegistrationEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowDiscoveryIndexEntry {
+    pub scope: RegistryScope,
+    pub id: String,
+    pub version: String,
+    pub lifecycle: Lifecycle,
+    pub owner: Owner,
+    pub summary: String,
+    pub tags: Vec<String>,
+    pub participating_capabilities: Vec<String>,
+    pub events_used: Vec<String>,
+    pub start_node: String,
+    pub terminal_nodes: Vec<String>,
+    pub registered_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowRegistrationEvidence {
+    pub evidence_id: String,
+    pub workflow_id: String,
+    pub workflow_version: String,
+    pub scope: RegistryScope,
+    pub governing_spec: String,
+    pub validator_version: String,
+    pub produced_at: String,
+    pub result: WorkflowRegistrationResult,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowRegistrationResult {
+    Passed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowRegistrationOutcome {
+    pub record: WorkflowRegistryRecord,
+    pub index_entry: WorkflowDiscoveryIndexEntry,
+    pub evidence: WorkflowRegistrationEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedWorkflow {
+    pub definition: WorkflowDefinition,
+    pub record: WorkflowRegistryRecord,
+    pub index_entry: WorkflowDiscoveryIndexEntry,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowErrorCode {
+    MissingRequiredField,
+    InvalidLiteral,
+    InvalidSemver,
+    DuplicateItem,
+    MissingReference,
+    InvalidStartNode,
+    InvalidTerminalNode,
+    InvalidEdgeReference,
+    InvalidEventEdge,
+    DeterministicCycleNotAllowed,
+    ImmutableVersionConflict,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowError {
+    pub code: WorkflowErrorCode,
+    pub path: String,
+    pub message: String,
+    pub severity: ErrorSeverity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowFailure {
+    pub errors: Vec<WorkflowError>,
+}
+
+#[derive(Debug, Default)]
+pub struct WorkflowRegistry {
+    definitions: BTreeMap<(RegistryScope, String, String), WorkflowDefinition>,
+    records: BTreeMap<(RegistryScope, String, String), WorkflowRegistryRecord>,
+    index: BTreeMap<(RegistryScope, String, String), WorkflowDiscoveryIndexEntry>,
+}
+
+impl WorkflowRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers one deterministic workflow definition.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkflowFailure`] when required fields are invalid, workflow
+    /// references are missing or incompatible, a deterministic cycle is found,
+    /// or an immutable published version would be changed.
+    pub fn register(
+        &mut self,
+        capabilities: &CapabilityRegistry,
+        request: WorkflowRegistration,
+    ) -> Result<WorkflowRegistrationOutcome, WorkflowFailure> {
+        let WorkflowRegistration {
+            scope,
+            definition,
+            workflow_path,
+            registered_at,
+            validator_version,
+        } = request;
+
+        let mut errors = Vec::new();
+        validate_workflow_fields(&definition, &workflow_path, &registered_at, &mut errors);
+        validate_workflow_references(scope, capabilities, &definition, &mut errors);
+
+        if !errors.is_empty() {
+            return Err(WorkflowFailure { errors });
+        }
+
+        let key = (scope, definition.id.clone(), definition.version.clone());
+        let digest = workflow_digest(&definition);
+        let record = WorkflowRegistryRecord {
+            scope,
+            id: definition.id.clone(),
+            version: definition.version.clone(),
+            lifecycle: definition.lifecycle.clone(),
+            owner: definition.owner.clone(),
+            workflow_path,
+            workflow_digest: digest.clone(),
+            registered_at: registered_at.clone(),
+            governing_spec: definition.governing_spec.clone(),
+            validator_version: validator_version.clone(),
+            evidence: WorkflowRegistrationEvidence {
+                evidence_id: format!("wfreg_{}_{}", definition.id, definition.version),
+                workflow_id: definition.id.clone(),
+                workflow_version: definition.version.clone(),
+                scope,
+                governing_spec: definition.governing_spec.clone(),
+                validator_version,
+                produced_at: registered_at.clone(),
+                result: WorkflowRegistrationResult::Passed,
+            },
+        };
+        let index_entry = build_workflow_index(scope, &definition, &registered_at);
+
+        if let Some(existing) = self.records.get(&key) {
+            let Some(existing_definition) = self.definitions.get(&key) else {
+                return Err(single_error(
+                    WorkflowErrorCode::ImmutableVersionConflict,
+                    "$.id",
+                    "existing workflow record is missing its authoritative definition",
+                ));
+            };
+            let Some(existing_index) = self.index.get(&key) else {
+                return Err(single_error(
+                    WorkflowErrorCode::ImmutableVersionConflict,
+                    "$.id",
+                    "existing workflow record is missing its discovery index entry",
+                ));
+            };
+
+            if existing == &record
+                && existing_index == &index_entry
+                && existing_definition == &definition
+            {
+                return Ok(WorkflowRegistrationOutcome {
+                    record: existing.clone(),
+                    index_entry: existing_index.clone(),
+                    evidence: existing.evidence.clone(),
+                });
+            }
+
+            if workflow_digest(existing_definition) != digest {
+                return Err(single_error(
+                    WorkflowErrorCode::ImmutableVersionConflict,
+                    "$.version",
+                    "published workflow versions are immutable within a scope",
+                ));
+            }
+
+            return Err(single_error(
+                WorkflowErrorCode::ImmutableVersionConflict,
+                "$.workflow_path",
+                "published workflow versions are immutable and cannot be republished with different metadata",
+            ));
+        }
+
+        self.definitions.insert(key.clone(), definition);
+        self.records.insert(key.clone(), record.clone());
+        self.index.insert(key, index_entry.clone());
+
+        Ok(WorkflowRegistrationOutcome {
+            evidence: record.evidence.clone(),
+            record,
+            index_entry,
+        })
+    }
+
+    #[must_use]
+    pub fn find_exact(
+        &self,
+        lookup_scope: LookupScope,
+        id: &str,
+        version: &str,
+    ) -> Option<ResolvedWorkflow> {
+        for &scope in lookup_order(lookup_scope) {
+            let key = (scope, id.to_string(), version.to_string());
+            if let Some(record) = self.records.get(&key) {
+                let definition = self.definitions.get(&key)?.clone();
+                let index_entry = self.index.get(&key)?.clone();
+                return Some(ResolvedWorkflow {
+                    definition,
+                    record: record.clone(),
+                    index_entry,
+                });
+            }
+        }
+        None
+    }
+}
+
+#[must_use]
+pub fn workflow_artifact_record(
+    workflow_id: &str,
+    workflow_version: &str,
+    artifact_ref: &str,
+) -> CapabilityArtifactRecord {
+    CapabilityArtifactRecord {
+        artifact_ref: artifact_ref.to_string(),
+        implementation_kind: ImplementationKind::Workflow,
+        source: crate::SourceReference {
+            kind: crate::SourceKind::Local,
+            location: format!("workflow://{workflow_id}@{workflow_version}"),
+        },
+        binary: None,
+        workflow_ref: Some(WorkflowReference {
+            workflow_id: workflow_id.to_string(),
+            workflow_version: workflow_version.to_string(),
+        }),
+        digests: crate::ArtifactDigests {
+            source_digest: format!("workflow:{workflow_id}:{workflow_version}"),
+            binary_digest: None,
+        },
+        provenance: crate::RegistryProvenance {
+            source: "workflow-registry".to_string(),
+            author: "cogolo".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+        },
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn validate_workflow_fields(
+    definition: &WorkflowDefinition,
+    workflow_path: &str,
+    registered_at: &str,
+    errors: &mut Vec<WorkflowError>,
+) {
+    require_non_empty(&definition.kind, "$.kind", errors);
+    require_non_empty(&definition.schema_version, "$.schema_version", errors);
+    require_non_empty(&definition.id, "$.id", errors);
+    require_non_empty(&definition.name, "$.name", errors);
+    require_non_empty(&definition.version, "$.version", errors);
+    require_non_empty(&definition.owner.team, "$.owner.team", errors);
+    require_non_empty(&definition.owner.contact, "$.owner.contact", errors);
+    require_non_empty(&definition.summary, "$.summary", errors);
+    require_non_empty(workflow_path, "$.workflow_path", errors);
+    require_non_empty(registered_at, "$.registered_at", errors);
+    require_non_empty(&definition.start_node, "$.start_node", errors);
+    require_non_empty(&definition.governing_spec, "$.governing_spec", errors);
+
+    if definition.kind != WORKFLOW_KIND {
+        errors.push(workflow_error(
+            WorkflowErrorCode::InvalidLiteral,
+            "$.kind",
+            "kind must equal workflow_definition",
+        ));
+    }
+    if definition.schema_version != WORKFLOW_SCHEMA_VERSION {
+        errors.push(workflow_error(
+            WorkflowErrorCode::InvalidLiteral,
+            "$.schema_version",
+            "schema_version must equal 1.0.0",
+        ));
+    }
+    if definition.governing_spec != WORKFLOW_GOVERNING_SPEC {
+        errors.push(workflow_error(
+            WorkflowErrorCode::InvalidLiteral,
+            "$.governing_spec",
+            "governing_spec must equal 007-workflow-registry-traversal",
+        ));
+    }
+    if Version::parse(&definition.version).is_err() {
+        errors.push(workflow_error(
+            WorkflowErrorCode::InvalidSemver,
+            "$.version",
+            "version must be valid semantic versioning",
+        ));
+    }
+    if definition.nodes.is_empty() {
+        errors.push(workflow_error(
+            WorkflowErrorCode::MissingRequiredField,
+            "$.nodes",
+            "nodes must not be empty",
+        ));
+    }
+    if definition.terminal_nodes.is_empty() {
+        errors.push(workflow_error(
+            WorkflowErrorCode::InvalidTerminalNode,
+            "$.terminal_nodes",
+            "terminal_nodes must not be empty",
+        ));
+    }
+
+    let mut node_ids = BTreeSet::new();
+    for (index, node) in definition.nodes.iter().enumerate() {
+        let base = format!("$.nodes[{index}]");
+        require_non_empty(&node.node_id, &format!("{base}.node_id"), errors);
+        require_non_empty(
+            &node.capability_id,
+            &format!("{base}.capability_id"),
+            errors,
+        );
+        require_non_empty(
+            &node.capability_version,
+            &format!("{base}.capability_version"),
+            errors,
+        );
+        if !node_ids.insert(node.node_id.clone()) {
+            errors.push(workflow_error(
+                WorkflowErrorCode::DuplicateItem,
+                &format!("{base}.node_id"),
+                "node_id values must be unique within one workflow definition",
+            ));
+        }
+        if Version::parse(&node.capability_version).is_err() {
+            errors.push(workflow_error(
+                WorkflowErrorCode::InvalidSemver,
+                &format!("{base}.capability_version"),
+                "capability_version must be valid semantic versioning",
+            ));
+        }
+    }
+
+    let mut terminal_ids = BTreeSet::new();
+    for (index, terminal) in definition.terminal_nodes.iter().enumerate() {
+        if !terminal_ids.insert(terminal.clone()) {
+            errors.push(workflow_error(
+                WorkflowErrorCode::DuplicateItem,
+                &format!("$.terminal_nodes[{index}]"),
+                "terminal_nodes must not contain duplicates",
+            ));
+        }
+    }
+
+    let mut edge_ids = BTreeSet::new();
+    for (index, edge) in definition.edges.iter().enumerate() {
+        let base = format!("$.edges[{index}]");
+        require_non_empty(&edge.edge_id, &format!("{base}.edge_id"), errors);
+        require_non_empty(&edge.from, &format!("{base}.from"), errors);
+        require_non_empty(&edge.to, &format!("{base}.to"), errors);
+        if !edge_ids.insert(edge.edge_id.clone()) {
+            errors.push(workflow_error(
+                WorkflowErrorCode::DuplicateItem,
+                &format!("{base}.edge_id"),
+                "edge_id values must be unique within one workflow definition",
+            ));
+        }
+        match edge.trigger {
+            WorkflowEdgeTrigger::Direct => {
+                if edge.event.is_some() {
+                    errors.push(workflow_error(
+                        WorkflowErrorCode::InvalidEventEdge,
+                        &format!("{base}.event"),
+                        "direct edges must not declare an event reference",
+                    ));
+                }
+            }
+            WorkflowEdgeTrigger::Event => {
+                let Some(event) = edge.event.as_ref() else {
+                    errors.push(workflow_error(
+                        WorkflowErrorCode::InvalidEventEdge,
+                        &format!("{base}.event"),
+                        "event edges must declare an event reference",
+                    ));
+                    continue;
+                };
+                if event.event_id.trim().is_empty() {
+                    errors.push(workflow_error(
+                        WorkflowErrorCode::InvalidEventEdge,
+                        &format!("{base}.event.event_id"),
+                        "event_id must be non-empty",
+                    ));
+                }
+                if Version::parse(&event.version).is_err() {
+                    errors.push(workflow_error(
+                        WorkflowErrorCode::InvalidSemver,
+                        &format!("{base}.event.version"),
+                        "event version must be valid semantic versioning",
+                    ));
+                }
+            }
+        }
+    }
+
+    if !node_ids.contains(&definition.start_node) {
+        errors.push(workflow_error(
+            WorkflowErrorCode::InvalidStartNode,
+            "$.start_node",
+            "start_node must reference a declared node",
+        ));
+    }
+    for (index, terminal) in definition.terminal_nodes.iter().enumerate() {
+        if !node_ids.contains(terminal) {
+            errors.push(workflow_error(
+                WorkflowErrorCode::InvalidTerminalNode,
+                &format!("$.terminal_nodes[{index}]"),
+                "terminal_nodes must reference declared node ids",
+            ));
+        }
+    }
+    for (index, edge) in definition.edges.iter().enumerate() {
+        if !node_ids.contains(&edge.from) {
+            errors.push(workflow_error(
+                WorkflowErrorCode::InvalidEdgeReference,
+                &format!("$.edges[{index}].from"),
+                "edge source must reference a declared node",
+            ));
+        }
+        if !node_ids.contains(&edge.to) {
+            errors.push(workflow_error(
+                WorkflowErrorCode::InvalidEdgeReference,
+                &format!("$.edges[{index}].to"),
+                "edge target must reference a declared node",
+            ));
+        }
+    }
+    if has_cycle(definition) {
+        errors.push(workflow_error(
+            WorkflowErrorCode::DeterministicCycleNotAllowed,
+            "$.edges",
+            "deterministic workflow cycles are not allowed in v0.1",
+        ));
+    }
+}
+
+fn validate_workflow_references(
+    scope: RegistryScope,
+    capabilities: &CapabilityRegistry,
+    definition: &WorkflowDefinition,
+    errors: &mut Vec<WorkflowError>,
+) {
+    let lookup_scope = match scope {
+        RegistryScope::Public => LookupScope::PublicOnly,
+        RegistryScope::Private => LookupScope::PreferPrivate,
+    };
+
+    let node_capabilities = definition
+        .nodes
+        .iter()
+        .map(|node| {
+            let resolved = capabilities.find_exact(
+                lookup_scope,
+                &node.capability_id,
+                &node.capability_version,
+            );
+            (node, resolved)
+        })
+        .collect::<Vec<_>>();
+
+    for (index, (_node, resolved)) in node_capabilities.iter().enumerate() {
+        let Some(capability) = resolved else {
+            errors.push(workflow_error(
+                WorkflowErrorCode::MissingReference,
+                &format!("$.nodes[{index}]"),
+                "workflow node must reference one registered capability contract version",
+            ));
+            continue;
+        };
+        if !capability.contract.lifecycle.is_runtime_eligible() {
+            errors.push(workflow_error(
+                WorkflowErrorCode::MissingReference,
+                &format!("$.nodes[{index}]"),
+                "workflow node must reference a runtime-eligible capability",
+            ));
+        }
+    }
+
+    let resolved_by_node = node_capabilities
+        .into_iter()
+        .filter_map(|(node, resolved)| {
+            resolved.map(|capability| (node.node_id.clone(), capability))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let mut direct_edges = BTreeMap::<&str, usize>::new();
+    let mut event_edges = BTreeMap::<&str, usize>::new();
+    for (index, edge) in definition.edges.iter().enumerate() {
+        match edge.trigger {
+            WorkflowEdgeTrigger::Direct => {
+                *direct_edges.entry(&edge.from).or_default() += 1;
+                if direct_edges[edge.from.as_str()] > 1 {
+                    errors.push(workflow_error(
+                        WorkflowErrorCode::DuplicateItem,
+                        &format!("$.edges[{index}]"),
+                        "nodes must not declare more than one direct outgoing edge in v0.1",
+                    ));
+                }
+            }
+            WorkflowEdgeTrigger::Event => {
+                *event_edges.entry(&edge.from).or_default() += 1;
+                if event_edges[edge.from.as_str()] > 1 {
+                    errors.push(workflow_error(
+                        WorkflowErrorCode::DuplicateItem,
+                        &format!("$.edges[{index}]"),
+                        "nodes must not declare more than one event outgoing edge in v0.1",
+                    ));
+                }
+
+                let Some(event) = edge.event.as_ref() else {
+                    continue;
+                };
+                let Some(source_capability) = resolved_by_node.get(&edge.from) else {
+                    continue;
+                };
+                let emits_event = source_capability
+                    .contract
+                    .emits
+                    .iter()
+                    .any(|declared| declared == event);
+                if !emits_event {
+                    errors.push(workflow_error(
+                        WorkflowErrorCode::InvalidEventEdge,
+                        &format!("$.edges[{index}].event"),
+                        "event edge must reference an event emitted by the source capability contract",
+                    ));
+                }
+            }
+        }
+    }
+}
+
+fn build_workflow_index(
+    scope: RegistryScope,
+    definition: &WorkflowDefinition,
+    registered_at: &str,
+) -> WorkflowDiscoveryIndexEntry {
+    WorkflowDiscoveryIndexEntry {
+        scope,
+        id: definition.id.clone(),
+        version: definition.version.clone(),
+        lifecycle: definition.lifecycle.clone(),
+        owner: definition.owner.clone(),
+        summary: definition.summary.clone(),
+        tags: dedup_strings(definition.tags.clone()),
+        participating_capabilities: dedup_strings(
+            definition
+                .nodes
+                .iter()
+                .map(|node| node.capability_id.clone())
+                .collect(),
+        ),
+        events_used: dedup_strings(
+            definition
+                .edges
+                .iter()
+                .filter_map(|edge| {
+                    edge.event
+                        .as_ref()
+                        .map(|event| format!("{}@{}", event.event_id, event.version))
+                })
+                .collect(),
+        ),
+        start_node: definition.start_node.clone(),
+        terminal_nodes: dedup_strings(definition.terminal_nodes.clone()),
+        registered_at: registered_at.to_string(),
+    }
+}
+
+fn dedup_strings(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn has_cycle(definition: &WorkflowDefinition) -> bool {
+    let mut adjacency = BTreeMap::<String, Vec<String>>::new();
+    for edge in &definition.edges {
+        adjacency
+            .entry(edge.from.clone())
+            .or_default()
+            .push(edge.to.clone());
+    }
+
+    let mut visiting = BTreeSet::new();
+    let mut visited = BTreeSet::new();
+    for node in definition.nodes.iter().map(|node| node.node_id.clone()) {
+        if dfs_cycle(&node, &adjacency, &mut visiting, &mut visited) {
+            return true;
+        }
+    }
+    false
+}
+
+fn dfs_cycle(
+    node: &str,
+    adjacency: &BTreeMap<String, Vec<String>>,
+    visiting: &mut BTreeSet<String>,
+    visited: &mut BTreeSet<String>,
+) -> bool {
+    if visited.contains(node) {
+        return false;
+    }
+    if !visiting.insert(node.to_string()) {
+        return true;
+    }
+    if let Some(next_nodes) = adjacency.get(node) {
+        for next in next_nodes {
+            if dfs_cycle(next, adjacency, visiting, visited) {
+                return true;
+            }
+        }
+    }
+    visiting.remove(node);
+    visited.insert(node.to_string());
+    false
+}
+
+fn workflow_digest(definition: &WorkflowDefinition) -> String {
+    let mut artifact = Map::new();
+    artifact.insert("kind".to_string(), Value::String(definition.kind.clone()));
+    artifact.insert(
+        "schema_version".to_string(),
+        Value::String(definition.schema_version.clone()),
+    );
+    artifact.insert("id".to_string(), Value::String(definition.id.clone()));
+    artifact.insert("name".to_string(), Value::String(definition.name.clone()));
+    artifact.insert(
+        "version".to_string(),
+        Value::String(definition.version.clone()),
+    );
+    artifact.insert(
+        "lifecycle".to_string(),
+        Value::String(format!("{:?}", definition.lifecycle)),
+    );
+    artifact.insert(
+        "owner".to_string(),
+        json!({
+            "team": definition.owner.team,
+            "contact": definition.owner.contact,
+        }),
+    );
+    artifact.insert(
+        "summary".to_string(),
+        Value::String(definition.summary.clone()),
+    );
+    artifact.insert("inputs".to_string(), definition.inputs.schema.clone());
+    artifact.insert("outputs".to_string(), definition.outputs.schema.clone());
+    artifact.insert(
+        "nodes".to_string(),
+        Value::Array(
+            definition
+                .nodes
+                .iter()
+                .map(|node| {
+                    json!({
+                        "node_id": node.node_id,
+                        "capability_id": node.capability_id,
+                        "capability_version": node.capability_version,
+                        "input": node.input.from_workflow_input,
+                        "output": node.output.to_workflow_state,
+                    })
+                })
+                .collect(),
+        ),
+    );
+    artifact.insert(
+        "edges".to_string(),
+        Value::Array(
+            definition
+                .edges
+                .iter()
+                .map(|edge| {
+                    json!({
+                        "edge_id": edge.edge_id,
+                        "from": edge.from,
+                        "to": edge.to,
+                        "trigger": match edge.trigger {
+                            WorkflowEdgeTrigger::Direct => "direct",
+                            WorkflowEdgeTrigger::Event => "event",
+                        },
+                        "event": edge.event.as_ref().map(|event| {
+                            json!({
+                                "event_id": event.event_id,
+                                "version": event.version,
+                            })
+                        }),
+                    })
+                })
+                .collect(),
+        ),
+    );
+    artifact.insert(
+        "start_node".to_string(),
+        Value::String(definition.start_node.clone()),
+    );
+    artifact.insert(
+        "terminal_nodes".to_string(),
+        Value::Array(
+            definition
+                .terminal_nodes
+                .iter()
+                .cloned()
+                .map(Value::String)
+                .collect(),
+        ),
+    );
+    artifact.insert(
+        "tags".to_string(),
+        Value::Array(definition.tags.iter().cloned().map(Value::String).collect()),
+    );
+    artifact.insert(
+        "governing_spec".to_string(),
+        Value::String(definition.governing_spec.clone()),
+    );
+
+    format!("workflow:{}", Value::Object(artifact))
+}
+
+fn require_non_empty(value: &str, path: &str, errors: &mut Vec<WorkflowError>) {
+    if value.trim().is_empty() {
+        errors.push(workflow_error(
+            WorkflowErrorCode::MissingRequiredField,
+            path,
+            "field must be non-empty",
+        ));
+    }
+}
+
+fn single_error(code: WorkflowErrorCode, path: &str, message: &str) -> WorkflowFailure {
+    WorkflowFailure {
+        errors: vec![workflow_error(code, path, message)],
+    }
+}
+
+fn workflow_error(code: WorkflowErrorCode, path: &str, message: &str) -> WorkflowError {
+    WorkflowError {
+        code,
+        path: path.to_string(),
+        message: message.to_string(),
+        severity: ErrorSeverity::Error,
+    }
+}
+
+fn lookup_order(lookup_scope: LookupScope) -> &'static [RegistryScope] {
+    match lookup_scope {
+        LookupScope::PublicOnly => &[RegistryScope::Public],
+        LookupScope::PreferPrivate => &[RegistryScope::Private, RegistryScope::Public],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ArtifactDigests, BinaryFormat, BinaryReference, CapabilityRegistration,
+        ComposabilityMetadata, CompositionKind, CompositionPattern, RegistryProvenance, SourceKind,
+        SourceReference,
+    };
+    use cogolo_contracts::{
+        BinaryFormat as ContractBinaryFormat, Condition, Entrypoint, EntrypointKind,
+        EvidenceStatus, EvidenceType, Execution, ExecutionConstraints, ExecutionTarget,
+        FilesystemAccess, HostApiAccess, NetworkAccess, Provenance, ProvenanceSource, SideEffect,
+        SideEffectKind, ValidationEvidence,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn registers_valid_workflow_and_supports_private_overlay_lookup() {
+        let capabilities = capability_registry();
+        let mut registry = WorkflowRegistry::new();
+
+        let public = register_workflow_ok(
+            &mut registry,
+            &capabilities,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition: valid_workflow_definition(),
+                workflow_path: "workflows/public.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "workflow-validator/0.1.0".to_string(),
+            },
+        );
+        let private = register_workflow_ok(
+            &mut registry,
+            &capabilities,
+            WorkflowRegistration {
+                scope: RegistryScope::Private,
+                definition: WorkflowDefinition {
+                    summary: "private summary".to_string(),
+                    ..valid_workflow_definition()
+                },
+                workflow_path: "workflows/private.json".to_string(),
+                registered_at: "2026-03-27T00:01:00Z".to_string(),
+                validator_version: "workflow-validator/0.1.0".to_string(),
+            },
+        );
+
+        assert_eq!(public.record.id, "content.comments.publish-comment");
+        let resolved = find_workflow_exact(
+            &registry,
+            LookupScope::PreferPrivate,
+            "content.comments.publish-comment",
+            "1.0.0",
+        );
+        assert_eq!(resolved.record.scope, RegistryScope::Private);
+        assert_eq!(resolved.record.workflow_path, "workflows/private.json");
+        assert_eq!(private.index_entry.summary, "private summary");
+    }
+
+    #[test]
+    fn rejects_invalid_workflow_fields_references_and_cycles() {
+        let capabilities = capability_registry();
+        let mut registry = WorkflowRegistry::new();
+        let mut definition = valid_workflow_definition();
+        definition.kind = "bad".to_string();
+        definition.schema_version = "2.0.0".to_string();
+        definition.version = "oops".to_string();
+        definition.owner.team.clear();
+        definition.start_node = "missing".to_string();
+        definition.terminal_nodes = vec!["missing".to_string(), "missing".to_string()];
+        definition.nodes[0].capability_version = "oops".to_string();
+        definition.nodes.push(definition.nodes[0].clone());
+        definition.edges.push(WorkflowEdge {
+            edge_id: "edge_1".to_string(),
+            from: "validate_comment".to_string(),
+            to: "create_draft".to_string(),
+            trigger: WorkflowEdgeTrigger::Direct,
+            event: Some(EventReference {
+                event_id: "content.comments.draft-created".to_string(),
+                version: "1.0.0".to_string(),
+            }),
+        });
+
+        let failure = register_workflow_err(
+            &mut registry,
+            &capabilities,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition,
+                workflow_path: String::new(),
+                registered_at: String::new(),
+                validator_version: "validator".to_string(),
+            },
+        );
+
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.code == WorkflowErrorCode::InvalidLiteral)
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.code == WorkflowErrorCode::InvalidSemver)
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.code == WorkflowErrorCode::DuplicateItem)
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.code == WorkflowErrorCode::InvalidStartNode)
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.code == WorkflowErrorCode::InvalidTerminalNode)
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.code == WorkflowErrorCode::DeterministicCycleNotAllowed)
+        );
+    }
+
+    #[test]
+    fn rejects_missing_capabilities_and_invalid_event_edges() {
+        let capabilities = capability_registry();
+        let mut registry = WorkflowRegistry::new();
+        let mut definition = valid_workflow_definition();
+        definition.nodes[0].capability_id = "missing".to_string();
+        definition.edges[1].event = Some(EventReference {
+            event_id: "content.comments.other".to_string(),
+            version: "1.0.0".to_string(),
+        });
+        definition.edges.push(WorkflowEdge {
+            edge_id: "duplicate_event".to_string(),
+            from: "validate_comment".to_string(),
+            to: "persist_comment".to_string(),
+            trigger: WorkflowEdgeTrigger::Event,
+            event: Some(EventReference {
+                event_id: "content.comments.validated".to_string(),
+                version: "1.0.0".to_string(),
+            }),
+        });
+
+        let failure = register_workflow_err(
+            &mut registry,
+            &capabilities,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition,
+                workflow_path: "workflows/public.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "validator".to_string(),
+            },
+        );
+
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.code == WorkflowErrorCode::MissingReference)
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.code == WorkflowErrorCode::InvalidEventEdge)
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.message.contains("more than one event outgoing edge"))
+        );
+    }
+
+    #[test]
+    fn preserves_immutable_published_workflow_versions() {
+        let capabilities = capability_registry();
+        let mut registry = WorkflowRegistry::new();
+        let request = WorkflowRegistration {
+            scope: RegistryScope::Public,
+            definition: valid_workflow_definition(),
+            workflow_path: "workflows/public.json".to_string(),
+            registered_at: "2026-03-27T00:00:00Z".to_string(),
+            validator_version: "validator".to_string(),
+        };
+        let first = register_workflow_ok(&mut registry, &capabilities, request.clone());
+        let second = register_workflow_ok(&mut registry, &capabilities, request);
+        assert_eq!(first.record, second.record);
+
+        let failure = register_workflow_err(
+            &mut registry,
+            &capabilities,
+            WorkflowRegistration {
+                definition: WorkflowDefinition {
+                    summary: "changed summary".to_string(),
+                    ..valid_workflow_definition()
+                },
+                workflow_path: "workflows/changed.json".to_string(),
+                registered_at: "2026-03-27T00:00:01Z".to_string(),
+                validator_version: "validator".to_string(),
+                scope: RegistryScope::Public,
+            },
+        );
+        assert_eq!(
+            failure.errors[0].code,
+            WorkflowErrorCode::ImmutableVersionConflict
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn covers_internal_registry_inconsistency_and_exact_lookup_miss_paths() {
+        let capabilities = capability_registry();
+        let request = WorkflowRegistration {
+            scope: RegistryScope::Public,
+            definition: valid_workflow_definition(),
+            workflow_path: "workflows/public.json".to_string(),
+            registered_at: "2026-03-27T00:00:00Z".to_string(),
+            validator_version: "validator".to_string(),
+        };
+        let mut registry = WorkflowRegistry::new();
+        let key = (
+            RegistryScope::Public,
+            request.definition.id.clone(),
+            request.definition.version.clone(),
+        );
+        let record = WorkflowRegistryRecord {
+            scope: RegistryScope::Public,
+            id: request.definition.id.clone(),
+            version: request.definition.version.clone(),
+            lifecycle: Lifecycle::Active,
+            owner: request.definition.owner.clone(),
+            workflow_path: "workflows/public.json".to_string(),
+            workflow_digest: "digest".to_string(),
+            registered_at: "2026-03-27T00:00:00Z".to_string(),
+            governing_spec: WORKFLOW_GOVERNING_SPEC.to_string(),
+            validator_version: "validator".to_string(),
+            evidence: WorkflowRegistrationEvidence {
+                evidence_id: "evidence".to_string(),
+                workflow_id: request.definition.id.clone(),
+                workflow_version: request.definition.version.clone(),
+                scope: RegistryScope::Public,
+                governing_spec: WORKFLOW_GOVERNING_SPEC.to_string(),
+                validator_version: "validator".to_string(),
+                produced_at: "2026-03-27T00:00:00Z".to_string(),
+                result: WorkflowRegistrationResult::Passed,
+            },
+        };
+        registry.records.insert(key.clone(), record.clone());
+        let failure = register_workflow_err(&mut registry, &capabilities, request.clone());
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.message.contains("authoritative definition"))
+        );
+
+        let mut registry = WorkflowRegistry::new();
+        registry.records.insert(key.clone(), record);
+        registry
+            .definitions
+            .insert(key.clone(), request.definition.clone());
+        let failure = register_workflow_err(&mut registry, &capabilities, request);
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.message.contains("discovery index entry"))
+        );
+
+        let registry = WorkflowRegistry::new();
+        assert!(
+            registry
+                .find_exact(LookupScope::PublicOnly, "missing", "1.0.0")
+                .is_none()
+        );
+
+        let mut registry = WorkflowRegistry::new();
+        register_workflow_ok(
+            &mut registry,
+            &capabilities,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition: WorkflowDefinition {
+                    edges: vec![WorkflowEdge {
+                        edge_id: "direct".to_string(),
+                        from: "create_draft".to_string(),
+                        to: "persist_comment".to_string(),
+                        trigger: WorkflowEdgeTrigger::Direct,
+                        event: None,
+                    }],
+                    ..valid_workflow_definition()
+                },
+                workflow_path: "workflows/direct.json".to_string(),
+                registered_at: "2026-03-27T00:02:00Z".to_string(),
+                validator_version: "validator".to_string(),
+            },
+        );
+        let failure = register_workflow_err(
+            &mut registry,
+            &capabilities,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition: WorkflowDefinition {
+                    edges: vec![WorkflowEdge {
+                        edge_id: "direct".to_string(),
+                        from: "create_draft".to_string(),
+                        to: "persist_comment".to_string(),
+                        trigger: WorkflowEdgeTrigger::Direct,
+                        event: None,
+                    }],
+                    ..valid_workflow_definition()
+                },
+                workflow_path: "workflows/direct-metadata-only.json".to_string(),
+                registered_at: "2026-03-27T00:03:00Z".to_string(),
+                validator_version: "validator".to_string(),
+            },
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.path == "$.workflow_path")
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn rejects_additional_invalid_shapes_and_non_runtime_references() {
+        let capabilities = capability_registry();
+        let mut registry = WorkflowRegistry::new();
+        let mut definition = valid_workflow_definition();
+        definition.governing_spec = "wrong".to_string();
+        definition.nodes = vec![WorkflowNode {
+            node_id: String::new(),
+            capability_id: String::new(),
+            capability_version: String::new(),
+            input: WorkflowNodeInput {
+                from_workflow_input: vec![],
+            },
+            output: WorkflowNodeOutput {
+                to_workflow_state: vec![],
+            },
+        }];
+        definition.terminal_nodes = Vec::new();
+        definition.edges = vec![
+            WorkflowEdge {
+                edge_id: "edge".to_string(),
+                from: "missing".to_string(),
+                to: "missing".to_string(),
+                trigger: WorkflowEdgeTrigger::Direct,
+                event: Some(EventReference {
+                    event_id: "content.comments.draft-created".to_string(),
+                    version: "1.0.0".to_string(),
+                }),
+            },
+            WorkflowEdge {
+                edge_id: "edge".to_string(),
+                from: String::new(),
+                to: String::new(),
+                trigger: WorkflowEdgeTrigger::Event,
+                event: None,
+            },
+            WorkflowEdge {
+                edge_id: "edge-3".to_string(),
+                from: "missing".to_string(),
+                to: "missing".to_string(),
+                trigger: WorkflowEdgeTrigger::Event,
+                event: Some(EventReference {
+                    event_id: String::new(),
+                    version: "bad".to_string(),
+                }),
+            },
+        ];
+        let failure = register_workflow_err(
+            &mut registry,
+            &capabilities,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition,
+                workflow_path: "workflows/bad.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "validator".to_string(),
+            },
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.message.contains("governing_spec"))
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.message.contains("nodes must not be empty")
+                    || error.path.contains("$.nodes[0].node_id"))
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.message.contains("terminal_nodes must not be empty"))
+        );
+        assert!(failure.errors.iter().any(|error| {
+            error
+                .message
+                .contains("direct edges must not declare an event reference")
+        }));
+        assert!(failure.errors.iter().any(|error| {
+            error
+                .message
+                .contains("event edges must declare an event reference")
+        }));
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.message.contains("event_id must be non-empty"))
+        );
+        assert!(failure.errors.iter().any(|error| {
+            error
+                .message
+                .contains("edge source must reference a declared node")
+        }));
+
+        let mut archived_capabilities = capability_registry();
+        let archived = capability_registration(
+            "content.comments.archived-step",
+            vec![EventReference {
+                event_id: "content.comments.archived".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+        );
+        let mut archived_contract = archived.contract.clone();
+        archived_contract.lifecycle = Lifecycle::Archived;
+        register_capability_ok(
+            &mut archived_capabilities,
+            CapabilityRegistration {
+                contract: archived_contract,
+                ..archived
+            },
+        );
+        let mut registry = WorkflowRegistry::new();
+        let failure = register_workflow_err(
+            &mut registry,
+            &archived_capabilities,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition: WorkflowDefinition {
+                    nodes: vec![WorkflowNode {
+                        node_id: "archived".to_string(),
+                        capability_id: "content.comments.archived-step".to_string(),
+                        capability_version: "1.0.0".to_string(),
+                        input: WorkflowNodeInput {
+                            from_workflow_input: vec![],
+                        },
+                        output: WorkflowNodeOutput {
+                            to_workflow_state: vec![],
+                        },
+                    }],
+                    edges: vec![
+                        WorkflowEdge {
+                            edge_id: "d1".to_string(),
+                            from: "archived".to_string(),
+                            to: "archived".to_string(),
+                            trigger: WorkflowEdgeTrigger::Direct,
+                            event: None,
+                        },
+                        WorkflowEdge {
+                            edge_id: "d2".to_string(),
+                            from: "archived".to_string(),
+                            to: "archived".to_string(),
+                            trigger: WorkflowEdgeTrigger::Direct,
+                            event: None,
+                        },
+                    ],
+                    start_node: "archived".to_string(),
+                    terminal_nodes: vec!["archived".to_string()],
+                    ..valid_workflow_definition()
+                },
+                workflow_path: "workflows/archived.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "validator".to_string(),
+            },
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.message.contains("runtime-eligible capability"))
+        );
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.message.contains("more than one direct outgoing edge"))
+        );
+
+        let mut registry = WorkflowRegistry::new();
+        let failure = register_workflow_err(
+            &mut registry,
+            &capabilities,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition: WorkflowDefinition {
+                    nodes: Vec::new(),
+                    terminal_nodes: vec!["persist_comment".to_string()],
+                    ..valid_workflow_definition()
+                },
+                workflow_path: "workflows/no-nodes.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "validator".to_string(),
+            },
+        );
+        assert!(failure.errors.iter().any(|error| error.path == "$.nodes"));
+    }
+
+    #[test]
+    fn helper_paths_cover_workflow_artifact_and_lookup_order() {
+        let artifact = workflow_artifact_record("wf", "1.0.0", "artifact");
+        assert_eq!(artifact.implementation_kind, ImplementationKind::Workflow);
+        assert!(artifact.binary.is_none());
+        assert_eq!(
+            artifact.workflow_ref,
+            Some(WorkflowReference {
+                workflow_id: "wf".to_string(),
+                workflow_version: "1.0.0".to_string(),
+            })
+        );
+        assert_eq!(
+            lookup_order(LookupScope::PublicOnly),
+            &[RegistryScope::Public]
+        );
+        assert_eq!(
+            lookup_order(LookupScope::PreferPrivate),
+            &[RegistryScope::Private, RegistryScope::Public]
+        );
+    }
+
+    fn capability_registry() -> CapabilityRegistry {
+        let mut registry = CapabilityRegistry::new();
+        for registration in [
+            capability_registration(
+                "content.comments.create-comment-draft",
+                vec![EventReference {
+                    event_id: "content.comments.draft-created".to_string(),
+                    version: "1.0.0".to_string(),
+                }],
+            ),
+            capability_registration(
+                "content.comments.validate-comment",
+                vec![EventReference {
+                    event_id: "content.comments.validated".to_string(),
+                    version: "1.0.0".to_string(),
+                }],
+            ),
+            capability_registration("content.comments.persist-comment", Vec::new()),
+        ] {
+            register_capability_ok(&mut registry, registration);
+        }
+        registry
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn capability_registration(
+        capability_id: &str,
+        emits: Vec<EventReference>,
+    ) -> CapabilityRegistration {
+        CapabilityRegistration {
+            scope: RegistryScope::Public,
+            contract: cogolo_contracts::CapabilityContract {
+                kind: "capability_contract".to_string(),
+                schema_version: "1.0.0".to_string(),
+                id: capability_id.to_string(),
+                namespace: "content.comments".to_string(),
+                name: capability_id
+                    .rsplit('.')
+                    .next()
+                    .unwrap_or("capability")
+                    .to_string(),
+                version: "1.0.0".to_string(),
+                lifecycle: Lifecycle::Active,
+                owner: Owner {
+                    team: "comments".to_string(),
+                    contact: "comments@example.com".to_string(),
+                },
+                summary: "fixture capability for workflow tests".to_string(),
+                description: "fixture capability used by workflow registry tests".to_string(),
+                inputs: SchemaContainer {
+                    schema: json!({
+                        "type": "object",
+                        "properties": {
+                            "comment_text": { "type": "string" },
+                            "draft_id": { "type": "string" }
+                        },
+                        "additionalProperties": true
+                    }),
+                },
+                outputs: SchemaContainer {
+                    schema: json!({
+                        "type": "object",
+                        "properties": {
+                            "draft_id": { "type": "string" },
+                            "comment_id": { "type": "string" }
+                        },
+                        "additionalProperties": true
+                    }),
+                },
+                preconditions: vec![Condition {
+                    id: "precondition".to_string(),
+                    description: "must be valid".to_string(),
+                }],
+                postconditions: vec![Condition {
+                    id: "postcondition".to_string(),
+                    description: "must produce output".to_string(),
+                }],
+                side_effects: vec![SideEffect {
+                    kind: SideEffectKind::MemoryOnly,
+                    description: "memory only".to_string(),
+                }],
+                emits,
+                consumes: Vec::new(),
+                permissions: Vec::new(),
+                execution: Execution {
+                    binary_format: ContractBinaryFormat::Wasm,
+                    entrypoint: Entrypoint {
+                        kind: EntrypointKind::WasiCommand,
+                        command: "run".to_string(),
+                    },
+                    preferred_targets: vec![ExecutionTarget::Local],
+                    constraints: ExecutionConstraints {
+                        host_api_access: HostApiAccess::None,
+                        network_access: NetworkAccess::Forbidden,
+                        filesystem_access: FilesystemAccess::None,
+                    },
+                },
+                policies: Vec::new(),
+                dependencies: Vec::new(),
+                provenance: Provenance {
+                    source: ProvenanceSource::Greenfield,
+                    author: "Enrico".to_string(),
+                    created_at: "2026-03-27T00:00:00Z".to_string(),
+                    spec_ref: Some("005-capability-registry".to_string()),
+                    adr_refs: Vec::new(),
+                    exception_refs: Vec::new(),
+                },
+                evidence: vec![ValidationEvidence {
+                    evidence_id: "evidence-fixture".to_string(),
+                    evidence_type: EvidenceType::ContractValidation,
+                    status: EvidenceStatus::Passed,
+                }],
+            },
+            contract_path: format!("contracts/{capability_id}.json"),
+            artifact: CapabilityArtifactRecord {
+                artifact_ref: format!("artifact-{capability_id}"),
+                implementation_kind: ImplementationKind::Executable,
+                source: SourceReference {
+                    kind: SourceKind::Git,
+                    location: format!("https://example.com/{capability_id}.git"),
+                },
+                binary: Some(BinaryReference {
+                    format: BinaryFormat::Wasm,
+                    location: format!("{capability_id}.wasm"),
+                }),
+                workflow_ref: None,
+                digests: ArtifactDigests {
+                    source_digest: "source".to_string(),
+                    binary_digest: Some("binary".to_string()),
+                },
+                provenance: RegistryProvenance {
+                    source: "fixtures".to_string(),
+                    author: "Enrico".to_string(),
+                    created_at: "2026-03-27T00:00:00Z".to_string(),
+                },
+            },
+            registered_at: "2026-03-27T00:00:00Z".to_string(),
+            tags: vec!["comments".to_string()],
+            composability: ComposabilityMetadata {
+                kind: CompositionKind::Atomic,
+                patterns: vec![CompositionPattern::Sequential],
+                provides: vec!["comment".to_string()],
+                requires: Vec::new(),
+            },
+            governing_spec: "005-capability-registry".to_string(),
+            validator_version: "validator".to_string(),
+        }
+    }
+
+    fn valid_workflow_definition() -> WorkflowDefinition {
+        WorkflowDefinition {
+            kind: WORKFLOW_KIND.to_string(),
+            schema_version: WORKFLOW_SCHEMA_VERSION.to_string(),
+            id: "content.comments.publish-comment".to_string(),
+            name: "publish-comment".to_string(),
+            version: "1.0.0".to_string(),
+            lifecycle: Lifecycle::Active,
+            owner: Owner {
+                team: "comments".to_string(),
+                contact: "comments@example.com".to_string(),
+            },
+            summary: "Publish a comment deterministically.".to_string(),
+            inputs: SchemaContainer {
+                schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "comment_text": { "type": "string" }
+                    },
+                    "required": ["comment_text"],
+                    "additionalProperties": true
+                }),
+            },
+            outputs: SchemaContainer {
+                schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "comment_id": { "type": "string" }
+                    },
+                    "required": ["comment_id"],
+                    "additionalProperties": true
+                }),
+            },
+            nodes: vec![
+                WorkflowNode {
+                    node_id: "create_draft".to_string(),
+                    capability_id: "content.comments.create-comment-draft".to_string(),
+                    capability_version: "1.0.0".to_string(),
+                    input: WorkflowNodeInput {
+                        from_workflow_input: vec!["comment_text".to_string()],
+                    },
+                    output: WorkflowNodeOutput {
+                        to_workflow_state: vec!["draft_id".to_string()],
+                    },
+                },
+                WorkflowNode {
+                    node_id: "validate_comment".to_string(),
+                    capability_id: "content.comments.validate-comment".to_string(),
+                    capability_version: "1.0.0".to_string(),
+                    input: WorkflowNodeInput {
+                        from_workflow_input: vec!["draft_id".to_string()],
+                    },
+                    output: WorkflowNodeOutput {
+                        to_workflow_state: vec!["draft_id".to_string()],
+                    },
+                },
+                WorkflowNode {
+                    node_id: "persist_comment".to_string(),
+                    capability_id: "content.comments.persist-comment".to_string(),
+                    capability_version: "1.0.0".to_string(),
+                    input: WorkflowNodeInput {
+                        from_workflow_input: vec!["draft_id".to_string()],
+                    },
+                    output: WorkflowNodeOutput {
+                        to_workflow_state: vec!["comment_id".to_string()],
+                    },
+                },
+            ],
+            edges: vec![
+                WorkflowEdge {
+                    edge_id: "draft_to_validate".to_string(),
+                    from: "create_draft".to_string(),
+                    to: "validate_comment".to_string(),
+                    trigger: WorkflowEdgeTrigger::Event,
+                    event: Some(EventReference {
+                        event_id: "content.comments.draft-created".to_string(),
+                        version: "1.0.0".to_string(),
+                    }),
+                },
+                WorkflowEdge {
+                    edge_id: "validate_to_persist".to_string(),
+                    from: "validate_comment".to_string(),
+                    to: "persist_comment".to_string(),
+                    trigger: WorkflowEdgeTrigger::Event,
+                    event: Some(EventReference {
+                        event_id: "content.comments.validated".to_string(),
+                        version: "1.0.0".to_string(),
+                    }),
+                },
+            ],
+            start_node: "create_draft".to_string(),
+            terminal_nodes: vec!["persist_comment".to_string()],
+            tags: vec!["comments".to_string(), "foundation".to_string()],
+            governing_spec: WORKFLOW_GOVERNING_SPEC.to_string(),
+        }
+    }
+
+    fn register_workflow_ok(
+        registry: &mut WorkflowRegistry,
+        capabilities: &CapabilityRegistry,
+        request: WorkflowRegistration,
+    ) -> WorkflowRegistrationOutcome {
+        match registry.register(capabilities, request) {
+            Ok(outcome) => outcome,
+            Err(error) => unreachable!("{error:?}"),
+        }
+    }
+
+    fn register_workflow_err(
+        registry: &mut WorkflowRegistry,
+        capabilities: &CapabilityRegistry,
+        request: WorkflowRegistration,
+    ) -> WorkflowFailure {
+        match registry.register(capabilities, request) {
+            Ok(_) => unreachable!("workflow registration unexpectedly succeeded"),
+            Err(error) => error,
+        }
+    }
+
+    fn find_workflow_exact(
+        registry: &WorkflowRegistry,
+        scope: LookupScope,
+        id: &str,
+        version: &str,
+    ) -> ResolvedWorkflow {
+        match registry.find_exact(scope, id, version) {
+            Some(workflow) => workflow,
+            None => unreachable!("workflow was not found"),
+        }
+    }
+
+    fn register_capability_ok(registry: &mut CapabilityRegistry, request: CapabilityRegistration) {
+        match registry.register(request) {
+            Ok(_) => {}
+            Err(error) => unreachable!("{error:?}"),
+        }
+    }
+}

--- a/crates/cogolo-runtime/src/lib.rs
+++ b/crates/cogolo-runtime/src/lib.rs
@@ -1,9 +1,12 @@
 //! Runtime control-plane support for Cogolo.
 
+mod workflows;
+pub use workflows::*;
+
 use cogolo_contracts::{ExecutionTarget, HostApiAccess, Lifecycle, NetworkAccess};
 use cogolo_registry::{
     CapabilityRegistry, DiscoveryQuery, ImplementationKind, LookupScope, RegistryScope,
-    ResolvedCapability,
+    ResolvedCapability, WorkflowRegistry,
 };
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -22,13 +25,24 @@ const TRACE_PREFIX: &str = "trace_";
 #[derive(Debug)]
 pub struct Runtime<E> {
     registry: CapabilityRegistry,
+    workflow_registry: WorkflowRegistry,
     executor: E,
 }
 
 impl<E> Runtime<E> {
     #[must_use]
     pub fn new(registry: CapabilityRegistry, executor: E) -> Self {
-        Self { registry, executor }
+        Self {
+            registry,
+            workflow_registry: WorkflowRegistry::new(),
+            executor,
+        }
+    }
+
+    #[must_use]
+    pub fn with_workflow_registry(mut self, workflow_registry: WorkflowRegistry) -> Self {
+        self.workflow_registry = workflow_registry;
+        self
     }
 }
 
@@ -524,6 +538,16 @@ where
             );
         }
 
+        if selected.record.implementation_kind == ImplementationKind::Workflow {
+            return self.execute_workflow_capability(
+                attempt,
+                emitter,
+                candidate_collection,
+                selection,
+                selected,
+            );
+        }
+
         let started_at = emitter.next_timestamp();
         emitter.push(
             RuntimeState::Executing,
@@ -998,11 +1022,11 @@ fn evaluate_candidate(candidate: ResolvedCapability) -> CandidateEvaluation {
             RejectedCandidateReason::LifecycleNotRunnable,
         );
     }
-    if candidate.record.implementation_kind != ImplementationKind::Executable {
-        return CandidateEvaluation::Rejected(
-            candidate,
-            RejectedCandidateReason::NotRunnableLocally,
-        );
+    if candidate.record.implementation_kind == ImplementationKind::Workflow {
+        if candidate.artifact.workflow_ref.is_some() {
+            return CandidateEvaluation::Eligible(candidate);
+        }
+        return CandidateEvaluation::Rejected(candidate, RejectedCandidateReason::ArtifactMissing);
     }
 
     let Some(binary) = candidate.artifact.binary.as_ref() else {
@@ -1390,8 +1414,16 @@ mod tests {
         );
         capability.record.implementation_kind = ImplementationKind::Workflow;
         assert!(matches!(
+            evaluate_candidate(capability.clone()),
+            CandidateEvaluation::Rejected(_, RejectedCandidateReason::ArtifactMissing)
+        ));
+        capability.artifact.workflow_ref = Some(cogolo_registry::WorkflowReference {
+            workflow_id: "workflow".to_string(),
+            workflow_version: "1.0.0".to_string(),
+        });
+        assert!(matches!(
             evaluate_candidate(capability),
-            CandidateEvaluation::Rejected(_, RejectedCandidateReason::NotRunnableLocally)
+            CandidateEvaluation::Eligible(_)
         ));
 
         let capability = resolved_capability(

--- a/crates/cogolo-runtime/src/workflows.rs
+++ b/crates/cogolo-runtime/src/workflows.rs
@@ -1,0 +1,1792 @@
+use crate::{
+    ExecutionFailureReason, ExecutionFailureState, LocalExecutor, Runtime, RuntimeError,
+    RuntimeErrorCode, RuntimeExecutionOutcome, SelectionRecord, execution_failure_outcome,
+    pre_execution_failure_outcome, runtime_error, successful_execution_outcome,
+    validate_payload_against_contract,
+};
+use cogolo_contracts::EventReference;
+use cogolo_registry::{
+    LookupScope, RegistryScope, ResolvedCapability, ResolvedWorkflow, WorkflowEdge,
+    WorkflowEdgeTrigger, WorkflowNode,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+
+const WORKFLOW_REQUEST_KIND: &str = "workflow_execution_request";
+const WORKFLOW_EVIDENCE_KIND: &str = "workflow_traversal_evidence";
+const WORKFLOW_SCHEMA_VERSION: &str = "1.0.0";
+const WORKFLOW_GOVERNING_SPEC: &str = "007-workflow-registry-traversal";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowExecutionRequest {
+    pub kind: String,
+    pub schema_version: String,
+    pub request_id: String,
+    pub workflow_id: String,
+    pub workflow_version: String,
+    pub scope: WorkflowLookupScope,
+    pub input: Value,
+    pub governing_spec: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowLookupScope {
+    PublicOnly,
+    PreferPrivate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowTraversalEvidence {
+    pub kind: String,
+    pub schema_version: String,
+    pub trace_id: String,
+    pub request_id: String,
+    pub workflow_id: String,
+    pub workflow_version: String,
+    pub governing_spec: String,
+    pub visited_nodes: Vec<WorkflowTraversalStepRecord>,
+    pub traversed_edges: Vec<WorkflowTraversalEdgeRecord>,
+    pub emitted_events: Vec<EventReference>,
+    pub result: WorkflowTraversalResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowTraversalStepRecord {
+    pub step_index: usize,
+    pub node_id: String,
+    pub capability_id: String,
+    pub capability_version: String,
+    pub status: WorkflowTraversalStepStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowTraversalStepStatus {
+    Entered,
+    Completed,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowTraversalEdgeRecord {
+    pub edge_id: String,
+    pub from: String,
+    pub to: String,
+    pub trigger: WorkflowTraversalTrigger,
+    #[serde(default)]
+    pub event: Option<EventReference>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowTraversalTrigger {
+    Direct,
+    Event,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowTraversalResult {
+    pub status: WorkflowTraversalStatus,
+    #[serde(default)]
+    pub failure_reason: Option<WorkflowTraversalFailureReason>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowTraversalStatus {
+    Completed,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowTraversalFailureReason {
+    WorkflowNotFound,
+    WorkflowInvalid,
+    AmbiguousNextEdge,
+    MissingRequiredEvent,
+    TerminalNodeNotReached,
+    StepExecutionFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkflowExecutionResult {
+    pub kind: String,
+    pub schema_version: String,
+    pub request_id: String,
+    pub workflow_id: String,
+    pub workflow_version: String,
+    pub status: WorkflowTraversalStatus,
+    #[serde(default)]
+    pub output: Option<Value>,
+    #[serde(default)]
+    pub error: Option<RuntimeError>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkflowExecutionOutcome {
+    pub result: WorkflowExecutionResult,
+    pub evidence: WorkflowTraversalEvidence,
+}
+
+impl<E> Runtime<E>
+where
+    E: LocalExecutor,
+{
+    #[must_use]
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn execute_workflow(&self, request: WorkflowExecutionRequest) -> WorkflowExecutionOutcome {
+        if let Some(error) = validate_workflow_request(&request) {
+            return workflow_failure(
+                &request,
+                WorkflowTraversalFailureReason::WorkflowInvalid,
+                error,
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            );
+        }
+
+        let lookup_scope = map_workflow_lookup_scope(request.scope);
+        let Some(workflow) = self.workflow_registry.find_exact(
+            lookup_scope,
+            &request.workflow_id,
+            &request.workflow_version,
+        ) else {
+            return workflow_failure(
+                &request,
+                WorkflowTraversalFailureReason::WorkflowNotFound,
+                runtime_error(
+                    RuntimeErrorCode::CapabilityNotFound,
+                    "workflow definition was not found in the workflow registry",
+                    json!({"workflow_id": request.workflow_id, "workflow_version": request.workflow_version}),
+                ),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            );
+        };
+
+        if let Err(error) = validate_payload_against_contract(
+            &request.input,
+            &workflow.definition.inputs.schema,
+            RuntimeErrorCode::RequestInvalid,
+            "workflow request input does not satisfy the workflow input contract",
+        ) {
+            return workflow_failure(
+                &request,
+                WorkflowTraversalFailureReason::WorkflowInvalid,
+                error,
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            );
+        }
+
+        match self.traverse_workflow(&request, &workflow) {
+            Ok(success) => success,
+            Err(failure) => failure,
+        }
+    }
+
+    pub(crate) fn execute_workflow_capability(
+        &self,
+        attempt: crate::AttemptContext,
+        emitter: crate::StateEmitter,
+        candidate_collection: crate::CandidateCollectionRecord,
+        selection: SelectionRecord,
+        selected: &ResolvedCapability,
+    ) -> RuntimeExecutionOutcome {
+        let Some(workflow_ref) = selected.artifact.workflow_ref.as_ref() else {
+            let error = runtime_error(
+                RuntimeErrorCode::ArtifactMissing,
+                "workflow-backed capability is missing its workflow reference",
+                json!({"artifact_ref": selected.record.artifact_ref}),
+            );
+            return pre_execution_failure_outcome(
+                attempt,
+                emitter,
+                candidate_collection,
+                selection,
+                Some(selected.record.artifact_ref.clone()),
+                ExecutionFailureReason::ArtifactMissing,
+                error,
+            );
+        };
+
+        let workflow_scope = match selected.record.scope {
+            RegistryScope::Public => WorkflowLookupScope::PublicOnly,
+            RegistryScope::Private => WorkflowLookupScope::PreferPrivate,
+        };
+        let workflow = self.execute_workflow(WorkflowExecutionRequest {
+            kind: WORKFLOW_REQUEST_KIND.to_string(),
+            schema_version: WORKFLOW_SCHEMA_VERSION.to_string(),
+            request_id: attempt.request.request_id.clone(),
+            workflow_id: workflow_ref.workflow_id.clone(),
+            workflow_version: workflow_ref.workflow_version.clone(),
+            scope: workflow_scope,
+            input: attempt.request.input.clone(),
+            governing_spec: WORKFLOW_GOVERNING_SPEC.to_string(),
+        });
+
+        match workflow.result.status {
+            WorkflowTraversalStatus::Completed => {
+                let output = workflow.result.output.unwrap_or(Value::Object(Map::new()));
+                successful_execution_outcome(
+                    attempt,
+                    emitter,
+                    candidate_collection,
+                    selection,
+                    selected,
+                    "2026-01-01T00:00:00Z".to_string(),
+                    output,
+                )
+            }
+            WorkflowTraversalStatus::Error => execution_failure_outcome(
+                attempt,
+                emitter,
+                candidate_collection,
+                selection,
+                ExecutionFailureState {
+                    artifact_ref: selected.record.artifact_ref.clone(),
+                    started_at: "2026-01-01T00:00:00Z".to_string(),
+                    failure_reason: ExecutionFailureReason::ExecutionFailed,
+                },
+                workflow.result.error.unwrap_or(runtime_error(
+                    RuntimeErrorCode::ExecutionFailed,
+                    "workflow-backed capability execution failed",
+                    json!({}),
+                )),
+            ),
+        }
+    }
+
+    #[allow(clippy::result_large_err, clippy::too_many_lines)]
+    fn traverse_workflow(
+        &self,
+        request: &WorkflowExecutionRequest,
+        workflow: &ResolvedWorkflow,
+    ) -> Result<WorkflowExecutionOutcome, WorkflowExecutionOutcome> {
+        let mut state = workflow_state(&request.input);
+        let mut current = workflow.definition.start_node.clone();
+        let mut step_index = 0;
+        let mut visited = Vec::new();
+        let mut traversed = Vec::new();
+        let mut emitted = Vec::new();
+
+        loop {
+            let Some(node) = workflow
+                .definition
+                .nodes
+                .iter()
+                .find(|node| node.node_id == current)
+            else {
+                return Err(workflow_failure(
+                    request,
+                    WorkflowTraversalFailureReason::WorkflowInvalid,
+                    runtime_error(
+                        RuntimeErrorCode::ExecutionFailed,
+                        "workflow node could not be resolved during traversal",
+                        json!({"node_id": current}),
+                    ),
+                    visited,
+                    traversed,
+                    emitted,
+                ));
+            };
+
+            visited.push(WorkflowTraversalStepRecord {
+                step_index,
+                node_id: node.node_id.clone(),
+                capability_id: node.capability_id.clone(),
+                capability_version: node.capability_version.clone(),
+                status: WorkflowTraversalStepStatus::Entered,
+            });
+
+            let lookup_scope = map_workflow_lookup_scope(request.scope);
+            let Some(capability) = self.registry.find_exact(
+                lookup_scope,
+                &node.capability_id,
+                &node.capability_version,
+            ) else {
+                return Err(workflow_failure(
+                    request,
+                    WorkflowTraversalFailureReason::WorkflowInvalid,
+                    runtime_error(
+                        RuntimeErrorCode::CapabilityNotFound,
+                        "workflow node capability was not found in the capability registry",
+                        json!({"capability_id": node.capability_id, "capability_version": node.capability_version}),
+                    ),
+                    visited,
+                    traversed,
+                    emitted,
+                ));
+            };
+
+            let node_input = node_input(&state, node);
+            if let Err(error) = validate_payload_against_contract(
+                &node_input,
+                &capability.contract.inputs.schema,
+                RuntimeErrorCode::RequestInvalid,
+                "workflow node input does not satisfy the capability input contract",
+            ) {
+                let mut failed = visited;
+                if let Some(last) = failed.last_mut() {
+                    last.status = WorkflowTraversalStepStatus::Failed;
+                }
+                return Err(workflow_failure(
+                    request,
+                    WorkflowTraversalFailureReason::StepExecutionFailed,
+                    error,
+                    failed,
+                    traversed,
+                    emitted,
+                ));
+            }
+
+            let output = match self.executor.execute(&capability, &node_input) {
+                Ok(output) => output,
+                Err(failure) => {
+                    let mut failed = visited;
+                    if let Some(last) = failed.last_mut() {
+                        last.status = WorkflowTraversalStepStatus::Failed;
+                    }
+                    return Err(workflow_failure(
+                        request,
+                        WorkflowTraversalFailureReason::StepExecutionFailed,
+                        runtime_error(
+                            RuntimeErrorCode::ExecutionFailed,
+                            &failure.message,
+                            json!({"code": format!("{:?}", failure.code)}),
+                        ),
+                        failed,
+                        traversed,
+                        emitted,
+                    ));
+                }
+            };
+
+            if let Err(error) = validate_payload_against_contract(
+                &output,
+                &capability.contract.outputs.schema,
+                RuntimeErrorCode::OutputValidationFailed,
+                "workflow node output does not satisfy the capability output contract",
+            ) {
+                let mut failed = visited;
+                if let Some(last) = failed.last_mut() {
+                    last.status = WorkflowTraversalStepStatus::Failed;
+                }
+                return Err(workflow_failure(
+                    request,
+                    WorkflowTraversalFailureReason::StepExecutionFailed,
+                    error,
+                    failed,
+                    traversed,
+                    emitted,
+                ));
+            }
+
+            update_state(&mut state, node, &output);
+            let node_emitted = emitted_events(&output);
+            emitted.extend(node_emitted.clone());
+            if let Some(last) = visited.last_mut() {
+                last.status = WorkflowTraversalStepStatus::Completed;
+            }
+
+            let outgoing = workflow
+                .definition
+                .edges
+                .iter()
+                .filter(|edge| edge.from == node.node_id)
+                .cloned()
+                .collect::<Vec<_>>();
+            let direct = outgoing
+                .iter()
+                .filter(|edge| edge.trigger == WorkflowEdgeTrigger::Direct)
+                .cloned()
+                .collect::<Vec<_>>();
+            if direct.len() > 1 {
+                return Err(workflow_failure(
+                    request,
+                    WorkflowTraversalFailureReason::AmbiguousNextEdge,
+                    runtime_error(
+                        RuntimeErrorCode::ExecutionFailed,
+                        "workflow traversal found more than one direct next edge",
+                        json!({"node_id": node.node_id}),
+                    ),
+                    visited,
+                    traversed,
+                    emitted,
+                ));
+            }
+            if let Some(edge) = direct.into_iter().next() {
+                traversed.push(edge_record(&edge));
+                current = edge.to;
+                step_index += 1;
+                continue;
+            }
+
+            let matched_event_edges = outgoing
+                .iter()
+                .filter(|edge| edge.trigger == WorkflowEdgeTrigger::Event)
+                .filter(|edge| {
+                    edge.event.as_ref().is_some_and(|required| {
+                        node_emitted
+                            .iter()
+                            .any(|emitted_event| emitted_event == required)
+                    })
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if matched_event_edges.len() > 1 {
+                return Err(workflow_failure(
+                    request,
+                    WorkflowTraversalFailureReason::AmbiguousNextEdge,
+                    runtime_error(
+                        RuntimeErrorCode::ExecutionFailed,
+                        "workflow traversal found more than one event next edge",
+                        json!({"node_id": node.node_id}),
+                    ),
+                    visited,
+                    traversed,
+                    emitted,
+                ));
+            }
+            if let Some(edge) = matched_event_edges.into_iter().next() {
+                traversed.push(edge_record(&edge));
+                current = edge.to;
+                step_index += 1;
+                continue;
+            }
+
+            if workflow.definition.terminal_nodes.contains(&node.node_id) {
+                let final_output = Value::Object(state.clone());
+                if let Err(error) = validate_payload_against_contract(
+                    &final_output,
+                    &workflow.definition.outputs.schema,
+                    RuntimeErrorCode::OutputValidationFailed,
+                    "workflow output does not satisfy the workflow output contract",
+                ) {
+                    return Err(workflow_failure(
+                        request,
+                        WorkflowTraversalFailureReason::WorkflowInvalid,
+                        error,
+                        visited,
+                        traversed,
+                        emitted,
+                    ));
+                }
+
+                let evidence = WorkflowTraversalEvidence {
+                    kind: WORKFLOW_EVIDENCE_KIND.to_string(),
+                    schema_version: WORKFLOW_SCHEMA_VERSION.to_string(),
+                    trace_id: format!("workflow_trace_{}", request.request_id),
+                    request_id: request.request_id.clone(),
+                    workflow_id: workflow.definition.id.clone(),
+                    workflow_version: workflow.definition.version.clone(),
+                    governing_spec: WORKFLOW_GOVERNING_SPEC.to_string(),
+                    visited_nodes: visited,
+                    traversed_edges: traversed,
+                    emitted_events: emitted,
+                    result: WorkflowTraversalResult {
+                        status: WorkflowTraversalStatus::Completed,
+                        failure_reason: None,
+                    },
+                };
+
+                return Ok(WorkflowExecutionOutcome {
+                    result: WorkflowExecutionResult {
+                        kind: WORKFLOW_REQUEST_KIND.to_string(),
+                        schema_version: WORKFLOW_SCHEMA_VERSION.to_string(),
+                        request_id: request.request_id.clone(),
+                        workflow_id: workflow.definition.id.clone(),
+                        workflow_version: workflow.definition.version.clone(),
+                        status: WorkflowTraversalStatus::Completed,
+                        output: Some(final_output),
+                        error: None,
+                    },
+                    evidence,
+                });
+            }
+
+            let failure_reason = if outgoing
+                .iter()
+                .any(|edge| edge.trigger == WorkflowEdgeTrigger::Event)
+            {
+                WorkflowTraversalFailureReason::MissingRequiredEvent
+            } else {
+                WorkflowTraversalFailureReason::TerminalNodeNotReached
+            };
+
+            return Err(workflow_failure(
+                request,
+                failure_reason,
+                runtime_error(
+                    RuntimeErrorCode::ExecutionFailed,
+                    "workflow traversal could not reach a valid next node",
+                    json!({"node_id": node.node_id}),
+                ),
+                visited,
+                traversed,
+                emitted,
+            ));
+        }
+    }
+}
+
+fn validate_workflow_request(request: &WorkflowExecutionRequest) -> Option<RuntimeError> {
+    if request.kind != WORKFLOW_REQUEST_KIND {
+        return Some(runtime_error(
+            RuntimeErrorCode::RequestInvalid,
+            "kind must equal workflow_execution_request",
+            json!({"path": "$.kind"}),
+        ));
+    }
+    if request.schema_version != WORKFLOW_SCHEMA_VERSION {
+        return Some(runtime_error(
+            RuntimeErrorCode::RequestInvalid,
+            "schema_version must equal 1.0.0",
+            json!({"path": "$.schema_version"}),
+        ));
+    }
+    if request.governing_spec != WORKFLOW_GOVERNING_SPEC {
+        return Some(runtime_error(
+            RuntimeErrorCode::RequestInvalid,
+            "governing_spec must equal 007-workflow-registry-traversal",
+            json!({"path": "$.governing_spec"}),
+        ));
+    }
+    if request.request_id.trim().is_empty()
+        || request.workflow_id.trim().is_empty()
+        || request.workflow_version.trim().is_empty()
+    {
+        return Some(runtime_error(
+            RuntimeErrorCode::RequestInvalid,
+            "request_id, workflow_id, and workflow_version must be non-empty",
+            json!({"path": "$"}),
+        ));
+    }
+    None
+}
+
+fn map_workflow_lookup_scope(scope: WorkflowLookupScope) -> LookupScope {
+    match scope {
+        WorkflowLookupScope::PublicOnly => LookupScope::PublicOnly,
+        WorkflowLookupScope::PreferPrivate => LookupScope::PreferPrivate,
+    }
+}
+
+fn workflow_state(input: &Value) -> Map<String, Value> {
+    match input {
+        Value::Object(map) => map.clone(),
+        other => {
+            let mut map = Map::new();
+            map.insert("input".to_string(), other.clone());
+            map
+        }
+    }
+}
+
+fn node_input(state: &Map<String, Value>, node: &WorkflowNode) -> Value {
+    let mut input = Map::new();
+    for key in &node.input.from_workflow_input {
+        if let Some(value) = state.get(key) {
+            input.insert(key.clone(), value.clone());
+        }
+    }
+    Value::Object(input)
+}
+
+fn update_state(state: &mut Map<String, Value>, node: &WorkflowNode, output: &Value) {
+    let Value::Object(object) = output else {
+        return;
+    };
+    for key in &node.output.to_workflow_state {
+        if let Some(value) = object.get(key) {
+            state.insert(key.clone(), value.clone());
+        }
+    }
+}
+
+fn emitted_events(output: &Value) -> Vec<EventReference> {
+    let Value::Object(object) = output else {
+        return Vec::new();
+    };
+    let Some(Value::Array(events)) = object.get("emitted_events") else {
+        return Vec::new();
+    };
+    events
+        .iter()
+        .filter_map(|event| {
+            let Value::Object(event) = event else {
+                return None;
+            };
+            Some(EventReference {
+                event_id: event.get("event_id")?.as_str()?.to_string(),
+                version: event.get("version")?.as_str()?.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn edge_record(edge: &WorkflowEdge) -> WorkflowTraversalEdgeRecord {
+    WorkflowTraversalEdgeRecord {
+        edge_id: edge.edge_id.clone(),
+        from: edge.from.clone(),
+        to: edge.to.clone(),
+        trigger: match edge.trigger {
+            WorkflowEdgeTrigger::Direct => WorkflowTraversalTrigger::Direct,
+            WorkflowEdgeTrigger::Event => WorkflowTraversalTrigger::Event,
+        },
+        event: edge.event.clone(),
+    }
+}
+
+fn workflow_failure(
+    request: &WorkflowExecutionRequest,
+    failure_reason: WorkflowTraversalFailureReason,
+    error: RuntimeError,
+    visited_nodes: Vec<WorkflowTraversalStepRecord>,
+    traversed_edges: Vec<WorkflowTraversalEdgeRecord>,
+    emitted_events: Vec<EventReference>,
+) -> WorkflowExecutionOutcome {
+    let evidence = WorkflowTraversalEvidence {
+        kind: WORKFLOW_EVIDENCE_KIND.to_string(),
+        schema_version: WORKFLOW_SCHEMA_VERSION.to_string(),
+        trace_id: format!("workflow_trace_{}", request.request_id),
+        request_id: request.request_id.clone(),
+        workflow_id: request.workflow_id.clone(),
+        workflow_version: request.workflow_version.clone(),
+        governing_spec: WORKFLOW_GOVERNING_SPEC.to_string(),
+        visited_nodes,
+        traversed_edges,
+        emitted_events,
+        result: WorkflowTraversalResult {
+            status: WorkflowTraversalStatus::Error,
+            failure_reason: Some(failure_reason),
+        },
+    };
+
+    WorkflowExecutionOutcome {
+        result: WorkflowExecutionResult {
+            kind: WORKFLOW_REQUEST_KIND.to_string(),
+            schema_version: WORKFLOW_SCHEMA_VERSION.to_string(),
+            request_id: request.request_id.clone(),
+            workflow_id: request.workflow_id.clone(),
+            workflow_version: request.workflow_version.clone(),
+            status: WorkflowTraversalStatus::Error,
+            output: None,
+            error: Some(error),
+        },
+        evidence,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        CandidateCollectionRecord, LocalExecutionFailure, LocalExecutionFailureCode,
+        RuntimeContext, RuntimeIntent, RuntimeLookup, RuntimeLookupScope, RuntimeRequest,
+        RuntimeResultStatus,
+    };
+    use cogolo_contracts::{
+        BinaryFormat as ContractBinaryFormat, CapabilityContract, Condition, Entrypoint,
+        EntrypointKind, EventReference, EvidenceStatus, EvidenceType, Execution,
+        ExecutionConstraints, ExecutionTarget, FilesystemAccess, HostApiAccess, IdReference,
+        Lifecycle, NetworkAccess, Owner, Provenance, ProvenanceSource, SchemaContainer, SideEffect,
+        SideEffectKind, ValidationEvidence,
+    };
+    use cogolo_registry::{
+        ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
+        CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
+        CompositionPattern, ImplementationKind, RegistryProvenance, RegistryScope, SourceKind,
+        SourceReference, WorkflowDefinition, WorkflowEdge, WorkflowEdgeTrigger, WorkflowNode,
+        WorkflowNodeInput, WorkflowNodeOutput, WorkflowRegistration, WorkflowRegistry,
+        WorkflowRegistryRecord, workflow_artifact_record,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn workflow_request_validation_rejects_invalid_guards() {
+        let mut request = valid_workflow_request();
+        request.kind = "bad".to_string();
+        assert_eq!(
+            validate_workflow_request(&request).map(|error| error.code),
+            Some(RuntimeErrorCode::RequestInvalid)
+        );
+
+        let mut request = valid_workflow_request();
+        request.schema_version = "2.0.0".to_string();
+        assert_eq!(
+            validate_workflow_request(&request).map(|error| error.code),
+            Some(RuntimeErrorCode::RequestInvalid)
+        );
+
+        let mut request = valid_workflow_request();
+        request.governing_spec = "bad".to_string();
+        assert_eq!(
+            validate_workflow_request(&request).map(|error| error.code),
+            Some(RuntimeErrorCode::RequestInvalid)
+        );
+
+        let mut request = valid_workflow_request();
+        request.request_id.clear();
+        assert_eq!(
+            validate_workflow_request(&request).map(|error| error.code),
+            Some(RuntimeErrorCode::RequestInvalid)
+        );
+    }
+
+    #[test]
+    fn workflow_helpers_cover_state_and_event_extraction_paths() {
+        let scalar = workflow_state(&json!("value"));
+        assert_eq!(scalar.get("input"), Some(&json!("value")));
+
+        let mut state = workflow_state(&json!({"comment_text": "hello"}));
+        let node = WorkflowNode {
+            node_id: "node".to_string(),
+            capability_id: "content.comments.create-comment-draft".to_string(),
+            capability_version: "1.0.0".to_string(),
+            input: WorkflowNodeInput {
+                from_workflow_input: vec!["comment_text".to_string(), "missing".to_string()],
+            },
+            output: WorkflowNodeOutput {
+                to_workflow_state: vec!["draft_id".to_string()],
+            },
+        };
+        assert_eq!(node_input(&state, &node), json!({"comment_text": "hello"}));
+        update_state(&mut state, &node, &json!({"draft_id": "draft-1"}));
+        assert_eq!(state.get("draft_id"), Some(&json!("draft-1")));
+        update_state(&mut state, &node, &json!("not-an-object"));
+
+        assert!(emitted_events(&json!("nope")).is_empty());
+        assert_eq!(
+            emitted_events(&json!({
+                "emitted_events": [
+                    "bad",
+                    {"event_id": "content.comments.draft-created", "version": "1.0.0"},
+                    {"event_id": "bad"}
+                ]
+            })),
+            vec![EventReference {
+                event_id: "content.comments.draft-created".to_string(),
+                version: "1.0.0".to_string(),
+            }]
+        );
+
+        let edge = WorkflowEdge {
+            edge_id: "edge".to_string(),
+            from: "a".to_string(),
+            to: "b".to_string(),
+            trigger: WorkflowEdgeTrigger::Event,
+            event: Some(EventReference {
+                event_id: "content.comments.draft-created".to_string(),
+                version: "1.0.0".to_string(),
+            }),
+        };
+        assert_eq!(edge_record(&edge).trigger, WorkflowTraversalTrigger::Event);
+        assert_eq!(
+            map_workflow_lookup_scope(WorkflowLookupScope::PreferPrivate),
+            LookupScope::PreferPrivate
+        );
+    }
+
+    #[test]
+    fn executes_workflow_deterministically_and_supports_workflow_backed_capabilities() {
+        let workflow_registry = workflow_registry_fixture();
+        let runtime = Runtime::new(capability_registry_fixture(), WorkflowExecutor)
+            .with_workflow_registry(workflow_registry);
+
+        let workflow = runtime.execute_workflow(valid_workflow_request());
+        assert_eq!(workflow.result.status, WorkflowTraversalStatus::Completed);
+        assert_eq!(
+            workflow.result.output,
+            Some(
+                json!({"comment_text": "hello", "draft_id": "draft-1", "comment_id": "comment-1"})
+            )
+        );
+        assert_eq!(workflow.evidence.visited_nodes.len(), 3);
+        assert_eq!(workflow.evidence.traversed_edges.len(), 2);
+
+        let mut composed_registry = capability_registry_fixture();
+        register_capability_ok(
+            &mut composed_registry,
+            CapabilityRegistration {
+                scope: RegistryScope::Public,
+                contract: capability_contract(
+                    "content.comments.publish-comment",
+                    vec![],
+                    json!({
+                        "type": "object",
+                        "properties": { "comment_text": { "type": "string" } },
+                        "required": ["comment_text"],
+                        "additionalProperties": true
+                    }),
+                    json!({
+                        "type": "object",
+                        "properties": { "comment_id": { "type": "string" } },
+                        "required": ["comment_id"],
+                        "additionalProperties": true
+                    }),
+                ),
+                contract_path: "contracts/publish-comment.json".to_string(),
+                artifact: workflow_artifact_record(
+                    "content.comments.publish-comment",
+                    "1.0.0",
+                    "artifact-workflow",
+                ),
+                registered_at: "2026-03-27T00:10:00Z".to_string(),
+                tags: vec!["comments".to_string()],
+                composability: ComposabilityMetadata {
+                    kind: CompositionKind::Composite,
+                    patterns: vec![
+                        CompositionPattern::Sequential,
+                        CompositionPattern::EventDriven,
+                    ],
+                    provides: vec!["published-comment".to_string()],
+                    requires: vec!["draft".to_string()],
+                },
+                governing_spec: "005-capability-registry".to_string(),
+                validator_version: "validator".to_string(),
+            },
+        );
+
+        let runtime = Runtime::new(composed_registry, WorkflowExecutor)
+            .with_workflow_registry(workflow_registry_fixture());
+        let result = runtime.execute(RuntimeRequest {
+            kind: "runtime_request".to_string(),
+            schema_version: "1.0.0".to_string(),
+            request_id: "request-workflow".to_string(),
+            intent: RuntimeIntent {
+                capability_id: Some("content.comments.publish-comment".to_string()),
+                capability_version: Some("1.0.0".to_string()),
+                intent_key: None,
+            },
+            input: json!({"comment_text": "hello"}),
+            lookup: RuntimeLookup {
+                scope: RuntimeLookupScope::PublicOnly,
+                allow_ambiguity: false,
+            },
+            context: RuntimeContext {
+                requested_target: crate::PlacementTarget::Local,
+                correlation_id: None,
+                caller: None,
+                metadata: None,
+            },
+            governing_spec: "006-runtime-request-execution".to_string(),
+        });
+        assert_eq!(result.result.status, RuntimeResultStatus::Completed);
+        assert_eq!(
+            result.result.output,
+            Some(
+                json!({"comment_text": "hello", "draft_id": "draft-1", "comment_id": "comment-1"})
+            )
+        );
+    }
+
+    #[test]
+    fn workflow_failures_cover_not_found_missing_events_and_step_failures() {
+        let workflow_registry = workflow_registry_fixture();
+        let runtime = Runtime::new(capability_registry_fixture(), WorkflowExecutor)
+            .with_workflow_registry(workflow_registry);
+
+        let mut missing_request = valid_workflow_request();
+        missing_request.workflow_id = "missing".to_string();
+        let missing = runtime.execute_workflow(missing_request);
+        assert_eq!(
+            missing.evidence.result.failure_reason,
+            Some(WorkflowTraversalFailureReason::WorkflowNotFound)
+        );
+
+        let workflow_registry = workflow_registry_fixture();
+        let runtime = Runtime::new(capability_registry_fixture(), MissingEventWorkflowExecutor)
+            .with_workflow_registry(workflow_registry);
+        let missing_event = runtime.execute_workflow(valid_workflow_request());
+        assert_eq!(
+            missing_event.evidence.result.failure_reason,
+            Some(WorkflowTraversalFailureReason::MissingRequiredEvent)
+        );
+
+        let runtime = Runtime::new(capability_registry_fixture(), FailingWorkflowExecutor)
+            .with_workflow_registry(workflow_registry_fixture());
+        let failed = runtime.execute_workflow(valid_workflow_request());
+        assert_eq!(
+            failed.evidence.result.failure_reason,
+            Some(WorkflowTraversalFailureReason::StepExecutionFailed)
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn workflow_runtime_covers_additional_failure_and_helper_branches() {
+        let runtime = Runtime::new(capability_registry_fixture(), WorkflowExecutor)
+            .with_workflow_registry(workflow_registry_fixture());
+
+        let invalid_input = runtime.execute_workflow(WorkflowExecutionRequest {
+            input: json!({}),
+            ..valid_workflow_request()
+        });
+        assert_eq!(
+            invalid_input.evidence.result.failure_reason,
+            Some(WorkflowTraversalFailureReason::WorkflowInvalid)
+        );
+
+        let invalid_request = runtime.execute_workflow(WorkflowExecutionRequest {
+            kind: "bad".to_string(),
+            ..valid_workflow_request()
+        });
+        assert_eq!(
+            invalid_request.evidence.result.failure_reason,
+            Some(WorkflowTraversalFailureReason::WorkflowInvalid)
+        );
+
+        let missing_node = runtime.traverse_workflow(
+            &valid_workflow_request(),
+            &resolved_workflow(WorkflowDefinition {
+                start_node: "missing".to_string(),
+                ..workflow_definition_fixture(
+                    Some(EventReference {
+                        event_id: "content.comments.validated".to_string(),
+                        version: "1.0.0".to_string(),
+                    }),
+                    None,
+                )
+            }),
+        );
+        assert!(missing_node.is_err());
+
+        let missing_capability_runtime = Runtime::new(CapabilityRegistry::new(), WorkflowExecutor)
+            .with_workflow_registry(workflow_registry_fixture());
+        let missing_capability =
+            missing_capability_runtime.execute_workflow(valid_workflow_request());
+        assert_eq!(
+            missing_capability.evidence.result.failure_reason,
+            Some(WorkflowTraversalFailureReason::WorkflowInvalid)
+        );
+
+        let strict_runtime =
+            Runtime::new(strict_input_capability_registry_fixture(), WorkflowExecutor)
+                .with_workflow_registry(workflow_registry_fixture());
+        let input_mismatch = strict_runtime.traverse_workflow(
+            &valid_workflow_request(),
+            &resolved_workflow(WorkflowDefinition {
+                nodes: vec![WorkflowNode {
+                    input: WorkflowNodeInput {
+                        from_workflow_input: vec!["missing".to_string()],
+                    },
+                    ..workflow_definition_fixture(
+                        Some(EventReference {
+                            event_id: "content.comments.validated".to_string(),
+                            version: "1.0.0".to_string(),
+                        }),
+                        None,
+                    )
+                    .nodes[0]
+                        .clone()
+                }],
+                edges: Vec::new(),
+                start_node: "create_draft".to_string(),
+                terminal_nodes: vec!["create_draft".to_string()],
+                ..workflow_definition_fixture(
+                    Some(EventReference {
+                        event_id: "content.comments.validated".to_string(),
+                        version: "1.0.0".to_string(),
+                    }),
+                    None,
+                )
+            }),
+        );
+        assert!(input_mismatch.is_err());
+
+        let bad_output_runtime =
+            Runtime::new(capability_registry_fixture(), BadOutputWorkflowExecutor)
+                .with_workflow_registry(workflow_registry_fixture());
+        let bad_output = bad_output_runtime.execute_workflow(valid_workflow_request());
+        assert_eq!(
+            bad_output.evidence.result.failure_reason,
+            Some(WorkflowTraversalFailureReason::StepExecutionFailed)
+        );
+
+        let direct_success = runtime.traverse_workflow(
+            &valid_workflow_request(),
+            &resolved_workflow(workflow_definition_fixture(
+                Some(EventReference {
+                    event_id: "content.comments.validated".to_string(),
+                    version: "1.0.0".to_string(),
+                }),
+                Some(WorkflowEdge {
+                    edge_id: "direct".to_string(),
+                    from: "create_draft".to_string(),
+                    to: "validate_comment".to_string(),
+                    trigger: WorkflowEdgeTrigger::Direct,
+                    event: None,
+                }),
+            )),
+        );
+        assert!(direct_success.is_ok());
+
+        let ambiguous_direct = runtime.traverse_workflow(
+            &valid_workflow_request(),
+            &resolved_workflow(WorkflowDefinition {
+                edges: vec![
+                    WorkflowEdge {
+                        edge_id: "direct-1".to_string(),
+                        from: "create_draft".to_string(),
+                        to: "validate_comment".to_string(),
+                        trigger: WorkflowEdgeTrigger::Direct,
+                        event: None,
+                    },
+                    WorkflowEdge {
+                        edge_id: "direct-2".to_string(),
+                        from: "create_draft".to_string(),
+                        to: "persist_comment".to_string(),
+                        trigger: WorkflowEdgeTrigger::Direct,
+                        event: None,
+                    },
+                ],
+                ..workflow_definition_fixture(
+                    Some(EventReference {
+                        event_id: "content.comments.validated".to_string(),
+                        version: "1.0.0".to_string(),
+                    }),
+                    None,
+                )
+            }),
+        );
+        assert!(ambiguous_direct.is_err());
+
+        let ambiguous_event = runtime.traverse_workflow(
+            &valid_workflow_request(),
+            &resolved_workflow(WorkflowDefinition {
+                edges: vec![
+                    WorkflowEdge {
+                        edge_id: "draft_to_validate".to_string(),
+                        from: "create_draft".to_string(),
+                        to: "validate_comment".to_string(),
+                        trigger: WorkflowEdgeTrigger::Event,
+                        event: Some(EventReference {
+                            event_id: "content.comments.draft-created".to_string(),
+                            version: "1.0.0".to_string(),
+                        }),
+                    },
+                    WorkflowEdge {
+                        edge_id: "draft_to_persist".to_string(),
+                        from: "create_draft".to_string(),
+                        to: "persist_comment".to_string(),
+                        trigger: WorkflowEdgeTrigger::Event,
+                        event: Some(EventReference {
+                            event_id: "content.comments.draft-created".to_string(),
+                            version: "1.0.0".to_string(),
+                        }),
+                    },
+                ],
+                ..workflow_definition_fixture(
+                    Some(EventReference {
+                        event_id: "content.comments.validated".to_string(),
+                        version: "1.0.0".to_string(),
+                    }),
+                    None,
+                )
+            }),
+        );
+        assert!(ambiguous_event.is_err());
+
+        let terminal_miss = runtime.traverse_workflow(
+            &valid_workflow_request(),
+            &resolved_workflow(WorkflowDefinition {
+                edges: Vec::new(),
+                terminal_nodes: vec!["persist_comment".to_string()],
+                ..workflow_definition_fixture(
+                    Some(EventReference {
+                        event_id: "content.comments.validated".to_string(),
+                        version: "1.0.0".to_string(),
+                    }),
+                    None,
+                )
+            }),
+        );
+        assert!(terminal_miss.is_err());
+
+        let invalid_final_output = runtime.traverse_workflow(
+            &valid_workflow_request(),
+            &resolved_workflow(WorkflowDefinition {
+                outputs: SchemaContainer {
+                    schema: json!({
+                        "type": "object",
+                        "properties": { "missing": { "type": "string" } },
+                        "required": ["missing"],
+                        "additionalProperties": true
+                    }),
+                },
+                ..workflow_definition_fixture(
+                    Some(EventReference {
+                        event_id: "content.comments.validated".to_string(),
+                        version: "1.0.0".to_string(),
+                    }),
+                    None,
+                )
+            }),
+        );
+        assert!(invalid_final_output.is_err());
+
+        let selection = SelectionRecord {
+            status: crate::SelectionStatus::Selected,
+            selected_capability_id: Some("content.comments.publish-comment".to_string()),
+            selected_capability_version: Some("1.0.0".to_string()),
+            failure_reason: None,
+            remaining_candidates: Vec::new(),
+        };
+        let mut selected = runtime
+            .registry
+            .find_exact(
+                LookupScope::PublicOnly,
+                "content.comments.create-comment-draft",
+                "1.0.0",
+            )
+            .unwrap_or_else(|| unreachable!("fixture capability missing"));
+        selected.record.implementation_kind = ImplementationKind::Workflow;
+        let (attempt, emitter) = super::super::begin_attempt(RuntimeRequest {
+            kind: "runtime_request".to_string(),
+            schema_version: "1.0.0".to_string(),
+            request_id: "workflow-capability".to_string(),
+            intent: RuntimeIntent {
+                capability_id: Some("content.comments.publish-comment".to_string()),
+                capability_version: Some("1.0.0".to_string()),
+                intent_key: None,
+            },
+            input: json!({"comment_text": "hello"}),
+            lookup: RuntimeLookup {
+                scope: RuntimeLookupScope::PublicOnly,
+                allow_ambiguity: false,
+            },
+            context: RuntimeContext {
+                requested_target: crate::PlacementTarget::Local,
+                correlation_id: None,
+                caller: None,
+                metadata: None,
+            },
+            governing_spec: "006-runtime-request-execution".to_string(),
+        });
+        let outcome = runtime.execute_workflow_capability(
+            attempt,
+            emitter,
+            CandidateCollectionRecord {
+                lookup_scope: RuntimeLookupScope::PublicOnly,
+                candidates: Vec::new(),
+                rejected_candidates: Vec::new(),
+            },
+            selection,
+            &selected,
+        );
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+
+        let mut selected = runtime
+            .registry
+            .find_exact(
+                LookupScope::PublicOnly,
+                "content.comments.create-comment-draft",
+                "1.0.0",
+            )
+            .unwrap_or_else(|| unreachable!("fixture capability missing"));
+        selected.record.scope = RegistryScope::Private;
+        selected.record.implementation_kind = ImplementationKind::Workflow;
+        selected.artifact.workflow_ref = Some(cogolo_registry::WorkflowReference {
+            workflow_id: "content.comments.publish-comment".to_string(),
+            workflow_version: "1.0.0".to_string(),
+        });
+        let (attempt, emitter) = super::super::begin_attempt(RuntimeRequest {
+            request_id: "workflow-private".to_string(),
+            ..valid_runtime_request()
+        });
+        let failing_runtime = Runtime::new(capability_registry_fixture(), FailingWorkflowExecutor)
+            .with_workflow_registry(workflow_registry_fixture());
+        let outcome = failing_runtime.execute_workflow_capability(
+            attempt,
+            emitter,
+            CandidateCollectionRecord {
+                lookup_scope: RuntimeLookupScope::PreferPrivate,
+                candidates: Vec::new(),
+                rejected_candidates: Vec::new(),
+            },
+            SelectionRecord {
+                status: crate::SelectionStatus::Selected,
+                selected_capability_id: Some("content.comments.publish-comment".to_string()),
+                selected_capability_version: Some("1.0.0".to_string()),
+                failure_reason: None,
+                remaining_candidates: Vec::new(),
+            },
+            &selected,
+        );
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+
+        let mut unknown = runtime
+            .registry
+            .find_exact(
+                LookupScope::PublicOnly,
+                "content.comments.create-comment-draft",
+                "1.0.0",
+            )
+            .unwrap_or_else(|| unreachable!("fixture capability missing"));
+        unknown.record.id = "unknown".to_string();
+        let _ = WorkflowExecutor.execute(&unknown, &json!({}));
+        let _ = MissingEventWorkflowExecutor.execute(&unknown, &json!({}));
+        let _ = BadOutputWorkflowExecutor.execute(&unknown, &json!({}));
+        unknown.record.id = "content.comments.persist-comment".to_string();
+        let _ = MissingEventWorkflowExecutor.execute(&unknown, &json!({}));
+    }
+
+    fn capability_registry_fixture() -> CapabilityRegistry {
+        build_capability_registry(false)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn build_capability_registry(strict_inputs: bool) -> CapabilityRegistry {
+        let mut registry = CapabilityRegistry::new();
+        for (id, emits, output, required_key) in [
+            (
+                "content.comments.create-comment-draft",
+                vec![EventReference {
+                    event_id: "content.comments.draft-created".to_string(),
+                    version: "1.0.0".to_string(),
+                }],
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "draft_id": { "type": "string" },
+                        "emitted_events": { "type": "array" }
+                    },
+                    "required": ["draft_id"],
+                    "additionalProperties": true
+                }),
+                "comment_text",
+            ),
+            (
+                "content.comments.validate-comment",
+                vec![EventReference {
+                    event_id: "content.comments.validated".to_string(),
+                    version: "1.0.0".to_string(),
+                }],
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "draft_id": { "type": "string" },
+                        "emitted_events": { "type": "array" }
+                    },
+                    "required": ["draft_id"],
+                    "additionalProperties": true
+                }),
+                "draft_id",
+            ),
+            (
+                "content.comments.persist-comment",
+                vec![],
+                json!({
+                    "type": "object",
+                    "properties": { "comment_id": { "type": "string" } },
+                    "required": ["comment_id"],
+                    "additionalProperties": true
+                }),
+                "draft_id",
+            ),
+        ] {
+            register_capability_ok(
+                &mut registry,
+                CapabilityRegistration {
+                    scope: RegistryScope::Public,
+                    contract: capability_contract(
+                        id,
+                        emits,
+                        json!({
+                            "type": "object",
+                            "properties": {
+                                "comment_text": { "type": "string" },
+                                "draft_id": { "type": "string" }
+                            },
+                            "required": if strict_inputs {
+                                vec![required_key]
+                            } else {
+                                Vec::<&str>::new()
+                            },
+                            "additionalProperties": true
+                        }),
+                        output,
+                    ),
+                    contract_path: format!("contracts/{id}.json"),
+                    artifact: CapabilityArtifactRecord {
+                        artifact_ref: format!("artifact-{id}"),
+                        implementation_kind: ImplementationKind::Executable,
+                        source: SourceReference {
+                            kind: SourceKind::Git,
+                            location: format!("https://example.com/{id}.git"),
+                        },
+                        binary: Some(BinaryReference {
+                            format: BinaryFormat::Wasm,
+                            location: format!("{id}.wasm"),
+                        }),
+                        workflow_ref: None,
+                        digests: ArtifactDigests {
+                            source_digest: "source".to_string(),
+                            binary_digest: Some("binary".to_string()),
+                        },
+                        provenance: RegistryProvenance {
+                            source: "fixtures".to_string(),
+                            author: "Enrico".to_string(),
+                            created_at: "2026-03-27T00:00:00Z".to_string(),
+                        },
+                    },
+                    registered_at: "2026-03-27T00:00:00Z".to_string(),
+                    tags: vec!["comments".to_string()],
+                    composability: ComposabilityMetadata {
+                        kind: CompositionKind::Atomic,
+                        patterns: vec![CompositionPattern::Sequential],
+                        provides: vec!["comment".to_string()],
+                        requires: Vec::new(),
+                    },
+                    governing_spec: "005-capability-registry".to_string(),
+                    validator_version: "validator".to_string(),
+                },
+            );
+        }
+        registry
+    }
+
+    fn strict_input_capability_registry_fixture() -> CapabilityRegistry {
+        build_capability_registry(true)
+    }
+
+    fn workflow_registry_fixture() -> WorkflowRegistry {
+        let registry = capability_registry_fixture();
+        let mut workflows = WorkflowRegistry::new();
+        register_workflow_ok(
+            &mut workflows,
+            &registry,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition: workflow_definition_fixture(
+                    Some(EventReference {
+                        event_id: "content.comments.validated".to_string(),
+                        version: "1.0.0".to_string(),
+                    }),
+                    None,
+                ),
+                workflow_path: "workflows/publish-comment.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "workflow-validator".to_string(),
+            },
+        );
+        workflows
+    }
+
+    fn workflow_definition_fixture(
+        second_event: Option<EventReference>,
+        direct_edge: Option<WorkflowEdge>,
+    ) -> WorkflowDefinition {
+        let mut edges = vec![
+            WorkflowEdge {
+                edge_id: "draft_to_validate".to_string(),
+                from: "create_draft".to_string(),
+                to: "validate_comment".to_string(),
+                trigger: WorkflowEdgeTrigger::Event,
+                event: Some(EventReference {
+                    event_id: "content.comments.draft-created".to_string(),
+                    version: "1.0.0".to_string(),
+                }),
+            },
+            WorkflowEdge {
+                edge_id: "validate_to_persist".to_string(),
+                from: "validate_comment".to_string(),
+                to: "persist_comment".to_string(),
+                trigger: WorkflowEdgeTrigger::Event,
+                event: second_event,
+            },
+        ];
+        if let Some(edge) = direct_edge {
+            edges.push(edge);
+        }
+        WorkflowDefinition {
+            kind: "workflow_definition".to_string(),
+            schema_version: "1.0.0".to_string(),
+            id: "content.comments.publish-comment".to_string(),
+            name: "publish-comment".to_string(),
+            version: "1.0.0".to_string(),
+            lifecycle: Lifecycle::Active,
+            owner: Owner {
+                team: "comments".to_string(),
+                contact: "comments@example.com".to_string(),
+            },
+            summary: "Publish a comment deterministically.".to_string(),
+            inputs: SchemaContainer {
+                schema: json!({
+                    "type": "object",
+                    "properties": { "comment_text": { "type": "string" } },
+                    "required": ["comment_text"],
+                    "additionalProperties": true
+                }),
+            },
+            outputs: SchemaContainer {
+                schema: json!({
+                    "type": "object",
+                    "properties": { "comment_id": { "type": "string" } },
+                    "required": ["comment_id"],
+                    "additionalProperties": true
+                }),
+            },
+            nodes: vec![
+                WorkflowNode {
+                    node_id: "create_draft".to_string(),
+                    capability_id: "content.comments.create-comment-draft".to_string(),
+                    capability_version: "1.0.0".to_string(),
+                    input: WorkflowNodeInput {
+                        from_workflow_input: vec!["comment_text".to_string()],
+                    },
+                    output: WorkflowNodeOutput {
+                        to_workflow_state: vec!["draft_id".to_string()],
+                    },
+                },
+                WorkflowNode {
+                    node_id: "validate_comment".to_string(),
+                    capability_id: "content.comments.validate-comment".to_string(),
+                    capability_version: "1.0.0".to_string(),
+                    input: WorkflowNodeInput {
+                        from_workflow_input: vec!["draft_id".to_string()],
+                    },
+                    output: WorkflowNodeOutput {
+                        to_workflow_state: vec!["draft_id".to_string()],
+                    },
+                },
+                WorkflowNode {
+                    node_id: "persist_comment".to_string(),
+                    capability_id: "content.comments.persist-comment".to_string(),
+                    capability_version: "1.0.0".to_string(),
+                    input: WorkflowNodeInput {
+                        from_workflow_input: vec!["draft_id".to_string()],
+                    },
+                    output: WorkflowNodeOutput {
+                        to_workflow_state: vec!["comment_id".to_string()],
+                    },
+                },
+            ],
+            edges,
+            start_node: "create_draft".to_string(),
+            terminal_nodes: vec!["persist_comment".to_string()],
+            tags: vec!["comments".to_string()],
+            governing_spec: "007-workflow-registry-traversal".to_string(),
+        }
+    }
+
+    fn capability_contract(
+        id: &str,
+        emits: Vec<EventReference>,
+        inputs: Value,
+        outputs: Value,
+    ) -> CapabilityContract {
+        CapabilityContract {
+            kind: "capability_contract".to_string(),
+            schema_version: "1.0.0".to_string(),
+            id: id.to_string(),
+            namespace: "content.comments".to_string(),
+            name: id.rsplit('.').next().unwrap_or("capability").to_string(),
+            version: "1.0.0".to_string(),
+            lifecycle: Lifecycle::Active,
+            owner: Owner {
+                team: "comments".to_string(),
+                contact: "comments@example.com".to_string(),
+            },
+            summary: "workflow fixture capability".to_string(),
+            description: "workflow fixture capability used in runtime tests".to_string(),
+            inputs: SchemaContainer { schema: inputs },
+            outputs: SchemaContainer { schema: outputs },
+            preconditions: vec![Condition {
+                id: "precondition".to_string(),
+                description: "must be valid".to_string(),
+            }],
+            postconditions: vec![Condition {
+                id: "postcondition".to_string(),
+                description: "must produce output".to_string(),
+            }],
+            side_effects: vec![SideEffect {
+                kind: SideEffectKind::MemoryOnly,
+                description: "memory only".to_string(),
+            }],
+            emits,
+            consumes: Vec::new(),
+            permissions: vec![IdReference {
+                id: "permission".to_string(),
+            }],
+            execution: Execution {
+                binary_format: ContractBinaryFormat::Wasm,
+                entrypoint: Entrypoint {
+                    kind: EntrypointKind::WasiCommand,
+                    command: "run".to_string(),
+                },
+                preferred_targets: vec![ExecutionTarget::Local],
+                constraints: ExecutionConstraints {
+                    host_api_access: HostApiAccess::None,
+                    network_access: NetworkAccess::Forbidden,
+                    filesystem_access: FilesystemAccess::None,
+                },
+            },
+            policies: Vec::new(),
+            dependencies: Vec::new(),
+            provenance: Provenance {
+                source: ProvenanceSource::Greenfield,
+                author: "Enrico".to_string(),
+                created_at: "2026-03-27T00:00:00Z".to_string(),
+                spec_ref: Some("007-workflow-registry-traversal".to_string()),
+                adr_refs: Vec::new(),
+                exception_refs: Vec::new(),
+            },
+            evidence: vec![ValidationEvidence {
+                evidence_id: "evidence".to_string(),
+                evidence_type: EvidenceType::ContractValidation,
+                status: EvidenceStatus::Passed,
+            }],
+        }
+    }
+
+    fn valid_workflow_request() -> WorkflowExecutionRequest {
+        WorkflowExecutionRequest {
+            kind: "workflow_execution_request".to_string(),
+            schema_version: "1.0.0".to_string(),
+            request_id: "workflow-request".to_string(),
+            workflow_id: "content.comments.publish-comment".to_string(),
+            workflow_version: "1.0.0".to_string(),
+            scope: WorkflowLookupScope::PublicOnly,
+            input: json!({"comment_text": "hello"}),
+            governing_spec: "007-workflow-registry-traversal".to_string(),
+        }
+    }
+
+    fn valid_runtime_request() -> RuntimeRequest {
+        RuntimeRequest {
+            kind: "runtime_request".to_string(),
+            schema_version: "1.0.0".to_string(),
+            request_id: "runtime-request".to_string(),
+            intent: RuntimeIntent {
+                capability_id: Some("content.comments.publish-comment".to_string()),
+                capability_version: Some("1.0.0".to_string()),
+                intent_key: None,
+            },
+            input: json!({"comment_text": "hello"}),
+            lookup: RuntimeLookup {
+                scope: RuntimeLookupScope::PublicOnly,
+                allow_ambiguity: false,
+            },
+            context: RuntimeContext {
+                requested_target: crate::PlacementTarget::Local,
+                correlation_id: None,
+                caller: None,
+                metadata: None,
+            },
+            governing_spec: "006-runtime-request-execution".to_string(),
+        }
+    }
+
+    struct WorkflowExecutor;
+
+    impl LocalExecutor for WorkflowExecutor {
+        fn execute(
+            &self,
+            capability: &ResolvedCapability,
+            _input: &Value,
+        ) -> Result<Value, LocalExecutionFailure> {
+            let output = match capability.record.id.as_str() {
+                "content.comments.create-comment-draft" => json!({
+                    "draft_id": "draft-1",
+                    "emitted_events": [
+                        {"event_id": "content.comments.draft-created", "version": "1.0.0"}
+                    ]
+                }),
+                "content.comments.validate-comment" => json!({
+                    "draft_id": "draft-1",
+                    "emitted_events": [
+                        {"event_id": "content.comments.validated", "version": "1.0.0"}
+                    ]
+                }),
+                "content.comments.persist-comment" => json!({
+                    "comment_id": "comment-1"
+                }),
+                _ => json!({}),
+            };
+            Ok(output)
+        }
+    }
+
+    struct FailingWorkflowExecutor;
+
+    impl LocalExecutor for FailingWorkflowExecutor {
+        fn execute(
+            &self,
+            _capability: &ResolvedCapability,
+            _input: &Value,
+        ) -> Result<Value, LocalExecutionFailure> {
+            Err(LocalExecutionFailure {
+                code: LocalExecutionFailureCode::ExecutionFailed,
+                message: "boom".to_string(),
+            })
+        }
+    }
+
+    struct MissingEventWorkflowExecutor;
+
+    struct BadOutputWorkflowExecutor;
+
+    impl LocalExecutor for MissingEventWorkflowExecutor {
+        fn execute(
+            &self,
+            capability: &ResolvedCapability,
+            _input: &Value,
+        ) -> Result<Value, LocalExecutionFailure> {
+            let output = match capability.record.id.as_str() {
+                "content.comments.create-comment-draft" => json!({
+                    "draft_id": "draft-1",
+                    "emitted_events": [
+                        {"event_id": "content.comments.draft-created", "version": "1.0.0"}
+                    ]
+                }),
+                "content.comments.validate-comment" => json!({
+                    "draft_id": "draft-1"
+                }),
+                "content.comments.persist-comment" => json!({
+                    "comment_id": "comment-1"
+                }),
+                _ => json!({}),
+            };
+            Ok(output)
+        }
+    }
+
+    impl LocalExecutor for BadOutputWorkflowExecutor {
+        fn execute(
+            &self,
+            capability: &ResolvedCapability,
+            _input: &Value,
+        ) -> Result<Value, LocalExecutionFailure> {
+            let output = match capability.record.id.as_str() {
+                "content.comments.create-comment-draft" => json!({
+                    "emitted_events": [
+                        {"event_id": "content.comments.draft-created", "version": "1.0.0"}
+                    ]
+                }),
+                _ => json!({}),
+            };
+            Ok(output)
+        }
+    }
+
+    fn register_capability_ok(registry: &mut CapabilityRegistry, request: CapabilityRegistration) {
+        match registry.register(request) {
+            Ok(_) => {}
+            Err(error) => unreachable!("{error:?}"),
+        }
+    }
+
+    fn register_workflow_ok(
+        registry: &mut WorkflowRegistry,
+        capabilities: &CapabilityRegistry,
+        request: WorkflowRegistration,
+    ) {
+        match registry.register(capabilities, request) {
+            Ok(_) => {}
+            Err(error) => unreachable!("{error:?}"),
+        }
+    }
+
+    #[test]
+    fn helper_guards_cover_unreachable_branches() {
+        let capability_panic = std::panic::catch_unwind(|| {
+            register_capability_ok(
+                &mut CapabilityRegistry::new(),
+                CapabilityRegistration {
+                    scope: RegistryScope::Public,
+                    contract: capability_contract("bad", Vec::new(), json!({}), json!({})),
+                    contract_path: String::new(),
+                    artifact: workflow_artifact_record("bad", "1.0.0", "artifact"),
+                    registered_at: String::new(),
+                    tags: Vec::new(),
+                    composability: ComposabilityMetadata {
+                        kind: CompositionKind::Atomic,
+                        patterns: Vec::new(),
+                        provides: Vec::new(),
+                        requires: Vec::new(),
+                    },
+                    governing_spec: "005-capability-registry".to_string(),
+                    validator_version: "validator".to_string(),
+                },
+            );
+        });
+        assert!(capability_panic.is_err());
+
+        let workflow_panic = std::panic::catch_unwind(|| {
+            register_workflow_ok(
+                &mut WorkflowRegistry::new(),
+                &CapabilityRegistry::new(),
+                WorkflowRegistration {
+                    scope: RegistryScope::Public,
+                    definition: workflow_definition_fixture(
+                        None,
+                        Some(WorkflowEdge {
+                            edge_id: "direct".to_string(),
+                            from: "create_draft".to_string(),
+                            to: "validate_comment".to_string(),
+                            trigger: WorkflowEdgeTrigger::Direct,
+                            event: None,
+                        }),
+                    ),
+                    workflow_path: String::new(),
+                    registered_at: String::new(),
+                    validator_version: "validator".to_string(),
+                },
+            );
+        });
+        assert!(workflow_panic.is_err());
+    }
+
+    fn resolved_workflow(definition: WorkflowDefinition) -> ResolvedWorkflow {
+        ResolvedWorkflow {
+            record: WorkflowRegistryRecord {
+                scope: RegistryScope::Public,
+                id: definition.id.clone(),
+                version: definition.version.clone(),
+                lifecycle: definition.lifecycle.clone(),
+                owner: definition.owner.clone(),
+                workflow_path: "workflows/manual.json".to_string(),
+                workflow_digest: "digest".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                governing_spec: "007-workflow-registry-traversal".to_string(),
+                validator_version: "validator".to_string(),
+                evidence: cogolo_registry::WorkflowRegistrationEvidence {
+                    evidence_id: "evidence".to_string(),
+                    workflow_id: definition.id.clone(),
+                    workflow_version: definition.version.clone(),
+                    scope: RegistryScope::Public,
+                    governing_spec: "007-workflow-registry-traversal".to_string(),
+                    validator_version: "validator".to_string(),
+                    produced_at: "2026-03-27T00:00:00Z".to_string(),
+                    result: cogolo_registry::WorkflowRegistrationResult::Passed,
+                },
+            },
+            index_entry: cogolo_registry::WorkflowDiscoveryIndexEntry {
+                scope: RegistryScope::Public,
+                id: definition.id.clone(),
+                version: definition.version.clone(),
+                lifecycle: definition.lifecycle.clone(),
+                owner: definition.owner.clone(),
+                summary: definition.summary.clone(),
+                tags: definition.tags.clone(),
+                participating_capabilities: definition
+                    .nodes
+                    .iter()
+                    .map(|node| node.capability_id.clone())
+                    .collect(),
+                events_used: Vec::new(),
+                start_node: definition.start_node.clone(),
+                terminal_nodes: definition.terminal_nodes.clone(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+            },
+            definition,
+        }
+    }
+}

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -66,6 +66,17 @@
       "governs": [
         "crates/cogolo-runtime/"
       ]
+    },
+    {
+      "id": "007-workflow-registry-traversal",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/007-workflow-registry-traversal/spec.md",
+      "governs": [
+        "crates/cogolo-registry/",
+        "crates/cogolo-runtime/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- implement workflow definition registration, immutable workflow storage, and workflow discovery metadata in `cogolo-registry`
- implement deterministic workflow traversal and workflow-backed capability execution in `cogolo-runtime`
- approve and register `007-workflow-registry-traversal` in the spec governance registry while keeping the workflow core at the protected coverage bar

## Governing Spec
- `004-spec-alignment-gate`
- `005-capability-registry`
- `006-runtime-request-execution`
- `007-workflow-registry-traversal`

## Project Item
- Closes #25

## Validation
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/rust_checks.sh`
- `bash scripts/ci/coverage_gate.sh`