### PR TITLE
Add hello-world onboarding example

### DIFF
--- a/contracts/examples/hello-world/capabilities/say-hello/contract.json
+++ b/contracts/examples/hello-world/capabilities/say-hello/contract.json
@@ -1,0 +1,112 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "hello.world.say-hello",
+  "namespace": "hello.world",
+  "name": "say-hello",
+  "version": "1.0.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Return a deterministic greeting for one provided name.",
+  "description": "Minimal governed hello-world capability for Traverse onboarding that proves the contract, package, request, and runtime path without requiring the larger expedition example domain.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "name",
+        "greeting"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "greeting": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "preconditions": [
+    {
+      "id": "name-provided",
+      "description": "The caller provides a non-empty name string."
+    }
+  ],
+  "postconditions": [
+    {
+      "id": "greeting-produced",
+      "description": "The capability returns a deterministic greeting that includes the provided name."
+    }
+  ],
+  "side_effects": [
+    {
+      "kind": "memory_only",
+      "description": "Produces one deterministic greeting payload for the provided name."
+    }
+  ],
+  "emits": [],
+  "consumes": [],
+  "permissions": [
+    {
+      "id": "hello.world.say-hello"
+    }
+  ],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "run"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [
+    {
+      "id": "manual-approval-required"
+    }
+  ],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-04-16T00:00:00Z",
+    "spec_ref": "001-foundation-v0-1@1.0.0",
+    "adr_refs": [
+      "0001-rust-wasm-foundation"
+    ],
+    "exception_refs": []
+  },
+  "evidence": [],
+  "service_type": "stateless",
+  "permitted_targets": [
+    "local",
+    "cloud",
+    "edge",
+    "device"
+  ],
+  "artifact_type": "native"
+}

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -590,6 +590,14 @@ fn render_agent_execution_summary(
                 lines.push(format!("required_actions: {joined}"));
             }
         }
+        "hello.world.say-hello" => {
+            if let Some(name) = output.get("name").and_then(Value::as_str) {
+                lines.push(format!("name: {name}"));
+            }
+            if let Some(greeting) = output.get("greeting").and_then(Value::as_str) {
+                lines.push(format!("greeting: {greeting}"));
+            }
+        }
         _ => {}
     }
 
@@ -737,6 +745,7 @@ impl LocalExecutor for AgentPackageExampleExecutor {
         input: &Value,
     ) -> Result<Value, LocalExecutionFailure> {
         match capability.contract.id.as_str() {
+            "hello.world.say-hello" => execute_hello_world(input),
             "expedition.planning.interpret-expedition-intent" => {
                 execute_interpret_expedition_intent(input)
             }
@@ -1210,6 +1219,16 @@ fn execute_assemble_expedition_plan(input: &Value) -> Result<Value, LocalExecuti
     }))
 }
 
