### PR TITLE
Write the first app-consumable quickstart for Traverse v0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Code, generated artifacts, and tests must align with the approved governing spec
 
 ## Key Docs
 
-- Start here: [quickstart.md](/private/tmp/cogolo-issue-122/quickstart.md)
+- First app-consumable quickstart: [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md)
 - Project direction: [draft.md](/Users/piovese/Documents/cogolo/draft.md)
 - Brainstorming decisions: [brainstorming.md](/Users/piovese/Documents/cogolo/brainstorming.md)
 - Quality standards: [docs/quality-standards.md](/Users/piovese/Documents/cogolo/docs/quality-standards.md)

--- a/apps/react-demo/README.md
+++ b/apps/react-demo/README.md
@@ -2,7 +2,7 @@
 
 This is the first checked-in React browser demo surface for Traverse.
 
-If you want the shortest end-to-end local path, start with [quickstart.md](/private/tmp/cogolo-issue-122/quickstart.md) and then come back here for the demo-specific details.
+If you want the shortest end-to-end local path, start with [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md) and then come back here for the demo-specific details.
 
 What it does:
 - renders one approved expedition flow
@@ -35,6 +35,8 @@ python3 -m http.server 4173 --directory apps/react-demo
 ```
 
 The fallback preview keeps the checked-in fixture-driven render path available for offline inspection and smoke validation.
+
+For the first app-consumable quickstart that uses the live browser adapter path, see [../../quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md).
 
 Live smoke path:
 

--- a/quickstart.md
+++ b/quickstart.md
@@ -1,64 +1,37 @@
 # Traverse v0.1 Quickstart
 
-This is the first app-consumable Traverse path for `Foundation v0.1`.
+This quickstart documents the first app-consumable Traverse flow: a browser-hosted app consuming Traverse through the live local browser adapter and the checked-in React demo surface.
 
-Use it when you want one clear local flow that proves:
+It is intentionally narrow. Use this path when you want one approved end-to-end consumer flow from setup through terminal outcome.
 
-- the Traverse runtime can serve the governed local browser adapter
-- a browser app can consume the ordered runtime stream through a same-origin local proxy
-- the canonical expedition request completes with a deterministic plan result
-- the runtime produces a final trace artifact that the app can inspect
+## What This Covers
 
-## What You Will Run
-
-This quickstart uses the checked-in, approved local path:
-
-- Traverse local browser adapter from `traverse-cli`
-- React browser demo from `apps/react-demo`
-- canonical expedition planning request
-- governed runtime state, trace, and terminal evidence
+- the Traverse runtime host
+- the live local browser adapter proxy
+- the React browser demo
+- one approved expedition request
+- ordered runtime updates, trace evidence, and terminal output
 
 ## Prerequisites
 
-Install the local tools used by the checked-in demo path:
+- A working Rust toolchain
+- Node.js 20 or later
+- Two terminals
+- The repository checked out with the approved browser adapter and browser demo implementation already merged
 
-- Rust toolchain with `cargo`
-- Node.js
+## Start The Live Browser Adapter
 
 From the repository root:
-
-```bash
-cargo test -p traverse-cli
-bash scripts/ci/browser_adapter_smoke.sh
-bash scripts/ci/react_demo_live_adapter_smoke.sh
-```
-
-Those commands prove the local adapter and browser demo path are healthy before you run the app manually.
-
-## Start The Local Browser Adapter
-
-In one terminal, start the governed local browser adapter:
 
 ```bash
 cargo run -p traverse-cli -- browser-adapter serve --bind 127.0.0.1:4174
 ```
 
-Expected output includes a line like:
+Keep this terminal open. The React demo proxies browser-subscription traffic through this local adapter.
 
-```text
-local browser adapter listening on http://127.0.0.1:4174
-```
+## Start The React Browser Demo
 
-The adapter exposes:
-
-- `POST /local/browser-subscriptions`
-- `GET /local/browser-subscriptions/{subscription_id}/stream`
-
-Those endpoints implement the governed transport in [specs/019-local-browser-adapter-transport/spec.md](/private/tmp/cogolo-issue-122/specs/019-local-browser-adapter-transport/spec.md).
-
-## Start The Browser App
-
-In a second terminal, start the checked-in local proxy and React app:
+In a second terminal from the repository root:
 
 ```bash
 node apps/react-demo/server.mjs --adapter http://127.0.0.1:4174 --port 4173
@@ -68,63 +41,52 @@ Open:
 
 - `http://127.0.0.1:4173`
 
-The proxy keeps the app on one local origin while forwarding governed browser adapter requests to the runtime.
+## Run The Approved Consumer Flow
 
-## Run The First App-Consumable Flow
+The demo is preloaded with the approved expedition request. Click **Submit approved request**.
 
-In the app:
+The approved request payload is:
 
-1. Open the Traverse React demo.
-2. Submit the approved expedition request.
-3. Wait for the ordered runtime stream to complete.
+```json
+{
+  "goal": "Plan a two-day alpine expedition for a four-person team.",
+  "requested_target": "local",
+  "caller": "browser_demo"
+}
+```
 
-This path uses the canonical expedition request and should end with a completed planning result.
+## What You Should See
 
-Expected successful outcome:
+- the status pill moves from `ready` to `streaming` and then `completed`
+- ordered runtime updates appear in the timeline
+- the terminal trace panel stays hidden until the stream completes
+- after completion, the trace panel shows the selected capability, emitted events, and final output
 
