### PR TITLE
Create downstream app starter kit and integration guide for youaskm3-style consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Code, generated artifacts, and tests must align with the approved governing spec
 - App-consumable acceptance: [docs/app-consumable-acceptance.md](/Users/piovese/Documents/cogolo/docs/app-consumable-acceptance.md)
 - Release and requirements traceability: [docs/app-consumable-requirements-traceability.md](/Users/piovese/Documents/cogolo/docs/app-consumable-requirements-traceability.md)
 - Dedicated MCP stdio server package: [docs/mcp-stdio-server.md](/Users/piovese/Documents/cogolo/docs/mcp-stdio-server.md)
+- youaskm3 starter kit and integration guide: [docs/youaskm3-starter-kit.md](/Users/piovese/Documents/cogolo/docs/youaskm3-starter-kit.md)
 - Project direction: [draft.md](/Users/piovese/Documents/cogolo/draft.md)
 - Brainstorming decisions: [brainstorming.md](/Users/piovese/Documents/cogolo/brainstorming.md)
 - First real youaskm3 integration validation: [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md)

--- a/apps/youaskm3-starter-kit/README.md
+++ b/apps/youaskm3-starter-kit/README.md
@@ -1,0 +1,31 @@
+# youaskm3 Traverse Starter Kit
+
+This starter kit is a reference integration package for browser-hosted downstream apps that want to adopt Traverse without repo archaeology.
+
+It is intentionally small:
+
+- it points to the versioned Traverse consumer bundle
+- it points to the browser-targeted consumer package
+- it points to the MCP consumption and compatibility validation paths
+- it leaves downstream UI and product behavior to the consuming app
+
+## What It Is For
+
+Use this starter kit as the first place a downstream app developer looks when wiring Traverse into a browser-hosted app such as `youaskm3`.
+
+It is not a replacement for the app-consumable docs.
+
+## Included References
+
+- [docs/app-consumable-consumer-bundle.md](/Users/piovese/Documents/cogolo/docs/app-consumable-consumer-bundle.md)
+- [docs/youaskm3-starter-kit.md](/Users/piovese/Documents/cogolo/docs/youaskm3-starter-kit.md)
+- [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md)
+- [docs/youaskm3-compatibility-conformance-suite.md](/Users/piovese/Documents/cogolo/docs/youaskm3-compatibility-conformance-suite.md)
+
+## Supported Assumptions
+
+- The consuming app is browser-hosted.
+- The consuming app uses the published Traverse consumer bundle.
+- The consuming app depends on the browser-targeted consumer package rather than Traverse internals.
+- The consuming app validates the browser-hosted and MCP-facing paths using the documented repo-local commands.
+

--- a/apps/youaskm3-starter-kit/package.json
+++ b/apps/youaskm3-starter-kit/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "youaskm3-traverse-starter-kit",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Reference starter kit for browser-hosted downstream apps adopting Traverse."
+}
+

--- a/docs/app-consumable-entry-path.md
+++ b/docs/app-consumable-entry-path.md
@@ -12,6 +12,7 @@ This is the canonical documentation path for humans and coding agents working on
    - [docs/app-consumable-consumer-bundle.md](/Users/piovese/Documents/cogolo/docs/app-consumable-consumer-bundle.md)
    - [docs/app-consumable-requirements-traceability.md](/Users/piovese/Documents/cogolo/docs/app-consumable-requirements-traceability.md)
    - [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md)
+   - [docs/youaskm3-starter-kit.md](/Users/piovese/Documents/cogolo/docs/youaskm3-starter-kit.md)
    - [apps/browser-consumer/README.md](/Users/piovese/Documents/cogolo/apps/browser-consumer/README.md)
 
 ## Canonical Rule
@@ -23,6 +24,7 @@ If a new human or agent asks where to begin, point them to the README first and 
 - The README is the front door.
 - The quickstart is the first executable consumer path.
 - The versioned consumer bundle explains what a downstream app installs and which released surfaces it may rely on.
