### PR TITLE
Add CLI inspect commands for expedition artifacts

### DIFF
--- a/crates/traverse-cli/Cargo.toml
+++ b/crates/traverse-cli/Cargo.toml
@@ -7,11 +7,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-traverse-registry = { path = "../traverse-registry" }
-
-[dev-dependencies]
 serde_json = "1.0.145"
 traverse-contracts = { path = "../traverse-contracts" }
+traverse-registry = { path = "../traverse-registry" }
 
 [lints]
 workspace = true

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -1,11 +1,17 @@
 use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use traverse_registry::{RegistryBundle, load_registry_bundle};
+use traverse_contracts::{
+    EventContract, EventValidationContext, parse_event_contract, validate_event_contract,
+};
+use traverse_registry::{RegistryBundle, WorkflowDefinition, load_registry_bundle};
 
 #[derive(Debug)]
 enum Command {
-    BundleInspect { manifest_path: PathBuf },
+    Bundle { manifest_path: PathBuf },
+    Event { contract_path: PathBuf },
+    Workflow { workflow_path: PathBuf },
 }
 
 fn main() -> ExitCode {
@@ -23,26 +29,88 @@ fn main() -> ExitCode {
 }
 
 fn run(args: &[String]) -> Result<String, String> {
-    let command = parse_command(args)?;
-    match command {
-        Command::BundleInspect { manifest_path } => inspect_bundle(&manifest_path),
+    match parse_command(args)? {
+        Command::Bundle { manifest_path } => inspect_bundle(&manifest_path),
+        Command::Event { contract_path } => inspect_event(&contract_path),
+        Command::Workflow { workflow_path } => inspect_workflow(&workflow_path),
     }
 }
 
 fn parse_command(args: &[String]) -> Result<Command, String> {
-    if args.len() != 4 || args[1] != "bundle" || args[2] != "inspect" {
-        return Err("usage: traverse-cli bundle inspect <bundle-manifest-path>".to_string());
+    if args.len() != 4 {
+        return Err(usage());
     }
 
-    Ok(Command::BundleInspect {
-        manifest_path: PathBuf::from(&args[3]),
-    })
+    match (args[1].as_str(), args[2].as_str()) {
+        ("bundle", "inspect") => Ok(Command::Bundle {
+            manifest_path: PathBuf::from(&args[3]),
+        }),
+        ("event", "inspect") => Ok(Command::Event {
+            contract_path: PathBuf::from(&args[3]),
+        }),
+        ("workflow", "inspect") => Ok(Command::Workflow {
+            workflow_path: PathBuf::from(&args[3]),
+        }),
+        _ => Err(usage()),
+    }
 }
 
 fn inspect_bundle(manifest_path: &Path) -> Result<String, String> {
     let bundle =
         load_registry_bundle(manifest_path).map_err(|failure| failure.errors[0].message.clone())?;
     Ok(render_bundle_summary(&bundle))
+}
+
+fn inspect_event(contract_path: &Path) -> Result<String, String> {
+    let contents = read_text_file(contract_path, "event contract")?;
+    let parsed = parse_event_contract(&contents)
+        .map_err(|failure| render_validation_failure("event contract", contract_path, failure))?;
+    let validated = validate_event_contract(
+        parsed,
+        &EventValidationContext {
+            governing_spec: "003-event-contracts",
+            validator_version: env!("CARGO_PKG_VERSION"),
+            existing_published: None,
+        },
+    )
+    .map_err(|failure| render_validation_failure("event contract", contract_path, failure))?;
+
+    Ok(render_event_summary(contract_path, &validated.normalized))
+}
+
+fn inspect_workflow(workflow_path: &Path) -> Result<String, String> {
+    let contents = read_text_file(workflow_path, "workflow artifact")?;
+    let definition = serde_json::from_str::<WorkflowDefinition>(&contents).map_err(|error| {
+        format!(
+            "failed to parse workflow artifact {}: {error}",
+            workflow_path.display()
+        )
+    })?;
+
+    Ok(render_workflow_summary(workflow_path, &definition))
+}
+
+fn read_text_file(path: &Path, artifact_kind: &str) -> Result<String, String> {
+    fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {artifact_kind} {}: {error}", path.display()))
+}
+
+fn render_validation_failure(
+    artifact_kind: &str,
+    path: &Path,
+    failure: traverse_contracts::ValidationFailure,
+) -> String {
+    let details = failure
+        .errors
+        .into_iter()
+        .map(|error| format!("{} at {}", error.message, error.path))
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    format!(
+        "failed to validate {artifact_kind} {}: {details}",
+        path.display()
+    )
 }
 
 fn render_bundle_summary(bundle: &RegistryBundle) -> String {
@@ -82,37 +150,112 @@ fn render_bundle_summary(bundle: &RegistryBundle) -> String {
     lines.join("\n")
 }
 
+fn render_event_summary(path: &Path, contract: &EventContract) -> String {
+    let mut lines = vec![
+        format!("path: {}", path.display()),
+        format!("id: {}", contract.id),
+        format!("version: {}", contract.version),
+        format!("lifecycle: {:?}", contract.lifecycle).to_lowercase(),
+        format!("event_type: {:?}", contract.classification.event_type).to_lowercase(),
+        format!("domain: {}", contract.classification.domain),
+        format!(
+            "bounded_context: {}",
+            contract.classification.bounded_context
+        ),
+        format!("publishers: {}", contract.publishers.len()),
+        format!("subscribers: {}", contract.subscribers.len()),
+        format!("tags: {}", contract.tags.join(",")),
+        "publisher_ids:".to_string(),
+    ];
+
+    for publisher in &contract.publishers {
+        lines.push(format!(
+            "  - {}@{}",
+            publisher.capability_id, publisher.version
+        ));
+    }
+
+    lines.push("subscriber_ids:".to_string());
+    for subscriber in &contract.subscribers {
+        lines.push(format!(
+            "  - {}@{}",
+            subscriber.capability_id, subscriber.version
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn render_workflow_summary(path: &Path, definition: &WorkflowDefinition) -> String {
+    let mut lines = vec![
+        format!("path: {}", path.display()),
+        format!("id: {}", definition.id),
+        format!("version: {}", definition.version),
+        format!("lifecycle: {:?}", definition.lifecycle).to_lowercase(),
+        format!("start_node: {}", definition.start_node),
+        format!("terminal_nodes: {}", definition.terminal_nodes.join(",")),
+        format!("node_count: {}", definition.nodes.len()),
+        format!("edge_count: {}", definition.edges.len()),
+        format!("governing_spec: {}", definition.governing_spec),
+        "node_capabilities:".to_string(),
+    ];
+
+    for node in &definition.nodes {
+        lines.push(format!(
+            "  - {} -> {}@{}",
+            node.node_id, node.capability_id, node.capability_version
+        ));
+    }
+
+    lines.push("edges:".to_string());
+    for edge in &definition.edges {
+        lines.push(format!(
+            "  - {}: {} -> {}",
+            edge.edge_id, edge.from, edge.to
+        ));
+    }
+
+    lines.join("\n")
+}
+
+fn usage() -> String {
+    "usage: traverse-cli <bundle|event|workflow> inspect <artifact-path>".to_string()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{RegistryBundle, inspect_bundle, parse_command, render_bundle_summary};
-    use serde_json::json;
+    #![allow(clippy::expect_used)]
+
+    use super::{inspect_bundle, inspect_event, inspect_workflow, parse_command};
     use std::fs;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
-    use traverse_contracts::{
-        CapabilityContract, Condition, DependencyReference, Entrypoint, EntrypointKind,
-        EventContract, EventPayload, EventProvenance, EventProvenanceSource, EventReference,
-        EventType, Execution, ExecutionConstraints, ExecutionTarget, FilesystemAccess,
-        HostApiAccess, IdReference, Lifecycle, NetworkAccess, Owner, PayloadCompatibility,
-        Provenance, ProvenanceSource, SchemaContainer, SideEffect, SideEffectKind,
-    };
-    use traverse_registry::{
-        BundleArtifactManifest, CapabilityBundleArtifact, EventBundleArtifact, RegistryScope,
-        WorkflowBundleArtifact, WorkflowDefinition, WorkflowNode, WorkflowNodeInput,
-        WorkflowNodeOutput,
-    };
 
     #[test]
-    fn parse_command_accepts_bundle_inspect() {
-        let args = vec![
+    fn parse_command_accepts_supported_inspect_commands() {
+        let bundle = vec![
             "traverse-cli".to_string(),
             "bundle".to_string(),
             "inspect".to_string(),
             "examples/expedition/registry-bundle/manifest.json".to_string(),
         ];
+        let event = vec![
+            "traverse-cli".to_string(),
+            "event".to_string(),
+            "inspect".to_string(),
+            "contracts/examples/expedition/events/expedition-objective-captured/contract.json"
+                .to_string(),
+        ];
+        let workflow = vec![
+            "traverse-cli".to_string(),
+            "workflow".to_string(),
+            "inspect".to_string(),
+            "workflows/examples/expedition/plan-expedition/workflow.json".to_string(),
+        ];
 
-        let command = parse_command(&args);
-        assert!(command.is_ok());
+        assert!(parse_command(&bundle).is_ok());
+        assert!(parse_command(&event).is_ok());
+        assert!(parse_command(&workflow).is_ok());
     }
 
     #[test]
@@ -121,67 +264,27 @@ mod tests {
         let result = parse_command(&args);
         assert!(result.is_err());
         let error = result.err().unwrap_or_default();
-        assert!(error.contains("usage: traverse-cli bundle inspect"));
+        assert!(error.contains("usage: traverse-cli"));
     }
 
     #[test]
-    fn render_bundle_summary_lists_governed_ids() {
-        let bundle = RegistryBundle {
-            bundle_id: "expedition.planning.seed-bundle".to_string(),
-            version: "1.0.0".to_string(),
-            scope: RegistryScope::Public,
-            capabilities: vec![CapabilityBundleArtifact {
-                manifest: BundleArtifactManifest {
-                    id: "expedition.planning.capture-expedition-objective".to_string(),
-                    version: "1.0.0".to_string(),
-                    path: "contracts/examples/expedition/capabilities/capture-expedition-objective/contract.json"
-                        .to_string(),
-                },
-                path: PathBuf::from(
-                    "contracts/examples/expedition/capabilities/capture-expedition-objective/contract.json",
-                ),
-                contract: example_capability_contract(),
-            }],
-            events: vec![EventBundleArtifact {
-                manifest: BundleArtifactManifest {
-                    id: "expedition.planning.expedition-objective-captured".to_string(),
-                    version: "1.0.0".to_string(),
-                    path: "contracts/examples/expedition/events/expedition-objective-captured/contract.json"
-                        .to_string(),
-                },
-                path: PathBuf::from(
-                    "contracts/examples/expedition/events/expedition-objective-captured/contract.json",
-                ),
-                contract: example_event_contract(),
-            }],
-            workflows: vec![WorkflowBundleArtifact {
-                manifest: BundleArtifactManifest {
-                    id: "expedition.planning.plan-expedition".to_string(),
-                    version: "1.0.0".to_string(),
-                    path: "workflows/examples/expedition/plan-expedition/workflow.json"
-                        .to_string(),
-                },
-                path: PathBuf::from("workflows/examples/expedition/plan-expedition/workflow.json"),
-                definition: example_workflow_definition(),
-            }],
-        };
+    fn inspect_bundle_renders_canonical_example_bundle() {
+        let manifest_path = repo_root().join("examples/expedition/registry-bundle/manifest.json");
 
-        let rendered = render_bundle_summary(&bundle);
-        assert!(rendered.contains("bundle_id: expedition.planning.seed-bundle"));
-        assert!(rendered.contains("expedition.planning.capture-expedition-objective@1.0.0"));
-        assert!(rendered.contains("expedition.planning.plan-expedition@1.0.0"));
+        let output = inspect_bundle(&manifest_path).expect("bundle inspect should succeed");
+
+        assert!(output.contains("bundle_id: expedition.planning.seed-bundle"));
+        assert!(output.contains("event_ids:"));
+        assert!(output.contains("workflow_ids:"));
     }
 
     #[test]
     fn inspect_bundle_rejects_missing_artifact_paths() {
         let temp_dir = unique_temp_dir();
-        assert!(fs::create_dir_all(&temp_dir).is_ok());
-
         let manifest_path = temp_dir.join("manifest.json");
-        assert!(
-            fs::write(
-                &manifest_path,
-                r#"{
+        fs::write(
+            &manifest_path,
+            r#"{
   "bundle_id": "expedition.planning.seed-bundle",
   "version": "1.0.0",
   "scope": "public",
@@ -195,14 +298,61 @@ mod tests {
   "events": [],
   "workflows": []
 }"#,
-            )
-            .is_ok()
+        )
+        .expect("manifest should write");
+
+        let error = inspect_bundle(&manifest_path).expect_err("missing artifact path should fail");
+        assert!(error.contains("missing artifact file"));
+    }
+
+    #[test]
+    fn inspect_event_renders_canonical_event_contract() {
+        let path = repo_root().join(
+            "contracts/examples/expedition/events/expedition-objective-captured/contract.json",
         );
 
-        let result = inspect_bundle(&manifest_path);
-        assert!(result.is_err());
-        let error = result.err().unwrap_or_default();
-        assert!(error.contains("missing artifact file"));
+        let output = inspect_event(&path).expect("event inspect should succeed");
+
+        assert!(output.contains("id: expedition.planning.expedition-objective-captured"));
+        assert!(output.contains("event_type: domain"));
+        assert!(output.contains("publisher_ids:"));
+    }
+
+    #[test]
+    fn inspect_event_rejects_malformed_contract() {
+        let temp_dir = unique_temp_dir();
+        let path = temp_dir.join("event.json");
+        fs::write(&path, "{\"kind\":\"event_contract\"}").expect("event file should write");
+
+        let error = inspect_event(&path).expect_err("malformed event contract should fail");
+
+        assert!(error.contains("failed to validate event contract"));
+    }
+
+    #[test]
+    fn inspect_workflow_renders_canonical_workflow() {
+        let path = repo_root().join("workflows/examples/expedition/plan-expedition/workflow.json");
+
+        let output = inspect_workflow(&path).expect("workflow inspect should succeed");
+
+        assert!(output.contains("id: expedition.planning.plan-expedition"));
+        assert!(output.contains("start_node: capture_objective"));
+        assert!(output.contains("node_capabilities:"));
+    }
+
+    #[test]
+    fn inspect_workflow_rejects_malformed_definition() {
+        let temp_dir = unique_temp_dir();
+        let path = temp_dir.join("workflow.json");
+        fs::write(&path, "{\"id\":true}").expect("workflow file should write");
+
+        let error = inspect_workflow(&path).expect_err("malformed workflow should fail");
+
+        assert!(error.contains("failed to parse workflow artifact"));
+    }
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
     }
 
     fn unique_temp_dir() -> PathBuf {
@@ -210,161 +360,8 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos();
-        std::env::temp_dir().join(format!("traverse-cli-test-{nanos}"))
-    }
-
-    fn example_capability_contract() -> CapabilityContract {
-        CapabilityContract {
-            kind: "capability_contract".to_string(),
-            schema_version: "1.0.0".to_string(),
-            id: "expedition.planning.capture-expedition-objective".to_string(),
-            namespace: "expedition.planning".to_string(),
-            name: "capture-expedition-objective".to_string(),
-            version: "1.0.0".to_string(),
-            lifecycle: Lifecycle::Active,
-            owner: Owner {
-                team: "Traverse".to_string(),
-                contact: "team@traverse.dev".to_string(),
-            },
-            summary: "Summary".to_string(),
-            description: "Description".to_string(),
-            inputs: SchemaContainer {
-                schema: json!({"type": "object"}),
-            },
-            outputs: SchemaContainer {
-                schema: json!({"type": "object"}),
-            },
-            preconditions: vec![Condition {
-                id: "input-available".to_string(),
-                description: "Input exists".to_string(),
-            }],
-            postconditions: vec![Condition {
-                id: "output-created".to_string(),
-                description: "Output exists".to_string(),
-            }],
-            side_effects: vec![SideEffect {
-                kind: SideEffectKind::None,
-                description: "No side effects".to_string(),
-            }],
-            emits: vec![EventReference {
-                event_id: "expedition.planning.expedition-objective-captured".to_string(),
-                version: "1.0.0".to_string(),
-            }],
-            consumes: vec![],
-            permissions: vec![IdReference {
-                id: "expedition.plan.capture-objective".to_string(),
-            }],
-            execution: Execution {
-                binary_format: traverse_contracts::BinaryFormat::Wasm,
-                entrypoint: Entrypoint {
-                    kind: EntrypointKind::WasiCommand,
-                    command: "run".to_string(),
-                },
-                preferred_targets: vec![ExecutionTarget::Local],
-                constraints: ExecutionConstraints {
-                    host_api_access: HostApiAccess::None,
-                    network_access: NetworkAccess::Forbidden,
-                    filesystem_access: FilesystemAccess::None,
-                },
-            },
-            policies: vec![IdReference {
-                id: "policy.expedition".to_string(),
-            }],
-            dependencies: vec![DependencyReference {
-                artifact_type: traverse_contracts::DependencyArtifactType::Policy,
-                id: "policy.expedition".to_string(),
-                version: "1.0.0".to_string(),
-            }],
-            provenance: Provenance {
-                source: ProvenanceSource::Greenfield,
-                author: "Traverse".to_string(),
-                created_at: "2026-03-30T00:00:00Z".to_string(),
-                spec_ref: Some("009-expedition-example-artifacts".to_string()),
-                adr_refs: vec![],
-                exception_refs: vec![],
-            },
-            evidence: vec![],
-        }
-    }
-
-    fn example_event_contract() -> EventContract {
-        EventContract {
-            kind: "event_contract".to_string(),
-            schema_version: "1.0.0".to_string(),
-            id: "expedition.planning.expedition-objective-captured".to_string(),
-            namespace: "expedition.planning".to_string(),
-            name: "expedition-objective-captured".to_string(),
-            version: "1.0.0".to_string(),
-            lifecycle: Lifecycle::Active,
-            owner: Owner {
-                team: "Traverse".to_string(),
-                contact: "team@traverse.dev".to_string(),
-            },
-            summary: "Summary".to_string(),
-            description: "Description".to_string(),
-            payload: EventPayload {
-                schema: json!({"type":"object"}),
-                compatibility: PayloadCompatibility::BackwardCompatible,
-            },
-            classification: traverse_contracts::EventClassification {
-                domain: "expedition".to_string(),
-                bounded_context: "planning".to_string(),
-                event_type: EventType::Domain,
-                tags: vec!["expedition".to_string()],
-            },
-            publishers: vec![traverse_contracts::CapabilityReference {
-                capability_id: "expedition.planning.capture-expedition-objective".to_string(),
-                version: "1.0.0".to_string(),
-            }],
-            subscribers: vec![],
-            policies: vec![IdReference {
-                id: "policy.expedition".to_string(),
-            }],
-            tags: vec!["expedition".to_string()],
-            provenance: EventProvenance {
-                source: EventProvenanceSource::Greenfield,
-                author: "Traverse".to_string(),
-                created_at: "2026-03-30T00:00:00Z".to_string(),
-            },
-            evidence: vec![],
-        }
-    }
-
-    fn example_workflow_definition() -> WorkflowDefinition {
-        WorkflowDefinition {
-            kind: "workflow_definition".to_string(),
-            schema_version: "1.0.0".to_string(),
-            id: "expedition.planning.plan-expedition".to_string(),
-            name: "plan-expedition".to_string(),
-            version: "1.0.0".to_string(),
-            lifecycle: Lifecycle::Active,
-            owner: Owner {
-                team: "Traverse".to_string(),
-                contact: "team@traverse.dev".to_string(),
-            },
-            summary: "Summary".to_string(),
-            inputs: SchemaContainer {
-                schema: json!({"type":"object"}),
-            },
-            outputs: SchemaContainer {
-                schema: json!({"type":"object"}),
-            },
-            nodes: vec![WorkflowNode {
-                node_id: "capture_objective".to_string(),
-                capability_id: "expedition.planning.capture-expedition-objective".to_string(),
-                capability_version: "1.0.0".to_string(),
-                input: WorkflowNodeInput {
-                    from_workflow_input: vec!["objective".to_string()],
-                },
-                output: WorkflowNodeOutput {
-                    to_workflow_state: vec!["objective".to_string()],
-                },
-            }],
-            edges: vec![],
-            start_node: "capture_objective".to_string(),
-            terminal_nodes: vec!["capture_objective".to_string()],
-            tags: vec!["expedition".to_string()],
-            governing_spec: "009-expedition-example-artifacts".to_string(),
-        }
+        let path = std::env::temp_dir().join(format!("traverse-cli-test-{nanos}"));
+        fs::create_dir_all(&path).expect("temporary directory should create");
+        path
     }
 }

--- a/docs/expedition-example-authoring.md
+++ b/docs/expedition-example-authoring.md
@@ -59,6 +59,18 @@ Registry bundle inspection:
 cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json
 ```
 
+Event contract inspection:
+
+```bash
+cargo run -p traverse-cli -- event inspect contracts/examples/expedition/events/expedition-objective-captured/contract.json
+```
+
+Workflow artifact inspection:
+
+```bash
+cargo run -p traverse-cli -- workflow inspect workflows/examples/expedition/plan-expedition/workflow.json
+```
+
 Repository checks:
 
 ```bash
@@ -79,3 +91,15 @@ The bundle inspection output must include:
 And the workflow section must include:
 
 - `expedition.planning.plan-expedition@1.0.0`
+
+The event inspection output must include:
+
+- `id: expedition.planning.expedition-objective-captured`
+- `event_type: domain`
+- `publisher_ids:`
+
+The workflow inspection output must include:
+
+- `id: expedition.planning.plan-expedition`
+- `start_node: capture_objective`
+- `node_capabilities:`


### PR DESCRIPTION
## Summary

Add CLI inspect commands for canonical expedition event contracts and workflow definitions, and switch `bundle inspect` to use the shared registry bundle loader on `main`.

## Governing Spec

- 001-foundation-v0-1
- 003-event-contracts
- 007-workflow-registry-traversal
- 009-expedition-example-artifacts

## Project Item

- Issue: https://github.com/enricopiovesan/Traverse/issues/87
- Project: https://github.com/users/enricopiovesan/projects/1/

## What Changed

- Contracts changed: no contract artifacts changed, but the CLI can now inspect approved expedition event contracts and workflow definitions directly.
- Runtime behavior changed: `traverse-cli bundle inspect` now uses the shared registry bundle loader, and the CLI exposes `event inspect` and `workflow inspect` commands.
- Compatibility impact: additive CLI surface only.
- ADR needed or linked: no new ADR.

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing
- [x] Core coverage preserved
- [x] Required validation gates passing

## Notes

This PR also closes the shared-loader integration gap left on `main` by making the CLI consume the registry bundle loader instead of maintaining a separate manifest parser.
