### PR TITLE
Publish versioned consumer bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Code, generated artifacts, and tests must align with the approved governing spec
 - Start here: [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md)
 - Documentation entry path: [docs/app-consumable-entry-path.md](/Users/piovese/Documents/cogolo/docs/app-consumable-entry-path.md)
 - App-consumable release checklist: [docs/app-consumable-release-checklist.md](/Users/piovese/Documents/cogolo/docs/app-consumable-release-checklist.md)
+- App-consumable consumer bundle: [docs/app-consumable-consumer-bundle.md](/Users/piovese/Documents/cogolo/docs/app-consumable-consumer-bundle.md)
 - App-consumable acceptance: [docs/app-consumable-acceptance.md](/Users/piovese/Documents/cogolo/docs/app-consumable-acceptance.md)
 - Release and requirements traceability: [docs/app-consumable-requirements-traceability.md](/Users/piovese/Documents/cogolo/docs/app-consumable-requirements-traceability.md)
 - Dedicated MCP stdio server package: [docs/mcp-stdio-server.md](/Users/piovese/Documents/cogolo/docs/mcp-stdio-server.md)

--- a/docs/app-consumable-consumer-bundle.md
+++ b/docs/app-consumable-consumer-bundle.md
@@ -1,0 +1,75 @@
+# Traverse v0.1 App-Consumable Consumer Bundle
+
+This document defines the first versioned Traverse consumer bundle for downstream app integration.
+
+The bundle is the release-facing adoption package for downstream apps such as `youaskm3`. It tells a downstream team what to install, which Traverse release tag to pin, and which public surfaces are supported together.
+
+## Bundle Purpose
+
+The consumer bundle exists so a downstream app can adopt Traverse without depending on source checkout details, internal crate layout, or ad hoc environment knowledge.
+
+It is a versioned compatibility record, not a new runtime behavior layer.
+
+## Supported v0.1 Surfaces
+
+For the first app-consumable release, the supported bundle points to:
+
+- the browser-targeted consumer package at [apps/browser-consumer/README.md](/Users/piovese/Documents/cogolo/apps/browser-consumer/README.md)
+- the dedicated MCP stdio server package at [docs/mcp-stdio-server.md](/Users/piovese/Documents/cogolo/docs/mcp-stdio-server.md)
+- the live browser adapter path described in [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md)
+- the downstream integration and validation docs for `youaskm3`
+
+Those surfaces must be consumed as one versioned release set.
+
+## Version Selection
+
+This section defines the supported version selection rules for downstream apps.
+
+Downstream apps SHOULD pin the same Traverse release tag for the consumer bundle, browser consumer package, and dedicated MCP surface references.
+
+Downstream apps SHOULD NOT mix a released consumer bundle with undocumented `main`-branch internals.
+
+If a downstream app needs a newer Traverse surface, it SHOULD move to a newer approved release bundle instead of cherry-picking unreleased pieces.
+
+## Installation Steps
+
+This section describes the installation steps for downstream repos.
+
+1. Select the approved Traverse v0.1 release tag.
+2. Follow the release publication bundle and quickstart references from the repo.
+3. Consume the browser-targeted consumer package for the browser-hosted path.
+4. Consume the dedicated MCP stdio server package for the MCP-facing path.
+5. Run the documented validation commands before declaring the integration complete.
+
+## Bundle Contents
+
+The first versioned consumer bundle MUST include:
+
+- the approved release tag or equivalent release pointer
+- the browser-targeted consumer package reference
+- the dedicated MCP stdio server package reference
+- the app-consumable quickstart reference
+- the browser live-adapter smoke reference
+- the MCP consumption validation reference
+- the `youaskm3` integration validation reference
+- the app-consumable acceptance reference
+- the release artifact and publication bundle reference
+
+## Verification
+
+A reviewer can verify the consumer bundle with:
+
+```bash
+bash scripts/ci/app_consumable_release_prep.sh
+```
+
+The release prep command confirms that the consumer bundle, release artifact, quickstart, and traceability docs are all present and linked together.
+
+## Known Limits
+
+The first versioned consumer bundle does not claim:
+
+- full auth hardening
+- multi-tenant guarantees
+- remote deployment guarantees beyond the approved local and documented paths
+- support for unreleased internal Traverse surfaces

--- a/docs/app-consumable-entry-path.md
+++ b/docs/app-consumable-entry-path.md
@@ -9,6 +9,7 @@ This is the canonical documentation path for humans and coding agents working on
 3. Use the relevant deeper docs only after the quickstart path is clear:
    - [docs/app-consumable-acceptance.md](/Users/piovese/Documents/cogolo/docs/app-consumable-acceptance.md)
    - [docs/app-consumable-release-checklist.md](/Users/piovese/Documents/cogolo/docs/app-consumable-release-checklist.md)
