### PR TITLE
Refresh release and requirements traceability docs for current v0.1 state

### DIFF
--- a/docs/app-consumable-requirements-traceability.md
+++ b/docs/app-consumable-requirements-traceability.md
@@ -1,0 +1,67 @@
+# App-Consumable Requirements Traceability
+
+This document maps the first app-consumable Traverse requirements to the current GitHub issue and Project 1 state.
+
+Project 1 is the canonical task board for this work. Every requirement area below must have one or more tickets in that project, and the ticket state must make the release picture obvious without having to reconcile old notes manually.
+
+## Functional Requirements
+
+| Requirement Area | Covered By Tickets | Current State |
+|---|---|---|
+| Root app-consumable onboarding | [#122](https://github.com/enricopiovesan/Traverse/issues/122), [#127](https://github.com/enricopiovesan/Traverse/issues/127), [#142](https://github.com/enricopiovesan/Traverse/issues/142), [#143](https://github.com/enricopiovesan/Traverse/issues/143) | `Done` / `In Progress` |
+| Canonical docs entry path | [#142](https://github.com/enricopiovesan/Traverse/issues/142), [#144](https://github.com/enricopiovesan/Traverse/issues/144) | `In Progress` / `Ready` |
+| Release checklist and release-readiness evidence | [#127](https://github.com/enricopiovesan/Traverse/issues/127), [#145](https://github.com/enricopiovesan/Traverse/issues/145), [#149](https://github.com/enricopiovesan/Traverse/issues/149) | `In Progress` / `In Progress` / `Ready` |
+| Live browser-consumer path | [#120](https://github.com/enricopiovesan/Traverse/issues/120), [#121](https://github.com/enricopiovesan/Traverse/issues/121), [#123](https://github.com/enricopiovesan/Traverse/issues/123) | `Done` |
+| Downstream consumer contract and app-facing validation | [#126](https://github.com/enricopiovesan/Traverse/issues/126), [#128](https://github.com/enricopiovesan/Traverse/issues/128), [#129](https://github.com/enricopiovesan/Traverse/issues/129) | `Done` |
+| MCP WASM server model and validation | [#146](https://github.com/enricopiovesan/Traverse/issues/146), [#148](https://github.com/enricopiovesan/Traverse/issues/148) | `Ready` / `Blocked` |
+
+## Non-Functional Requirements
+
+| Requirement Area | Covered By Tickets | Current State |
+|---|---|---|
+| Documentation clarity for the first app-consumable path | [#142](https://github.com/enricopiovesan/Traverse/issues/142), [#143](https://github.com/enricopiovesan/Traverse/issues/143), [#145](https://github.com/enricopiovesan/Traverse/issues/145) | `In Progress` / `Done` / `In Progress` |
+| Traceability from requirements to release artifacts | [#145](https://github.com/enricopiovesan/Traverse/issues/145), [#149](https://github.com/enricopiovesan/Traverse/issues/149) | `In Progress` / `Ready` |
+| Operational safety boundary for app consumers | [#131](https://github.com/enricopiovesan/Traverse/issues/131) | `Blocked` |
+| First app-consumable performance baseline | [#130](https://github.com/enricopiovesan/Traverse/issues/130) | `Blocked` |
+
+## Current Open First-Release Ticket Set
+
+- [#127](https://github.com/enricopiovesan/Traverse/issues/127) `Prepare the Traverse v0.1 release checklist for app consumers` - `In Progress`
+- [#142](https://github.com/enricopiovesan/Traverse/issues/142) `Refresh README for v0.1 release-candidate state` - `In Progress`
+- [#144](https://github.com/enricopiovesan/Traverse/issues/144) `Establish one canonical documentation entry path for humans and agents` - `Ready`
+- [#145](https://github.com/enricopiovesan/Traverse/issues/145) `Refresh release and requirements traceability docs for current v0.1 state` - `In Progress`
+- [#146](https://github.com/enricopiovesan/Traverse/issues/146) `Specify the first dedicated Traverse MCP WASM server model` - `Ready`
+- [#149](https://github.com/enricopiovesan/Traverse/issues/149) `Define Traverse v0.1 release artifact and publication bundle` - `Ready` but dependency-gated by `#127`
+- [#130](https://github.com/enricopiovesan/Traverse/issues/130) `Define first app-consumable performance baseline` - `Blocked`
+- [#131](https://github.com/enricopiovesan/Traverse/issues/131) `Define app-facing security and safety boundary for browser and MCP consumers` - `Blocked`
+
+## v0.1 Release Ordering
+
+### Must Have For v0.1
+
+- [#120](https://github.com/enricopiovesan/Traverse/issues/120) local browser adapter transport
+- [#121](https://github.com/enricopiovesan/Traverse/issues/121) live browser demo over the adapter
+- [#122](https://github.com/enricopiovesan/Traverse/issues/122) app-consumable quickstart
+- [#123](https://github.com/enricopiovesan/Traverse/issues/123) end-to-end acceptance validation
+- [#126](https://github.com/enricopiovesan/Traverse/issues/126) downstream-consumer contract
+- [#127](https://github.com/enricopiovesan/Traverse/issues/127) release checklist
+- [#128](https://github.com/enricopiovesan/Traverse/issues/128) real `youaskm3` integration validation
+- [#129](https://github.com/enricopiovesan/Traverse/issues/129) app-facing MCP consumption validation
+
+### Should Have Soon After v0.1
+
+- [#142](https://github.com/enricopiovesan/Traverse/issues/142) README release-candidate refresh
+- [#144](https://github.com/enricopiovesan/Traverse/issues/144) canonical documentation entry path
+- [#145](https://github.com/enricopiovesan/Traverse/issues/145) requirements traceability refresh
+- [#146](https://github.com/enricopiovesan/Traverse/issues/146) dedicated MCP WASM server model
+- [#149](https://github.com/enricopiovesan/Traverse/issues/149) release artifact and publication bundle
+
+### Later
+
+- [#130](https://github.com/enricopiovesan/Traverse/issues/130) first app-consumable performance baseline
+- [#131](https://github.com/enricopiovesan/Traverse/issues/131) app-facing security and safety boundary
+- [#148](https://github.com/enricopiovesan/Traverse/issues/148) downstream validation for the dedicated MCP WASM server
+
+## Rule
+
+If a new app-consumable requirement appears and cannot be mapped to one or more tickets above, create the missing issue first and add it to Project 1 before calling the release backlog complete.

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -24,6 +24,7 @@ required_files=(
   "docs/wasm-agent-team-readiness-example.md"
   "docs/app-consumable-acceptance.md"
   "docs/app-consumable-entry-path.md"
+  "docs/app-consumable-requirements-traceability.md"
   "docs/executable-package-template.md"
   "docs/local-runtime-home.md"
   "quickstart.md"
@@ -101,6 +102,9 @@ grep -q "React browser demo" docs/app-consumable-acceptance.md
 grep -q "Canonical Rule" docs/app-consumable-entry-path.md
 grep -q "Start Here" docs/app-consumable-entry-path.md
 grep -q "quickstart.md" docs/app-consumable-entry-path.md
+grep -q "Current Open First-Release Ticket Set" docs/app-consumable-requirements-traceability.md
+grep -q "v0.1 Release Ordering" docs/app-consumable-requirements-traceability.md
+grep -q "Traceability from requirements to release artifacts" docs/app-consumable-requirements-traceability.md
 grep -q "bash scripts/ci/executable_package_template_smoke.sh" docs/executable-package-template.md
 grep -q "docs/local-runtime-home.md" docs/executable-package-template.md
 grep -q "cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json" docs/expedition-example-authoring.md


### PR DESCRIPTION
## Summary
- Refresh the release and requirements traceability docs to match the current v0.1 issue and project state
- Capture the current must-have, ready, blocked, and in-progress release tickets in one place
- Keep the release story aligned with the current app-consumable path

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate
- 019-downstream-consumer-contract

## Project Item
- #145

## Validation
- bash scripts/ci/repository_checks.sh