+- The starter kit explains the downstream adoption path for browser-hosted apps.
 - The deeper docs explain validation, release, and traceability after the first path is understood.
 - Competing entrypoints should be treated as references, not as the first recommended path.
 

--- a/docs/youaskm3-integration-validation.md
+++ b/docs/youaskm3-integration-validation.md
@@ -8,8 +8,10 @@ It stays on governed public Traverse surfaces only:
 - the checked-in React browser demo
 - the downstream MCP consumption validation path
 - the first app-consumable quickstart
+- the `youaskm3` starter kit and integration guide
 
 For the shortest Traverse-side start path, begin with [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md).
+The starter-kit entry point is documented in [docs/youaskm3-starter-kit.md](/Users/piovese/Documents/cogolo/docs/youaskm3-starter-kit.md).
 
 ## Governing Spec
 
@@ -42,6 +44,12 @@ Then run the integration validation wrapper:
 bash scripts/ci/youaskm3_integration_validation.sh
 ```
 
+For the starter-kit smoke path, also run:
+
+```bash
+bash scripts/ci/youaskm3_starter_kit_smoke.sh
+```
+
 ## Expected Evidence
 
 The validation path should prove:
@@ -52,6 +60,7 @@ The validation path should prove:
 - `consumer_name: youaskm3`
 - `validated_flow_id: youaskm3_mcp_validation`
 - no dependency on private Traverse internals or undocumented setup
+- the starter kit and integration guide remain aligned with the released consumer bundle
 
 ## Known Failure Modes
 

--- a/docs/youaskm3-starter-kit.md
+++ b/docs/youaskm3-starter-kit.md
@@ -1,0 +1,53 @@
+# youaskm3 Starter Kit and Integration Guide
+
+This document is the first integration guide for browser-hosted downstream apps such as `youaskm3`.
+
+It pairs with the reference starter kit at [apps/youaskm3-starter-kit/README.md](/Users/piovese/Documents/cogolo/apps/youaskm3-starter-kit/README.md).
+
+This youaskm3 starter kit and integration guide is the canonical browser-hosted adoption path for the downstream app.
+
+## Goal
+
+The goal is to give a downstream app team one clear adoption path for Traverse without forcing them to reverse-engineer the repo.
+
+## What to Install
+
+Downstream apps should adopt the versioned Traverse consumer bundle and the browser-targeted consumer package documented in:
+
+- [docs/app-consumable-consumer-bundle.md](/Users/piovese/Documents/cogolo/docs/app-consumable-consumer-bundle.md)
+- [apps/browser-consumer/README.md](/Users/piovese/Documents/cogolo/apps/browser-consumer/README.md)
+
+## Setup
+
+1. Read the root [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md).
+2. Review the app-consumable consumer bundle.
+3. Use the browser-targeted consumer package from the starter kit.
+4. Run the browser-hosted and MCP-facing validation paths.
+5. Use the documented browser-hosted and MCP-facing validations to prove the release pairing.
+
+## Supported Surfaces
+
+The integration guide covers:
+
+- the versioned Traverse consumer bundle
+- the browser-targeted consumer package
+- the browser-hosted live adapter validation path
+- the MCP consumption validation path
+
+## Validation
+
+Run the documented repo-local commands:
+
+```bash
+bash scripts/ci/youaskm3_integration_validation.sh
+bash scripts/ci/youaskm3_starter_kit_smoke.sh
+```
+
+## Known Limits
+
+This guide does not promise:
+
+- custom downstream app UX
+- full auth hardening
+- multi-tenant deployment guarantees
+- direct Traverse source checkout coupling

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -24,8 +24,11 @@ required_files=(
   "docs/app-consumable-consumer-bundle.md"
   "docs/app-consumable-release-artifact.md"
   "docs/youaskm3-integration-validation.md"
+  "docs/youaskm3-starter-kit.md"
   "apps/browser-consumer/README.md"
   "apps/browser-consumer/package.json"
+  "apps/youaskm3-starter-kit/README.md"
+  "apps/youaskm3-starter-kit/package.json"
   "docs/wasm-agent-team-readiness-example.md"
   "docs/app-consumable-acceptance.md"
   "docs/app-consumable-entry-path.md"
@@ -46,6 +49,7 @@ required_files=(
   "apps/react-demo/src/browser-adapter-client.js"
   "scripts/ci/react_demo_live_adapter_smoke.sh"
   "scripts/ci/mcp_stdio_server_execution_report_smoke.sh"
+  "scripts/ci/youaskm3_starter_kit_smoke.sh"
   "scripts/ci/browser_consumer_package_smoke.sh"
   "scripts/ci/youaskm3_integration_validation.sh"
   "scripts/ci/app_consumable_release_prep.sh"
@@ -123,6 +127,14 @@ grep -q "core-runtime-example" docs/mcp-stdio-server.md
 grep -q "mcp_stdio_server_execution_report_smoke.sh" docs/mcp-stdio-server.md
 grep -q "render_execution_report" docs/mcp-stdio-server.md
 grep -q "docs/youaskm3-integration-validation.md" docs/mcp-consumption-validation.md
+grep -q "docs/youaskm3-starter-kit.md" README.md
+grep -q "docs/youaskm3-starter-kit.md" docs/app-consumable-entry-path.md
+grep -q "docs/youaskm3-starter-kit.md" docs/youaskm3-integration-validation.md
+grep -q "youaskm3 starter kit and integration guide" README.md
+grep -q "youaskm3 starter kit and integration guide" docs/youaskm3-starter-kit.md
+grep -q "bash scripts/ci/youaskm3_starter_kit_smoke.sh" docs/youaskm3-starter-kit.md
+grep -q "starter kit and integration guide" docs/youaskm3-integration-validation.md
+grep -q "bash scripts/ci/youaskm3_starter_kit_smoke.sh" docs/youaskm3-integration-validation.md
 grep -q "apps/browser-consumer/README.md" docs/mcp-consumption-validation.md
 grep -q "docs/app-consumable-consumer-bundle.md" README.md
 grep -q "docs/app-consumable-consumer-bundle.md" docs/app-consumable-entry-path.md

--- a/scripts/ci/youaskm3_starter_kit_smoke.sh
+++ b/scripts/ci/youaskm3_starter_kit_smoke.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+
+test -s "${repo_root}/apps/youaskm3-starter-kit/README.md"
+test -s "${repo_root}/apps/youaskm3-starter-kit/package.json"
+test -s "${repo_root}/docs/youaskm3-starter-kit.md"
+grep -q "youaskm3 Traverse Starter Kit" "${repo_root}/apps/youaskm3-starter-kit/README.md"
+grep -q "versioned Traverse consumer bundle" "${repo_root}/apps/youaskm3-starter-kit/README.md"
+grep -q "browser-targeted consumer package" "${repo_root}/apps/youaskm3-starter-kit/README.md"
+grep -q "youaskm3 Starter Kit and Integration Guide" "${repo_root}/docs/youaskm3-starter-kit.md"
+grep -q "starter kit and integration guide" "${repo_root}/docs/youaskm3-starter-kit.md"
+grep -q "bash scripts/ci/youaskm3_integration_validation.sh" "${repo_root}/docs/youaskm3-starter-kit.md"
+
+echo "youaskm3 starter kit smoke passed."


### PR DESCRIPTION
Implements issue #178: browser-targeted starter kit guide for downstream youaskm3-style consumers.

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate
- 023-browser-hosted-mcp-consumer-model

## Project Item
- https://github.com/enricopiovesan/Traverse/issues/178

## Summary
- adds a starter-kit guide for downstream youaskm3-style consumers
- adds a minimal starter-kit package surface
- links the guide from the main entry docs and integration validation docs
- keeps repository checks aligned with the starter-kit docs

## Validation
- bash scripts/ci/youaskm3_starter_kit_smoke.sh
- bash scripts/ci/repository_checks.sh
