### PR TITLE
Author expedition atomic capability contract files

### DIFF
--- a/contracts/examples/expedition/capabilities/assemble-expedition-plan/contract.json
+++ b/contracts/examples/expedition/capabilities/assemble-expedition-plan/contract.json
@@ -1,0 +1,301 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "expedition.planning.assemble-expedition-plan",
+  "namespace": "expedition.planning",
+  "name": "assemble-expedition-plan",
+  "version": "1.0.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Assemble the normalized expedition planning outputs into one final plan artifact.",
+  "description": "Portable deterministic capability for combining the normalized expedition objective, interpreted intent, conditions summary, and readiness result into one governed expedition plan artifact suitable for downstream consumption.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "objective",
+        "interpreted_intent",
+        "conditions_summary",
+        "readiness_result"
+      ],
+      "properties": {
+        "objective": {
+          "type": "object",
+          "required": [
+            "objective_id",
+            "destination",
+            "target_window",
+            "preferences",
+            "notes"
+          ],
+          "properties": {
+            "objective_id": {
+              "type": "string"
+            },
+            "destination": {
+              "type": "string"
+            },
+            "target_window": {
+              "type": "object",
+              "required": [
+                "start",
+                "end"
+              ],
+              "properties": {
+                "start": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "end": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "preferences": {
+              "type": "object",
+              "required": [
+                "style",
+                "risk_tolerance",
+                "priority"
+              ],
+              "properties": {
+                "style": {
+                  "type": "string"
+                },
+                "risk_tolerance": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "string"
+                }
+              }
+            },
+            "notes": {
+              "type": "string"
+            }
+          }
+        },
+        "interpreted_intent": {
+          "type": "object",
+          "required": [
+            "intent_id",
+            "objective_id",
+            "route_preferences",
+            "constraints",
+            "assumptions",
+            "confidence"
+          ],
+          "properties": {
+            "intent_id": {
+              "type": "string"
+            },
+            "objective_id": {
+              "type": "string"
+            },
+            "route_preferences": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "constraints": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "confidence": {
+              "type": "number"
+            }
+          }
+        },
+        "conditions_summary": {
+          "type": "object",
+          "required": [
+            "conditions_summary_id",
+            "objective_id",
+            "overall_rating",
+            "key_findings",
+            "blocking_concerns"
+          ],
+          "properties": {
+            "conditions_summary_id": {
+              "type": "string"
+            },
+            "objective_id": {
+              "type": "string"
+            },
+            "overall_rating": {
+              "type": "string"
+            },
+            "key_findings": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "blocking_concerns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "readiness_result": {
+          "type": "object",
+          "required": [
+            "readiness_result_id",
+            "objective_id",
+            "status",
+            "reasons",
+            "required_actions"
+          ],
+          "properties": {
+            "readiness_result_id": {
+              "type": "string"
+            },
+            "objective_id": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "reasons": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "required_actions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "plan_id",
+        "objective_id",
+        "status",
+        "recommended_route_style",
+        "key_steps",
+        "constraints",
+        "readiness_notes",
+        "summary"
+      ],
+      "properties": {
+        "plan_id": {
+          "type": "string"
+        },
+        "objective_id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "recommended_route_style": {
+          "type": "string"
+        },
+        "key_steps": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "readiness_notes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "preconditions": [
+    {
+      "id": "all-upstream-planning-artifacts-available",
+      "description": "The normalized objective, interpreted intent, conditions summary, and readiness result are all available and refer to the same expedition objective."
+    }
+  ],
+  "postconditions": [
+    {
+      "id": "plan-assembled",
+      "description": "One final expedition plan artifact is returned for downstream consumption."
+    }
+  ],
+  "side_effects": [
+    {
+      "kind": "event_emission",
+      "description": "Emits the expedition-plan-assembled domain event after the final plan is assembled."
+    }
+  ],
+  "emits": [
+    {
+      "event_id": "expedition.planning.expedition-plan-assembled",
+      "version": "1.0.0"
+    }
+  ],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "dependencies": [
+    {
+      "artifact_type": "event",
+      "id": "expedition.planning.expedition-plan-assembled",
+      "version": "1.0.0"
+    }
+  ],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-27T00:00:00Z",
+    "spec_ref": "009-expedition-example-artifacts"
+  },
+  "evidence": []
+}

--- a/contracts/examples/expedition/capabilities/assess-conditions-summary/contract.json
+++ b/contracts/examples/expedition/capabilities/assess-conditions-summary/contract.json
@@ -1,0 +1,218 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "expedition.planning.assess-conditions-summary",
+  "namespace": "expedition.planning",
+  "name": "assess-conditions-summary",
+  "version": "1.0.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Assess expedition conditions and produce a deterministic planning summary.",
+  "description": "Portable deterministic capability for combining the normalized expedition objective with interpreted planning intent context to produce a governed conditions summary covering overall rating, key findings, and blocking concerns.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "objective",
+        "interpreted_intent"
+      ],
+      "properties": {
+        "objective": {
+          "type": "object",
+          "required": [
+            "objective_id",
+            "destination",
+            "target_window",
+            "preferences",
+            "notes"
+          ],
+          "properties": {
+            "objective_id": {
+              "type": "string"
+            },
+            "destination": {
+              "type": "string"
+            },
+            "target_window": {
+              "type": "object",
+              "required": [
+                "start",
+                "end"
+              ],
+              "properties": {
+                "start": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "end": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "preferences": {
+              "type": "object",
+              "required": [
+                "style",
+                "risk_tolerance",
+                "priority"
+              ],
+              "properties": {
+                "style": {
+                  "type": "string"
+                },
+                "risk_tolerance": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "string"
+                }
+              }
+            },
+            "notes": {
+              "type": "string"
+            }
+          }
+        },
+        "interpreted_intent": {
+          "type": "object",
+          "required": [
+            "intent_id",
+            "objective_id",
+            "route_preferences",
+            "constraints",
+            "assumptions",
+            "confidence"
+          ],
+          "properties": {
+            "intent_id": {
+              "type": "string"
+            },
+            "objective_id": {
+              "type": "string"
+            },
+            "route_preferences": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "constraints": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "assumptions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "confidence": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "conditions_summary_id",
+        "objective_id",
+        "overall_rating",
+        "key_findings",
+        "blocking_concerns"
+      ],
+      "properties": {
+        "conditions_summary_id": {
+          "type": "string"
+        },
+        "objective_id": {
+          "type": "string"
+        },
+        "overall_rating": {
+          "type": "string"
+        },
+        "key_findings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "blocking_concerns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "preconditions": [
+    {
+      "id": "objective-and-intent-aligned",
+      "description": "The normalized expedition objective and interpreted intent refer to the same planning objective."
+    }
+  ],
+  "postconditions": [
+    {
+      "id": "conditions-summary-produced",
+      "description": "A deterministic conditions summary is returned for downstream readiness validation."
+    }
+  ],
+  "side_effects": [
+    {
+      "kind": "event_emission",
+      "description": "Emits the conditions-summary-assessed domain event after the summary is produced."
+    }
+  ],
+  "emits": [
+    {
+      "event_id": "expedition.planning.conditions-summary-assessed",
+      "version": "1.0.0"
+    }
+  ],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "dependencies": [
+    {
+      "artifact_type": "event",
+      "id": "expedition.planning.conditions-summary-assessed",
+      "version": "1.0.0"
+    }
+  ],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-27T00:00:00Z",
+    "spec_ref": "009-expedition-example-artifacts"
+  },
+  "evidence": []
+}

--- a/contracts/examples/expedition/capabilities/capture-expedition-objective/contract.json
+++ b/contracts/examples/expedition/capabilities/capture-expedition-objective/contract.json
@@ -1,0 +1,189 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "expedition.planning.capture-expedition-objective",
+  "namespace": "expedition.planning",
+  "name": "capture-expedition-objective",
+  "version": "1.0.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Capture a structured expedition goal and normalize it into one governed objective record.",
+  "description": "Portable capability for accepting structured expedition goal input, normalizing destination, timing, and planning preferences, and producing the canonical expedition objective boundary without interpreting intent or validating readiness.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "destination",
+        "target_window",
+        "preferences",
+        "notes"
+      ],
+      "properties": {
+        "destination": {
+          "type": "string"
+        },
+        "target_window": {
+          "type": "object",
+          "required": [
+            "start",
+            "end"
+          ],
+          "properties": {
+            "start": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "end": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "preferences": {
+          "type": "object",
+          "required": [
+            "style",
+            "risk_tolerance",
+            "priority"
+          ],
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "risk_tolerance": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string"
+            }
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "objective_id",
+        "destination",
+        "target_window",
+        "preferences",
+        "notes"
+      ],
+      "properties": {
+        "objective_id": {
+          "type": "string"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "target_window": {
+          "type": "object",
+          "required": [
+            "start",
+            "end"
+          ],
+          "properties": {
+            "start": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "end": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        },
+        "preferences": {
+          "type": "object",
+          "required": [
+            "style",
+            "risk_tolerance",
+            "priority"
+          ],
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "risk_tolerance": {
+              "type": "string"
+            },
+            "priority": {
+              "type": "string"
+            }
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "preconditions": [
+    {
+      "id": "objective-input-provided",
+      "description": "The caller provides structured expedition goal input with destination, target window, preferences, and notes."
+    }
+  ],
+  "postconditions": [
+    {
+      "id": "objective-normalized",
+      "description": "A normalized expedition objective record is returned for downstream planning steps."
+    }
+  ],
+  "side_effects": [
+    {
+      "kind": "event_emission",
+      "description": "Emits the expedition-objective-captured domain event after normalization succeeds."
+    }
+  ],
+  "emits": [
+    {
+      "event_id": "expedition.planning.expedition-objective-captured",
+      "version": "1.0.0"
+    }
+  ],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "dependencies": [
+    {
+      "artifact_type": "event",
+      "id": "expedition.planning.expedition-objective-captured",
+      "version": "1.0.0"
+    }
+  ],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-27T00:00:00Z",
+    "spec_ref": "009-expedition-example-artifacts"
+  },
+  "evidence": []
+}

--- a/contracts/examples/expedition/capabilities/interpret-expedition-intent/contract.json
+++ b/contracts/examples/expedition/capabilities/interpret-expedition-intent/contract.json
@@ -1,0 +1,192 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "expedition.planning.interpret-expedition-intent",
+  "namespace": "expedition.planning",
+  "name": "interpret-expedition-intent",
+  "version": "1.0.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Interpret free-form planning intent into a structured expedition intent record.",
+  "description": "Portable AI-assisted capability for converting a normalized expedition objective plus free-form planning intent into structured route preferences, constraints, assumptions, and confidence while remaining bounded away from deterministic readiness or final plan assembly decisions.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "objective",
+        "free_form_intent"
+      ],
+      "properties": {
+        "objective": {
+          "type": "object",
+          "required": [
+            "objective_id",
+            "destination",
+            "target_window",
+            "preferences",
+            "notes"
+          ],
+          "properties": {
+            "objective_id": {
+              "type": "string"
+            },
+            "destination": {
+              "type": "string"
+            },
+            "target_window": {
+              "type": "object",
+              "required": [
+                "start",
+                "end"
+              ],
+              "properties": {
+                "start": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "end": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "preferences": {
+              "type": "object",
+              "required": [
+                "style",
+                "risk_tolerance",
+                "priority"
+              ],
+              "properties": {
+                "style": {
+                  "type": "string"
+                },
+                "risk_tolerance": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "string"
+                }
+              }
+            },
+            "notes": {
+              "type": "string"
+            }
+          }
+        },
+        "free_form_intent": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "intent_id",
+        "objective_id",
+        "route_preferences",
+        "constraints",
+        "assumptions",
+        "confidence"
+      ],
+      "properties": {
+        "intent_id": {
+          "type": "string"
+        },
+        "objective_id": {
+          "type": "string"
+        },
+        "route_preferences": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "assumptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "confidence": {
+          "type": "number"
+        }
+      }
+    }
+  },
+  "preconditions": [
+    {
+      "id": "objective-available",
+      "description": "A normalized expedition objective record is available to ground interpretation."
+    },
+    {
+      "id": "free-form-intent-provided",
+      "description": "The caller provides free-form expedition planning intent that needs structured interpretation."
+    }
+  ],
+  "postconditions": [
+    {
+      "id": "intent-structured",
+      "description": "A structured interpreted intent record is returned for deterministic downstream planning steps."
+    }
+  ],
+  "side_effects": [
+    {
+      "kind": "event_emission",
+      "description": "Emits the expedition-intent-interpreted domain event after structured interpretation is produced."
+    }
+  ],
+  "emits": [
+    {
+      "event_id": "expedition.planning.expedition-intent-interpreted",
+      "version": "1.0.0"
+    }
+  ],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "dependencies": [
+    {
+      "artifact_type": "event",
+      "id": "expedition.planning.expedition-intent-interpreted",
+      "version": "1.0.0"
+    }
+  ],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-27T00:00:00Z",
+    "spec_ref": "009-expedition-example-artifacts"
+  },
+  "evidence": []
+}

