### PR TITLE
Add expedition planning golden-path validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Run expedition trace smoke path
         run: TRAVERSE_REPO_ROOT="$PWD" bash scripts/ci/expedition_trace_smoke.sh
 
+      - name: Run expedition golden path
+        run: TRAVERSE_REPO_ROOT="$PWD" bash scripts/ci/expedition_golden_path.sh
+
       - name: Run repository checks
         run: bash scripts/ci/repository_checks.sh
 

--- a/docs/expedition-example-authoring.md
+++ b/docs/expedition-example-authoring.md
@@ -102,6 +102,12 @@ Repository checks:
 bash scripts/ci/repository_checks.sh
 ```
 
+Golden path proof:
+
+```bash
+bash scripts/ci/expedition_golden_path.sh
+```
+
 ## What Good Output Looks Like
 
 The bundle inspection output must include:
@@ -136,6 +142,13 @@ The trace inspection output must include:
 - `trace_id: trace_exec_expedition-plan-request-001`
 - `result_status: completed`
 - `selected_capability_id: expedition.planning.plan-expedition`
+
+The golden path validation must prove all of these in one run:
+
+- bundle registration succeeds for the canonical manifest
+- execution succeeds for the canonical runtime request
+- trace inspection succeeds for the generated runtime trace
+- a missing required bundle artifact fails deterministically
 
 The event inspection output must include:
 

--- a/docs/expedition-example-smoke.md
+++ b/docs/expedition-example-smoke.md
@@ -47,3 +47,16 @@ What it validates:
 - the expedition execution path can persist a governed runtime trace artifact
 - the trace inspection command renders deterministic trace metadata for the canonical request
 - malformed trace input fails deterministically
+
+Run the expedition golden-path validation with:
+
+```bash
+bash scripts/ci/expedition_golden_path.sh
+```
+
+What it validates:
+
+- the canonical expedition bundle registers successfully
+- the canonical expedition request executes successfully and produces a trace artifact
+- the trace inspection command renders the generated trace deterministically
+- the validation fails deterministically when the bundle is incomplete

--- a/scripts/ci/expedition_golden_path.sh
+++ b/scripts/ci/expedition_golden_path.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${TRAVERSE_REPO_ROOT:-$(pwd)}"
+manifest_path="${repo_root}/examples/expedition/registry-bundle/manifest.json"
+request_path="${repo_root}/examples/expedition/runtime-requests/plan-expedition.json"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+trace_path="${tmpdir}/plan-expedition-trace.json"
+invalid_manifest_path="${tmpdir}/invalid-manifest.json"
+
+pushd "${repo_root}" >/dev/null
+
+register_output="$(cargo run -p traverse-cli -- bundle register "${manifest_path}")"
+printf '%s\n' "${register_output}"
+
+grep -q "registered_capabilities: 6" <<<"${register_output}"
+grep -q "registered_events: 5" <<<"${register_output}"
+grep -q "registered_workflows: 1" <<<"${register_output}"
+
+execution_output="$(cargo run -p traverse-cli -- expedition execute "${request_path}" --trace-out "${trace_path}")"
+printf '%s\n' "${execution_output}"
+
+grep -q "status: completed" <<<"${execution_output}"
+grep -q "recommended_route_style: conservative-alpine-push" <<<"${execution_output}"
+grep -q "trace_path: ${trace_path}" <<<"${execution_output}"
+
+trace_output="$(cargo run -p traverse-cli -- trace inspect "${trace_path}")"
+printf '%s\n' "${trace_output}"
+
+grep -q "result_status: completed" <<<"${trace_output}"
+grep -q "selected_capability_id: expedition.planning.plan-expedition" <<<"${trace_output}"
+grep -q "terminal_transition: completed -> ready (execution_closed)" <<<"${trace_output}"
+
+python3 - "${manifest_path}" "${invalid_manifest_path}" <<'PY'
+import json
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1])
+target = pathlib.Path(sys.argv[2])
+payload = json.loads(source.read_text())
+payload["workflows"][0]["path"] = "missing/plan-expedition/workflow.json"
+target.write_text(json.dumps(payload, indent=2) + "\n")
+PY
+
+set +e
+invalid_output="$(cargo run -p traverse-cli -- bundle register "${invalid_manifest_path}" 2>&1)"
+invalid_status=$?
+set -e
+
+if [[ ${invalid_status} -eq 0 ]]; then
+  echo "expected bundle registration with a missing workflow artifact to fail" >&2
+  exit 1
+fi
+
+grep -q "missing artifact file" <<<"${invalid_output}"
+
+popd >/dev/null

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -67,10 +67,12 @@ grep -q "Starter Prompts" docs/multi-thread-workflow.md
 grep -q "bash scripts/ci/expedition_artifact_smoke.sh" docs/expedition-example-smoke.md
 grep -q "bash scripts/ci/expedition_execution_smoke.sh" docs/expedition-example-smoke.md
 grep -q "bash scripts/ci/expedition_trace_smoke.sh" docs/expedition-example-smoke.md
+grep -q "bash scripts/ci/expedition_golden_path.sh" docs/expedition-example-smoke.md
 grep -q "TRAVERSE_REPO_ROOT" docs/expedition-example-smoke.md
 grep -q "cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json" docs/expedition-example-authoring.md
 grep -q "cargo run -p traverse-cli -- expedition execute examples/expedition/runtime-requests/plan-expedition.json" docs/expedition-example-authoring.md
 grep -q "cargo run -p traverse-cli -- trace inspect" docs/expedition-example-authoring.md
+grep -q "cargo run -p traverse-cli -- bundle register examples/expedition/registry-bundle/manifest.json" docs/expedition-example-authoring.md
 grep -q "workflows/examples/expedition/plan-expedition/workflow.json" docs/expedition-example-authoring.md
 grep -q "label: Definition of done" .github/ISSUE_TEMPLATE/task.yml
 grep -q "label: Validation" .github/ISSUE_TEMPLATE/task.yml


### PR DESCRIPTION
## Summary

Adds the first end-to-end expedition MVP proof path covering bundle registration, workflow-backed execution, generated trace inspection, and deterministic failure for an incomplete bundle.

## Governing Spec

- 001-foundation-v0-1
- 004-spec-alignment-gate
- 006-runtime-request-execution
- 008-expedition-example-domain
- 009-expedition-example-artifacts

## Project Item

- Closes #88
- [Project 1](https://github.com/users/enricopiovesan/projects/1/)

## What Changed

- Contracts changed: none.
- Runtime behavior changed: none; this slice adds the governed MVP proof path around the existing canonical bundle and CLI flow.
- Compatibility impact: additive CI and documentation only.
- ADR needed or linked: none.

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing
- [x] Core coverage preserved
- [x] Required validation gates passing

## Notes

- Replaces the earlier stacked PR after #103 merged and the branch was rebased onto `main`.
- Adds `bash scripts/ci/expedition_golden_path.sh` as the expedition MVP proof path.