+   - [docs/app-consumable-consumer-bundle.md](/Users/piovese/Documents/cogolo/docs/app-consumable-consumer-bundle.md)
    - [docs/app-consumable-requirements-traceability.md](/Users/piovese/Documents/cogolo/docs/app-consumable-requirements-traceability.md)
    - [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md)
    - [apps/browser-consumer/README.md](/Users/piovese/Documents/cogolo/apps/browser-consumer/README.md)
@@ -21,6 +22,7 @@ If a new human or agent asks where to begin, point them to the README first and 
 
 - The README is the front door.
 - The quickstart is the first executable consumer path.
+- The versioned consumer bundle explains what a downstream app installs and which released surfaces it may rely on.
 - The deeper docs explain validation, release, and traceability after the first path is understood.
 - Competing entrypoints should be treated as references, not as the first recommended path.
 

--- a/docs/app-consumable-release-artifact.md
+++ b/docs/app-consumable-release-artifact.md
@@ -19,6 +19,7 @@ The release bundle is a publication record, not a new runtime behavior layer.
 
 The first release bundle MUST include:
 
+- the versioned consumer bundle reference
 - the release notes scope
 - the release checklist reference
 - the governed consumer contract reference
@@ -47,6 +48,7 @@ Release notes SHOULD avoid promising broader production hardening than the appro
 The release publication bundle MUST reference evidence for:
 
 - the first app-consumable quickstart
+- the versioned consumer bundle
 - the live browser adapter smoke path
 - the app-consumable acceptance path
 - the downstream consumer contract
