### PR TITLE
Remove machine-specific absolute paths from portable docs

### DIFF
--- a/docs/app-consumable-acceptance.md
+++ b/docs/app-consumable-acceptance.md
@@ -38,6 +38,6 @@ The acceptance path fails deterministically when:
 
 ## Related Docs
 
-- [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md)
-- [apps/react-demo/README.md](/Users/piovese/Documents/cogolo/apps/react-demo/README.md)
-- [docs/expedition-example-smoke.md](/Users/piovese/Documents/cogolo/docs/expedition-example-smoke.md)
+- [quickstart.md](../quickstart.md)
+- [apps/react-demo/README.md](../apps/react-demo/README.md)
+- [docs/expedition-example-smoke.md](expedition-example-smoke.md)

--- a/docs/app-consumable-consumer-bundle.md
+++ b/docs/app-consumable-consumer-bundle.md
@@ -3,9 +3,9 @@
 This document defines the first versioned Traverse consumer bundle for downstream app integration.
 
 The bundle is the release-facing adoption package for downstream apps such as `youaskm3`. It tells a downstream team what to install, which Traverse release tag to pin, and which public surfaces are supported together.
-The bundle is paired with the package release pointer at [docs/app-consumable-package-release-pointer.md](/Users/piovese/Documents/cogolo/docs/app-consumable-package-release-pointer.md).
-The downstream publication strategy for packaged Traverse runtime and MCP artifacts is defined in [specs/023-downstream-publication-strategy/spec.md](/Users/piovese/Documents/cogolo/specs/023-downstream-publication-strategy/spec.md).
-The packaged runtime artifact is defined in [docs/packaged-traverse-runtime-artifact.md](/Users/piovese/Documents/cogolo/docs/packaged-traverse-runtime-artifact.md).
+The bundle is paired with the package release pointer at [docs/app-consumable-package-release-pointer.md](app-consumable-package-release-pointer.md).
+The downstream publication strategy for packaged Traverse runtime and MCP artifacts is defined in [specs/023-downstream-publication-strategy/spec.md](../specs/023-downstream-publication-strategy/spec.md).
+The packaged runtime artifact is defined in [docs/packaged-traverse-runtime-artifact.md](packaged-traverse-runtime-artifact.md).
 
 ## Bundle Purpose
 
@@ -17,9 +17,9 @@ It is a versioned compatibility record, not a new runtime behavior layer.
 
 For the first app-consumable release, the supported bundle points to:
 
-- the browser-targeted consumer package at [apps/browser-consumer/README.md](/Users/piovese/Documents/cogolo/apps/browser-consumer/README.md)
-- the dedicated MCP stdio server package at [docs/mcp-stdio-server.md](/Users/piovese/Documents/cogolo/docs/mcp-stdio-server.md)
-- the live browser adapter path described in [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md)
+- the browser-targeted consumer package at [apps/browser-consumer/README.md](../apps/browser-consumer/README.md)
+- the dedicated MCP stdio server package at [docs/mcp-stdio-server.md](mcp-stdio-server.md)
+- the live browser adapter path described in [quickstart.md](../quickstart.md)
 - the downstream integration and validation docs for `youaskm3`
 
 Those surfaces must be consumed as one versioned release set.

--- a/docs/app-consumable-entry-path.md
+++ b/docs/app-consumable-entry-path.md
@@ -4,19 +4,19 @@ This is the canonical documentation path for humans and coding agents working on
 
 ## Start Here
 
-1. Read the repository root [README.md](/Users/piovese/Documents/cogolo/README.md)
-2. Open [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md)
+1. Read the repository root [README.md](../README.md)
+2. Open [quickstart.md](../quickstart.md)
 3. Use the relevant deeper docs only after the quickstart path is clear:
