### PR TITLE
Clarify supported MCP bootstrap path

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ This project supports AI-assisted development with Codex and Claude Code running
 | `traverse-contracts` | Contract definitions, parsing, and validation |
 | `traverse-registry` | Capability and event registries with deterministic traversal |
 | `traverse-cli` | Command-line interface: register, list, validate, run |
-| `traverse-mcp` | Model Context Protocol surface (in progress) |
+| `traverse-mcp` | Model Context Protocol stdio server and governed MCP-facing surface |
 
 ### Governance
 
@@ -177,6 +177,8 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 #### Build and authoring guides
 
 - [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md) — canonical example authoring flow
+- [docs/adapter-boundaries.md](docs/adapter-boundaries.md) — adapter and portability boundaries
+- [docs/mcp-stdio-server.md](docs/mcp-stdio-server.md) — supported MCP server bootstrap path and command surface
 - [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md) — how to create new WASM agents
 - [docs/wasm-agent-team-readiness-example.md](docs/wasm-agent-team-readiness-example.md) — second governed WASM AI agent example
 - [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) — how to create new WASM microservices

--- a/docs/mcp-stdio-server.md
+++ b/docs/mcp-stdio-server.md
@@ -11,6 +11,23 @@ It is intentionally narrow:
 - it exposes discovery, description, validation, execution, and execution-report rendering through one stdio command surface
 - it is documented and runnable locally
 
+## Supported Bootstrap Path
+
+The supported developer bootstrap path for the dedicated MCP server is:
+
+```bash
+cargo run -p traverse-mcp -- stdio
+```
+
+That `stdio` command is the only supported bootstrap mode in the current app-consumable release path.
+
+Unsupported bootstrap attempts fail loudly:
+
+- omitting the command prints the usage line and exits non-zero
+- using any command other than `stdio` prints `Unsupported command: <command>` and exits non-zero
+
+Developers and agents should treat other bootstrap ideas as unsupported unless they are explicitly documented in this page or in the packaged artifact docs.
+
 ## Start The Server
 
 From the repository root:


### PR DESCRIPTION
## Summary
- remove misleading README language that still presented `traverse-mcp` as merely in progress
- point the root docs map at the supported MCP stdio server bootstrap page
- make the supported `traverse-mcp stdio` bootstrap path and unsupported-command failure behavior explicit

## Governing Spec
- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `015-capability-discovery-mcp`

## Project Item
- Closes #266
- Tracked in Project 1

## Validation
- `bash scripts/ci/repository_checks.sh`
- `cargo test -p traverse-mcp`