+fn execute_hello_world(input: &Value) -> Result<Value, LocalExecutionFailure> {
+    let map = input_object(input)?;
+    let name = required_string(map, "name")?;
+
+    Ok(serde_json::json!({
+        "name": name,
+        "greeting": format!("Hello, {name}!"),
+    }))
+}
+
 fn event_ref(event_id: &str) -> Value {
     serde_json::json!({
         "event_id": event_id,
@@ -1553,6 +1572,33 @@ mod tests {
     }
 
     #[test]
+    fn inspect_agent_renders_hello_world_package() {
+        let fixture = create_hello_world_agent_fixture();
+
+        let output = inspect_agent(&fixture.manifest_path).expect("agent inspect should succeed");
+
+        assert!(output.contains("package_id: hello.world.say-hello-agent"));
+        assert!(output.contains("capability_id: hello.world.say-hello"));
+        assert!(output.contains("binary_digest: fnv1a64:"));
+        assert!(output.contains("workflow_refs: hello.world.say-hello@1.0.0"));
+    }
+
+    #[test]
+    fn execute_agent_runs_hello_world_request() {
+        let fixture = create_hello_world_agent_fixture();
+        let request_path = repo_root().join("examples/hello-world/runtime-requests/say-hello.json");
+
+        let output = execute_agent(&fixture.manifest_path, &request_path)
+            .expect("hello-world agent execution should succeed");
+
+        assert!(output.contains("package_id: hello.world.say-hello-agent"));
+        assert!(output.contains("capability_id: hello.world.say-hello"));
+        assert!(output.contains("status: completed"));
+        assert!(output.contains("name: Traverse"));
+        assert!(output.contains("greeting: Hello, Traverse!"));
+    }
+
+    #[test]
     fn execute_expedition_writes_trace_artifact_when_requested() {
         let request_path =
             repo_root().join("examples/expedition/runtime-requests/plan-expedition.json");
@@ -1721,6 +1767,7 @@ mod tests {
             "contracts/examples/expedition/capabilities/interpret-expedition-intent/contract.json",
             "expedition-intent-interpretation-v1",
             "Interpret free-form expedition planning intent into governed route preferences and assumptions.",
+            "expedition.planning.plan-expedition",
         )
     }
 
@@ -1733,6 +1780,20 @@ mod tests {
             "contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
             "expedition-readiness-validation-v1",
             "Validate expedition team readiness against governed objective, conditions, and team profile context.",
+            "expedition.planning.plan-expedition",
+        )
+    }
+
+    fn create_hello_world_agent_fixture() -> AgentFixture {
+        create_agent_package_fixture(
+            "hello.world.say-hello-agent",
+            "hello.world.say-hello",
+            "say-hello-agent.wasm",
+            "Minimal governed hello-world agent package for Traverse onboarding.",
+            "contracts/examples/hello-world/capabilities/say-hello/contract.json",
+            "hello-world-greeting-v1",
+            "Produce a simple deterministic greeting string for onboarding validation.",
+            "hello.world.say-hello",
         )
     }
 
@@ -1744,6 +1805,7 @@ mod tests {
         contract_path: &str,
         model_interface: &str,
         model_purpose: &str,
+        workflow_id: &str,
     ) -> AgentFixture {
         let temp_dir = unique_temp_dir();
         let package_dir = temp_dir.join("agent");
@@ -1779,7 +1841,7 @@ mod tests {
   }},
   "workflow_refs": [
     {{
-      "workflow_id": "expedition.planning.plan-expedition",
+      "workflow_id": "{}",
       "workflow_version": "1.0.0"
     }}
   ],
@@ -1809,6 +1871,7 @@ mod tests {
             summary,
             capability_id,
             repo_root.join(contract_path).display(),
+            workflow_id,
             binary_name,
             fnv1a64(&wasm_bytes),
             model_interface,

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -1759,54 +1759,56 @@ mod tests {
     }
 
     fn create_interpret_expedition_intent_agent_fixture() -> AgentFixture {
-        create_agent_package_fixture(
-            "expedition.planning.interpret-expedition-intent-agent",
-            "expedition.planning.interpret-expedition-intent",
-            "interpret-expedition-intent-agent.wasm",
-            "Governed WASM AI agent example for expedition intent interpretation.",
-            "contracts/examples/expedition/capabilities/interpret-expedition-intent/contract.json",
-            "expedition-intent-interpretation-v1",
-            "Interpret free-form expedition planning intent into governed route preferences and assumptions.",
-            "expedition.planning.plan-expedition",
-        )
+        create_agent_package_fixture(&AgentPackageFixtureSpec {
+            package_id: "expedition.planning.interpret-expedition-intent-agent",
+            capability_id: "expedition.planning.interpret-expedition-intent",
+            binary_name: "interpret-expedition-intent-agent.wasm",
+            summary: "Governed WASM AI agent example for expedition intent interpretation.",
+            contract_path: "contracts/examples/expedition/capabilities/interpret-expedition-intent/contract.json",
+            model_interface: "expedition-intent-interpretation-v1",
+            model_purpose: "Interpret free-form expedition planning intent into governed route preferences and assumptions.",
+            workflow_id: "expedition.planning.plan-expedition",
+        })
     }
 
     fn create_validate_team_readiness_agent_fixture() -> AgentFixture {
-        create_agent_package_fixture(
-            "expedition.planning.validate-team-readiness-agent",
-            "expedition.planning.validate-team-readiness",
-            "validate-team-readiness-agent.wasm",
-            "Governed WASM AI agent example for expedition readiness validation.",
-            "contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
-            "expedition-readiness-validation-v1",
-            "Validate expedition team readiness against governed objective, conditions, and team profile context.",
-            "expedition.planning.plan-expedition",
-        )
+        create_agent_package_fixture(&AgentPackageFixtureSpec {
+            package_id: "expedition.planning.validate-team-readiness-agent",
+            capability_id: "expedition.planning.validate-team-readiness",
+            binary_name: "validate-team-readiness-agent.wasm",
+            summary: "Governed WASM AI agent example for expedition readiness validation.",
+            contract_path: "contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+            model_interface: "expedition-readiness-validation-v1",
+            model_purpose: "Validate expedition team readiness against governed objective, conditions, and team profile context.",
+            workflow_id: "expedition.planning.plan-expedition",
+        })
     }
 
     fn create_hello_world_agent_fixture() -> AgentFixture {
-        create_agent_package_fixture(
-            "hello.world.say-hello-agent",
-            "hello.world.say-hello",
-            "say-hello-agent.wasm",
-            "Minimal governed hello-world agent package for Traverse onboarding.",
-            "contracts/examples/hello-world/capabilities/say-hello/contract.json",
-            "hello-world-greeting-v1",
-            "Produce a simple deterministic greeting string for onboarding validation.",
-            "hello.world.say-hello",
-        )
+        create_agent_package_fixture(&AgentPackageFixtureSpec {
+            package_id: "hello.world.say-hello-agent",
+            capability_id: "hello.world.say-hello",
+            binary_name: "say-hello-agent.wasm",
+            summary: "Minimal governed hello-world agent package for Traverse onboarding.",
+            contract_path: "contracts/examples/hello-world/capabilities/say-hello/contract.json",
+            model_interface: "hello-world-greeting-v1",
+            model_purpose: "Produce a simple deterministic greeting string for onboarding validation.",
+            workflow_id: "hello.world.say-hello",
+        })
     }
 
-    fn create_agent_package_fixture(
-        package_id: &str,
-        capability_id: &str,
-        binary_name: &str,
-        summary: &str,
-        contract_path: &str,
-        model_interface: &str,
-        model_purpose: &str,
-        workflow_id: &str,
-    ) -> AgentFixture {
+    struct AgentPackageFixtureSpec<'a> {
+        package_id: &'a str,
+        capability_id: &'a str,
+        binary_name: &'a str,
+        summary: &'a str,
+        contract_path: &'a str,
+        model_interface: &'a str,
+        model_purpose: &'a str,
+        workflow_id: &'a str,
+    }
+
+    fn create_agent_package_fixture(spec: &AgentPackageFixtureSpec<'_>) -> AgentFixture {
         let temp_dir = unique_temp_dir();
         let package_dir = temp_dir.join("agent");
         let artifact_dir = package_dir.join("artifacts");
@@ -1817,11 +1819,14 @@ mod tests {
         let wasm_bytes = hex_to_bytes(
             "0061736d0100000001040160000003020100070a01065f737461727400000a040102000b",
         );
-        let binary_path = artifact_dir.join(binary_name);
+        let binary_path = artifact_dir.join(spec.binary_name);
         fs::write(&binary_path, &wasm_bytes).expect("wasm binary should write");
         fs::write(
             source_dir.join("agent.rs"),
-            format!("pub fn run() -> &'static str {{ \"{capability_id}\" }}\n"),
+            format!(
+                "pub fn run() -> &'static str {{ \"{}\" }}\n",
+                spec.capability_id
+            ),
         )
         .expect("source file should write");
 
@@ -1867,15 +1872,15 @@ mod tests {
     }}
   ]
 }}"#,
-            package_id,
-            summary,
-            capability_id,
-            repo_root.join(contract_path).display(),
-            workflow_id,
-            binary_name,
+            spec.package_id,
+            spec.summary,
+            spec.capability_id,
+            repo_root.join(spec.contract_path).display(),
+            spec.workflow_id,
+            spec.binary_name,
             fnv1a64(&wasm_bytes),
-            model_interface,
-            model_purpose
+            spec.model_interface,
+            spec.model_purpose
         );
         fs::write(&manifest_path, manifest).expect("manifest should write");
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -226,7 +226,8 @@ After this guide, you should be able to answer:
 
 Use these in order:
 