-   - [docs/app-consumable-acceptance.md](/Users/piovese/Documents/cogolo/docs/app-consumable-acceptance.md)
-   - [docs/app-consumable-release-checklist.md](/Users/piovese/Documents/cogolo/docs/app-consumable-release-checklist.md)
-   - [docs/app-consumable-consumer-bundle.md](/Users/piovese/Documents/cogolo/docs/app-consumable-consumer-bundle.md)
-   - [docs/app-consumable-package-release-pointer.md](/Users/piovese/Documents/cogolo/docs/app-consumable-package-release-pointer.md)
-   - [docs/app-consumable-requirements-traceability.md](/Users/piovese/Documents/cogolo/docs/app-consumable-requirements-traceability.md)
-   - [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md)
-   - [docs/youaskm3-published-artifact-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-published-artifact-validation.md)
-   - [docs/youaskm3-compatibility-conformance-suite.md](/Users/piovese/Documents/cogolo/docs/youaskm3-compatibility-conformance-suite.md)
-   - [docs/youaskm3-real-shell-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-real-shell-validation.md)
-   - [apps/browser-consumer/README.md](/Users/piovese/Documents/cogolo/apps/browser-consumer/README.md)
+   - [docs/app-consumable-acceptance.md](app-consumable-acceptance.md)
+   - [docs/app-consumable-release-checklist.md](app-consumable-release-checklist.md)
+   - [docs/app-consumable-consumer-bundle.md](app-consumable-consumer-bundle.md)
+   - [docs/app-consumable-package-release-pointer.md](app-consumable-package-release-pointer.md)
+   - [docs/app-consumable-requirements-traceability.md](app-consumable-requirements-traceability.md)
+   - [docs/youaskm3-integration-validation.md](youaskm3-integration-validation.md)
+   - [docs/youaskm3-published-artifact-validation.md](youaskm3-published-artifact-validation.md)
+   - [docs/youaskm3-compatibility-conformance-suite.md](youaskm3-compatibility-conformance-suite.md)
+   - [docs/youaskm3-real-shell-validation.md](youaskm3-real-shell-validation.md)
+   - [apps/browser-consumer/README.md](../apps/browser-consumer/README.md)
 
 ## Canonical Rule
 

--- a/docs/app-consumable-release-artifact.md
+++ b/docs/app-consumable-release-artifact.md
@@ -2,12 +2,12 @@
 
 This document defines what the first Traverse v0.1 app-consumable release actually publishes.
 
-The release checklist at [docs/app-consumable-release-checklist.md](/Users/piovese/Documents/cogolo/docs/app-consumable-release-checklist.md) explains when the release is allowed. This document explains what the release artifact is once that checklist is satisfied.
-The package release pointer is defined in [docs/app-consumable-package-release-pointer.md](/Users/piovese/Documents/cogolo/docs/app-consumable-package-release-pointer.md).
-The downstream publication strategy for packaged Traverse runtime and MCP artifacts is defined in [specs/023-downstream-publication-strategy/spec.md](/Users/piovese/Documents/cogolo/specs/023-downstream-publication-strategy/spec.md).
-For the packaged runtime artifact itself, see [docs/packaged-traverse-runtime-artifact.md](/Users/piovese/Documents/cogolo/docs/packaged-traverse-runtime-artifact.md).
-For the packaged MCP server artifact itself, see [docs/packaged-traverse-mcp-server-artifact.md](/Users/piovese/Documents/cogolo/docs/packaged-traverse-mcp-server-artifact.md).
-For the downstream published-artifact validation path, see [docs/youaskm3-published-artifact-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-published-artifact-validation.md).
+The release checklist at [docs/app-consumable-release-checklist.md](app-consumable-release-checklist.md) explains when the release is allowed. This document explains what the release artifact is once that checklist is satisfied.
+The package release pointer is defined in [docs/app-consumable-package-release-pointer.md](app-consumable-package-release-pointer.md).
+The downstream publication strategy for packaged Traverse runtime and MCP artifacts is defined in [specs/023-downstream-publication-strategy/spec.md](../specs/023-downstream-publication-strategy/spec.md).
+For the packaged runtime artifact itself, see [docs/packaged-traverse-runtime-artifact.md](packaged-traverse-runtime-artifact.md).
+For the packaged MCP server artifact itself, see [docs/packaged-traverse-mcp-server-artifact.md](packaged-traverse-mcp-server-artifact.md).
+For the downstream published-artifact validation path, see [docs/youaskm3-published-artifact-validation.md](youaskm3-published-artifact-validation.md).
 
 ## Publication Shape
 

