### PR TITLE
Add Traverse CLI reference guide

### DIFF
--- a/docs/app-consumable-entry-path.md
+++ b/docs/app-consumable-entry-path.md
@@ -7,6 +7,7 @@ This is the canonical documentation path for humans and coding agents working on
 1. Read the repository root [README.md](../README.md)
 2. Open [quickstart.md](../quickstart.md)
 3. Use the relevant deeper docs only after the quickstart path is clear:
+   - [docs/cli-reference.md](cli-reference.md)
    - [docs/app-consumable-acceptance.md](app-consumable-acceptance.md)
    - [docs/app-consumable-release-checklist.md](app-consumable-release-checklist.md)
    - [docs/app-consumable-consumer-bundle.md](app-consumable-consumer-bundle.md)
@@ -26,6 +27,7 @@ If a new human or agent asks where to begin, point them to the README first and 
 
 - The README is the front door.
 - The quickstart is the first executable consumer path.
+- The CLI reference explains the supported command surface and separates public commands from internal/test-only paths.
 - The versioned consumer bundle explains what a downstream app installs and which released surfaces it may rely on.
 - The package release pointer explains how the governed app-consumable package release is identified downstream.
 - The published-artifact validation explains how `youaskm3` consumes the released runtime and MCP artifacts.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,80 @@
+# Traverse CLI Reference
+
+This page documents the supported `traverse-cli` command surface as it exists today.
+
+It is meant to be a stable reference for humans and agents. It distinguishes the public command surface from example-only and test-only paths so downstream users do not have to infer the API from source code.
+
+## Help Behavior
+
+The current binary exposes a single top-level usage string.
+
+These invocations all print the same usage synopsis today:
+
+- `cargo run -p traverse-cli -- --help`
+- `cargo run -p traverse-cli -- help`
+- `cargo run -p traverse-cli -- agent --help`
+- `cargo run -p traverse-cli -- browser-adapter serve --help`
+
+There is not yet a nested help tree with per-subcommand long-form help pages.
+
+## Supported Commands
+
+| Command | Purpose | Example | Expected Output |
+|---|---|---|---|
+| `bundle inspect <manifest-path>` | Validate and summarize a registry bundle manifest. | `cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json` | Prints `bundle_id`, `version`, `scope`, artifact counts, and the discovered capability/event/workflow ids. |
+| `bundle register <manifest-path>` | Load a registry bundle and register its contents into in-memory registries. | `cargo run -p traverse-cli -- bundle register examples/expedition/registry-bundle/manifest.json` | Prints `bundle_id`, `version`, `scope`, registered counts, and registration record summaries. |
+| `browser-adapter serve [--bind <address>]` | Start the local browser adapter for the governed browser consumer path. | `cargo run -p traverse-cli -- browser-adapter serve --bind 127.0.0.1:4174` | Prints `local browser adapter listening on http://...` and stays running until stopped. |
+| `agent inspect <manifest-path>` | Load and summarize a governed WASM agent package manifest. | `cargo run -p traverse-cli -- agent inspect examples/agents/expedition-intent-agent/manifest.json` | Prints `path`, `package_id`, `package_version`, `capability_id`, binary location, digest, and model/workflow references. |
+| `agent execute <manifest-path> <request-path>` | Load a governed WASM agent package and execute it against a runtime request. | `cargo run -p traverse-cli -- agent execute examples/agents/expedition-intent-agent/manifest.json examples/agents/runtime-requests/interpret-expedition-intent.json` | Prints `request_id`, `execution_id`, `package_id`, `capability_id`, `trace_ref`, `status`, and capability-specific result fields. |
+| `event inspect <contract-path>` | Parse and validate an event contract. | `cargo run -p traverse-cli -- event inspect contracts/examples/expedition/events/expedition-objective-captured/contract.json` | Prints `path`, `id`, `version`, lifecycle, classification, publisher/subscriber counts, and publisher/subscriber ids. |
+| `trace inspect <trace-path>` | Parse and summarize a runtime trace artifact. | `cargo run -p traverse-cli -- trace inspect target/traces/plan-expedition.json` | Prints `trace_id`, `execution_id`, `request_id`, governing spec, state-machine validation, state transition counts, and terminal outcome details. |
+| `workflow inspect <workflow-path>` | Parse and summarize a workflow definition artifact. | `cargo run -p traverse-cli -- workflow inspect workflows/examples/expedition/plan-expedition/workflow.json` | Prints `id`, `version`, lifecycle, start node, terminal nodes, node/edge counts, and workflow edges. |
+| `expedition execute <request-path> [--trace-out <trace-path>]` | Execute the canonical expedition workflow through the Traverse runtime. | `cargo run -p traverse-cli -- expedition execute examples/expedition/runtime-requests/plan-expedition.json --trace-out target/traces/plan-expedition.json` | Prints `request_id`, `execution_id`, `capability_id`, `status`, `trace_ref`, and expedition result fields such as `plan_id` and `summary`. |
+
+## Stable Public Surface
+
+The following command families are intended to be the public documented surface for the current release line:
+
+- `bundle inspect`
+- `bundle register`
+- `browser-adapter serve`
+- `agent inspect`
+- `agent execute`
+- `event inspect`
+- `trace inspect`
+- `workflow inspect`
+- `expedition execute`
+
+These commands are the ones a downstream developer should rely on when working with Traverse from the terminal.
+
+## Internal Or Test-Only Paths
+
+The following are not CLI commands and should be treated as reference assets, examples, or validation helpers rather than stable user-facing entry points:
+
+- `scripts/ci/*.sh` smoke and validation scripts
+- artifact trees under `contracts/examples/`
+- workflow trees under `workflows/examples/`
+- example package trees under `examples/`
+- generated trace artifacts under `target/` or other local output directories
+
+Those paths are useful for testing and documentation, but they are not a promise of a product API.
+
+## Notes On Outputs
+
+- Inspect commands print structured summaries to stdout.
+- Execute commands print structured execution summaries to stdout.
+- The browser adapter prints a listening address and then remains active.
+- Error cases are written to stderr and return a non-zero exit code.
+
+## Validation
+
+This reference was checked against the live CLI behavior with:
+
+- `cargo run -p traverse-cli -- --help`
+- `cargo run -p traverse-cli -- help`
+- `cargo run -p traverse-cli -- agent --help`
+- `cargo run -p traverse-cli -- browser-adapter serve --help`
+
+It should also remain consistent with:
+
+- `bash scripts/ci/repository_checks.sh`