-1. [quickstart.md](../quickstart.md) for the first browser-consumable flow
-2. [docs/expedition-example-authoring.md](./expedition-example-authoring.md) for the full governed expedition artifact set
-3. [docs/wasm-agent-authoring-guide.md](./wasm-agent-authoring-guide.md) for packaged WASM agent authoring
-4. [docs/wasm-microservice-authoring-guide.md](./wasm-microservice-authoring-guide.md) for packaged WASM microservice authoring
+1. [examples/hello-world/README.md](../examples/hello-world/README.md) for the smallest runnable Traverse example
+2. [quickstart.md](../quickstart.md) for the first browser-consumable flow
+3. [docs/expedition-example-authoring.md](./expedition-example-authoring.md) for the full governed expedition artifact set
+4. [docs/wasm-agent-authoring-guide.md](./wasm-agent-authoring-guide.md) for packaged WASM agent authoring
+5. [docs/wasm-microservice-authoring-guide.md](./wasm-microservice-authoring-guide.md) for packaged WASM microservice authoring

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,60 @@
+# Traverse Hello World Example
+
+This is the smallest governed example in the repo.
+
+Use it when you want one command path that proves:
+
+- a capability contract exists
+- a packaged executable artifact exists
+- a runtime request exists
+- Traverse can inspect and execute the package locally
+
+## Files
+
+- contract:
+  - `contracts/examples/hello-world/capabilities/say-hello/contract.json`
+- workflow reference:
+  - `workflows/examples/hello-world/say-hello/workflow.json`
+- package:
+  - `examples/hello-world/say-hello-agent/manifest.json`
+- request:
+  - `examples/hello-world/runtime-requests/say-hello.json`
+
+## Run It
+
+Build the deterministic local fixture:
+
+```bash
+bash examples/hello-world/say-hello-agent/build-fixture.sh
+```
+
+Inspect the package:
+
+```bash
+cargo run -p traverse-cli -- agent inspect \
+  examples/hello-world/say-hello-agent/manifest.json
+```
+
+Execute the package:
+
+```bash
+cargo run -p traverse-cli -- agent execute \
+  examples/hello-world/say-hello-agent/manifest.json \
+  examples/hello-world/runtime-requests/say-hello.json
+```
+
+What good output looks like:
+
+- `package_id: hello.world.say-hello-agent`
+- `capability_id: hello.world.say-hello`
+- `status: completed`
+- `name: Traverse`
+- `greeting: Hello, Traverse!`
+
+## Validation
+
+Run the example smoke path:
+
+```bash
+bash scripts/ci/hello_world_example_smoke.sh
+```