--- a/docs/app-consumable-release-checklist.md
+++ b/docs/app-consumable-release-checklist.md
@@ -14,18 +14,18 @@ It does not redefine the downstream contract or the validation specs. It only st
 
 Traverse MUST NOT claim `app-consumable v0.1` unless all of the following are satisfied:
 
-- [ ] The governed browser consumer path exists and is documented in [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md).
-- [ ] The live local browser adapter path passes [scripts/ci/react_demo_live_adapter_smoke.sh](/Users/piovese/Documents/cogolo/scripts/ci/react_demo_live_adapter_smoke.sh).
-- [ ] The browser demo path is documented as a real live adapter consumer in [apps/react-demo/README.md](/Users/piovese/Documents/cogolo/apps/react-demo/README.md).
-- [ ] The first versioned Traverse consumer bundle is documented in [docs/app-consumable-consumer-bundle.md](/Users/piovese/Documents/cogolo/docs/app-consumable-consumer-bundle.md).
-- [ ] The downstream MCP consumption path exists and passes [scripts/ci/mcp_consumption_validation.sh](/Users/piovese/Documents/cogolo/scripts/ci/mcp_consumption_validation.sh).
-- [ ] The first real `youaskm3` integration path exists and passes [scripts/ci/youaskm3_integration_validation.sh](/Users/piovese/Documents/cogolo/scripts/ci/youaskm3_integration_validation.sh).
-- [ ] The real browser-hosted `youaskm3` shell validation exists and passes [scripts/ci/youaskm3_real_shell_validation.sh](/Users/piovese/Documents/cogolo/scripts/ci/youaskm3_real_shell_validation.sh).
-- [ ] The published-artifact validation path exists and passes [scripts/ci/youaskm3_published_artifact_validation.sh](/Users/piovese/Documents/cogolo/scripts/ci/youaskm3_published_artifact_validation.sh).
-- [ ] The published-artifact validation path is documented in [docs/youaskm3-published-artifact-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-published-artifact-validation.md).
-- [ ] The end-to-end acceptance path exists and passes [scripts/ci/app_consumable_acceptance.sh](/Users/piovese/Documents/cogolo/scripts/ci/app_consumable_acceptance.sh).
-- [ ] The package release pointer exists and is documented in [docs/app-consumable-package-release-pointer.md](/Users/piovese/Documents/cogolo/docs/app-consumable-package-release-pointer.md).
-- [ ] The operational constraints for app-facing browser and MCP surfaces are documented in [docs/adapter-boundaries.md](/Users/piovese/Documents/cogolo/docs/adapter-boundaries.md) and [docs/compatibility-policy.md](/Users/piovese/Documents/cogolo/docs/compatibility-policy.md).
+- [ ] The governed browser consumer path exists and is documented in [quickstart.md](../quickstart.md).
+- [ ] The live local browser adapter path passes [scripts/ci/react_demo_live_adapter_smoke.sh](../scripts/ci/react_demo_live_adapter_smoke.sh).
+- [ ] The browser demo path is documented as a real live adapter consumer in [apps/react-demo/README.md](../apps/react-demo/README.md).
+- [ ] The first versioned Traverse consumer bundle is documented in [docs/app-consumable-consumer-bundle.md](app-consumable-consumer-bundle.md).
+- [ ] The downstream MCP consumption path exists and passes [scripts/ci/mcp_consumption_validation.sh](../scripts/ci/mcp_consumption_validation.sh).
+- [ ] The first real `youaskm3` integration path exists and passes [scripts/ci/youaskm3_integration_validation.sh](../scripts/ci/youaskm3_integration_validation.sh).
+- [ ] The real browser-hosted `youaskm3` shell validation exists and passes [scripts/ci/youaskm3_real_shell_validation.sh](../scripts/ci/youaskm3_real_shell_validation.sh).
+- [ ] The published-artifact validation path exists and passes [scripts/ci/youaskm3_published_artifact_validation.sh](../scripts/ci/youaskm3_published_artifact_validation.sh).
+- [ ] The published-artifact validation path is documented in [docs/youaskm3-published-artifact-validation.md](youaskm3-published-artifact-validation.md).
+- [ ] The end-to-end acceptance path exists and passes [scripts/ci/app_consumable_acceptance.sh](../scripts/ci/app_consumable_acceptance.sh).
+- [ ] The package release pointer exists and is documented in [docs/app-consumable-package-release-pointer.md](app-consumable-package-release-pointer.md).
+- [ ] The operational constraints for app-facing browser and MCP surfaces are documented in [docs/adapter-boundaries.md](adapter-boundaries.md) and [docs/compatibility-policy.md](compatibility-policy.md).
 - [ ] The consumer contract and integration-validation model remain aligned with approved governing specs.
 
 If any item above is unchecked, `app-consumable v0.1` is blocked.