-- lifecycle updates appear first
-- state updates include the governed runtime progression
-- a final trace artifact is rendered
-- the terminal result reports `status: completed`
-- the resulting plan id is `plan-objective-skypilot`
+The expected final consumer outcome is a completed expedition plan with the governed trace snapshot visible in the app.
 
-The live demo smoke path checks the same success condition automatically:
+## Known Limitations
+
+- This is the first supported consumer path, not a production deployment guide.
+- The browser app must proxy through the local browser adapter to use the live path.
+- The fallback static preview path in `apps/react-demo/README.md` is useful for offline inspection, but it is not the app-consumable v0.1 path.
+- This quickstart does not redefine Traverse internals; it only documents the governed consumer flow that is already checked in.
+
+## Validation
+
+Run the live consumer path smoke test:
 
 ```bash
 bash scripts/ci/react_demo_live_adapter_smoke.sh
 ```
 
-## Inspect The Example Surfaces
-
-The quickstart is built on these checked-in example surfaces:
-
-- browser app guide: [apps/react-demo/README.md](/private/tmp/cogolo-issue-122/apps/react-demo/README.md)
-- expedition smoke paths: [docs/expedition-example-smoke.md](/private/tmp/cogolo-issue-122/docs/expedition-example-smoke.md)
-- first WASM agent example: [docs/wasm-agent-example.md](/private/tmp/cogolo-issue-122/docs/wasm-agent-example.md)
-- downstream app MCP validation: [docs/mcp-consumption-validation.md](/private/tmp/cogolo-issue-122/docs/mcp-consumption-validation.md)
-
-If you want to validate the public downstream-consumer path used for `youaskm3`, run:
+Run the fallback static preview smoke test:
 
 ```bash
-bash scripts/ci/mcp_consumption_validation.sh
+bash scripts/ci/react_demo_smoke.sh
 ```
 
-That smoke path verifies the public app-facing MCP surface separately from the browser demo path.
+Run repository checks:
 
-## Known Limitations
-
-This first consumable slice is intentionally narrow:
-
-- it covers one approved expedition flow only
-- it assumes the runtime and browser adapter are started locally by the developer
-- it uses a local proxy for the browser app instead of a packaged production transport
-- it proves one governed browser path and one governed MCP validation path, not general multi-app onboarding
-- native demo validation for macOS and Android can still require fuller local platform toolchains
-
-## Next Docs
-
-After this quickstart, the most useful next references are:
-
-- [docs/local-runtime-home.md](/private/tmp/cogolo-issue-122/docs/local-runtime-home.md)
-- [docs/adapter-boundaries.md](/private/tmp/cogolo-issue-122/docs/adapter-boundaries.md)
-- [docs/compatibility-policy.md](/private/tmp/cogolo-issue-122/docs/compatibility-policy.md)
+```bash
+bash scripts/ci/repository_checks.sh
+```

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -22,6 +22,7 @@ required_files=(
   "docs/wasm-agent-team-readiness-example.md"
   "docs/executable-package-template.md"
   "docs/local-runtime-home.md"
+  "quickstart.md"
   "examples/expedition/runtime-requests/plan-expedition.json"
   "docs/exception-process.md"
   "docs/project-management.md"
@@ -59,6 +60,7 @@ grep -q "GitHub Project 1" README.md
 grep -q "Apache-2.0" README.md
 grep -q "personal research" README.md
 grep -q "docs/adapter-boundaries.md" README.md
+grep -q "quickstart.md" README.md
 grep -q "Definition of Done" docs/ticket-standard.md
 grep -q "in-progress" docs/ticket-standard.md
 grep -q "active branch, PR, or an explicitly assigned developer" docs/ticket-standard.md
@@ -116,6 +118,12 @@ grep -q "runLiveBrowserSubscription" apps/react-demo/src/browser-adapter-client.
 grep -q "applyBrowserSubscriptionMessage" apps/react-demo/src/browser-adapter-client.js
 grep -q "App" apps/react-demo/src/main.js
 grep -q "react_demo_live_adapter_smoke.sh" scripts/ci/react_demo_live_adapter_smoke.sh
+grep -q "## Prerequisites" quickstart.md
+grep -q "browser-adapter serve --bind 127.0.0.1:4174" quickstart.md
+grep -q "node apps/react-demo/server.mjs --adapter http://127.0.0.1:4174 --port 4173" quickstart.md
+grep -q "bash scripts/ci/react_demo_live_adapter_smoke.sh" quickstart.md
+grep -q "bash scripts/ci/react_demo_smoke.sh" quickstart.md
+grep -q "## Known Limitations" quickstart.md
 grep -q "## Governing Spec" .github/pull_request_template.md
 
 echo "Repository checks passed."


### PR DESCRIPTION
## Summary
Document the first app-consumable quickstart for Traverse v0.1.

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate

## Project Item
- #122

## What Changed
- Added a root quickstart for the live local browser adapter and React demo flow.
- Linked the quickstart from the root README and the React browser demo README.
- Tightened repository checks to assert the quickstarts live-path commands and docs references.

## Validation
- bash scripts/ci/react_demo_live_adapter_smoke.sh
- bash scripts/ci/react_demo_smoke.sh
- bash scripts/ci/repository_checks.sh
