### PR TITLE
Validate downstream consumption of the dedicated Traverse MCP WASM server

### DIFF
--- a/docs/mcp-consumption-validation.md
+++ b/docs/mcp-consumption-validation.md
@@ -4,8 +4,6 @@ Traverse uses `youaskm3` as the first proving downstream app for the app-facing 
 
 For the shortest local start path before you run this downstream validation, begin with [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md).
 
-For the dedicated Traverse MCP server package, see [docs/mcp-stdio-server.md](/Users/piovese/Documents/cogolo/docs/mcp-stdio-server.md).
-
 For the dedicated Traverse MCP server package foundation, begin with [docs/mcp-stdio-server.md](/Users/piovese/Documents/cogolo/docs/mcp-stdio-server.md).
 
 This validation path is governed by:


### PR DESCRIPTION
Closes #148

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate
- 017-ai-agent-packaging

## Project Item
- Project 1 item: Validate downstream consumption of the dedicated Traverse MCP WASM server

## Summary
- fixes the stale quickstart path in the downstream MCP validation doc
- keeps the validation path rooted in the repository quickstart and documented MCP consumption flow
- preserves the deterministic validation flow for youaskm3-facing MCP consumption

## Validation
- bash scripts/ci/mcp_consumption_validation.sh
- bash scripts/ci/repository_checks.sh