--- a/docs/app-consumable-requirements-traceability.md
+++ b/docs/app-consumable-requirements-traceability.md
@@ -15,20 +15,20 @@ Project 1 remains the coordination surface for the work, but this document is no
 | Live browser-consumer path | [#120](https://github.com/enricopiovesan/Traverse/issues/120), [#121](https://github.com/enricopiovesan/Traverse/issues/121), [#123](https://github.com/enricopiovesan/Traverse/issues/123) | The browser adapter and live demo path are the supported consumable path for the published release. |
 | Downstream consumer contract and app-facing validation | [#126](https://github.com/enricopiovesan/Traverse/issues/126), [#128](https://github.com/enricopiovesan/Traverse/issues/128), [#129](https://github.com/enricopiovesan/Traverse/issues/129) | The consumer contract and validation path define what downstream apps may rely on. |
 | Real browser-hosted `youaskm3` shell validation | [#179](https://github.com/enricopiovesan/Traverse/issues/179) | The real downstream shell validation proves the published bundle works in a browser-hosted consumer. |
-| Published-artifact validation against packaged Traverse runtime and MCP artifacts | [#200](https://github.com/enricopiovesan/Traverse/issues/200), [docs/youaskm3-published-artifact-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-published-artifact-validation.md) | This is the published-artifact proof path for the released runtime and MCP artifacts. |
+| Published-artifact validation against packaged Traverse runtime and MCP artifacts | [#200](https://github.com/enricopiovesan/Traverse/issues/200), [docs/youaskm3-published-artifact-validation.md](youaskm3-published-artifact-validation.md) | This is the published-artifact proof path for the released runtime and MCP artifacts. |
 | MCP WASM server model and validation | [#146](https://github.com/enricopiovesan/Traverse/issues/146), [#158](https://github.com/enricopiovesan/Traverse/issues/158), [#148](https://github.com/enricopiovesan/Traverse/issues/148) | The MCP surface is now part of the published v0.1 app-consumable release story. |
 
 ## Published Release Bundle
 
 The published release picture is anchored by these docs:
 
-- [docs/app-consumable-release-artifact.md](/Users/piovese/Documents/cogolo/docs/app-consumable-release-artifact.md)
-- [docs/app-consumable-consumer-bundle.md](/Users/piovese/Documents/cogolo/docs/app-consumable-consumer-bundle.md)
-- [docs/app-consumable-package-release-pointer.md](/Users/piovese/Documents/cogolo/docs/app-consumable-package-release-pointer.md)
-- [docs/app-consumable-release-checklist.md](/Users/piovese/Documents/cogolo/docs/app-consumable-release-checklist.md)
-- [docs/packaged-traverse-runtime-artifact.md](/Users/piovese/Documents/cogolo/docs/packaged-traverse-runtime-artifact.md)
-- [docs/packaged-traverse-mcp-server-artifact.md](/Users/piovese/Documents/cogolo/docs/packaged-traverse-mcp-server-artifact.md)
-- [docs/youaskm3-published-artifact-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-published-artifact-validation.md)
+- [docs/app-consumable-release-artifact.md](app-consumable-release-artifact.md)
+- [docs/app-consumable-consumer-bundle.md](app-consumable-consumer-bundle.md)
+- [docs/app-consumable-package-release-pointer.md](app-consumable-package-release-pointer.md)
+- [docs/app-consumable-release-checklist.md](app-consumable-release-checklist.md)
+- [docs/packaged-traverse-runtime-artifact.md](packaged-traverse-runtime-artifact.md)
+- [docs/packaged-traverse-mcp-server-artifact.md](packaged-traverse-mcp-server-artifact.md)
+- [docs/youaskm3-published-artifact-validation.md](youaskm3-published-artifact-validation.md)
 
 The release artifact and publication bundle are the bridge between the runtime and MCP artifact docs, the consumer bundle, the quickstart, and the published-artifact validation path.
 

--- a/docs/mcp-consumption-validation.md
+++ b/docs/mcp-consumption-validation.md
@@ -2,11 +2,11 @@
 
 Traverse uses `youaskm3` as the first proving downstream app for the app-facing MCP substrate.
 
-For the shortest local start path before you run this downstream validation, begin with [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md).
+For the shortest local start path before you run this downstream validation, begin with [quickstart.md](../quickstart.md).
 
-For the dedicated Traverse MCP server package foundation, begin with [docs/mcp-stdio-server.md](/Users/piovese/Documents/cogolo/docs/mcp-stdio-server.md).
+For the dedicated Traverse MCP server package foundation, begin with [docs/mcp-stdio-server.md](mcp-stdio-server.md).
 
-For the packaged MCP server artifact, see [docs/packaged-traverse-mcp-server-artifact.md](/Users/piovese/Documents/cogolo/docs/packaged-traverse-mcp-server-artifact.md).
+For the packaged MCP server artifact, see [docs/packaged-traverse-mcp-server-artifact.md](packaged-traverse-mcp-server-artifact.md).
 
 This validation path is governed by:
 
@@ -14,9 +14,9 @@ This validation path is governed by:
 - `specs/020-downstream-integration-validation/spec.md`
 - `specs/021-app-facing-operational-constraints/spec.md`
 
-For the first real downstream browser + MCP integration path, also see [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md), [docs/youaskm3-compatibility-conformance-suite.md](/Users/piovese/Documents/cogolo/docs/youaskm3-compatibility-conformance-suite.md), and the browser-targeted consumer package at [apps/browser-consumer/README.md](/Users/piovese/Documents/cogolo/apps/browser-consumer/README.md).
+For the first real downstream browser + MCP integration path, also see [docs/youaskm3-integration-validation.md](youaskm3-integration-validation.md), [docs/youaskm3-compatibility-conformance-suite.md](youaskm3-compatibility-conformance-suite.md), and the browser-targeted consumer package at [apps/browser-consumer/README.md](../apps/browser-consumer/README.md).
 
-For the real-agent exercise against the same MCP substrate, also see [docs/mcp-real-agent-exercise.md](/Users/piovese/Documents/cogolo/docs/mcp-real-agent-exercise.md).
+For the real-agent exercise against the same MCP substrate, also see [docs/mcp-real-agent-exercise.md](mcp-real-agent-exercise.md).
 
 ## Validation Path
 

--- a/docs/mcp-real-agent-exercise.md
+++ b/docs/mcp-real-agent-exercise.md
@@ -17,9 +17,9 @@ The goal is to prove that a real agent can connect to the governed `traverse-mcp
 
 The real-agent exercise should use the same public surfaces documented in:
 
-- [docs/mcp-stdio-server.md](/Users/piovese/Documents/cogolo/docs/mcp-stdio-server.md)
-- [docs/mcp-consumption-validation.md](/Users/piovese/Documents/cogolo/docs/mcp-consumption-validation.md)
-- [docs/youaskm3-integration-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-integration-validation.md)
+- [docs/mcp-stdio-server.md](mcp-stdio-server.md)
+- [docs/mcp-consumption-validation.md](mcp-consumption-validation.md)
+- [docs/youaskm3-integration-validation.md](youaskm3-integration-validation.md)
 
 The real-agent exercise should validate the following entry points:
 

--- a/docs/mcp-stdio-server.md
+++ b/docs/mcp-stdio-server.md
@@ -2,7 +2,7 @@
 
 The dedicated Traverse MCP WASM server package is the thin, governed host-facing surface for the app-consumable MCP path.
 
-The packaged MCP server artifact is defined in [docs/packaged-traverse-mcp-server-artifact.md](/Users/piovese/Documents/cogolo/docs/packaged-traverse-mcp-server-artifact.md).
+The packaged MCP server artifact is defined in [docs/packaged-traverse-mcp-server-artifact.md](packaged-traverse-mcp-server-artifact.md).
 
 It is intentionally narrow:
 

--- a/docs/multi-thread-workflow.md
+++ b/docs/multi-thread-workflow.md
@@ -65,7 +65,7 @@ Do not move work to `In Progress` merely because it is a candidate for parallel 
 
 If a ticket has an open PR, it must be labeled `in-progress` and its Project 1 item must also be `In Progress`. The PM thread should fix mismatches immediately.
 
-The backlog audit logic lives in [scripts/ci/project_board_audit.sh](/Users/piovese/Documents/cogolo/scripts/ci/project_board_audit.sh).
+The backlog audit logic lives in [scripts/ci/project_board_audit.sh](../scripts/ci/project_board_audit.sh).
 
 ## Required Parallel Work Rules
 

--- a/docs/packaged-traverse-mcp-server-artifact.md
+++ b/docs/packaged-traverse-mcp-server-artifact.md
@@ -4,7 +4,7 @@ This document defines the first governed packaged Traverse MCP server artifact f
 
 The published MCP server artifact is the MCP-facing release form that downstream consumers can obtain and run without relying on source checkout details or repo archaeology.
 
-The downstream publication strategy for packaged Traverse runtime and MCP artifacts is defined in [specs/023-downstream-publication-strategy/spec.md](/Users/piovese/Documents/cogolo/specs/023-downstream-publication-strategy/spec.md).
+The downstream publication strategy for packaged Traverse runtime and MCP artifacts is defined in [specs/023-downstream-publication-strategy/spec.md](../specs/023-downstream-publication-strategy/spec.md).
 
 ## Publication Shape
 

--- a/docs/packaged-traverse-runtime-artifact.md
+++ b/docs/packaged-traverse-runtime-artifact.md
@@ -4,7 +4,7 @@ This document defines the first governed packaged Traverse runtime artifact for 
 
 The published runtime artifact is the runtime-facing release form that downstream consumers can obtain and run without relying on source checkout details or repo archaeology.
 
-The downstream publication strategy for packaged Traverse runtime and MCP artifacts is defined in [specs/023-downstream-publication-strategy/spec.md](/Users/piovese/Documents/cogolo/specs/023-downstream-publication-strategy/spec.md).
+The downstream publication strategy for packaged Traverse runtime and MCP artifacts is defined in [specs/023-downstream-publication-strategy/spec.md](../specs/023-downstream-publication-strategy/spec.md).
 
 ## Publication Shape
 

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -16,8 +16,8 @@ This is the default Traverse operating rule for spec slices, implementation slic
 
 Ticket quality rules are defined in:
 
-- [docs/ticket-standard.md](/Users/piovese/Documents/cogolo/docs/ticket-standard.md)
-- [docs/multi-thread-workflow.md](/Users/piovese/Documents/cogolo/docs/multi-thread-workflow.md)
+- [docs/ticket-standard.md](ticket-standard.md)
+- [docs/multi-thread-workflow.md](multi-thread-workflow.md)
 
 ## Preferred Flow
 
@@ -104,7 +104,7 @@ Only tickets with real active execution should appear on Project 1 as `In Progre
 
 For true parallel execution, use separate Codex threads with separate issues, branches, and PRs. The operating model is documented in:
 
-- [docs/multi-thread-workflow.md](/Users/piovese/Documents/cogolo/docs/multi-thread-workflow.md)
+- [docs/multi-thread-workflow.md](multi-thread-workflow.md)
 
 Run the board audit when you change issue labels, Project 1 status, or PR state:
 
@@ -112,4 +112,4 @@ Run the board audit when you change issue labels, Project 1 status, or PR state:
 bash scripts/ci/project_board_audit.sh
 ```
 
-The board audit logic lives in [scripts/ci/project_board_audit.sh](/Users/piovese/Documents/cogolo/scripts/ci/project_board_audit.sh).
+The board audit logic lives in [scripts/ci/project_board_audit.sh](../scripts/ci/project_board_audit.sh).

--- a/docs/wasm-agent-authoring-guide.md
+++ b/docs/wasm-agent-authoring-guide.md
@@ -4,9 +4,9 @@ This guide shows how to create a new governed WASM agent in Traverse without inv
 
 Use the checked-in examples as the source of truth:
 
-- [`examples/templates/executable-capability-package/manifest.template.json`](/Users/piovese/Documents/cogolo/examples/templates/executable-capability-package/manifest.template.json)
-- [`examples/agents/expedition-intent-agent/manifest.json`](/Users/piovese/Documents/cogolo/examples/agents/expedition-intent-agent/manifest.json)
-- [`examples/agents/team-readiness-agent/manifest.json`](/Users/piovese/Documents/cogolo/examples/agents/team-readiness-agent/manifest.json)
+- [`examples/templates/executable-capability-package/manifest.template.json`](../examples/templates/executable-capability-package/manifest.template.json)
+- [`examples/agents/expedition-intent-agent/manifest.json`](../examples/agents/expedition-intent-agent/manifest.json)
+- [`examples/agents/team-readiness-agent/manifest.json`](../examples/agents/team-readiness-agent/manifest.json)
 
 ## Start From a Governed Package
 

--- a/docs/wasm-microservice-authoring-guide.md
+++ b/docs/wasm-microservice-authoring-guide.md
@@ -6,10 +6,10 @@ Traverse does not currently treat a microservice as a separate runtime category 
 
 Use the checked-in examples and references as the source of truth:
 
-- [`examples/templates/executable-capability-package/manifest.template.json`](/Users/piovese/Documents/cogolo/examples/templates/executable-capability-package/manifest.template.json)
-- [`docs/adapter-boundaries.md`](/Users/piovese/Documents/cogolo/docs/adapter-boundaries.md)
-- [`docs/compatibility-policy.md`](/Users/piovese/Documents/cogolo/docs/compatibility-policy.md)
-- [`docs/oss-pattern-extraction.md`](/Users/piovese/Documents/cogolo/docs/oss-pattern-extraction.md)
+- [`examples/templates/executable-capability-package/manifest.template.json`](../examples/templates/executable-capability-package/manifest.template.json)
+- [`docs/adapter-boundaries.md`](adapter-boundaries.md)
+- [`docs/compatibility-policy.md`](compatibility-policy.md)
+- [`docs/oss-pattern-extraction.md`](oss-pattern-extraction.md)
 
 ## Start From a Governed Package
 

--- a/docs/youaskm3-compatibility-conformance-suite.md
+++ b/docs/youaskm3-compatibility-conformance-suite.md
@@ -3,7 +3,7 @@
 This document defines the first deterministic compatibility and conformance suite for Traverse and `youaskm3`.
 
 The suite exists so a reviewer can prove that the released Traverse surfaces remain consumable by `youaskm3` without depending on repo archaeology, ad hoc environment setup, or private Traverse internals.
-The real browser-hosted shell validation is documented separately in [docs/youaskm3-real-shell-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-real-shell-validation.md).
+The real browser-hosted shell validation is documented separately in [docs/youaskm3-real-shell-validation.md](youaskm3-real-shell-validation.md).
 
 This youaskm3 compatibility conformance suite is the release-aligned proof path for the downstream consumer contract.
 

--- a/docs/youaskm3-integration-validation.md
+++ b/docs/youaskm3-integration-validation.md
@@ -11,13 +11,13 @@ It stays on governed public Traverse surfaces only:
 - the versioned Traverse consumer bundle
 - the real-agent MCP exercise guide
 - the published-artifact validation path for the released Traverse runtime and MCP artifacts
-- [docs/youaskm3-published-artifact-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-published-artifact-validation.md)
-- [docs/youaskm3-compatibility-conformance-suite.md](/Users/piovese/Documents/cogolo/docs/youaskm3-compatibility-conformance-suite.md)
+- [docs/youaskm3-published-artifact-validation.md](youaskm3-published-artifact-validation.md)
+- [docs/youaskm3-compatibility-conformance-suite.md](youaskm3-compatibility-conformance-suite.md)
 - the `youaskm3` compatibility conformance suite
-- [docs/youaskm3-real-shell-validation.md](/Users/piovese/Documents/cogolo/docs/youaskm3-real-shell-validation.md)
+- [docs/youaskm3-real-shell-validation.md](youaskm3-real-shell-validation.md)
 - the `youaskm3` real shell validation
 
-For the shortest Traverse-side start path, begin with [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md).
+For the shortest Traverse-side start path, begin with [quickstart.md](../quickstart.md).
 
 ## Governing Spec
 

--- a/docs/youaskm3-starter-kit.md
+++ b/docs/youaskm3-starter-kit.md
@@ -2,7 +2,7 @@
 
 This document is the first integration guide for browser-hosted downstream apps such as `youaskm3`.
 
-It pairs with the reference starter kit at [apps/youaskm3-starter-kit/README.md](/Users/piovese/Documents/cogolo/apps/youaskm3-starter-kit/README.md).
+It pairs with the reference starter kit at [apps/youaskm3-starter-kit/README.md](../apps/youaskm3-starter-kit/README.md).
 
 This youaskm3 starter kit and integration guide is the canonical browser-hosted adoption path for the downstream app.
 
@@ -14,12 +14,12 @@ The goal is to give a downstream app team one clear adoption path for Traverse w
 
 Downstream apps should adopt the versioned Traverse consumer bundle and the browser-targeted consumer package documented in:
 
-- [docs/app-consumable-consumer-bundle.md](/Users/piovese/Documents/cogolo/docs/app-consumable-consumer-bundle.md)
-- [apps/browser-consumer/README.md](/Users/piovese/Documents/cogolo/apps/browser-consumer/README.md)
+- [docs/app-consumable-consumer-bundle.md](app-consumable-consumer-bundle.md)
+- [apps/browser-consumer/README.md](../apps/browser-consumer/README.md)
 
 ## Setup
 
-1. Read the root [quickstart.md](/Users/piovese/Documents/cogolo/quickstart.md).
+1. Read the root [quickstart.md](../quickstart.md).
 2. Review the app-consumable consumer bundle.
 3. Use the browser-targeted consumer package from the starter kit.
 4. Run the browser-hosted and MCP-facing validation paths.


### PR DESCRIPTION
## Summary
- remove machine-specific absolute paths from developer-facing docs
- replace them with portable relative references
- keep the published app-consumable traceability doc aligned with the portable doc set

## Governing Spec
- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `019-downstream-consumer-contract`
- `023-browser-hosted-mcp-consumer-model`
- `028-schema-alignment-gate-v02`

## Project Item
- Closes #255
- Tracked in Project 1

## Validation
- `rg -n '/Users/piovese/' README.md docs quickstart.md`
- `bash scripts/ci/repository_checks.sh`
