### PR TITLE
Establish one canonical documentation entry path for humans and agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Code, generated artifacts, and tests must align with the approved governing spec
 ## Key Docs
 
 - Start here: [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md)
+- Documentation entry path: [docs/app-consumable-entry-path.md](/Users/piovese/Documents/cogolo/docs/app-consumable-entry-path.md)
 - App-consumable release checklist: [docs/app-consumable-release-checklist.md](/Users/piovese/Documents/cogolo/docs/app-consumable-release-checklist.md)
 - App-consumable acceptance: [docs/app-consumable-acceptance.md](/Users/piovese/Documents/cogolo/docs/app-consumable-acceptance.md)
 - Release and requirements traceability: [docs/app-consumable-requirements-traceability.md](/Users/piovese/Documents/cogolo/docs/app-consumable-requirements-traceability.md)

--- a/docs/app-consumable-entry-path.md
+++ b/docs/app-consumable-entry-path.md
@@ -1,0 +1,30 @@
+# App-Consumable Documentation Entry Path
+
+This is the canonical documentation path for humans and coding agents working on the first app-consumable Traverse flow.
+
+## Start Here
+
+1. Read the repository root [README.md](/Users/piovese/Documents/cogolo/README.md)
+2. Open [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md)
+3. Use the relevant deeper docs only after the quickstart path is clear:
+   - [docs/app-consumable-acceptance.md](/Users/piovese/Documents/cogolo/docs/app-consumable-acceptance.md)
+   - [docs/app-consumable-release-checklist.md](/Users/piovese/Documents/cogolo/docs/app-consumable-release-checklist.md)
+   - [docs/app-consumable-requirements-traceability.md](/Users/piovese/Documents/cogolo/docs/app-consumable-requirements-traceability.md)
+   - [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md)
+
+## Canonical Rule
+
+If a new human or agent asks where to begin, point them to the README first and then to the root quickstart.
+
+## Why This Exists
+
+- The README is the front door.
+- The quickstart is the first executable consumer path.
+- The deeper docs explain validation, release, and traceability after the first path is understood.
+- Competing entrypoints should be treated as references, not as the first recommended path.
+
+## Validation
+
+- The README links to the root quickstart.
+- The quickstart links to the deeper app-consumable docs when needed.
+- The canonical path is easy to describe without repository archaeology.

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -23,6 +23,7 @@ required_files=(
   "docs/youaskm3-integration-validation.md"
   "docs/wasm-agent-team-readiness-example.md"
   "docs/app-consumable-acceptance.md"
+  "docs/app-consumable-entry-path.md"
   "docs/executable-package-template.md"
   "docs/local-runtime-home.md"
   "quickstart.md"
@@ -97,6 +98,9 @@ grep -q "quickstart.md" docs/app-consumable-release-checklist.md
 grep -q "bash scripts/ci/wasm_agent_team_readiness_smoke.sh" docs/wasm-agent-team-readiness-example.md
 grep -q "bash scripts/ci/app_consumable_acceptance.sh" docs/app-consumable-acceptance.md
 grep -q "React browser demo" docs/app-consumable-acceptance.md
+grep -q "Canonical Rule" docs/app-consumable-entry-path.md
+grep -q "Start Here" docs/app-consumable-entry-path.md
+grep -q "quickstart.md" docs/app-consumable-entry-path.md
 grep -q "bash scripts/ci/executable_package_template_smoke.sh" docs/executable-package-template.md
 grep -q "docs/local-runtime-home.md" docs/executable-package-template.md
 grep -q "cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json" docs/expedition-example-authoring.md


### PR DESCRIPTION
## Summary
- Add a canonical docs entry path for the first app-consumable Traverse flow
- Make the README point at the root quickstart and entry-path doc
- Keep humans and coding agents pointed at the same onboarding route

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate

## Project Item
- #144

## Validation
- bash scripts/ci/repository_checks.sh