--- a/examples/hello-world/runtime-requests/say-hello.json
+++ b/examples/hello-world/runtime-requests/say-hello.json
@@ -1,0 +1,21 @@
+{
+  "kind": "runtime_request",
+  "schema_version": "1.0.0",
+  "request_id": "hello-world-say-hello-001",
+  "intent": {
+    "capability_id": "hello.world.say-hello",
+    "capability_version": "1.0.0"
+  },
+  "input": {
+    "name": "Traverse"
+  },
+  "lookup": {
+    "scope": "public_only",
+    "allow_ambiguity": false
+  },
+  "context": {
+    "requested_target": "local",
+    "caller": "hello-world-example"
+  },
+  "governing_spec": "006-runtime-request-execution"
+}

--- a/examples/hello-world/say-hello-agent/artifacts/.gitignore
+++ b/examples/hello-world/say-hello-agent/artifacts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/examples/hello-world/say-hello-agent/build-fixture.sh
+++ b/examples/hello-world/say-hello-agent/build-fixture.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+artifact_dir="$script_dir/artifacts"
+artifact_path="$artifact_dir/say-hello-agent.wasm"
+
+mkdir -p "$artifact_dir"
+
+printf '\x00\x61\x73\x6d\x01\x00\x00\x00\x01\x04\x01\x60\x00\x00\x03\x02\x01\x00\x07\x0a\x01\x06\x5f\x73\x74\x61\x72\x74\x00\x00\x0a\x04\x01\x02\x00\x0b' > "$artifact_path"
+
+printf 'built %s\n' "$artifact_path"

