### PR TITLE
Add UMA connection and fix repository checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,28 @@
 
 Traverse is a contract-driven runtime for discovering, validating, and composing portable business capabilities through events, policies, constraints, and graph-based workflows — across browser, edge, cloud, and device environments.
 
+This is personal research and development by [Enrico Piovesan](https://enricopiovesan.com), built to prove in code the ideas behind [Universal Microservices Architecture (UMA)](https://github.com/enricopiovesan/UMA-code-examples). Created on personal time, not affiliated with Autodesk.
+
+---
+
+## Built on UMA
+
+Traverse is the runtime that [Universal Microservices Architecture](https://www.universalmicroservices.com/) describes.
+
+UMA answers the question: *how do you keep one business behavior portable and governed as execution moves across browser, edge, cloud, workflows, and AI?* Traverse is the answer in working Rust code — contracts, registries, a governed runtime, and structured traces.
+
+| | UMA | Traverse |
+|---|---|---|
+| What it is | Architecture model + book | Working runtime implementation |
+| Business capabilities | Defines the concept | Executes them with contracts and specs |
+| Portability | Describes the pattern | Enforces it through WASM and adapters |
+| Governance | Specifies the rules | Implements them as immutable specs and CI gates |
+| AI safety | Describes requirements | Delivers through explainable runtime traces |
+
+**If you want to understand the ideas:** [read the UMA book](https://www.universalmicroservices.com/) and explore the [UMA code examples](https://github.com/enricopiovesan/UMA-code-examples).
+
+**If you want to run them:** you're in the right place.
+
 ---
 
 ## For Humans


### PR DESCRIPTION
## Governing Spec

- `001-foundation-v0-1`

## Project Item

https://github.com/users/enricopiovesan/projects/1

## Summary
- Add **Built on UMA** section: connects Traverse to the Universal Microservices Architecture book and code examples with an honest theory-vs-implementation framing and a comparison table
- Restore personal research disclaimer required by repository checks (was accidentally removed)

## Validation

- `repository-checks` — passes locally (`bash scripts/ci/repository_checks.sh`)
- `cargo test` — no Rust code changed
- Spec `001-foundation-v0-1` declared — README.md is governed by this spec

🤖 Generated with [Claude Code](https://claude.ai/claude-code)