### PR TITLE
Implement browser-targeted consumer package

### DIFF
--- a/apps/browser-consumer/README.md
+++ b/apps/browser-consumer/README.md
@@ -1,0 +1,37 @@
+# Traverse Browser Consumer Package
+
+This is the browser-targeted consumer package for downstream apps such as `youaskm3`.
+
+It stays focused on the first governed browser-hosted path:
+
+- it reuses the approved live browser adapter client
+- it exposes a browser-safe subscription flow for the downstream app
+- it keeps runtime ordering, trace visibility, and terminal outcomes governed by Traverse surfaces rather than private app logic
+- it does not define UI, branding, or app-specific product behavior
+
+## Supported Use
+
+The package is intended to be consumed by a browser-hosted app that can bundle the façade and point it at the live browser adapter proxy.
+
+It provides:
+
+- a browser consumer session shape
+- approved subscription request construction
+- live subscription execution
+- ordered browser subscription message application
+- terminal trace summarization
+
+## Browser-Hosted Assumptions
+
+- The browser-hosted app has access to the approved live browser adapter proxy path.
+- The browser-hosted app uses the published consumer façade rather than internal Traverse crate layout.
+- The browser-hosted app relies on governed runtime updates, trace visibility, and terminal outcomes from Traverse.
+- Unsupported auth, remote deployment, and multi-tenant guarantees remain out of scope for the first slice.
+
+## Quick Start
+
+```bash
+node -e "const client = require('./apps/browser-consumer'); console.log(client.APPROVED_BROWSER_CONSUMER_SESSION.title)"
+```
+
+For the deterministic browser-hosted smoke path, see [../../scripts/ci/browser_consumer_package_smoke.sh](/Users/piovese/Documents/cogolo/scripts/ci/browser_consumer_package_smoke.sh).

--- a/apps/browser-consumer/index.js
+++ b/apps/browser-consumer/index.js
@@ -1,0 +1,67 @@
+(function (root, factory) {
+  const client = factory();
+
+  if (typeof module === "object" && module.exports) {
+    module.exports = client;
+  }
+
+  if (root) {
+    root.TraverseBrowserConsumer = client;
+  }
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  let baseClient = null;
+
+  if (typeof require === "function") {
+    try {
+      baseClient = require("../react-demo/src/browser-adapter-client.js");
+    } catch {
+      baseClient = null;
+    }
+  }
+
+  if (!baseClient && typeof globalThis !== "undefined" && globalThis.TraverseReactDemoClient) {
+    baseClient = globalThis.TraverseReactDemoClient;
+  }
+
+  if (!baseClient) {
+    throw new Error(
+      "Traverse browser consumer requires the approved browser adapter client to be available.",
+    );
+  }
+
+  const APPROVED_BROWSER_CONSUMER_SESSION = {
+    ...baseClient.APPROVED_BROWSER_DEMO_SESSION,
+    title: "Traverse Browser Consumer",
+    summary:
+      "Traverse's browser-targeted consumer facade for downstream browser-hosted apps like youaskm3.",
+  };
+
+  function createBrowserConsumerState() {
+    return baseClient.createLiveDemoState();
+  }
+
+  function buildBrowserConsumerSubscriptionRequest() {
+    return baseClient.buildApprovedSubscriptionRequest();
+  }
+
+  function runBrowserConsumerSubscription(options = {}) {
+    return baseClient.runLiveBrowserSubscription(options);
+  }
+
+  function applyBrowserConsumerMessage(state, message, created) {
+    return baseClient.applyBrowserSubscriptionMessage(state, message, created);
+  }
+
+  function browserConsumerTraceSummary(trace, terminalResult) {
+    return baseClient.traceSummary(trace, terminalResult);
+  }
+
+  return {
+    APPROVED_BROWSER_CONSUMER_SESSION,
+    applyBrowserConsumerMessage,
+    browserConsumerTraceSummary,
+    buildBrowserConsumerSubscriptionRequest,
+    createBrowserConsumerState,
+    runBrowserConsumerSubscription,
+  };
+});

--- a/apps/browser-consumer/package.json
+++ b/apps/browser-consumer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "traverse-browser-consumer",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js",
+  "description": "Traverse browser-targeted consumer facade for downstream browser-hosted apps."
+}