--- a/examples/hello-world/say-hello-agent/manifest.json
+++ b/examples/hello-world/say-hello-agent/manifest.json
@@ -1,0 +1,39 @@
+{
+  "kind": "agent_package",
+  "schema_version": "1.0.0",
+  "package_id": "hello.world.say-hello-agent",
+  "version": "1.0.0",
+  "summary": "Minimal governed hello-world agent package for Traverse onboarding.",
+  "capability_ref": {
+    "id": "hello.world.say-hello",
+    "version": "1.0.0",
+    "contract_path": "../../../contracts/examples/hello-world/capabilities/say-hello/contract.json"
+  },
+  "workflow_refs": [
+    {
+      "workflow_id": "hello.world.say-hello",
+      "workflow_version": "1.0.0"
+    }
+  ],
+  "source": {
+    "path": "./src/agent.rs",
+    "language": "rust",
+    "entry": "run"
+  },
+  "binary": {
+    "path": "./artifacts/say-hello-agent.wasm",
+    "format": "wasm",
+    "expected_digest": "fnv1a64:dffc31d6401c84d6"
+  },
+  "constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "model_dependencies": [
+    {
+      "interface": "hello-world-greeting-v1",
+      "purpose": "Produce a simple deterministic greeting string for onboarding validation."
+    }
+  ]
+}

--- a/examples/hello-world/say-hello-agent/src/agent.rs
+++ b/examples/hello-world/say-hello-agent/src/agent.rs
@@ -1,0 +1,3 @@
+pub fn run() -> &'static str {
+    "say-hello"
+}

--- a/scripts/ci/hello_world_example_smoke.sh
+++ b/scripts/ci/hello_world_example_smoke.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${TRAVERSE_REPO_ROOT:-$(pwd)}"
+cd "$repo_root"
+
+agent_manifest="examples/hello-world/say-hello-agent/manifest.json"
+agent_request="examples/hello-world/runtime-requests/say-hello.json"
+
+bash examples/hello-world/say-hello-agent/build-fixture.sh >/tmp/traverse-hello-world-build.out
+
+inspect_output="$(cargo run -q -p traverse-cli -- agent inspect "$agent_manifest")"
+printf '%s\n' "$inspect_output"
+
+grep -q "package_id: hello.world.say-hello-agent" <<<"$inspect_output"
+grep -q "capability_id: hello.world.say-hello" <<<"$inspect_output"
+grep -q "workflow_refs: hello.world.say-hello@1.0.0" <<<"$inspect_output"
+
+execute_output="$(cargo run -q -p traverse-cli -- agent execute "$agent_manifest" "$agent_request")"
+printf '%s\n' "$execute_output"
+
+grep -q "status: completed" <<<"$execute_output"
+grep -q "capability_id: hello.world.say-hello" <<<"$execute_output"
+grep -q "name: Traverse" <<<"$execute_output"
+grep -q "greeting: Hello, Traverse!" <<<"$execute_output"

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -244,11 +244,8 @@ grep -q "cargo run -p traverse-cli -- bundle register" docs/getting-started.md
 grep -q "cargo run -p traverse-cli -- expedition execute" docs/getting-started.md
 grep -q "cargo run -p traverse-cli -- trace inspect" docs/getting-started.md
 grep -q "bash scripts/ci/expedition_golden_path.sh" docs/getting-started.md
-<<<<<<< HEAD
-=======
 grep -q "cargo run -p traverse-cli -- agent execute" examples/hello-world/README.md
 grep -q "hello.world.say-hello" examples/hello-world/README.md
