### PR TITLE
Add developer setup validation script

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,6 +20,7 @@ This is intentionally narrower than [quickstart.md](../quickstart.md). `quicksta
 From the repository root, confirm the workspace builds:
 
 ```bash
+bash scripts/validate-setup.sh
 cargo build
 ```
 
@@ -208,6 +209,7 @@ What you should see:
 Run the canonical expedition example smoke and repository checks:
 
 ```bash
+bash scripts/validate-setup.sh
 bash scripts/ci/expedition_golden_path.sh
 bash scripts/ci/repository_checks.sh
 ```

--- a/quickstart.md
+++ b/quickstart.md
@@ -19,6 +19,12 @@ It is intentionally narrow. Use this path when you want one approved end-to-end 
 - Two terminals
 - The repository checked out with the approved browser adapter and browser demo implementation already merged
 
+Confirm the local environment first:
+
+```bash
+bash scripts/validate-setup.sh
+```
+
 ## Start The Live Browser Adapter
 
 From the repository root:

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -48,6 +48,7 @@ required_files=(
   "docs/local-runtime-home.md"
   "docs/getting-started.md"
   "quickstart.md"
+  "scripts/validate-setup.sh"
   "examples/expedition/runtime-requests/plan-expedition.json"
   "examples/hello-world/README.md"
   "examples/hello-world/runtime-requests/say-hello.json"
@@ -122,6 +123,8 @@ grep -q "docs/adapter-boundaries.md" README.md
 grep -q "docs/troubleshooting.md" README.md
 grep -q "docs/getting-started.md" README.md
 grep -q "quickstart.md" README.md
+grep -q "bash scripts/validate-setup.sh" docs/getting-started.md
+grep -q "bash scripts/validate-setup.sh" quickstart.md
 grep -q "Definition of Done" docs/ticket-standard.md
 grep -q "in-progress" docs/ticket-standard.md
 grep -q "active branch, PR, or an explicitly assigned developer" docs/ticket-standard.md

--- a/scripts/validate-setup.sh
+++ b/scripts/validate-setup.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+failures=()
+
+note_failure() {
+  failures+=("$1")
+}
+
+check_command() {
+  local command_name="$1"
+  local install_hint="$2"
+
+  if command -v "${command_name}" >/dev/null 2>&1; then
+    printf '[ok] %s is installed\n' "${command_name}"
+  else
+    printf '[missing] %s\n' "${command_name}"
+    note_failure "${command_name}: ${install_hint}"
+  fi
+}
+
+version_at_least() {
+  local actual="$1"
+  local required="$2"
+
+  local lower
+  lower="$(printf '%s\n%s\n' "${actual}" "${required}" | sort -V | head -n1)"
+  [[ "${lower}" == "${required}" ]]
+}
+
+check_rust_toolchain() {
+  local rustc_version
+  local cargo_version
+  local rustc_semver
+  local cargo_semver
+
+  if ! command -v rustc >/dev/null 2>&1; then
+    printf '[missing] rustc\n'
+    note_failure "rustc: install Rust 1.94 or later from https://rustup.rs"
+    return
+  fi
+
+  if ! command -v cargo >/dev/null 2>&1; then
+    printf '[missing] cargo\n'
+    note_failure "cargo: install Rust 1.94 or later from https://rustup.rs"
+    return
+  fi
+
+  rustc_version="$(rustc --version)"
+  cargo_version="$(cargo --version)"
+  rustc_semver="$(printf '%s\n' "${rustc_version}" | awk '{print $2}')"
+  cargo_semver="$(printf '%s\n' "${cargo_version}" | awk '{print $2}')"
+
+  if version_at_least "${rustc_semver}" "1.94.0"; then
+    printf '[ok] rustc %s\n' "${rustc_semver}"
+  else
+    printf '[unsupported] rustc %s\n' "${rustc_semver}"
+    note_failure "rustc: expected 1.94.0 or later, found ${rustc_semver}"
+  fi
+
+  if version_at_least "${cargo_semver}" "1.94.0"; then
+    printf '[ok] cargo %s\n' "${cargo_semver}"
+  else
+    printf '[unsupported] cargo %s\n' "${cargo_semver}"
+    note_failure "cargo: expected 1.94.0 or later, found ${cargo_semver}"
+  fi
+}
+
+check_node() {
+  local node_version
+  local node_semver
+
+  if ! command -v node >/dev/null 2>&1; then
+    printf '[missing] node\n'
+    note_failure "node: install Node.js 20 or later for the browser quickstart"
+    return
+  fi
+
+  node_version="$(node --version)"
+  node_semver="${node_version#v}"
+
+  if version_at_least "${node_semver}" "20.0.0"; then
+    printf '[ok] node %s\n' "${node_semver}"
+  else
+    printf '[unsupported] node %s\n' "${node_semver}"
+    note_failure "node: expected 20.0.0 or later, found ${node_semver}"
+  fi
+}
+
+check_repo_shape() {
+  if [[ -f "${repo_root}/README.md" && -f "${repo_root}/Cargo.toml" ]]; then
+    printf '[ok] repository root detected at %s\n' "${repo_root}"
+  else
+    printf '[missing] repository root markers\n'
+    note_failure "repo: run this script from a Traverse checkout with README.md and Cargo.toml present"
+  fi
+}
+
+main() {
+  printf 'Traverse setup validation\n'
+  printf 'Repository root: %s\n\n' "${repo_root}"
+
+  check_repo_shape
+  check_rust_toolchain
+  check_command bash "use a shell that can run the checked-in validation scripts"
+  check_node
+
+  printf '\n'
+
+  if ((${#failures[@]} > 0)); then
+    printf 'Setup is not ready yet.\n'
+    printf 'Fix these items before starting the documented developer paths:\n'
+    for failure in "${failures[@]}"; do
+      printf -- '- %s\n' "${failure}"
+    done
+    exit 1
+  fi
+
+  printf 'Setup looks ready for the documented Traverse developer paths.\n'
+  printf 'Next steps:\n'
+  printf -- '- bash scripts/ci/repository_checks.sh\n'
+  printf -- '- cargo build\n'
+  printf -- '- Follow docs/getting-started.md or quickstart.md\n'
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a developer setup validation script for the documented Traverse onboarding path
- wire the setup check into getting-started and quickstart prerequisites
- extend repository checks so the setup validator stays documented and required

## Governing Spec
- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `028-schema-alignment-gate-v02`

## Project Item
- Closes #259
- Tracked in Project 1

## Validation
- `bash scripts/validate-setup.sh`
- `bash scripts/ci/repository_checks.sh`
