### PR TITLE
Prepare the Traverse v0.1 release checklist for app consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Code, generated artifacts, and tests must align with the approved governing spec
 
 - Start here: [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md)
 - App-consumable acceptance: [docs/app-consumable-acceptance.md](/Users/piovese/Documents/cogolo/docs/app-consumable-acceptance.md)
+- App-consumable release checklist: [docs/app-consumable-release-checklist.md](/Users/piovese/Documents/cogolo/docs/app-consumable-release-checklist.md)
 - Project direction: [draft.md](/Users/piovese/Documents/cogolo/draft.md)
 - Brainstorming decisions: [brainstorming.md](/Users/piovese/Documents/cogolo/brainstorming.md)
 - First real youaskm3 integration validation: [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md)

--- a/docs/app-consumable-release-checklist.md
+++ b/docs/app-consumable-release-checklist.md
@@ -1,0 +1,63 @@
+# Traverse v0.1 App-Consumable Release Checklist
+
+This checklist is the release decision aid for the first app-consumable Traverse release.
+
+It does not redefine the downstream contract or the validation specs. It only states what must be true before Traverse can claim `app-consumable v0.1`, and what can safely wait until after release.
+
+## Governing Specs
+
+- `specs/019-downstream-consumer-contract/spec.md`
+- `specs/020-downstream-integration-validation/spec.md`
+- `specs/021-app-facing-operational-constraints/spec.md`
+
+## Release Blockers
+
+Traverse MUST NOT claim `app-consumable v0.1` unless all of the following are satisfied:
+
+- [ ] The governed browser consumer path exists and is documented in [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md).
+- [ ] The live local browser adapter path passes [scripts/ci/react_demo_live_adapter_smoke.sh](/Users/piovese/Documents/cogolo/scripts/ci/react_demo_live_adapter_smoke.sh).
+- [ ] The browser demo path is documented as a real live adapter consumer in [apps/react-demo/README.md](/Users/piovese/Documents/cogolo/apps/react-demo/README.md).
+- [ ] The downstream MCP consumption path exists and passes [scripts/ci/mcp_consumption_validation.sh](/Users/piovese/Documents/cogolo/scripts/ci/mcp_consumption_validation.sh).
+- [ ] The first real `youaskm3` integration path exists and passes [scripts/ci/youaskm3_integration_validation.sh](/Users/piovese/Documents/cogolo/scripts/ci/youaskm3_integration_validation.sh).
+- [ ] The end-to-end acceptance path exists and passes [scripts/ci/app_consumable_acceptance.sh](/Users/piovese/Documents/cogolo/scripts/ci/app_consumable_acceptance.sh).
+- [ ] The operational constraints for app-facing browser and MCP surfaces are documented in [docs/adapter-boundaries.md](/Users/piovese/Documents/cogolo/docs/adapter-boundaries.md) and [docs/compatibility-policy.md](/Users/piovese/Documents/cogolo/docs/compatibility-policy.md).
+- [ ] The consumer contract and integration-validation model remain aligned with approved governing specs.
+
+If any item above is unchecked, `app-consumable v0.1` is blocked.
+
+## Required Evidence
+
+The release decision should be backed by:
+
+- the first app-consumable quickstart
+- the browser live-adapter smoke path
+- the MCP consumption validation path
+- the first real `youaskm3` integration validation path
+- the end-to-end app-consumable acceptance path
+- reviewable PR checks on the release-related documentation and validation artifacts
+
+## Post-Release Follow-Up
+
+The following are valid follow-up items after `app-consumable v0.1` and do not block the first release:
+
+- release automation and packaging polish
+- broader app-consumer templates for future downstream apps
+- stronger production deployment hardening
+- full auth and multi-tenant policy work
+- broader performance baselines and load testing
+- additional downstream validation paths beyond `youaskm3`
+
+## Reviewer Shortcut
+
+A reviewer can answer the release question by checking:
+
+1. the governed consumer contract
+2. the downstream integration-validation spec
+3. the operational-constraints spec
+4. the quickstart
+5. the live browser adapter smoke path
+6. the MCP validation path
+7. the first real `youaskm3` integration validation path
+8. the end-to-end acceptance path
+
+If those artifacts and checks exist and are passing, the first app-consumable release can be evaluated on evidence rather than interpretation.

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -19,6 +19,7 @@ required_files=(
   "docs/expedition-example-authoring.md"
   "docs/expedition-example-smoke.md"
   "docs/mcp-consumption-validation.md"
+  "docs/app-consumable-release-checklist.md"
   "docs/youaskm3-integration-validation.md"
   "docs/wasm-agent-team-readiness-example.md"
   "docs/app-consumable-acceptance.md"
@@ -89,6 +90,10 @@ grep -q "bash scripts/ci/event_driven_workflow_smoke.sh" docs/expedition-example
 grep -q "TRAVERSE_REPO_ROOT" docs/expedition-example-smoke.md
 grep -q "bash scripts/ci/mcp_consumption_validation.sh" docs/mcp-consumption-validation.md
 grep -q "docs/youaskm3-integration-validation.md" docs/mcp-consumption-validation.md
+grep -q "app-consumable v0.1" docs/app-consumable-release-checklist.md
+grep -q "Release Blockers" docs/app-consumable-release-checklist.md
+grep -q "Post-Release Follow-Up" docs/app-consumable-release-checklist.md
+grep -q "quickstart.md" docs/app-consumable-release-checklist.md
 grep -q "bash scripts/ci/wasm_agent_team_readiness_smoke.sh" docs/wasm-agent-team-readiness-example.md
 grep -q "bash scripts/ci/app_consumable_acceptance.sh" docs/app-consumable-acceptance.md
 grep -q "React browser demo" docs/app-consumable-acceptance.md


### PR DESCRIPTION
## Summary
- Add the first app-consumable release checklist for Traverse v0.1
- Document the release blockers, required evidence, and post-release follow-up
- Link the checklist from the root README and enforce its presence in repository checks

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate

## Project Item
- #127

## Validation
- bash scripts/ci/repository_checks.sh
