### PR TITLE
Add CLI trace inspection for expedition executions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Run expedition execution smoke path
         run: TRAVERSE_REPO_ROOT="$PWD" bash scripts/ci/expedition_execution_smoke.sh
 
+      - name: Run expedition trace smoke path
+        run: TRAVERSE_REPO_ROOT="$PWD" bash scripts/ci/expedition_trace_smoke.sh
+
       - name: Run repository checks
         run: bash scripts/ci/repository_checks.sh
 

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -16,16 +16,31 @@ use traverse_registry::{
 };
 use traverse_runtime::{
     LocalExecutionFailure, LocalExecutionFailureCode, LocalExecutor, Runtime,
-    RuntimeExecutionOutcome, RuntimeRequest, RuntimeResultStatus, parse_runtime_request,
+    RuntimeExecutionOutcome, RuntimeRequest, RuntimeResultStatus, RuntimeTrace,
+    parse_runtime_request,
 };
 
 #[derive(Debug)]
 enum Command {
-    BundleInspect { manifest_path: PathBuf },
-    BundleRegister { manifest_path: PathBuf },
-    ExpeditionExecute { request_path: PathBuf },
-    Event { contract_path: PathBuf },
-    Workflow { workflow_path: PathBuf },
+    BundleInspect {
+        manifest_path: PathBuf,
+    },
+    BundleRegister {
+        manifest_path: PathBuf,
+    },
+    ExpeditionExecute {
+        request_path: PathBuf,
+        trace_output_path: Option<PathBuf>,
+    },
+    Event {
+        contract_path: PathBuf,
+    },
+    TraceInspect {
+        trace_path: PathBuf,
+    },
+    Workflow {
+        workflow_path: PathBuf,
+    },
 }
 
 fn main() -> ExitCode {
@@ -46,13 +61,27 @@ fn run(args: &[String]) -> Result<String, String> {
     match parse_command(args)? {
         Command::BundleInspect { manifest_path } => inspect_bundle(&manifest_path),
         Command::BundleRegister { manifest_path } => register_bundle(&manifest_path),
-        Command::ExpeditionExecute { request_path } => execute_expedition(&request_path),
+        Command::ExpeditionExecute {
+            request_path,
+            trace_output_path,
+        } => execute_expedition(&request_path, trace_output_path.as_deref()),
         Command::Event { contract_path } => inspect_event(&contract_path),
+        Command::TraceInspect { trace_path } => inspect_trace(&trace_path),
         Command::Workflow { workflow_path } => inspect_workflow(&workflow_path),
     }
 }
 
 fn parse_command(args: &[String]) -> Result<Command, String> {
+    match (
+        args.get(1).map(String::as_str),
+        args.get(2).map(String::as_str),
+    ) {
+        (Some("expedition"), Some("execute")) => parse_expedition_execute_command(args),
+        _ => parse_fixed_arity_command(args),
+    }
+}
+
+fn parse_fixed_arity_command(args: &[String]) -> Result<Command, String> {
     if args.len() != 4 {
         return Err(usage());
     }
@@ -64,15 +93,31 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
         ("bundle", "register") => Ok(Command::BundleRegister {
             manifest_path: PathBuf::from(&args[3]),
         }),
-        ("expedition", "execute") => Ok(Command::ExpeditionExecute {
-            request_path: PathBuf::from(&args[3]),
-        }),
         ("event", "inspect") => Ok(Command::Event {
             contract_path: PathBuf::from(&args[3]),
+        }),
+        ("trace", "inspect") => Ok(Command::TraceInspect {
+            trace_path: PathBuf::from(&args[3]),
         }),
         ("workflow", "inspect") => Ok(Command::Workflow {
             workflow_path: PathBuf::from(&args[3]),
         }),
+        _ => Err(usage()),
+    }
+}
+
+fn parse_expedition_execute_command(args: &[String]) -> Result<Command, String> {
+    match args {
+        [_, _, _, request_path] => Ok(Command::ExpeditionExecute {
+            request_path: PathBuf::from(request_path),
+            trace_output_path: None,
+        }),
+        [_, _, _, request_path, flag, trace_output_path] if flag == "--trace-out" => {
+            Ok(Command::ExpeditionExecute {
+                request_path: PathBuf::from(request_path),
+                trace_output_path: Some(PathBuf::from(trace_output_path)),
+            })
+        }
         _ => Err(usage()),
     }
 }
