### PR TITLE
Issue #42: Author expedition event contract files

### DIFF
--- a/contracts/examples/expedition/events/conditions-summary-assessed/contract.json
+++ b/contracts/examples/expedition/events/conditions-summary-assessed/contract.json
@@ -1,0 +1,84 @@
+{
+  "kind": "event_contract",
+  "schema_version": "1.0.0",
+  "id": "expedition.planning.conditions-summary-assessed",
+  "namespace": "expedition.planning",
+  "name": "conditions-summary-assessed",
+  "version": "1.0.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "A deterministic expedition conditions summary has been assessed for the current planning context.",
+  "description": "Governed event contract for the conditions summary emitted after assess-conditions-summary evaluates route, weather, hazard, and environmental planning inputs deterministically.",
+  "payload": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "conditions_summary_id",
+        "objective_id",
+        "overall_rating",
+        "key_findings",
+        "blocking_concerns"
+      ],
+      "properties": {
+        "conditions_summary_id": {
+          "type": "string"
+        },
+        "objective_id": {
+          "type": "string"
+        },
+        "overall_rating": {
+          "type": "string"
+        },
+        "key_findings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blocking_concerns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "compatibility": "backward-compatible"
+  },
+  "classification": {
+    "domain": "expedition",
+    "bounded_context": "planning",
+    "event_type": "domain",
+    "tags": [
+      "conditions",
+      "expedition",
+      "planning"
+    ]
+  },
+  "publishers": [
+    {
+      "capability_id": "expedition.planning.assess-conditions-summary",
+      "version": "1.0.0"
+    }
+  ],
+  "subscribers": [],
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "tags": [
+    "conditions-summary-assessed",
+    "expedition",
+    "example-domain"
+  ],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-27T00:00:00Z"
+  },
+  "evidence": []
+}

--- a/contracts/examples/expedition/events/expedition-intent-interpreted/contract.json
+++ b/contracts/examples/expedition/events/expedition-intent-interpreted/contract.json
@@ -1,0 +1,91 @@
+{
+  "kind": "event_contract",
+  "schema_version": "1.0.0",
+  "id": "expedition.planning.expedition-intent-interpreted",
+  "namespace": "expedition.planning",
+  "name": "expedition-intent-interpreted",
+  "version": "1.0.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "An expedition intent has been interpreted into structured planning inputs for downstream steps.",
+  "description": "Governed event contract for the AI-assisted interpretation emitted after interpret-expedition-intent converts free-form planning intent into structured route preferences, constraints, and assumptions.",
+  "payload": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "intent_id",
+        "objective_id",
+        "route_preferences",
+        "constraints",
+        "assumptions",
+        "confidence"
+      ],
+      "properties": {
+        "intent_id": {
+          "type": "string"
+        },
+        "objective_id": {
+          "type": "string"
+        },
+        "route_preferences": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "assumptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "confidence": {
+          "type": "number"
+        }
+      }
+    },
+    "compatibility": "backward-compatible"
+  },
+  "classification": {
+    "domain": "expedition",
+    "bounded_context": "planning",
+    "event_type": "domain",
+    "tags": [
+      "expedition",
+      "intent",
+      "planning"
+    ]
+  },
+  "publishers": [
+    {
+      "capability_id": "expedition.planning.interpret-expedition-intent",
+      "version": "1.0.0"
+    }
+  ],
+  "subscribers": [],
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "tags": [
+    "expedition",
+    "intent-interpreted",
+    "example-domain"
+  ],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-27T00:00:00Z"
+  },
+  "evidence": []
+}

--- a/contracts/examples/expedition/events/expedition-objective-captured/contract.json
+++ b/contracts/examples/expedition/events/expedition-objective-captured/contract.json
@@ -1,0 +1,108 @@
+{
+  "kind": "event_contract",
+  "schema_version": "1.0.0",
+  "id": "expedition.planning.expedition-objective-captured",
+  "namespace": "expedition.planning",
+  "name": "expedition-objective-captured",
+  "version": "1.0.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "A normalized expedition objective has been captured and is ready for downstream planning.",
+  "description": "Governed event contract for the structured expedition objective emitted after capture-expedition-objective normalizes destination, timing, and planning preferences.",
+  "payload": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "objective_id",
+        "destination",
+        "target_window",
+        "preferences",
+        "notes"
+      ],
+      "properties": {
+        "objective_id": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "target_window": {
+          "type": "object",
+          "required": [
+            "start",
+            "end"
+          ],
+          "properties": {
+            "start": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "end": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "preferences": {
+          "type": "object",
+          "required": [
+            "style",
+            "risk_tolerance",
+            "priority"
+          ],
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "risk_tolerance": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string"
+            }
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "compatibility": "backward-compatible"
+  },
+  "classification": {
+    "domain": "expedition",
+    "bounded_context": "planning",
+    "event_type": "domain",
+    "tags": [
+      "expedition",
+      "objective",
+      "planning"
+    ]
+  },
+  "publishers": [
+    {
+      "capability_id": "expedition.planning.capture-expedition-objective",
+      "version": "1.0.0"
+    }
+  ],
+  "subscribers": [],
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "tags": [
+    "expedition",
+    "objective-captured",
+    "example-domain"
+  ],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-27T00:00:00Z"
+  },
+  "evidence": []
+}

