### PR TITLE
Upgrade React browser demo to consume the live local browser adapter

### DIFF
--- a/apps/react-demo/README.md
+++ b/apps/react-demo/README.md
@@ -5,14 +5,15 @@ This is the first checked-in React browser demo surface for Traverse.
 What it does:
 - renders one approved expedition flow
 - allows one approved request submission path
-- shows ordered runtime state updates
+- shows ordered runtime state updates streamed from the live local browser adapter
 - shows the final trace snapshot and output panel after the stream completes
-- uses the approved browser-subscription session shape through a deterministic fixture-driven rendering path
+- keeps the approved browser-subscription session shape while consuming the live adapter through a same-origin local proxy
 
-Local run path:
+Local live run path:
 
 ```bash
-python3 -m http.server 4173 --directory apps/react-demo
+cargo run -p traverse-cli -- browser-adapter serve --bind 127.0.0.1:4174
+node apps/react-demo/server.mjs --adapter http://127.0.0.1:4174 --port 4173
 ```
 
 Open:
@@ -21,10 +22,25 @@ Open:
 
 Note:
 
-- the documented local run path uses a simple static file server and works on a normal local machine
-- the checked-in repo smoke path stays static and does not bind a local port, because the sandboxed validation environment blocks local socket binding
+- the React app consumes the live browser adapter through the local proxy server
+- if the local adapter cannot be started automatically, use the fallback preview path below
+- Run the local browser adapter proxy again if you need to refresh the live stream setup
 