@@ -93,7 +138,10 @@ fn register_bundle(manifest_path: &Path) -> Result<String, String> {
     ))
 }
 
-fn execute_expedition(request_path: &Path) -> Result<String, String> {
+fn execute_expedition(
+    request_path: &Path,
+    trace_output_path: Option<&Path>,
+) -> Result<String, String> {
     let request = load_runtime_request(request_path)?;
     let registered = load_registered_bundle(&canonical_expedition_bundle_path())?;
     let runtime = Runtime::new(registered.capability_registry, ExpeditionExampleExecutor)
@@ -104,7 +152,14 @@ fn execute_expedition(request_path: &Path) -> Result<String, String> {
         return Err(render_runtime_execution_failure(&outcome));
     }
 
-    Ok(render_runtime_execution_summary(&outcome))
+    if let Some(path) = trace_output_path {
+        write_trace_artifact(path, &outcome.trace)?;
+    }
+
+    Ok(render_runtime_execution_summary(
+        &outcome,
+        trace_output_path,
+    ))
 }
 
 fn inspect_event(contract_path: &Path) -> Result<String, String> {
@@ -134,6 +189,18 @@ fn inspect_workflow(workflow_path: &Path) -> Result<String, String> {
     })?;
 
     Ok(render_workflow_summary(workflow_path, &definition))
+}
+
+fn inspect_trace(trace_path: &Path) -> Result<String, String> {
+    let contents = read_text_file(trace_path, "runtime trace")?;
+    let trace = serde_json::from_str::<RuntimeTrace>(&contents).map_err(|error| {
+        format!(
+            "failed to parse runtime trace {}: {error}",
+            trace_path.display()
+        )
+    })?;
+
+    Ok(render_trace_summary(trace_path, &trace))
 }
 
 fn read_text_file(path: &Path, artifact_kind: &str) -> Result<String, String> {
@@ -297,7 +364,10 @@ fn render_workflow_summary(path: &Path, definition: &WorkflowDefinition) -> Stri
     lines.join("\n")
 }
 
