### PR TITLE
Prepare app-consumable release bundle

### DIFF
--- a/docs/app-consumable-release-artifact.md
+++ b/docs/app-consumable-release-artifact.md
@@ -60,6 +60,16 @@ The first release MUST point to at least one runnable consumer artifact that pro
 
 For v0.1, the supported runnable artifact is the checked-in first app-consumable browser flow and its associated validation paths.
 
+## Preparation and Verification
+
+The release steward can verify the first app-consumable publication bundle with:
+
+```bash
+bash scripts/ci/app_consumable_release_prep.sh
+```
+
+That check confirms the release checklist, publication bundle definition, quickstart, and traceability docs are present and linked together.
+
 ## Post-Release Policy
 
 Items that do not belong in the first release bundle include:

--- a/docs/app-consumable-requirements-traceability.md
+++ b/docs/app-consumable-requirements-traceability.md
@@ -10,7 +10,7 @@ Project 1 is the canonical task board for this work. Every requirement area belo
 |---|---|---|
 | Root app-consumable onboarding | [#122](https://github.com/enricopiovesan/Traverse/issues/122), [#127](https://github.com/enricopiovesan/Traverse/issues/127), [#142](https://github.com/enricopiovesan/Traverse/issues/142), [#143](https://github.com/enricopiovesan/Traverse/issues/143) | `Done` / `In Progress` |
 | Canonical docs entry path | [#142](https://github.com/enricopiovesan/Traverse/issues/142), [#144](https://github.com/enricopiovesan/Traverse/issues/144) | `In Progress` / `Ready` |
-| Release checklist and release-readiness evidence | [#127](https://github.com/enricopiovesan/Traverse/issues/127), [#145](https://github.com/enricopiovesan/Traverse/issues/145), [#149](https://github.com/enricopiovesan/Traverse/issues/149) | `In Progress` / `In Progress` / `Ready` |
+| Release checklist and release-readiness evidence | [#127](https://github.com/enricopiovesan/Traverse/issues/127), [#145](https://github.com/enricopiovesan/Traverse/issues/145), [#150](https://github.com/enricopiovesan/Traverse/issues/150) | `In Progress` / `In Progress` / `In Progress` |
 | Live browser-consumer path | [#120](https://github.com/enricopiovesan/Traverse/issues/120), [#121](https://github.com/enricopiovesan/Traverse/issues/121), [#123](https://github.com/enricopiovesan/Traverse/issues/123) | `Done` |
 | Downstream consumer contract and app-facing validation | [#126](https://github.com/enricopiovesan/Traverse/issues/126), [#128](https://github.com/enricopiovesan/Traverse/issues/128), [#129](https://github.com/enricopiovesan/Traverse/issues/129) | `Done` |
 | MCP WASM server model and validation | [#146](https://github.com/enricopiovesan/Traverse/issues/146), [#158](https://github.com/enricopiovesan/Traverse/issues/158), [#148](https://github.com/enricopiovesan/Traverse/issues/148) | `Done` / `In Progress` / `Blocked` |
@@ -20,7 +20,7 @@ Project 1 is the canonical task board for this work. Every requirement area belo
 | Requirement Area | Covered By Tickets | Current State |
 |---|---|---|
 | Documentation clarity for the first app-consumable path | [#142](https://github.com/enricopiovesan/Traverse/issues/142), [#143](https://github.com/enricopiovesan/Traverse/issues/143), [#145](https://github.com/enricopiovesan/Traverse/issues/145) | `In Progress` / `Done` / `In Progress` |
-| Traceability from requirements to release artifacts | [#145](https://github.com/enricopiovesan/Traverse/issues/145), [#149](https://github.com/enricopiovesan/Traverse/issues/149) | `In Progress` / `Ready` |
+| Traceability from requirements to release artifacts | [#145](https://github.com/enricopiovesan/Traverse/issues/145), [#150](https://github.com/enricopiovesan/Traverse/issues/150) | `In Progress` / `In Progress` |
 | Operational safety boundary for app consumers | [#131](https://github.com/enricopiovesan/Traverse/issues/131) | `Blocked` |
 | First app-consumable performance baseline | [#130](https://github.com/enricopiovesan/Traverse/issues/130) | `Blocked` |
 
@@ -31,7 +31,7 @@ Project 1 is the canonical task board for this work. Every requirement area belo
 - [#144](https://github.com/enricopiovesan/Traverse/issues/144) `Establish one canonical documentation entry path for humans and agents` - `Ready`
 - [#145](https://github.com/enricopiovesan/Traverse/issues/145) `Refresh release and requirements traceability docs for current v0.1 state` - `In Progress`
 - [#158](https://github.com/enricopiovesan/Traverse/issues/158) `Implement MCP stdio server package foundation` - `In Progress`
-- [#149](https://github.com/enricopiovesan/Traverse/issues/149) `Define Traverse v0.1 release artifact and publication bundle` - `Ready` but dependency-gated by `#127`
+- [#150](https://github.com/enricopiovesan/Traverse/issues/150) `Prepare and validate the first Traverse v0.1 GitHub release artifact` - `In Progress`
 - [#130](https://github.com/enricopiovesan/Traverse/issues/130) `Define first app-consumable performance baseline` - `Blocked`
 - [#131](https://github.com/enricopiovesan/Traverse/issues/131) `Define app-facing security and safety boundary for browser and MCP consumers` - `Blocked`
 
@@ -54,7 +54,7 @@ Project 1 is the canonical task board for this work. Every requirement area belo
 - [#144](https://github.com/enricopiovesan/Traverse/issues/144) canonical documentation entry path
 - [#145](https://github.com/enricopiovesan/Traverse/issues/145) requirements traceability refresh
 - [#158](https://github.com/enricopiovesan/Traverse/issues/158) dedicated MCP stdio server package foundation
-- [#149](https://github.com/enricopiovesan/Traverse/issues/149) release artifact and publication bundle
+- [#150](https://github.com/enricopiovesan/Traverse/issues/150) release artifact and publication bundle
 
 ### Later
 

--- a/scripts/ci/app_consumable_release_prep.sh
+++ b/scripts/ci/app_consumable_release_prep.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+
+required_files=(
+  "docs/app-consumable-release-checklist.md"
+  "docs/app-consumable-release-artifact.md"
+  "docs/app-consumable-requirements-traceability.md"
+  "docs/app-consumable-acceptance.md"
+  "docs/youaskm3-integration-validation.md"
+  "quickstart.md"
+)
+
+for file in "${required_files[@]}"; do
+  test -s "${repo_root}/${file}"
+done
+
+grep -q "publication bundle" "${repo_root}/docs/app-consumable-release-artifact.md"
+grep -q "release checklist reference" "${repo_root}/docs/app-consumable-release-artifact.md"
+grep -q "supported runnable consumer artifact reference" "${repo_root}/docs/app-consumable-release-artifact.md"
+grep -q "bash scripts/ci/app_consumable_release_prep.sh" "${repo_root}/docs/app-consumable-release-artifact.md"
+grep -q "## Release Blockers" "${repo_root}/docs/app-consumable-release-checklist.md"
+grep -q "release artifact and publication bundle" "${repo_root}/docs/app-consumable-requirements-traceability.md"
+
+echo "Traverse v0.1 app-consumable release preparation bundle is ready."

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -43,6 +43,7 @@ required_files=(
   "apps/react-demo/src/browser-adapter-client.js"
   "scripts/ci/react_demo_live_adapter_smoke.sh"
   "scripts/ci/youaskm3_integration_validation.sh"
+  "scripts/ci/app_consumable_release_prep.sh"
   "scripts/ci/mcp_stdio_server_smoke.sh"
   "scripts/ci/mcp_stdio_server_discovery_smoke.sh"
   "scripts/ci/project_board_audit.sh"
@@ -118,6 +119,7 @@ grep -q "quickstart.md" docs/app-consumable-release-checklist.md
 grep -q "publication bundle" docs/app-consumable-release-artifact.md
 grep -q "GitHub release entry" docs/app-consumable-release-artifact.md
 grep -q "supported runnable artifact" docs/app-consumable-release-artifact.md
+grep -q "bash scripts/ci/app_consumable_release_prep.sh" docs/app-consumable-release-artifact.md
 grep -q "bash scripts/ci/wasm_agent_team_readiness_smoke.sh" docs/wasm-agent-team-readiness-example.md
 grep -q "bash scripts/ci/app_consumable_acceptance.sh" docs/app-consumable-acceptance.md
 grep -q "React browser demo" docs/app-consumable-acceptance.md


### PR DESCRIPTION
Implements #150.

## Governing Spec
- 004-spec-alignment-gate
- 019-downstream-consumer-contract

## Project Item
- Project 1 item: Prepare and validate the first Traverse v0.1 GitHub release artifact

Summary:
- adds the v0.1 app-consumable release-prep script
- links the release artifact doc to the checklist, quickstart, and traceability docs
- updates repository checks to require the release-prep bundle

## Validation
- bash scripts/ci/app_consumable_release_prep.sh
- bash scripts/ci/repository_checks.sh