-Local smoke path:
+Fallback preview path:
+
+```bash
+python3 -m http.server 4173 --directory apps/react-demo
+```
+
+The fallback preview keeps the checked-in fixture-driven render path available for offline inspection and smoke validation.
+
+Live smoke path:
+
+```bash
+bash scripts/ci/react_demo_live_adapter_smoke.sh
+```
+
+Fallback smoke path:
 
 ```bash
 bash scripts/ci/react_demo_smoke.sh

--- a/apps/react-demo/index.html
+++ b/apps/react-demo/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="./src/browser-adapter-client.js"></script>
     <script src="./vendor/react.development.js"></script>
     <script src="./vendor/react-dom.development.js"></script>
     <script src="./src/main.js"></script>

--- a/apps/react-demo/server.mjs
+++ b/apps/react-demo/server.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { extname, join, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = fileURLToPath(new URL(".", import.meta.url));
+const defaultPort = 4173;
+const defaultAdapterBaseUrl = "http://127.0.0.1:4174";
+
+const { port, adapterBaseUrl } = parseArgs(process.argv.slice(2));
+const adapterOrigin = new URL(adapterBaseUrl);
+
+const server = createServer(async (request, response) => {
+  try {
+    if (request.url?.startsWith("/local/browser-subscriptions")) {
+      await proxyBrowserAdapter(request, response, adapterOrigin);
+      return;
+    }
+
+    await serveStaticAsset(request, response);
+  } catch (error) {
+    response.statusCode = 500;
+    response.setHeader("Content-Type", "text/plain; charset=utf-8");
+    response.end(String(error));
+  }
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`Traverse React demo serving on http://127.0.0.1:${port}`);
+  console.log(`Proxying browser adapter requests to ${adapterOrigin.origin}`);
+});
+
+function parseArgs(args) {
+  let port = defaultPort;
+  let adapterBaseUrl = defaultAdapterBaseUrl;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+    if (current === "--port" && args[index + 1]) {
+      port = Number(args[index + 1]);
+      index += 1;
+    } else if (current === "--adapter" && args[index + 1]) {
+      adapterBaseUrl = args[index + 1];
+      index += 1;
+    }
+  }
+
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error(`invalid port: ${port}`);
+  }
+
+  return { port, adapterBaseUrl };
+}
+
+async function proxyBrowserAdapter(request, response, adapterOrigin) {
+  const targetUrl = new URL(request.url, adapterOrigin);
+  const headers = new Headers();
+
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (["host", "connection", "content-length"].includes(name.toLowerCase())) {
+      continue;
+    }
+    headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+  }
+
+  let body = undefined;
+  if (!["GET", "HEAD"].includes(request.method || "")) {
+    body = await readRequestBody(request);
+  }
+
+  const upstreamResponse = await fetch(targetUrl, {
+    method: request.method,
+    headers,
+    body,
+  });
+
+  response.statusCode = upstreamResponse.status;
+  response.statusMessage = upstreamResponse.statusText;
+
+  upstreamResponse.headers.forEach((value, name) => {
+    if (name.toLowerCase() === "content-length") {
+      return;
+    }
+    response.setHeader(name, value);
+  });
+
+  if (!upstreamResponse.body) {
+    response.end();
+    return;
+  }
+
+  const reader = upstreamResponse.body.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    response.write(Buffer.from(value));
+  }
+
+  response.end();
+}
+
+async function serveStaticAsset(request, response) {
+  const requestPath = request.url?.split("?")[0] ?? "/";
+  const normalizedPath = normalize(requestPath).replace(/^([.][.][/\\])+/, "");
+  const filePath = normalizedPath === "/" ? "index.html" : normalizedPath.replace(/^\//, "");
+  const resolvedPath = join(rootDir, filePath);
+
+  try {
+    const contents = await readFile(resolvedPath);
+    response.statusCode = 200;
+    response.setHeader("Content-Type", contentTypeFor(resolvedPath));
+    response.end(contents);
+  } catch {
+    if (requestPath !== "/") {
+      const indexPath = join(rootDir, "index.html");
+      const contents = await readFile(indexPath);
+      response.statusCode = 200;
+      response.setHeader("Content-Type", "text/html; charset=utf-8");
+      response.end(contents);
+      return;
+    }
+
+    response.statusCode = 404;
+    response.setHeader("Content-Type", "text/plain; charset=utf-8");
+    response.end("Not found");
+  }
+}
+
+function contentTypeFor(filePath) {
+  switch (extname(filePath)) {
+    case ".html":
+      return "text/html; charset=utf-8";
+    case ".js":
+      return "text/javascript; charset=utf-8";
+    case ".css":
+      return "text/css; charset=utf-8";
+    case ".json":
+      return "application/json; charset=utf-8";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+async function readRequestBody(request) {
+  const chunks = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}

--- a/apps/react-demo/src/browser-adapter-client.js
+++ b/apps/react-demo/src/browser-adapter-client.js
@@ -1,0 +1,330 @@
+(function (root, factory) {
+  const client = factory();
+
+  if (typeof module === "object" && module.exports) {
+    module.exports = client;
+  }
+
+  if (root) {
+    root.TraverseReactDemoClient = client;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  const APPROVED_BROWSER_DEMO_SESSION = {
+    title: "Plan Expedition",
+    summary:
+      "Traverse evaluates the governed expedition workflow and assembles a final expedition plan.",
+    request: {
+      goal: "Plan a two-day alpine expedition for a four-person team.",
+      requested_target: "local",
+      caller: "browser_demo",
+    },
+    request_id: "expedition-plan-request-001",
+    execution_id: "exec_expedition-plan-request-001",
+    trace_id: "trace_exec_expedition-plan-request-001",
+  };
+
+  function createLiveDemoState() {
+    return {
+      phase: "idle",
+      statusLabel: "ready",
+      streamBanner: "No subscription active yet. Submit the approved request to begin.",
+      requestId: null,
+      executionId: null,
+      stateUpdates: [],
+      liveTrace: null,
+      liveResult: null,
+      error: "",
+    };
+  }
+
+  function buildApprovedSubscriptionRequest() {
+    return {
+      subscription_request: {
+        kind: "browser_runtime_subscription_request",
+        schema_version: "1.0.0",
+        governing_spec: "013-browser-runtime-subscription",
+        request_id: APPROVED_BROWSER_DEMO_SESSION.request_id,
+      },
+    };
+  }
+
+  function humanizeName(value) {
+    return value
+      .toString()
+      .split("_")
+      .filter(Boolean)
+      .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+      .join(" ");
+  }
+
+  function formatDetailValue(value) {
+    if (value === null || value === undefined) {
+      return "";
+    }
+    if (typeof value === "string") {
+      return value;
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      return String(value);
+    }
+    return JSON.stringify(value);
+  }
+
+  function describeStateEvent(stateEvent) {
+    const details = stateEvent.details || {};
+    const parts = [];
+
+    if (details.transition_reason) {
+      parts.push(humanizeName(details.transition_reason));
+    }
+
+    for (const [key, value] of Object.entries(details)) {
+      if (key === "transition_reason") {
+        continue;
+      }
+      parts.push(`${humanizeName(key)}: ${formatDetailValue(value)}`);
+    }
+
+    return parts.length > 0 ? parts.join(" · ") : "State update received.";
+  }
+
+  function formatStateUpdate(stateEvent) {
+    return {
+      state: stateEvent.state,
+      title: humanizeName(stateEvent.state),
+      timestamp: stateEvent.entered_at,
+      detail: describeStateEvent(stateEvent),
+    };
+  }
+
+  function normalizeSubscriptionMessage(message) {
+    const variant = Object.keys(message || {})[0];
+    if (!variant) {
+      return null;
+    }
+    return {
+      variant,
+      payload: message[variant],
+    };
+  }
+
+  function parseSubscriptionFrame(frame) {
+    let eventName = "";
+    let data = "";
+
+    for (const line of frame.split(/\r?\n/)) {
+      if (line.startsWith("event: ")) {
+        eventName = line.slice("event: ".length);
+      } else if (line.startsWith("data: ")) {
+        data += line.slice("data: ".length);
+      }
+    }
+
+    if (!eventName || !data) {
+      return null;
+    }
+
+    return {
+      event: eventName,
+      data: JSON.parse(data),
+    };
+  }
+
+  function parseSubscriptionFrames(text) {
+    return text
+      .split(/\r?\n\r?\n/)
+      .map((frame) => frame.trim())
+      .filter(Boolean)
+      .map(parseSubscriptionFrame)
+      .filter(Boolean);
+  }
+
+  async function runLiveBrowserSubscription({
+    baseUrl = "",
+    fetchImpl = globalThis.fetch,
+    onMessage,
+  } = {}) {
+    const adapterPrefix = baseUrl.replace(/\/$/, "");
+    const createResponse = await fetchImpl(`${adapterPrefix}/local/browser-subscriptions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(buildApprovedSubscriptionRequest()),
+    });
+
+    const createdPayload = await createResponse.text();
+    if (!createResponse.ok) {
+      throw new Error(`local browser adapter setup failed: ${createdPayload}`);
+    }
+
+    const created = JSON.parse(createdPayload);
+    const streamResponse = await fetchImpl(`${adapterPrefix}${created.stream_url}`, {
+      headers: {
+        Accept: "text/event-stream",
+      },
+    });
+
+    if (!streamResponse.ok) {
+      const errorPayload = await streamResponse.text();
+      throw new Error(`local browser adapter stream failed: ${errorPayload}`);
+    }
+
+    if (!streamResponse.body || typeof streamResponse.body.getReader !== "function") {
+      throw new Error("local browser adapter stream did not expose a readable body");
+    }
+
+    const reader = streamResponse.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const messages = [];
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const frames = buffer.split(/\r?\n\r?\n/);
+      buffer = frames.pop() || "";
+
+      for (const frame of frames) {
+        const parsed = parseSubscriptionFrame(frame.trim());
+        if (!parsed) {
+          continue;
+        }
+
+        const normalized = normalizeSubscriptionMessage(parsed.data);
+        if (!normalized) {
+          continue;
+        }
+
+        messages.push(normalized);
+        if (typeof onMessage === "function") {
+          onMessage(normalized, created);
+        }
+      }
+    }
+
+    const tail = buffer.trim();
+    if (tail) {
+      const parsed = parseSubscriptionFrame(tail);
+      if (parsed) {
+        const normalized = normalizeSubscriptionMessage(parsed.data);
+        if (normalized) {
+          messages.push(normalized);
+          if (typeof onMessage === "function") {
+            onMessage(normalized, created);
+          }
+        }
+      }
+    }
+
+    return {
+      created,
+      messages,
+    };
+  }
+
+  function applyBrowserSubscriptionMessage(state, message, created) {
+    const nextState = {
+      ...state,
+      error: "",
+    };
+
+    switch (message.variant) {
+      case "Lifecycle": {
+        const lifecycle = message.payload;
+        nextState.requestId = lifecycle.request_id;
+        nextState.executionId = lifecycle.execution_id;
+        nextState.statusLabel =
+          lifecycle.status === "subscription_established"
+            ? "streaming"
+            : lifecycle.status === "stream_completed"
+              ? "completed"
+              : lifecycle.status;
+        nextState.streamBanner =
+          lifecycle.status === "subscription_established"
+            ? "Subscription established. Streaming ordered runtime updates."
+            : "Stream completed. Final trace artifact is now visible.";
+        nextState.phase =
+          lifecycle.status === "subscription_established"
+            ? "streaming"
+            : lifecycle.status === "stream_completed"
+              ? "completed"
+              : nextState.phase;
+        if (created) {
+          nextState.subscriptionId = created.subscription_id;
+        }
+        return nextState;
+      }
+      case "State": {
+        nextState.phase = "streaming";
+        nextState.statusLabel = "streaming";
+        nextState.streamBanner = "Subscription established. Streaming ordered runtime updates.";
+        nextState.stateUpdates = nextState.stateUpdates.concat(formatStateUpdate(message.payload.state_event));
+        return nextState;
+      }
+      case "TraceArtifact": {
+        nextState.liveTrace = message.payload.trace;
+        return nextState;
+      }
+      case "StreamTerminal": {
+        nextState.liveResult = message.payload.result;
+        nextState.phase = "completed";
+        nextState.statusLabel = "completed";
+        nextState.streamBanner = "Stream completed. Final trace artifact is now visible.";
+        return nextState;
+      }
+      case "Error": {
+        nextState.phase = "error";
+        nextState.statusLabel = "error";
+        nextState.error = message.payload.message;
+        nextState.streamBanner = message.payload.message;
+        return nextState;
+      }
+      default:
+        return nextState;
+    }
+  }
+
+  function traceSummary(trace, terminalResult) {
+    if (!trace || !trace.selection || !trace.execution) {
+      return null;
+    }
+
+    const output = (terminalResult && terminalResult.output) || (trace.result && trace.result.output) || null;
+    return {
+      selection: {
+        capability: trace.selection.selected_capability_id,
+        version: trace.selection.selected_capability_version,
+        placementTarget: trace.execution.placement.selected_target,
+        placementReason: trace.execution.placement.reason,
+      },
+      emittedEvents: trace.emitted_events || [],
+      output: output
+        ? {
+            planId: output.plan_id,
+            route: output.route,
+            weatherSummary: output.weather_summary,
+            teamStatus: output.team_status,
+            nextAction: output.next_action,
+          }
+        : null,
+    };
+  }
+
+  return {
+    APPROVED_BROWSER_DEMO_SESSION,
+    applyBrowserSubscriptionMessage,
+    buildApprovedSubscriptionRequest,
+    createLiveDemoState,
+    humanizeName,
+    normalizeSubscriptionMessage,
+    parseSubscriptionFrames,
+    parseSubscriptionFrame,
+    runLiveBrowserSubscription,
+    traceSummary,
+  };
+});

--- a/apps/react-demo/src/main.js
+++ b/apps/react-demo/src/main.js
@@ -1,4 +1,7 @@
-const { createElement: h, useEffect, useState } = React;
+const { createElement: h, useState } = React;
+
+const DemoClient = window.TraverseReactDemoClient;
+const APPROVED_SESSION = DemoClient.APPROVED_BROWSER_DEMO_SESSION;
 
 function labeledCard(label, value) {
   return h(
@@ -31,7 +34,17 @@ function timelineItem(update) {
   );
 }
 
-function traceSection(session) {
+function liveTraceSection(trace, terminalResult) {
+  const summary = DemoClient.traceSummary(trace, terminalResult);
+
+  if (!summary) {
+    return h(
+      "div",
+      { className: "trace-placeholder" },
+      "Terminal trace is withheld until the ordered state stream reaches completion.",
+    );
+  }
+
   return [
     h(
       "div",
@@ -40,11 +53,11 @@ function traceSection(session) {
       h(
         "dl",
         { className: "trace-list" },
-        labeledCard("Capability", session.trace.selected_capability_id),
-        labeledCard("Version", session.trace.selected_capability_version),
+        labeledCard("Capability", summary.selection.capability),
+        labeledCard("Version", summary.selection.version),
         labeledCard(
           "Placement",
-          `${session.trace.placement.selected_target} · ${session.trace.placement.reason}`,
+          `${summary.selection.placementTarget} · ${summary.selection.placementReason}`,
         ),
       ),
     ),
@@ -55,7 +68,7 @@ function traceSection(session) {
       h(
         "ul",
         { className: "event-list" },
-        session.trace.emitted_events.map((eventId) => h("li", { key: eventId }, eventId)),
+        summary.emittedEvents.map((eventId) => h("li", { key: eventId }, eventId)),
       ),
     ),
     h(
@@ -65,60 +78,51 @@ function traceSection(session) {
       h(
         "dl",
         { className: "trace-list" },
-        labeledCard("Plan", session.trace.output.plan_id),
-        labeledCard("Route", session.trace.output.route),
-        labeledCard("Weather", session.trace.output.weather_summary),
-        labeledCard("Team Status", session.trace.output.team_status),
-        labeledCard("Next Action", session.trace.output.next_action),
+        labeledCard("Plan", summary.output.planId),
+        labeledCard("Route", summary.output.route),
+        labeledCard("Weather", summary.output.weatherSummary),
+        labeledCard("Team Status", summary.output.teamStatus),
+        labeledCard("Next Action", summary.output.nextAction),
       ),
     ),
   ];
 }
 
 function DemoApp() {
-  const [session, setSession] = useState(null);
+  const [sessionState, setSessionState] = useState(() => DemoClient.createLiveDemoState());
   const [error, setError] = useState("");
-  const [phase, setPhase] = useState("loading");
-  const [visibleCount, setVisibleCount] = useState(0);
 
-  useEffect(() => {
-    fetch("./public/expedition-runtime-session.json")
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`failed to load fixture: ${response.status}`);
-        }
-        return response.json();
-      })
-      .then((loadedSession) => {
-        setSession(loadedSession);
-        setPhase("idle");
-      })
-      .catch((reason) => {
-        setError(String(reason));
+  async function handleSubmitRequest() {
+    if (sessionState.phase === "streaming") {
+      return;
+    }
+
+    setError("");
+    setSessionState(DemoClient.createLiveDemoState());
+
+    try {
+      await DemoClient.runLiveBrowserSubscription({
+        onMessage: (message, created) => {
+          setSessionState((current) => DemoClient.applyBrowserSubscriptionMessage(current, message, created));
+        },
       });
-  }, []);
-
-  useEffect(() => {
-    if (!session || phase !== "streaming") {
-      return undefined;
+    } catch (reason) {
+      const message = String(reason);
+      setError(message);
+      setSessionState((current) => ({
+        ...current,
+        phase: "error",
+        statusLabel: "error",
+        streamBanner: message,
+        error: message,
+      }));
     }
-
-    if (visibleCount >= session.state_updates.length) {
-      setPhase("completed");
-      return undefined;
-    }
-
-    const timer = window.setTimeout(() => {
-      setVisibleCount((current) => current + 1);
-    }, 450);
-
-    return () => window.clearTimeout(timer);
-  }, [phase, session, visibleCount]);
-
-  function handleSubmitRequest() {
-    setVisibleCount(0);
-    setPhase("streaming");
   }
+
+  const statusLabel = sessionState.statusLabel;
+  const hasTerminalTrace = sessionState.phase === "completed" && sessionState.liveTrace;
+  const isStreaming = sessionState.phase === "streaming";
+  const visibleUpdates = sessionState.stateUpdates;
 
   if (error) {
     return h(
@@ -131,52 +135,16 @@ function DemoApp() {
           "div",
           { className: "hero-copy" },
           h("p", { className: "eyebrow" }, "Traverse Browser Runtime"),
-          h("h1", null, "Fixture loading failed."),
+          h("h1", null, "Live adapter connection failed."),
           h("p", { className: "lede" }, error),
-        ),
-      ),
-    );
-  }
-
-  if (!session) {
-    return h(
-      "main",
-      { className: "page" },
-      h(
-        "section",
-        { className: "hero" },
-        h(
-          "div",
-          { className: "hero-copy" },
-          h("p", { className: "eyebrow" }, "Traverse Browser Runtime"),
-          h("h1", null, "Loading the governed expedition session..."),
           h(
             "p",
             { className: "lede" },
-            "Preparing ordered runtime state updates and the terminal trace artifact.",
+            "Run the local browser adapter proxy again, or use the documented fixture preview fallback.",
           ),
         ),
       ),
     );
-  }
-
-  const visibleUpdates = session.state_updates.slice(0, visibleCount);
-  const hasTerminalTrace = phase === "completed";
-  const isStreaming = phase === "streaming";
-  const statusLabel =
-    phase === "idle"
-      ? "ready"
-      : phase === "streaming"
-        ? "streaming"
-        : phase === "completed"
-          ? session.status
-          : "loading";
-
-  let streamBanner = "No subscription active yet. Submit the approved request to begin.";
-  if (phase === "streaming") {
-    streamBanner = "Subscription established. Streaming ordered runtime updates.";
-  } else if (phase === "completed") {
-    streamBanner = "Stream completed. Final trace artifact is now visible.";
   }
 
   return h(
@@ -189,14 +157,15 @@ function DemoApp() {
         "div",
         { className: "hero-copy" },
         h("p", { className: "eyebrow" }, "Traverse Browser Runtime"),
-        h("h1", null, session.title),
-        h("p", { className: "lede" }, session.summary),
+        h("h1", null, APPROVED_SESSION.title),
+        h("p", { className: "lede" }, APPROVED_SESSION.summary),
         h(
           "dl",
           { className: "request-meta" },
-          labeledCard("Goal", session.request.goal),
-          labeledCard("Target", session.request.requested_target),
-          labeledCard("Trace", session.trace_id),
+          labeledCard("Goal", APPROVED_SESSION.request.goal),
+          labeledCard("Target", APPROVED_SESSION.request.requested_target),
+          labeledCard("Trace", APPROVED_SESSION.trace_id),
+          labeledCard("Request", APPROVED_SESSION.request_id),
         ),
       ),
       h("div", { className: "status-pill" }, statusLabel),
@@ -224,8 +193,8 @@ function DemoApp() {
             "div",
             null,
             h("p", { className: "request-label" }, "Approved request"),
-            h("h3", null, session.title),
-            h("p", null, session.request.goal),
+            h("h3", null, APPROVED_SESSION.title),
+            h("p", null, APPROVED_SESSION.request.goal),
           ),
           h(
             "button",
@@ -238,7 +207,7 @@ function DemoApp() {
             isStreaming ? "Streaming approved request..." : "Submit approved request",
           ),
         ),
-        h("div", { className: "stream-banner" }, streamBanner),
+        h("div", { className: "stream-banner" }, sessionState.streamBanner),
         h("ol", { className: "timeline" }, visibleUpdates.map(timelineItem)),
       ),
       h(
@@ -251,7 +220,7 @@ function DemoApp() {
           h("p", null, "The final governed selection, placement, and output snapshot."),
         ),
         hasTerminalTrace
-          ? traceSection(session)
+          ? liveTraceSection(sessionState.liveTrace, sessionState.liveResult)
           : h(
               "div",
               { className: "trace-placeholder" },

--- a/scripts/ci/react_demo_live_adapter_smoke.sh
+++ b/scripts/ci/react_demo_live_adapter_smoke.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# scripts/ci/react_demo_live_adapter_smoke.sh verifies the live browser adapter path end to end.
+
+repo_root="${TRAVERSE_REPO_ROOT:-$(pwd)}"
+tmpdir="$(mktemp -d)"
+adapter_log="${tmpdir}/browser-adapter.log"
+demo_log="${tmpdir}/react-demo.log"
+adapter_pid=""
+demo_pid=""
+
+cleanup() {
+  if [[ -n "${demo_pid}" ]] && kill -0 "${demo_pid}" 2>/dev/null; then
+    kill "${demo_pid}" 2>/dev/null || true
+    wait "${demo_pid}" 2>/dev/null || true
+  fi
+  if [[ -n "${adapter_pid}" ]] && kill -0 "${adapter_pid}" 2>/dev/null; then
+    kill "${adapter_pid}" 2>/dev/null || true
+    wait "${adapter_pid}" 2>/dev/null || true
+  fi
+  rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+pushd "${repo_root}" >/dev/null
+
+cargo run -p traverse-cli -- browser-adapter serve --bind 127.0.0.1:4174 >"${adapter_log}" 2>&1 &
+adapter_pid=$!
+
+for _ in $(seq 1 200); do
+  if grep -q "local browser adapter listening on " "${adapter_log}" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "${adapter_pid}" 2>/dev/null; then
+    cat "${adapter_log}" >&2
+    echo "browser adapter exited before it reported a listening address" >&2
+    exit 1
+  fi
+  sleep 0.05
+done
+
+node apps/react-demo/server.mjs --adapter http://127.0.0.1:4174 --port 4173 >"${demo_log}" 2>&1 &
+demo_pid=$!
+
+for _ in $(seq 1 200); do
+  if grep -q "Traverse React demo serving on http://127.0.0.1:4173" "${demo_log}" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "${demo_pid}" 2>/dev/null; then
+    cat "${demo_log}" >&2
+    echo "react demo server exited before it reported a listening address" >&2
+    exit 1
+  fi
+  sleep 0.05
+done
+
+node <<'NODE'
+const assert = require('node:assert/strict');
+const client = require('./apps/react-demo/src/browser-adapter-client.js');
+
+(async () => {
+  const root = await fetch('http://127.0.0.1:4173/');
+  assert.equal(root.status, 200);
+  const html = await root.text();
+  assert.match(html, /Traverse React Demo/);
+
+  const createAndStream = await client.runLiveBrowserSubscription({
+    baseUrl: 'http://127.0.0.1:4173',
+  });
+
+  assert.ok(createAndStream.created.subscription_id);
+  assert.ok(createAndStream.messages.length > 0);
+  assert.equal(createAndStream.messages[0].variant, 'Lifecycle');
+  assert.equal(
+    createAndStream.messages[createAndStream.messages.length - 1].variant,
+    'Lifecycle',
+  );
+  assert.ok(createAndStream.messages.some((message) => message.variant === 'State'));
+  assert.ok(createAndStream.messages.some((message) => message.variant === 'TraceArtifact'));
+  assert.ok(createAndStream.messages.some((message) => message.variant === 'StreamTerminal'));
+
+  const traceMessage = createAndStream.messages.find((message) => message.variant === 'TraceArtifact');
+  assert.ok(traceMessage);
+
+  const terminalMessage = createAndStream.messages.find((message) => message.variant === 'StreamTerminal');
+  assert.ok(terminalMessage);
+  assert.equal(terminalMessage.payload.result.status, 'completed');
+  assert.equal(terminalMessage.payload.result.output.plan_id, 'plan-objective-skypilot');
+
+  const trace = traceMessage.payload.trace;
+  const summary = client.traceSummary(traceMessage.payload.trace, terminalMessage.payload.result);
+  assert.ok(summary);
+  assert.equal(summary.selection.capability, 'expedition.planning.plan-expedition');
+  assert.equal(summary.output.planId, 'plan-objective-skypilot');
+
+  const invalidResponse = await fetch('http://127.0.0.1:4173/local/browser-subscriptions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      subscription_request: {
+        kind: 'browser_runtime_subscription_request',
+        schema_version: '1.0.0',
+        governing_spec: '013-browser-runtime-subscription',
+      },
+    }),
+  });
+  assert.equal(invalidResponse.status, 400);
+  const invalidPayload = await invalidResponse.json();
+  assert.equal(invalidPayload.kind, 'local_browser_subscription_setup_error');
+  assert.equal(invalidPayload.code, 'invalid_request');
+
+  const missingStream = await fetch('http://127.0.0.1:4173/local/browser-subscriptions/lbs_9999/stream', {
+    headers: {
+      Accept: 'text/event-stream',
+    },
+  });
+  assert.equal(missingStream.status, 404);
+  const missingPayload = await missingStream.json();
+  assert.equal(missingPayload.kind, 'local_browser_subscription_stream_error');
+  assert.equal(missingPayload.code, 'not_found');
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+NODE
+
+popd >/dev/null

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -30,6 +30,9 @@ required_files=(
   "docs/adr/README.md"
   "docs/adr/0001-rust-wasm-foundation.md"
   "scripts/ci/browser_adapter_smoke.sh"
+  "apps/react-demo/server.mjs"
+  "apps/react-demo/src/browser-adapter-client.js"
+  "scripts/ci/react_demo_live_adapter_smoke.sh"
   ".github/ISSUE_TEMPLATE/task.yml"
   "specs/001-foundation-v0-1/spec.md"
   "specs/001-foundation-v0-1/plan.md"
@@ -100,6 +103,15 @@ grep -q "specs/013-browser-runtime-subscription/spec.md" docs/adapter-boundaries
 grep -q "specs/014-mcp-surface/spec.md" docs/adapter-boundaries.md
 grep -q "mandatory sidecar topology" docs/adapter-boundaries.md
 grep -q "optional adapter choices" docs/adapter-boundaries.md
+grep -q "browser-adapter serve" apps/react-demo/README.md
+grep -q "react_demo_live_adapter_smoke.sh" apps/react-demo/README.md
+grep -q "same-origin local proxy" apps/react-demo/README.md
+grep -q "Run the local browser adapter proxy again" apps/react-demo/README.md
+grep -q "Traverse React demo serving on" apps/react-demo/server.mjs
+grep -q "runLiveBrowserSubscription" apps/react-demo/src/browser-adapter-client.js
+grep -q "applyBrowserSubscriptionMessage" apps/react-demo/src/browser-adapter-client.js
+grep -q "App" apps/react-demo/src/main.js
+grep -q "react_demo_live_adapter_smoke.sh" scripts/ci/react_demo_live_adapter_smoke.sh
 grep -q "## Governing Spec" .github/pull_request_template.md
 
 echo "Repository checks passed."


### PR DESCRIPTION
## Summary
Upgrade the React browser demo to consume the live local browser adapter through a same-origin proxy, preserving the approved request flow and ordered runtime stream.

## Governing Spec
- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `013-browser-runtime-subscription`
- `019-local-browser-adapter-transport`

## Project Item
- `#121`

## What Changed
- Contracts changed: none
- Runtime behavior changed: React demo now streams from the live local browser adapter through a same-origin proxy
- Compatibility impact: preserves the approved browser subscription request shape and adds a documented live adapter path
- ADR needed or linked: none

## Validation
- `bash scripts/ci/react_demo_live_adapter_smoke.sh`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/rust_checks.sh`
- `bash scripts/ci/coverage_gate.sh`

## Notes
Includes a documented fallback preview path for environments that cannot start the live adapter automatically.