### PR DESCRIPTION
## Summary

Add a dedicated Traverse CLI reference guide for the supported command surface, expected outputs, and stable versus internal/test-only paths.

## Governing Spec

- `004-spec-alignment-gate`
- `019-downstream-consumer-contract`
- `023-browser-hosted-mcp-consumer-model`

## Project Item

- `#256`

## What Changed

- Contracts changed: none
- Runtime behavior changed: none
- Compatibility impact: documentation-only
- ADR needed or linked: none

## Validation

- `bash scripts/ci/repository_checks.sh`
- `cargo run -p traverse-cli -- --help`
- `cargo run -p traverse-cli -- help`
- `cargo run -p traverse-cli -- agent --help`
- `cargo run -p traverse-cli -- browser-adapter serve --help`
- `cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json`
- `cargo run -p traverse-cli -- bundle register examples/expedition/registry-bundle/manifest.json`
- `cargo run -p traverse-cli -- agent inspect examples/agents/expedition-intent-agent/manifest.json`
- `cargo run -p traverse-cli -- event inspect contracts/examples/expedition/events/expedition-objective-captured/contract.json`
- `cargo run -p traverse-cli -- workflow inspect workflows/examples/expedition/plan-expedition/workflow.json`
- `cargo run -p traverse-cli -- expedition execute examples/expedition/runtime-requests/plan-expedition.json`
- `cargo run -p traverse-cli -- expedition execute examples/expedition/runtime-requests/plan-expedition.json --trace-out /tmp/cli-reference-trace.json`
- `cargo run -p traverse-cli -- trace inspect /tmp/cli-reference-trace.json`

## Notes

The onboarding index links to the new CLI reference and README.md was not modified.