-fn render_runtime_execution_summary(outcome: &RuntimeExecutionOutcome) -> String {
+fn render_runtime_execution_summary(
+    outcome: &RuntimeExecutionOutcome,
+    trace_output_path: Option<&Path>,
+) -> String {
     let output = outcome.result.output.as_ref().unwrap_or(&Value::Null);
     let mut lines = vec![
         format!("request_id: {}", outcome.result.request_id),
@@ -307,6 +377,10 @@ fn render_runtime_execution_summary(outcome: &RuntimeExecutionOutcome) -> String
         "status: completed".to_string(),
         format!("trace_ref: {}", outcome.result.trace_ref),
     ];
+
+    if let Some(path) = trace_output_path {
+        lines.push(format!("trace_path: {}", path.display()));
+    }
 
     if let Some(plan_id) = output.get("plan_id").and_then(Value::as_str) {
         lines.push(format!("plan_id: {plan_id}"));
@@ -327,8 +401,94 @@ fn render_runtime_execution_summary(outcome: &RuntimeExecutionOutcome) -> String
     lines.join("\n")
 }
 
+fn render_trace_summary(trace_path: &Path, trace: &RuntimeTrace) -> String {
+    let final_transition = trace.state_transitions.last();
+    let mut lines = vec![
+        format!("path: {}", trace_path.display()),
+        format!("trace_id: {}", trace.trace_id),
+        format!("execution_id: {}", trace.execution_id),
+        format!("request_id: {}", trace.request_id),
+        format!("governing_spec: {}", trace.governing_spec),
+        format!("result_status: {:?}", trace.result.status).to_lowercase(),
+        format!(
+            "state_machine_validation: {:?}",
+            trace.state_machine_validation.status
+        )
+        .to_lowercase(),
+        format!("state_transition_count: {}", trace.state_transitions.len()),
+        format!(
+            "candidate_count: {}",
+            trace.candidate_collection.candidates.len()
+        ),
+        format!(
+            "rejected_candidate_count: {}",
+            trace.candidate_collection.rejected_candidates.len()
+        ),
+        format!("execution_status: {:?}", trace.execution.status).to_lowercase(),
+    ];
+
+    if let Some(selected) = &trace.selection.selected_capability_id {
+        lines.push(format!("selected_capability_id: {selected}"));
+    }
+    if let Some(version) = &trace.selection.selected_capability_version {
+        lines.push(format!("selected_capability_version: {version}"));
+    }
+    if let Some(artifact_ref) = &trace.execution.artifact_ref {
+        lines.push(format!("artifact_ref: {artifact_ref}"));
+    }
+    if let Some(transition) = final_transition {
+        lines.push(format!(
+            "terminal_transition: {} -> {} ({})",
+            format!("{:?}", transition.from_state).to_lowercase(),
+            format!("{:?}", transition.to_state).to_lowercase(),
+            debug_enum_to_snake_case(&format!("{:?}", transition.reason_code))
+        ));
+    }
+    if let Some(error) = &trace.result.error {
+        lines.push(format!("error_code: {:?}", error.code).to_lowercase());
+        lines.push(format!("error_message: {}", error.message));
+    }
+
+    lines.join("\n")
+}
+
 fn usage() -> String {
-    "usage: traverse-cli <bundle|event|workflow|expedition> <inspect|register|execute> <artifact-path>".to_string()
+    "usage: traverse-cli <bundle|event|trace|workflow|expedition> <inspect|register|execute> <artifact-path> [--trace-out <trace-path>]".to_string()
+}
+
+fn write_trace_artifact(path: &Path, trace: &RuntimeTrace) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "failed to create trace artifact directory {}: {error}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let serialized = serde_json::to_string_pretty(trace).map_err(|error| {
+        format!(
+            "failed to serialize runtime trace {}: {error}",
+            path.display()
+        )
+    })?;
+    fs::write(path, format!("{serialized}\n"))
+        .map_err(|error| format!("failed to write runtime trace {}: {error}", path.display()))
+}
+
+fn debug_enum_to_snake_case(value: &str) -> String {
+    let mut output = String::with_capacity(value.len() + 4);
+    for (index, ch) in value.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if index > 0 {
+                output.push('_');
+            }
+            output.push(ch.to_ascii_lowercase());
+        } else {
+            output.push(ch);
+        }
+    }
+    output
 }
 
 #[derive(Debug)]
@@ -918,8 +1078,8 @@ mod tests {
     #![allow(clippy::expect_used)]
 
     use super::{
-        execute_expedition, inspect_bundle, inspect_event, inspect_workflow, parse_command,
-        register_bundle,
+        execute_expedition, inspect_bundle, inspect_event, inspect_trace, inspect_workflow,
+        parse_command, register_bundle,
     };
     use std::fs;
     use std::path::PathBuf;
@@ -952,17 +1112,33 @@ mod tests {
             "contracts/examples/expedition/events/expedition-objective-captured/contract.json"
                 .to_string(),
         ];
+        let trace = vec![
+            "traverse-cli".to_string(),
+            "trace".to_string(),
+            "inspect".to_string(),
+            "/tmp/plan-expedition-trace.json".to_string(),
+        ];
         let workflow = vec![
             "traverse-cli".to_string(),
             "workflow".to_string(),
             "inspect".to_string(),
             "workflows/examples/expedition/plan-expedition/workflow.json".to_string(),
         ];
+        let expedition_execute_with_trace = vec![
+            "traverse-cli".to_string(),
+            "expedition".to_string(),
+            "execute".to_string(),
+            "examples/expedition/runtime-requests/plan-expedition.json".to_string(),
+            "--trace-out".to_string(),
+            "/tmp/plan-expedition-trace.json".to_string(),
+        ];
 
         assert!(parse_command(&bundle).is_ok());
         assert!(parse_command(&bundle_register).is_ok());
         assert!(parse_command(&expedition_execute).is_ok());
+        assert!(parse_command(&expedition_execute_with_trace).is_ok());
         assert!(parse_command(&event).is_ok());
+        assert!(parse_command(&trace).is_ok());
         assert!(parse_command(&workflow).is_ok());
     }
 