--- a/contracts/examples/expedition/events/expedition-plan-assembled/contract.json
+++ b/contracts/examples/expedition/events/expedition-plan-assembled/contract.json
@@ -1,0 +1,99 @@
+{
+  "kind": "event_contract",
+  "schema_version": "1.0.0",
+  "id": "expedition.planning.expedition-plan-assembled",
+  "namespace": "expedition.planning",
+  "name": "expedition-plan-assembled",
+  "version": "1.0.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "A final expedition plan has been assembled and is ready for downstream consumption.",
+  "description": "Governed event contract for the final expedition plan emitted after assemble-expedition-plan combines objective, interpreted intent, conditions, and readiness into one composed planning artifact.",
+  "payload": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "plan_id",
+        "objective_id",
+        "status",
+        "recommended_route_style",
+        "key_steps",
+        "constraints",
+        "readiness_notes",
+        "summary"
+      ],
+      "properties": {
+        "plan_id": {
+          "type": "string"
+        },
+        "objective_id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "recommended_route_style": {
+          "type": "string"
+        },
+        "key_steps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "readiness_notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        }
+      }
+    },
+    "compatibility": "backward-compatible"
+  },
+  "classification": {
+    "domain": "expedition",
+    "bounded_context": "planning",
+    "event_type": "domain",
+    "tags": [
+      "expedition",
+      "plan",
+      "planning"
+    ]
+  },
+  "publishers": [
+    {
+      "capability_id": "expedition.planning.assemble-expedition-plan",
+      "version": "1.0.0"
+    }
+  ],
+  "subscribers": [],
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "tags": [
+    "example-domain",
+    "expedition",
+    "expedition-plan-assembled"
+  ],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-27T00:00:00Z"
+  },
+  "evidence": []
+}

--- a/contracts/examples/expedition/events/team-readiness-validated/contract.json
+++ b/contracts/examples/expedition/events/team-readiness-validated/contract.json
@@ -1,0 +1,84 @@
+{
+  "kind": "event_contract",
+  "schema_version": "1.0.0",
+  "id": "expedition.planning.team-readiness-validated",
+  "namespace": "expedition.planning",
+  "name": "team-readiness-validated",
+  "version": "1.0.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "A team readiness result has been validated for the expedition objective and conditions context.",
+  "description": "Governed event contract for the readiness validation emitted after validate-team-readiness determines expedition team status, reasons, and required follow-up actions deterministically.",
+  "payload": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "readiness_result_id",
+        "objective_id",
+        "status",
+        "reasons",
+        "required_actions"
+      ],
+      "properties": {
+        "readiness_result_id": {
+          "type": "string"
+        },
+        "objective_id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "required_actions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "compatibility": "backward-compatible"
+  },
+  "classification": {
+    "domain": "expedition",
+    "bounded_context": "planning",
+    "event_type": "domain",
+    "tags": [
+      "expedition",
+      "planning",
+      "readiness"
+    ]
+  },
+  "publishers": [
+    {
+      "capability_id": "expedition.planning.validate-team-readiness",
+      "version": "1.0.0"
+    }
+  ],
+  "subscribers": [],
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "tags": [
+    "example-domain",
+    "expedition",
+    "team-readiness-validated"
+  ],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-27T00:00:00Z"
+  },
+  "evidence": []
+}


### PR DESCRIPTION
## Summary
- add the five governed expedition example event contract artifacts under contracts/examples/expedition/events/
- align each event id, namespace, version, and publisher mapping with the approved expedition example specs
- keep the change scoped to issue #42 with no extra expedition event contracts

Closes #42

## Governing Spec
- 008-expedition-example-domain

## Project Item
- Traverse Project 1 item linked to issue #42

## Validation
- rg -n '"id"': '"expedition\\.planning\\.' contracts/examples/expedition/events
- find contracts/examples/expedition/events -name contract.json | wc -l -> 5
- bash scripts/ci/repository_checks.sh