### PR TITLE
Add ordered tutorial index

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cargo run -p traverse-cli     # run the CLI
 
 **Requirements**: Rust 1.94+
 
-New to Traverse authoring? Start with [docs/getting-started.md](docs/getting-started.md) for the first capability path, then come back to [quickstart.md](quickstart.md) for the first app-consumable browser flow.
+New to Traverse? Start with [docs/tutorial-index.md](docs/tutorial-index.md) for the ordered onboarding path, then use [docs/getting-started.md](docs/getting-started.md) for the first capability path and [quickstart.md](quickstart.md) for the first app-consumable browser flow.
 
 ### What it does
 
@@ -154,6 +154,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 ### Key docs
 
 - [docs/getting-started.md](docs/getting-started.md) — first capability path for new developers
+- [docs/tutorial-index.md](docs/tutorial-index.md) — ordered onboarding path for new developers and agents
 - [quickstart.md](quickstart.md) — start here for the first runnable flow
 - [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) — first app-consumable flow
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle

--- a/docs/tutorial-index.md
+++ b/docs/tutorial-index.md
@@ -1,0 +1,35 @@
+# Traverse Tutorial Index
+
+This is the ordered onboarding path for new Traverse developers and coding agents.
+
+Use it in sequence unless you already know the slice you need:
+
+1. [README.md](../README.md)
+2. [docs/getting-started.md](getting-started.md)
+3. [quickstart.md](../quickstart.md)
+4. [docs/app-consumable-entry-path.md](app-consumable-entry-path.md)
+5. [docs/expedition-example-authoring.md](expedition-example-authoring.md)
+6. [docs/wasm-agent-authoring-guide.md](wasm-agent-authoring-guide.md)
+7. [docs/wasm-microservice-authoring-guide.md](wasm-microservice-authoring-guide.md)
+8. [docs/app-consumable-acceptance.md](app-consumable-acceptance.md)
+9. [docs/app-consumable-release-checklist.md](app-consumable-release-checklist.md)
+10. [docs/app-consumable-consumer-bundle.md](app-consumable-consumer-bundle.md)
+11. [docs/youaskm3-integration-validation.md](youaskm3-integration-validation.md)
+12. [docs/youaskm3-published-artifact-validation.md](youaskm3-published-artifact-validation.md)
+13. [docs/youaskm3-compatibility-conformance-suite.md](youaskm3-compatibility-conformance-suite.md)
+14. [docs/youaskm3-real-shell-validation.md](youaskm3-real-shell-validation.md)
+15. [docs/quality-standards.md](quality-standards.md)
+16. [docs/compatibility-policy.md](compatibility-policy.md)
+17. [docs/multi-thread-workflow.md](multi-thread-workflow.md)
+18. [docs/project-management.md](project-management.md)
+19. [docs/adr/README.md](adr/README.md)
+
+## How To Read It
+
+If your goal is only the first governed capability path, stop after `docs/getting-started.md`.
+
+If your goal is the first app-consumable browser flow, continue through `quickstart.md` and `docs/app-consumable-entry-path.md`.
+
+If your goal is downstream app support such as `youaskm3`, continue into the app-consumable and validation docs after that.
+
+If your goal is documentation hygiene, onboarding, or process work, finish with the standards, compatibility, workflow, and project-management docs.


### PR DESCRIPTION
## Summary
- add an ordered onboarding index for Traverse developers and agents
- link the README to the new index
- keep the path rooted in existing docs only

## Governing Spec
- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `028-schema-alignment-gate-v02`

## Project Item
- Closes #254
- Tracked in Project 1

## Validation
- `bash scripts/ci/repository_checks.sh`
