### PR TITLE
chore: bump workspace version to 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ target/
 *.profraw
 *.profdata
 coverage.profdata
+
+# Local-only agent tooling and scratch workspaces (must not enter the repo).
+.claude/
+external/
+references/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "semver",
  "serde",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "semver",
  "serde",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-repository = "https://github.com/enricopiovesan/cogolo"
+repository = "https://github.com/enricopiovesan/Traverse"
 rust-version = "1.94"
-version = "0.1.0"
+version = "0.2.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -105,12 +105,24 @@ for file in "${required_files[@]}"; do
 done
 
 if command -v rg >/dev/null 2>&1; then
-  if rg -n "Cogollo|Cogolo" . --hidden -g '!.git' -g '!scripts/ci/repository_checks.sh'; then
+  if rg -n "Cogollo|Cogolo" . \
+    --hidden \
+    -g '!.git' \
+    -g '!.claude' \
+    -g '!external' \
+    -g '!references' \
+    -g '!scripts/ci/repository_checks.sh'; then
     echo "Found stale project name references; expected 'Traverse'." >&2
     exit 1
   fi
 else
-  if grep -RInE --exclude='repository_checks.sh' --exclude-dir='.git' 'Cogollo|Cogolo' .; then
+  if grep -RInE \
+    --exclude='repository_checks.sh' \
+    --exclude-dir='.git' \
+    --exclude-dir='.claude' \
+    --exclude-dir='external' \
+    --exclude-dir='references' \
+    'Cogollo|Cogolo' .; then
     echo "Found stale project name references; expected 'Traverse'." >&2
     exit 1
   fi


### PR DESCRIPTION
## Governing Spec

- 004-spec-alignment-gate
- 025-wasm-executor-adapter
- 028-schema-alignment-gate-v02

## Project Item

- Issue: https://github.com/enricopiovesan/Traverse/issues/321
- Project 1: https://github.com/users/enricopiovesan/projects/1

## Validation

- cargo test
- bash scripts/ci/repository_checks.sh

## Notes

Bumps workspace version metadata to 0.2.0 (main is currently ahead of v0.1.0) and fixes the workspace repository URL to point at Traverse. Also ensures local-only scratch dirs (.claude/external/references) do not break repo-wide checks.