@@ -1065,11 +1241,27 @@ mod tests {
             repo_root().join("examples/expedition/runtime-requests/plan-expedition.json");
 
         let output =
-            execute_expedition(&request_path).expect("expedition execution should succeed");
+            execute_expedition(&request_path, None).expect("expedition execution should succeed");
 
         assert!(output.contains("capability_id: expedition.planning.plan-expedition"));
         assert!(output.contains("status: completed"));
         assert!(output.contains("recommended_route_style: conservative-alpine-push"));
+    }
+
+    #[test]
+    fn execute_expedition_writes_trace_artifact_when_requested() {
+        let request_path =
+            repo_root().join("examples/expedition/runtime-requests/plan-expedition.json");
+        let temp_dir = unique_temp_dir();
+        let trace_path = temp_dir.join("plan-expedition-trace.json");
+
+        let output = execute_expedition(&request_path, Some(&trace_path))
+            .expect("expedition execution with trace output should succeed");
+
+        assert!(output.contains(&format!("trace_path: {}", trace_path.display())));
+        let trace_contents = fs::read_to_string(&trace_path).expect("trace file should exist");
+        assert!(trace_contents.contains("\"kind\": \"runtime_trace\""));
+        assert!(trace_contents.contains("\"trace_id\":"));
     }
 
     #[test]
@@ -1118,10 +1310,38 @@ mod tests {
         .expect("runtime request should write");
 
         let error =
-            execute_expedition(&path).expect_err("invalid expedition execution should fail");
+            execute_expedition(&path, None).expect_err("invalid expedition execution should fail");
 
         assert!(error.contains("runtime execution failed"));
         assert!(error.contains("runtime request input does not satisfy"));
+    }
+
+    #[test]
+    fn inspect_trace_renders_generated_expedition_trace() {
+        let request_path =
+            repo_root().join("examples/expedition/runtime-requests/plan-expedition.json");
+        let temp_dir = unique_temp_dir();
+        let trace_path = temp_dir.join("plan-expedition-trace.json");
+
+        execute_expedition(&request_path, Some(&trace_path))
+            .expect("expedition execution with trace output should succeed");
+
+        let output = inspect_trace(&trace_path).expect("trace inspect should succeed");
+
+        assert!(output.contains("trace_id: trace_exec_expedition-plan-request-001"));
+        assert!(output.contains("result_status: completed"));
+        assert!(output.contains("selected_capability_id: expedition.planning.plan-expedition"));
+    }
+
+    #[test]
+    fn inspect_trace_rejects_malformed_trace_artifact() {
+        let temp_dir = unique_temp_dir();
+        let path = temp_dir.join("trace.json");
+        fs::write(&path, "{\"trace_id\":true}").expect("trace file should write");
+
+        let error = inspect_trace(&path).expect_err("malformed trace should fail");
+
+        assert!(error.contains("failed to parse runtime trace"));
     }
 
     #[test]

--- a/docs/expedition-example-authoring.md
+++ b/docs/expedition-example-authoring.md
@@ -71,6 +71,19 @@ Expedition execution:
 cargo run -p traverse-cli -- expedition execute examples/expedition/runtime-requests/plan-expedition.json
 ```
 
+Expedition execution with persisted trace:
+
+```bash
+tmpdir="$(mktemp -d)"
+cargo run -p traverse-cli -- expedition execute examples/expedition/runtime-requests/plan-expedition.json --trace-out "$tmpdir/plan-expedition-trace.json"
+```
+
+Trace inspection:
+
+```bash
+cargo run -p traverse-cli -- trace inspect "$tmpdir/plan-expedition-trace.json"
+```
+
 Event contract inspection:
 
 ```bash
@@ -116,6 +129,13 @@ The expedition execution output must include:
 - `capability_id: expedition.planning.plan-expedition`
 - `status: completed`
 - `recommended_route_style: conservative-alpine-push`
+- `trace_ref: trace_exec_expedition-plan-request-001`
+
+The trace inspection output must include:
+
+- `trace_id: trace_exec_expedition-plan-request-001`
+- `result_status: completed`
+- `selected_capability_id: expedition.planning.plan-expedition`
 
 The event inspection output must include:
 

--- a/docs/expedition-example-smoke.md
+++ b/docs/expedition-example-smoke.md
@@ -35,3 +35,15 @@ What it validates:
 - the canonical expedition runtime request can execute `expedition.planning.plan-expedition`
 - the output includes a completed workflow-backed planning result
 - invalid expedition execution input fails deterministically