--- a/contracts/examples/expedition/capabilities/validate-team-readiness/contract.json
+++ b/contracts/examples/expedition/capabilities/validate-team-readiness/contract.json
@@ -1,0 +1,231 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "expedition.planning.validate-team-readiness",
+  "namespace": "expedition.planning",
+  "name": "validate-team-readiness",
+  "version": "1.0.0",
+  "lifecycle": "draft",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Validate expedition team readiness against the objective and conditions context.",
+  "description": "Portable deterministic capability for evaluating expedition team profile context together with the normalized objective and conditions summary to produce a governed readiness result with status, reasons, and required actions.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "objective",
+        "conditions_summary",
+        "team_profile"
+      ],
+      "properties": {
+        "objective": {
+          "type": "object",
+          "required": [
+            "objective_id",
+            "destination",
+            "target_window",
+            "preferences",
+            "notes"
+          ],
+          "properties": {
+            "objective_id": {
+              "type": "string"
+            },
+            "destination": {
+              "type": "string"
+            },
+            "target_window": {
+              "type": "object",
+              "required": [
+                "start",
+                "end"
+              ],
+              "properties": {
+                "start": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "end": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "preferences": {
+              "type": "object",
+              "required": [
+                "style",
+                "risk_tolerance",
+                "priority"
+              ],
+              "properties": {
+                "style": {
+                  "type": "string"
+                },
+                "risk_tolerance": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "string"
+                }
+              }
+            },
+            "notes": {
+              "type": "string"
+            }
+          }
+        },
+        "conditions_summary": {
+          "type": "object",
+          "required": [
+            "conditions_summary_id",
+            "objective_id",
+            "overall_rating",
+            "key_findings",
+            "blocking_concerns"
+          ],
+          "properties": {
+            "conditions_summary_id": {
+              "type": "string"
+            },
+            "objective_id": {
+              "type": "string"
+            },
+            "overall_rating": {
+              "type": "string"
+            },
+            "key_findings": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "blocking_concerns": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "team_profile": {
+          "type": "object",
+          "required": [
+            "team_size",
+            "experience_summary",
+            "equipment_status"
+          ],
+          "properties": {
+            "team_size": {
+              "type": "integer"
+            },
+            "experience_summary": {
+              "type": "string"
+            },
+            "equipment_status": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "readiness_result_id",
+        "objective_id",
+        "status",
+        "reasons",
+        "required_actions"
+      ],
+      "properties": {
+        "readiness_result_id": {
+          "type": "string"
+        },
+        "objective_id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "required_actions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "preconditions": [
+    {
+      "id": "objective-conditions-and-team-profile-available",
+      "description": "The normalized expedition objective, deterministic conditions summary, and team profile context are all available."
+    }
+  ],
+  "postconditions": [
+    {
+      "id": "readiness-result-produced",
+      "description": "A deterministic readiness result is returned with status, reasons, and required actions."
+    }
+  ],
+  "side_effects": [
+    {
+      "kind": "event_emission",
+      "description": "Emits the team-readiness-validated domain event after readiness validation completes."
+    }
+  ],
+  "emits": [
+    {
+      "event_id": "expedition.planning.team-readiness-validated",
+      "version": "1.0.0"
+    }
+  ],
+  "consumes": [],
+  "permissions": [],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "dependencies": [
+    {
+      "artifact_type": "event",
+      "id": "expedition.planning.team-readiness-validated",
+      "version": "1.0.0"
+    }
+  ],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-03-27T00:00:00Z",
+    "spec_ref": "009-expedition-example-artifacts"
+  },
+  "evidence": []
+}


### PR DESCRIPTION
## Governing Spec
- 008-expedition-example-domain

## Project Item
- #44

## Summary
- add the five governed expedition capability contract artifacts under contracts/examples/expedition/capabilities/
- keep all artifacts in namespace expedition.planning at version 1.0.0
- align each contract boundary with the approved expedition example domain spec and the issue-defined artifact scope

## Validation
- rg -n '"id": "expedition\.planning\.' contracts/examples/expedition/capabilities
- find contracts/examples/expedition/capabilities -name contract.json | wc -l
- bash scripts/ci/repository_checks.sh
- cargo test -p traverse-contracts

Closes #44