### PR TITLE
Add Claude Code as parallel AI development agent

### DIFF
--- a/.agents/skills/speckit-plan/SKILL.md
+++ b/.agents/skills/speckit-plan/SKILL.md
@@ -138,6 +138,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 3. **Agent context update**:
    - Run `.specify/scripts/bash/update-agent-context.sh codex`
+   - Run `.specify/scripts/bash/update-agent-context.sh claude`
    - These scripts detect which AI agent is in use
    - Update the appropriate agent-specific context file
    - Add only new technology from current plan

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,5 +1,5 @@
 {
-  "ai": "codex",
+  "ai": ["codex", "claude"],
   "ai_commands_dir": null,
   "ai_skills": true,
   "branch_numbering": "sequential",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# Traverse Development Guidelines
+
+Auto-generated from all feature plans. Last updated: 2026-04-07
+
+## Active Technologies
+
+- Rust 1.94+
+- Cargo workspace
+- serde (JSON serialization)
+- semver
+- WASM (target)
+
+## Project Structure
+
+```text
+crates/
+  traverse-runtime/      # Core execution engine
+  traverse-contracts/    # Contract definitions and validation
+  traverse-registry/     # Capability and event registries
+  traverse-cli/          # Command-line interface
+  traverse-mcp/          # Model Context Protocol (stub)
+specs/                   # Versioned, immutable governing specs
+contracts/               # Capability and event contracts
+docs/                    # ADRs, quality standards, policies
+.specify/                # Speckit: constitution, scripts, templates
+scripts/ci/              # Deterministic spec-alignment gate
+```
+
+## Commands
+
+```bash
+cargo build
+cargo test
+cargo clippy -- -D warnings
+cargo run -p traverse-cli
+bash scripts/ci/spec_alignment_check.sh
+```
+
+## Code Style
+
+- No `unsafe`, no `unwrap()`, no `panic!()`, no TODO comments
+- 100% test coverage for core business and runtime logic
+- Deterministic: same inputs must produce same outputs
+
+## Recent Changes
+
+- 183-add-claude-code-agent: Added Claude Code as parallel AI agent (CLAUDE.md, init-options.json, speckit-plan skill)
+
+<!-- MANUAL ADDITIONS START -->
+## Governance
+
+Read `.specify/memory/constitution.md` before any implementation work.
+
+### Key rules
+
+1. **Spec-first**: every feature needs an approved spec in `specs/` before code — no spec, no merge
+2. **Contract-first**: contracts are source of truth; code conforms to contracts, not vice versa
+3. **Spec-alignment gate**: CI blocks PRs that drift from `specs/governance/approved-specs.json`
+4. **Traceability**: all work must have a GitHub issue + Project 1 item + PR
+
+### Approved specs
+
+| ID  | Name |
+|-----|------|
+| 001 | foundation-v0-1 |
+| 002 | capability-contracts |
+| 003 | event-contracts |
+| 004 | spec-alignment-gate |
+| 005 | capability-registry |
+| 006 | runtime-request-execution |
+| 007 | workflow-registry-traversal |
+| 008 | expedition-example-domain |
+| 009 | expedition-example-artifacts |
+
+### Feature branch convention
+
+Feature branches must follow `NNN-feature-name` or `YYYYMMDD-HHMMSS-feature-name`.
+Each feature gets a directory at `specs/<branch-name>/` with `spec.md` and `plan.md`.
+
+### Development workflow
+
+1. Clarify capability boundary
+2. Define or amend governing spec in `specs/`
+3. Define contracts in `contracts/`
+4. Write tests
+5. Implement smallest change satisfying spec + contract
+6. Verify CI gate passes before opening PR
+<!-- MANUAL ADDITIONS END -->

--- a/specs/183-add-claude-code-agent/plan.md
+++ b/specs/183-add-claude-code-agent/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: Add Claude Code as parallel AI development agent
+
+**Branch**: `183-add-claude-code-agent` | **Date**: 2026-04-07 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/183-add-claude-code-agent/spec.md`
+
+## Summary
+
+Register Claude Code as a first-class parallel AI agent in the Traverse Speckit governance framework. Three files change: CLAUDE.md is created at the repo root as Claude Code's entry point; init-options.json gains `"claude"` as a supported `"ai"` value; speckit-plan SKILL.md gains a second `update-agent-context.sh claude` invocation in Phase 1. No Rust code, no contract, no CI gate changes.
+
+## Technical Context
+
+**Language/Version**: Rust 1.94+ (workspace, unchanged); bash scripting; Markdown
+**Primary Dependencies**: `.specify/scripts/bash/update-agent-context.sh` (already supports `claude`); `.specify/templates/agent-file-template.md`
+**Storage**: N/A
+**Testing**: Manual — open Claude Code at repo root, confirm CLAUDE.md loaded; run speckit-plan, confirm CLAUDE.md updated
+**Target Platform**: Developer workstation; Claude Code CLI
+**Project Type**: Dev tooling configuration
+**Performance Goals**: N/A
+**Constraints**: Must not break existing Codex flows; must not touch any Rust crate, contract, or CI gate
+**Scale/Scope**: Three files modified or created; zero new runtime capabilities
+
+## Constitution Check
+
+This feature is **dev tooling only**. No constitution gates block this work.
+
+| Gate | Status | Note |
+|------|--------|------|
+| Capability-First Boundaries | N/A | No business capability defined |
+| Contracts Are Source of Truth | Pass | No contracts touched |
+| Specs Are Versioned, Immutable, Merge-Gating | Pass | This spec governs the work |
+| Portability Over Host Coupling | N/A | Dev tooling; outside runtime portability boundary |
+| Discoverability and Governance by Default | Pass | CLAUDE.md improves governance discoverability |
+| Runtime Decisions Must Be Explainable | N/A | No runtime behavior changes |
+| Small, Verifiable v0.1 | Pass | Smallest possible change; traverse-mcp deferred |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/183-add-claude-code-agent/
+├── spec.md
+└── plan.md              # This file
+```
+
+### Files touched
+
+```text
+CLAUDE.md                                    # CREATED — Claude Code entry point
+.specify/init-options.json                   # MODIFIED — add "claude" as valid ai value
+.agents/skills/speckit-plan/SKILL.md         # MODIFIED — add update-agent-context.sh claude call
+```
+
+## Phase 0: Research
+
+No unknowns. All inputs are resolved:
+
+- `update-agent-context.sh claude` is implemented at line 619; writes to `$REPO_ROOT/CLAUDE.md` using the agent-file-template.md. No script changes required.
+- speckit-plan SKILL.md Phase 1 step 3 currently only calls `codex`. Adding `claude` is the entire change.
+- init-options.json has no enum validation blocking a new `"ai"` value.
+- CLAUDE.md initial content: use the agent-file-template.md structure with a hand-authored `## Governance` section inside the manual additions markers.
+
+## Phase 1: Design & Contracts
+
+No external contracts. This feature has no runtime-facing interfaces.
+
+### CLAUDE.md structure
+
+Must satisfy two purposes: (1) human-readable governance reference and (2) machine-updatable via update-agent-context.sh. The script looks for `## Active Technologies`, `## Recent Changes`, and `<!-- MANUAL ADDITIONS START/END -->` markers.
+
+```text
+# Traverse Development Guidelines
+Auto-generated. Last updated: <date>
+
+## Active Technologies        ← auto-updated
+## Project Structure          ← auto-updated
+## Commands                   ← auto-updated
+## Code Style                 ← auto-updated
+## Recent Changes             ← auto-updated
+
+<!-- MANUAL ADDITIONS START -->
+## Governance                 ← hand-authored, preserved across updates
+<!-- MANUAL ADDITIONS END -->
+```
+
+### speckit-plan SKILL.md change
+
+Phase 1, step 3 — add immediately after existing codex line:
+```
+- Run `.specify/scripts/bash/update-agent-context.sh claude`
+```
+
+### init-options.json change
+
+Change `"ai": "codex"` → `"ai": ["codex", "claude"]` to declare both agents active.
+
+## Implementation Sequence
+
+1. Create `CLAUDE.md` at repo root
+2. Edit `.agents/skills/speckit-plan/SKILL.md` — add claude invocation
+3. Edit `.specify/init-options.json` — declare both agents
+4. Run `update-agent-context.sh claude` to verify script path works end-to-end (requires active plan.md; manual verification)
+5. Verify `cargo test && cargo clippy` unchanged
+6. Commit, push, open PR referencing #183

--- a/specs/183-add-claude-code-agent/spec.md
+++ b/specs/183-add-claude-code-agent/spec.md
@@ -1,0 +1,87 @@
+# Feature Specification: Add Claude Code as parallel AI development agent
+
+**Feature Branch**: `183-add-claude-code-agent`
+**Created**: 2026-04-07
+**Status**: Draft
+**Input**: GitHub issue #183 — Add Claude Code as parallel AI development agent
+
+> **Governance note**: This is dev tooling, not a runtime capability. The constitution's Capability-First Boundaries rule (Principle I) does not apply here. No new business capability is being introduced, no contract is being created or amended, and no runtime behavior is changing. This spec governs tooling and developer workflow configuration only.
+
+## User Scenarios & Testing
+
+### User Story 1 - Start work with Claude Code and receive project context (Priority: P1)
+
+As a developer using Claude Code on the Traverse project, I want Claude Code to automatically load the project's governance rules, constitution, and active spec when I open a session, so that I can plan and implement features under the same governance framework as Codex without manually locating those documents.
+
+**Why this priority**: CLAUDE.md is the entry point Claude Code reads at session start. Without it, Claude Code has no awareness of the Speckit framework, the constitution, or the active branch's spec. Every other story depends on this being in place first.
+
+**Independent Test**: Open Claude Code at the repo root. Verify that the session context includes references to the constitution and the active spec directory without any manual prompting.
+
+**Acceptance Scenarios**:
+
+1. **Given** CLAUDE.md exists at the project root, **When** Claude Code initializes a session, **Then** Claude Code's context includes the constitution location, the specs directory convention, and the governance rules governing feature work.
+2. **Given** a developer is on a feature branch with a corresponding `specs/<branch>/` directory, **When** Claude Code starts, **Then** CLAUDE.md directs Claude Code to load the relevant spec artifacts for that branch.
+3. **Given** CLAUDE.md is present, **When** a developer asks Claude Code to begin planning or implementing a feature, **Then** Claude Code applies the spec-first, contract-first governance rules from the constitution rather than inventing its own process.
+
+---
+
+### User Story 2 - Run speckit-plan and have Claude Code context updated automatically (Priority: P2)
+
+As a developer using Claude Code, I want the speckit-plan skill to update CLAUDE.md with the current plan's technical context alongside AGENTS.md, so that both Codex and Claude Code receive consistent, up-to-date project information after every planning cycle.
+
+**Why this priority**: Without this, CLAUDE.md would become stale after new plans are created. The update-agent-context.sh script already supports the `claude` agent type; the speckit-plan SKILL.md just needs to invoke it.
+
+**Independent Test**: Run the speckit-plan skill on any feature branch that has a plan.md. Confirm that CLAUDE.md is created or updated with the current plan's language, framework, and branch entry.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed plan.md on a feature branch, **When** speckit-plan Phase 1 executes, **Then** `update-agent-context.sh claude` is invoked and CLAUDE.md reflects the plan's technical context.
+2. **Given** CLAUDE.md already exists from a prior run, **When** speckit-plan is re-run on a new branch, **Then** CLAUDE.md is updated with the new branch's technology additions while preserving manual additions between the designated markers.
+3. **Given** speckit-plan runs successfully, **When** both agent context updates complete, **Then** AGENTS.md and CLAUDE.md are consistent in their technology stack and recent changes entries for the same plan.
+
+---
+
+### User Story 3 - Declare claude as a supported init AI agent type (Priority: P3)
+
+As a developer setting up a new Speckit project, I want to choose `claude` as the AI agent type in init-options.json so that project initialization targets Claude Code's entry point file.
+
+**Why this priority**: Supporting `claude` in init-options.json makes the choice declarative. Lower priority because the update script already works independently.
+
+**Independent Test**: Set `"ai": "claude"` in init-options.json. Run any agent context update flow. Confirm CLAUDE.md is created at the root level.
+
+**Acceptance Scenarios**:
+
+1. **Given** `"ai": "claude"` in init-options.json, **When** the agent context update runs, **Then** CLAUDE.md is the target output file.
+2. **Given** `"ai": "codex"` in init-options.json, **When** the agent context update runs, **Then** AGENTS.md remains the output, unchanged from current behavior.
+3. **Given** both agent files already exist in a repo with mixed agent usage, **When** the update-all path runs, **Then** both CLAUDE.md and AGENTS.md are updated correctly.
+
+---
+
+### Edge Cases
+
+- What happens if CLAUDE.md exists but was authored manually without the auto-update markers? The update script must not overwrite manual content outside the designated markers.
+- What happens if speckit-plan is run when CLAUDE.md already references a different branch? The script appends the new branch entry and caps the recent changes list at three entries.
+- What happens if both `"ai": "codex"` and CLAUDE.md already exist? The update-all path updates both without duplication.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The project MUST have a CLAUDE.md at the repository root serving as Claude Code's entry point, referencing the constitution, specs directory, and Speckit governance workflow.
+- **FR-002**: init-options.json MUST support `"claude"` as a valid value for the `"ai"` field alongside the existing `"codex"` value.
+- **FR-003**: The speckit-plan SKILL.md MUST invoke `update-agent-context.sh claude` during Phase 1, in addition to the existing `update-agent-context.sh codex` invocation.
+- **FR-004**: CLAUDE.md MUST be maintained by update-agent-context.sh, preserving manual additions between the existing marker comments.
+
+## Success Criteria
+
+- **SC-001**: After merging, a developer can open Claude Code at the Traverse repo root and immediately read the governance rules, constitution reference, and active spec guidance from CLAUDE.md with no manual setup.
+- **SC-002**: Running speckit-plan on any feature branch results in both AGENTS.md and CLAUDE.md being updated with consistent technical context from that branch's plan.md.
+- **SC-003**: Existing CI gate (`cargo test`, `cargo clippy`, spec-alignment checks) passes without modification.
+- **SC-004**: init-options.json accepts `"claude"` as a valid `"ai"` value without breaking existing Codex-based flows.
+
+## Assumptions
+
+- Claude Code reads CLAUDE.md from the repository root when initializing a session.
+- The existing update-agent-context.sh `claude` case (line 619) is already correct — only the call site in speckit-plan SKILL.md is missing.
+- traverse-mcp expansion for Claude Code's MCP surface is out of scope; it requires a separate spec.
+- Developers using Codex and Claude Code may coexist; both AGENTS.md and CLAUDE.md can be committed together.


### PR DESCRIPTION
## Governing spec
`specs/183-add-claude-code-agent/spec.md` — dev tooling only, no runtime capability, no contract changes.

## Summary
- **CLAUDE.md** created at repo root — Claude Code's entry point with governance reference, spec directory convention, approved spec index, and auto-update markers compatible with `update-agent-context.sh`
- **init-options.json** updated — `"ai": ["codex", "claude"]` declares both agents active
- **speckit-plan SKILL.md** updated — Phase 1 now invokes `update-agent-context.sh claude` alongside the existing `codex` call so CLAUDE.md stays in sync with every planning cycle

## Constitution check
Dev tooling only. No business capability, no contracts, no runtime changes. All constitution gates pass or are N/A. See `specs/183-add-claude-code-agent/spec.md` for full gate evaluation.

## Verification
- `cargo test` — all tests pass, no changes to Rust code
- `cargo clippy` — no new lints introduced
- Spec-alignment CI gate — no governed spec touched

Closes #183

🤖 Generated with [Claude Code](https://claude.ai/claude-code)