->>>>>>> 6bb7be9 (Add hello-world onboarding example)
 grep -q "bash scripts/ci/runtime_home_smoke.sh" docs/local-runtime-home.md
 grep -q "label: Definition of done" .github/ISSUE_TEMPLATE/task.yml
 grep -q "label: Validation" .github/ISSUE_TEMPLATE/task.yml

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -45,10 +45,16 @@ required_files=(
   "docs/app-consumable-entry-path.md"
   "docs/executable-package-template.md"
   "docs/local-runtime-home.md"
+  "docs/getting-started.md"
   "quickstart.md"
   "examples/expedition/runtime-requests/plan-expedition.json"
+  "examples/hello-world/README.md"
+  "examples/hello-world/runtime-requests/say-hello.json"
+  "examples/hello-world/say-hello-agent/manifest.json"
+  "examples/hello-world/say-hello-agent/build-fixture.sh"
+  "contracts/examples/hello-world/capabilities/say-hello/contract.json"
+  "workflows/examples/hello-world/say-hello/workflow.json"
   "docs/exception-process.md"
-  "docs/getting-started.md"
   "docs/project-management.md"
   "docs/multi-thread-workflow.md"
   "docs/ticket-standard.md"
@@ -69,6 +75,7 @@ required_files=(
   "scripts/ci/app_consumable_release_prep.sh"
   "scripts/ci/app_consumable_package_release_pointer.sh"
   "scripts/ci/wasm_agent_authoring_guide_smoke.sh"
+  "scripts/ci/hello_world_example_smoke.sh"
   "scripts/ci/wasm_microservice_authoring_guide_smoke.sh"
   "scripts/ci/downstream_publication_strategy_smoke.sh"
   "scripts/ci/mcp_stdio_server_smoke.sh"
@@ -232,10 +239,16 @@ grep -q "cargo run -p traverse-cli -- bundle register examples/expedition/regist
 grep -q "workflows/examples/expedition/plan-expedition/workflow.json" docs/expedition-example-authoring.md
 grep -q ".traverse/local/" docs/expedition-example-authoring.md
 grep -q "capture-expedition-objective/contract.json" docs/getting-started.md
+grep -q "examples/hello-world/README.md" docs/getting-started.md
 grep -q "cargo run -p traverse-cli -- bundle register" docs/getting-started.md
 grep -q "cargo run -p traverse-cli -- expedition execute" docs/getting-started.md
 grep -q "cargo run -p traverse-cli -- trace inspect" docs/getting-started.md
 grep -q "bash scripts/ci/expedition_golden_path.sh" docs/getting-started.md
+<<<<<<< HEAD
+=======
+grep -q "cargo run -p traverse-cli -- agent execute" examples/hello-world/README.md
+grep -q "hello.world.say-hello" examples/hello-world/README.md
+>>>>>>> 6bb7be9 (Add hello-world onboarding example)
 grep -q "bash scripts/ci/runtime_home_smoke.sh" docs/local-runtime-home.md
 grep -q "label: Definition of done" .github/ISSUE_TEMPLATE/task.yml
 grep -q "label: Validation" .github/ISSUE_TEMPLATE/task.yml

--- a/workflows/examples/hello-world/say-hello/workflow.json
+++ b/workflows/examples/hello-world/say-hello/workflow.json
@@ -1,0 +1,74 @@
+{
+  "kind": "workflow_definition",
+  "schema_version": "1.0.0",
+  "id": "hello.world.say-hello",
+  "name": "say-hello",
+  "version": "1.0.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Run the minimal hello-world greeting flow as one governed workflow-backed example.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "name",
+        "greeting"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "greeting": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "nodes": [
+    {
+      "node_id": "say_hello",
+      "capability_id": "hello.world.say-hello",
+      "capability_version": "1.0.0",
+      "input": {
+        "from_workflow_input": [
+          "name"
+        ]
+      },
+      "output": {
+        "to_workflow_state": [
+          "name",
+          "greeting"
+        ]
+      }
+    }
+  ],
+  "edges": [],
+  "start_node": "say_hello",
+  "terminal_nodes": [
+    "say_hello"
+  ],
+  "tags": [
+    "hello-world",
+    "onboarding",
+    "example-domain"
+  ],
+  "governing_spec": "007-workflow-registry-traversal"
+}


### PR DESCRIPTION
## Summary
- add a minimal hello-world onboarding example with a governed contract, workflow reference, package, request, and README
- extend the CLI example executor and tests so the hello-world path is actually runnable and protected
- link the example from the getting-started onboarding path and validate it through a dedicated smoke script

## Governing Spec
- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `008-expedition-example-domain`
- `009-expedition-example-artifacts`
- `014-service-type-taxonomy`
- `017-ai-agent-packaging`
- `028-schema-alignment-gate-v02`

## Project Item
- Closes #253
- Tracked in Project 1

## Validation
- `cargo test -p traverse-cli`
- `bash scripts/ci/hello_world_example_smoke.sh`
- `bash scripts/ci/repository_checks.sh`