@@ -68,7 +70,7 @@ The release steward can verify the first app-consumable publication bundle with:
 bash scripts/ci/app_consumable_release_prep.sh
 ```
 
-That check confirms the release checklist, publication bundle definition, quickstart, and traceability docs are present and linked together.
+That check confirms the release checklist, publication bundle definition, versioned consumer bundle, quickstart, and traceability docs are present and linked together.
 
 ## Post-Release Policy
 

--- a/docs/app-consumable-release-checklist.md
+++ b/docs/app-consumable-release-checklist.md
@@ -17,6 +17,7 @@ Traverse MUST NOT claim `app-consumable v0.1` unless all of the following are sa
 - [ ] The governed browser consumer path exists and is documented in [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md).
 - [ ] The live local browser adapter path passes [scripts/ci/react_demo_live_adapter_smoke.sh](/Users/piovese/Documents/cogolo/scripts/ci/react_demo_live_adapter_smoke.sh).
 - [ ] The browser demo path is documented as a real live adapter consumer in [apps/react-demo/README.md](/Users/piovese/Documents/cogolo/apps/react-demo/README.md).
+- [ ] The first versioned Traverse consumer bundle is documented in [docs/app-consumable-consumer-bundle.md](/Users/piovese/Documents/cogolo/docs/app-consumable-consumer-bundle.md).
 - [ ] The downstream MCP consumption path exists and passes [scripts/ci/mcp_consumption_validation.sh](/Users/piovese/Documents/cogolo/scripts/ci/mcp_consumption_validation.sh).
 - [ ] The first real `youaskm3` integration path exists and passes [scripts/ci/youaskm3_integration_validation.sh](/Users/piovese/Documents/cogolo/scripts/ci/youaskm3_integration_validation.sh).
 - [ ] The end-to-end acceptance path exists and passes [scripts/ci/app_consumable_acceptance.sh](/Users/piovese/Documents/cogolo/scripts/ci/app_consumable_acceptance.sh).
@@ -30,6 +31,7 @@ If any item above is unchecked, `app-consumable v0.1` is blocked.
 The release decision should be backed by:
 
 - the release artifact and publication bundle definition
+- the versioned consumer bundle definition
 - the first app-consumable quickstart
 - the browser live-adapter smoke path
 - the MCP consumption validation path
@@ -56,10 +58,11 @@ A reviewer can answer the release question by checking:
 2. the downstream integration-validation spec
 3. the operational-constraints spec
 4. the quickstart
-5. the live browser adapter smoke path
-6. the MCP validation path
-7. the first real `youaskm3` integration validation path
-8. the end-to-end acceptance path
-9. the release artifact and publication bundle definition
+5. the versioned consumer bundle
+6. the live browser adapter smoke path
+7. the MCP validation path
+8. the first real `youaskm3` integration validation path
+9. the end-to-end acceptance path
+10. the release artifact and publication bundle definition
 
 If those artifacts and checks exist and are passing, the first app-consumable release can be evaluated on evidence rather than interpretation.

--- a/docs/app-consumable-requirements-traceability.md
+++ b/docs/app-consumable-requirements-traceability.md
@@ -11,6 +11,7 @@ Project 1 is the canonical task board for this work. Every requirement area belo
 | Root app-consumable onboarding | [#122](https://github.com/enricopiovesan/Traverse/issues/122), [#127](https://github.com/enricopiovesan/Traverse/issues/127), [#142](https://github.com/enricopiovesan/Traverse/issues/142), [#143](https://github.com/enricopiovesan/Traverse/issues/143) | `Done` / `In Progress` |
 | Canonical docs entry path | [#142](https://github.com/enricopiovesan/Traverse/issues/142), [#144](https://github.com/enricopiovesan/Traverse/issues/144) | `In Progress` / `Ready` |
 | Release checklist and release-readiness evidence | [#127](https://github.com/enricopiovesan/Traverse/issues/127), [#145](https://github.com/enricopiovesan/Traverse/issues/145), [#150](https://github.com/enricopiovesan/Traverse/issues/150) | `In Progress` / `In Progress` / `In Progress` |
+| Versioned consumer bundle and installation steps | [#176](https://github.com/enricopiovesan/Traverse/issues/176) | `Ready` |
 | Live browser-consumer path | [#120](https://github.com/enricopiovesan/Traverse/issues/120), [#121](https://github.com/enricopiovesan/Traverse/issues/121), [#123](https://github.com/enricopiovesan/Traverse/issues/123) | `Done` |
 | Downstream consumer contract and app-facing validation | [#126](https://github.com/enricopiovesan/Traverse/issues/126), [#128](https://github.com/enricopiovesan/Traverse/issues/128), [#129](https://github.com/enricopiovesan/Traverse/issues/129) | `Done` |
 | MCP WASM server model and validation | [#146](https://github.com/enricopiovesan/Traverse/issues/146), [#158](https://github.com/enricopiovesan/Traverse/issues/158), [#148](https://github.com/enricopiovesan/Traverse/issues/148) | `Done` / `In Progress` / `Blocked` |
@@ -32,6 +33,7 @@ Project 1 is the canonical task board for this work. Every requirement area belo
 - [#145](https://github.com/enricopiovesan/Traverse/issues/145) `Refresh release and requirements traceability docs for current v0.1 state` - `In Progress`
 - [#158](https://github.com/enricopiovesan/Traverse/issues/158) `Implement MCP stdio server package foundation` - `In Progress`
 - [#150](https://github.com/enricopiovesan/Traverse/issues/150) `Prepare and validate the first Traverse v0.1 GitHub release artifact` - `In Progress`
+- [#176](https://github.com/enricopiovesan/Traverse/issues/176) `Publish versioned Traverse consumer bundle for downstream app integration` - `Ready`
 - [#130](https://github.com/enricopiovesan/Traverse/issues/130) `Define first app-consumable performance baseline` - `Blocked`
 - [#131](https://github.com/enricopiovesan/Traverse/issues/131) `Define app-facing security and safety boundary for browser and MCP consumers` - `Blocked`
 
@@ -55,6 +57,7 @@ Project 1 is the canonical task board for this work. Every requirement area belo
 - [#145](https://github.com/enricopiovesan/Traverse/issues/145) requirements traceability refresh
 - [#158](https://github.com/enricopiovesan/Traverse/issues/158) dedicated MCP stdio server package foundation
 - [#150](https://github.com/enricopiovesan/Traverse/issues/150) release artifact and publication bundle
+- [#176](https://github.com/enricopiovesan/Traverse/issues/176) versioned consumer bundle and installation steps
 
 ### Later
 

--- a/scripts/ci/app_consumable_release_prep.sh
+++ b/scripts/ci/app_consumable_release_prep.sh
@@ -6,6 +6,7 @@ repo_root=$(git rev-parse --show-toplevel)
 
 required_files=(
   "docs/app-consumable-release-checklist.md"
+  "docs/app-consumable-consumer-bundle.md"
   "docs/app-consumable-release-artifact.md"
   "docs/app-consumable-requirements-traceability.md"
   "docs/app-consumable-acceptance.md"
@@ -19,9 +20,11 @@ done
 
 grep -q "publication bundle" "${repo_root}/docs/app-consumable-release-artifact.md"
 grep -q "release checklist reference" "${repo_root}/docs/app-consumable-release-artifact.md"
+grep -q "versioned consumer bundle reference" "${repo_root}/docs/app-consumable-release-artifact.md"
 grep -q "supported runnable consumer artifact reference" "${repo_root}/docs/app-consumable-release-artifact.md"
 grep -q "bash scripts/ci/app_consumable_release_prep.sh" "${repo_root}/docs/app-consumable-release-artifact.md"
 grep -q "## Release Blockers" "${repo_root}/docs/app-consumable-release-checklist.md"
+grep -q "docs/app-consumable-consumer-bundle.md" "${repo_root}/docs/app-consumable-release-checklist.md"
 grep -q "release artifact and publication bundle" "${repo_root}/docs/app-consumable-requirements-traceability.md"
 
 echo "Traverse v0.1 app-consumable release preparation bundle is ready."

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -21,6 +21,7 @@ required_files=(
   "docs/mcp-consumption-validation.md"
   "docs/mcp-stdio-server.md"
   "docs/app-consumable-release-checklist.md"
+  "docs/app-consumable-consumer-bundle.md"
   "docs/app-consumable-release-artifact.md"
   "docs/youaskm3-integration-validation.md"
   "apps/browser-consumer/README.md"
@@ -123,11 +124,21 @@ grep -q "mcp_stdio_server_execution_report_smoke.sh" docs/mcp-stdio-server.md
 grep -q "render_execution_report" docs/mcp-stdio-server.md
 grep -q "docs/youaskm3-integration-validation.md" docs/mcp-consumption-validation.md
 grep -q "apps/browser-consumer/README.md" docs/mcp-consumption-validation.md
+grep -q "docs/app-consumable-consumer-bundle.md" README.md
+grep -q "docs/app-consumable-consumer-bundle.md" docs/app-consumable-entry-path.md
+grep -q "versioned Traverse consumer bundle" docs/app-consumable-consumer-bundle.md
+grep -q "supported version selection" docs/app-consumable-consumer-bundle.md
+grep -q "installation steps" docs/app-consumable-consumer-bundle.md
+grep -q "apps/browser-consumer/README.md" docs/app-consumable-consumer-bundle.md
+grep -q "docs/mcp-stdio-server.md" docs/app-consumable-consumer-bundle.md
+grep -q "bash scripts/ci/app_consumable_release_prep.sh" docs/app-consumable-consumer-bundle.md
 grep -q "app-consumable v0.1" docs/app-consumable-release-checklist.md
 grep -q "Release Blockers" docs/app-consumable-release-checklist.md
 grep -q "Post-Release Follow-Up" docs/app-consumable-release-checklist.md
 grep -q "quickstart.md" docs/app-consumable-release-checklist.md
+grep -q "docs/app-consumable-consumer-bundle.md" docs/app-consumable-release-checklist.md
 grep -q "publication bundle" docs/app-consumable-release-artifact.md
+grep -q "versioned consumer bundle" docs/app-consumable-release-artifact.md
 grep -q "GitHub release entry" docs/app-consumable-release-artifact.md
 grep -q "supported runnable artifact" docs/app-consumable-release-artifact.md
 grep -q "bash scripts/ci/app_consumable_release_prep.sh" docs/app-consumable-release-artifact.md
@@ -166,6 +177,8 @@ grep -q "react_demo_live_adapter_smoke.sh" apps/react-demo/README.md
 grep -q "same-origin local proxy" apps/react-demo/README.md
 grep -q "app-consumable acceptance" apps/react-demo/README.md
 grep -q "Run the local browser adapter proxy again" apps/react-demo/README.md
+grep -q "browser-targeted consumer package" docs/app-consumable-consumer-bundle.md
+grep -q "consumer bundle" docs/app-consumable-consumer-bundle.md
 grep -q "youaskm3 integration validation" README.md
 grep -q "Traverse React demo serving on" apps/react-demo/server.mjs
 grep -q "runLiveBrowserSubscription" apps/react-demo/src/browser-adapter-client.js


### PR DESCRIPTION
Implements issue #176: versioned Traverse consumer bundle for downstream app integration.

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate
- 019-downstream-consumer-contract
- 023-browser-hosted-mcp-consumer-model

## Project Item
- https://github.com/enricopiovesan/Traverse/issues/176

## Summary
- adds docs/app-consumable-consumer-bundle.md defining supported version selection and installation steps
- links the bundle doc from the release checklist, release artifact, README, and app-consumable entry path
- tightens repo checks so the bundle doc stays wired into the release process

## Validation
- bash scripts/ci/app_consumable_release_prep.sh
- bash scripts/ci/repository_checks.sh