--- a/docs/app-consumable-entry-path.md
+++ b/docs/app-consumable-entry-path.md
@@ -11,6 +11,7 @@ This is the canonical documentation path for humans and coding agents working on
    - [docs/app-consumable-release-checklist.md](/Users/piovese/Documents/cogolo/docs/app-consumable-release-checklist.md)
    - [docs/app-consumable-requirements-traceability.md](/Users/piovese/Documents/cogolo/docs/app-consumable-requirements-traceability.md)
    - [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md)
+   - [apps/browser-consumer/README.md](/Users/piovese/Documents/cogolo/apps/browser-consumer/README.md)
 
 ## Canonical Rule
 

--- a/docs/mcp-consumption-validation.md
+++ b/docs/mcp-consumption-validation.md
@@ -12,7 +12,7 @@ This validation path is governed by:
 - `specs/020-downstream-integration-validation/spec.md`
 - `specs/021-app-facing-operational-constraints/spec.md`
 
-For the first real downstream browser + MCP integration path, also see [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md).
+For the first real downstream browser + MCP integration path, also see [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md) and the browser-targeted consumer package at [apps/browser-consumer/README.md](/Users/piovese/Documents/cogolo/apps/browser-consumer/README.md).
 
 ## Validation Path
 

--- a/scripts/ci/browser_consumer_package_smoke.sh
+++ b/scripts/ci/browser_consumer_package_smoke.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${TRAVERSE_REPO_ROOT:-$(pwd)}"
+tmpdir="$(mktemp -d)"
+adapter_log="${tmpdir}/browser-adapter.log"
+demo_log="${tmpdir}/react-demo.log"
+adapter_pid=""
+demo_pid=""
+
+cleanup() {
+  if [[ -n "${demo_pid}" ]] && kill -0 "${demo_pid}" 2>/dev/null; then
+    kill "${demo_pid}" 2>/dev/null || true
+    wait "${demo_pid}" 2>/dev/null || true
+  fi
+  if [[ -n "${adapter_pid}" ]] && kill -0 "${adapter_pid}" 2>/dev/null; then
+    kill "${adapter_pid}" 2>/dev/null || true
+    wait "${adapter_pid}" 2>/dev/null || true
+  fi
+  rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+pushd "${repo_root}" >/dev/null
+
+cargo run -p traverse-cli -- browser-adapter serve --bind 127.0.0.1:4174 >"${adapter_log}" 2>&1 &
+adapter_pid=$!
+
+for _ in $(seq 1 200); do
+  if grep -q "local browser adapter listening on " "${adapter_log}" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "${adapter_pid}" 2>/dev/null; then
+    cat "${adapter_log}" >&2
+    echo "browser adapter exited before it reported a listening address" >&2
+    exit 1
+  fi
+  sleep 0.05
+done
+
+node apps/react-demo/server.mjs --adapter http://127.0.0.1:4174 --port 4173 >"${demo_log}" 2>&1 &
+demo_pid=$!
+
+for _ in $(seq 1 200); do
+  if grep -q "Traverse React demo serving on http://127.0.0.1:4173" "${demo_log}" 2>/dev/null; then
+    break
+  fi
+  if ! kill -0 "${demo_pid}" 2>/dev/null; then
+    cat "${demo_log}" >&2
+    echo "react demo server exited before it reported a listening address" >&2
+    exit 1
+  fi
+  sleep 0.05
+done
+
+node <<'NODE'
+const assert = require('node:assert/strict');
+const consumer = require('./apps/browser-consumer');
+
+(async () => {
+  assert.equal(
+    consumer.APPROVED_BROWSER_CONSUMER_SESSION.title,
+    'Traverse Browser Consumer',
+  );
+
+  const createAndStream = await consumer.runBrowserConsumerSubscription({
+    baseUrl: 'http://127.0.0.1:4173',
+  });
+
+  assert.ok(createAndStream.created.subscription_id);
+  assert.ok(createAndStream.messages.length > 0);
+  assert.equal(createAndStream.messages[0].variant, 'Lifecycle');
+  assert.equal(
+    createAndStream.messages[createAndStream.messages.length - 1].variant,
+    'Lifecycle',
+  );
+  assert.ok(createAndStream.messages.some((message) => message.variant === 'State'));
+  assert.ok(createAndStream.messages.some((message) => message.variant === 'TraceArtifact'));
+  assert.ok(createAndStream.messages.some((message) => message.variant === 'StreamTerminal'));
+
+  const terminalMessage = createAndStream.messages.find((message) => message.variant === 'StreamTerminal');
+  assert.ok(terminalMessage);
+  assert.equal(terminalMessage.payload.result.status, 'completed');
+
+  const traceMessage = createAndStream.messages.find((message) => message.variant === 'TraceArtifact');
+  assert.ok(traceMessage);
+
+  const summary = consumer.browserConsumerTraceSummary(
+    traceMessage.payload.trace,
+    terminalMessage.payload.result,
+  );
+  assert.ok(summary);
+  assert.equal(summary.selection.capability, 'expedition.planning.plan-expedition');
+  assert.equal(summary.output.planId, 'plan-objective-skypilot');
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+NODE
+
+popd >/dev/null

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -23,6 +23,8 @@ required_files=(
   "docs/app-consumable-release-checklist.md"
   "docs/app-consumable-release-artifact.md"
   "docs/youaskm3-integration-validation.md"
+  "apps/browser-consumer/README.md"
+  "apps/browser-consumer/package.json"
   "docs/wasm-agent-team-readiness-example.md"
   "docs/app-consumable-acceptance.md"
   "docs/app-consumable-entry-path.md"
@@ -43,6 +45,7 @@ required_files=(
   "apps/react-demo/src/browser-adapter-client.js"
   "scripts/ci/react_demo_live_adapter_smoke.sh"
   "scripts/ci/mcp_stdio_server_execution_report_smoke.sh"
+  "scripts/ci/browser_consumer_package_smoke.sh"
   "scripts/ci/youaskm3_integration_validation.sh"
   "scripts/ci/app_consumable_release_prep.sh"
   "scripts/ci/mcp_stdio_server_smoke.sh"
@@ -119,6 +122,7 @@ grep -q "core-runtime-example" docs/mcp-stdio-server.md
 grep -q "mcp_stdio_server_execution_report_smoke.sh" docs/mcp-stdio-server.md
 grep -q "render_execution_report" docs/mcp-stdio-server.md
 grep -q "docs/youaskm3-integration-validation.md" docs/mcp-consumption-validation.md
+grep -q "apps/browser-consumer/README.md" docs/mcp-consumption-validation.md
 grep -q "app-consumable v0.1" docs/app-consumable-release-checklist.md
 grep -q "Release Blockers" docs/app-consumable-release-checklist.md
 grep -q "Post-Release Follow-Up" docs/app-consumable-release-checklist.md
@@ -171,6 +175,10 @@ grep -q "react_demo_live_adapter_smoke.sh" scripts/ci/react_demo_live_adapter_sm
 grep -q "## Prerequisites" quickstart.md
 grep -q "browser-adapter serve --bind 127.0.0.1:4174" quickstart.md
 grep -q "node apps/react-demo/server.mjs --adapter http://127.0.0.1:4174 --port 4173" quickstart.md
+grep -q "apps/browser-consumer/README.md" docs/app-consumable-entry-path.md
+grep -q "browser-targeted consumer package" apps/browser-consumer/README.md
+grep -q "browser_consumer_package_smoke.sh" apps/browser-consumer/README.md
+grep -q "browser-hosted app" apps/browser-consumer/README.md
 grep -q "bash scripts/ci/react_demo_live_adapter_smoke.sh" quickstart.md
 grep -q "bash scripts/ci/react_demo_smoke.sh" quickstart.md
 grep -q "## Known Limitations" quickstart.md


### PR DESCRIPTION
Implements issue #175.

## Governing Spec
- 004-spec-alignment-gate
- 023-browser-hosted-mcp-consumer-model

## Project Item
- https://github.com/enricopiovesan/Traverse/issues/175

## Summary
- defines the browser-targeted Traverse consumer package for downstream browser-hosted apps
- wraps the approved live browser adapter client in a browser-facing package
- keeps the browser-targeted consumer package distinct from the app-consumable quickstart and the browser-hosted consumer model

## Validation
- browser consumer package smoke path added
- repository checks updated to include the new package surface