+
+Run the expedition trace smoke path with:
+
+```bash
+bash scripts/ci/expedition_trace_smoke.sh
+```
+
+What it validates:
+
+- the expedition execution path can persist a governed runtime trace artifact
+- the trace inspection command renders deterministic trace metadata for the canonical request
+- malformed trace input fails deterministically

--- a/scripts/ci/expedition_trace_smoke.sh
+++ b/scripts/ci/expedition_trace_smoke.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${TRAVERSE_REPO_ROOT:-$(pwd)}"
+request_path="${repo_root}/examples/expedition/runtime-requests/plan-expedition.json"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+trace_path="${tmpdir}/plan-expedition-trace.json"
+
+pushd "${repo_root}" >/dev/null
+
+execution_output="$(cargo run -p traverse-cli -- expedition execute "${request_path}" --trace-out "${trace_path}")"
+printf '%s\n' "${execution_output}"
+
+test -f "${trace_path}"
+grep -q "trace_path: ${trace_path}" <<<"${execution_output}"
+
+inspect_output="$(cargo run -p traverse-cli -- trace inspect "${trace_path}")"
+printf '%s\n' "${inspect_output}"
+
+grep -q "trace_id: trace_exec_expedition-plan-request-001" <<<"${inspect_output}"
+grep -q "result_status: completed" <<<"${inspect_output}"
+grep -q "selected_capability_id: expedition.planning.plan-expedition" <<<"${inspect_output}"
+
+printf '{"trace_id":true}\n' > "${tmpdir}/invalid-trace.json"
+
+set +e
+invalid_output="$(cargo run -p traverse-cli -- trace inspect "${tmpdir}/invalid-trace.json" 2>&1)"
+invalid_status=$?
+set -e
+
+if [[ ${invalid_status} -eq 0 ]]; then
+  echo "expected malformed trace inspection to fail" >&2
+  exit 1
+fi
+
+grep -q "failed to parse runtime trace" <<<"${invalid_output}"
+
+popd >/dev/null

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -66,9 +66,11 @@ grep -q "One Codex thread is one active worker" docs/multi-thread-workflow.md
 grep -q "Starter Prompts" docs/multi-thread-workflow.md
 grep -q "bash scripts/ci/expedition_artifact_smoke.sh" docs/expedition-example-smoke.md
 grep -q "bash scripts/ci/expedition_execution_smoke.sh" docs/expedition-example-smoke.md
+grep -q "bash scripts/ci/expedition_trace_smoke.sh" docs/expedition-example-smoke.md
 grep -q "TRAVERSE_REPO_ROOT" docs/expedition-example-smoke.md
 grep -q "cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json" docs/expedition-example-authoring.md
 grep -q "cargo run -p traverse-cli -- expedition execute examples/expedition/runtime-requests/plan-expedition.json" docs/expedition-example-authoring.md
+grep -q "cargo run -p traverse-cli -- trace inspect" docs/expedition-example-authoring.md
 grep -q "workflows/examples/expedition/plan-expedition/workflow.json" docs/expedition-example-authoring.md
 grep -q "label: Definition of done" .github/ISSUE_TEMPLATE/task.yml
 grep -q "label: Validation" .github/ISSUE_TEMPLATE/task.yml


### PR DESCRIPTION
## Summary

Adds a governed trace inspection path for the expedition example by letting the CLI persist runtime traces and inspect them deterministically.

## Governing Spec

- 001-foundation-v0-1
- 004-spec-alignment-gate
- 006-runtime-request-execution
- 008-expedition-example-domain
- 009-expedition-example-artifacts

## Project Item

- Closes #86
- [Project 1](https://github.com/users/enricopiovesan/projects/1/)

## What Changed

- Contracts changed: none.
- Runtime behavior changed: `traverse-cli expedition execute` can now persist a runtime trace artifact with `--trace-out`, and `traverse-cli trace inspect` renders deterministic trace summaries.
- Compatibility impact: additive CLI and CI behavior only.
- ADR needed or linked: none.

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing
- [x] Core coverage preserved
- [x] Required validation gates passing

## Notes

- Adds `bash scripts/ci/expedition_trace_smoke.sh` and wires it into CI.
- Keeps the trace artifact format aligned with the existing governed runtime trace rather than inventing a second CLI-only shape.
