### PR TITLE
docs: contract authoring guides, architecture explainer, and field reference docs

### DIFF
--- a/docs/architecture-execution-models.md
+++ b/docs/architecture-execution-models.md
@@ -1,0 +1,125 @@
+# Traverse Architecture: Execution and Consumption Models
+
+Traverse exposes three distinct surfaces for building and consuming capabilities. Understanding how they relate — and when to use each — is essential for designing your integration.
+
+## The Three Models
+
+### 1. WASM Capabilities (Local Execution)
+
+**What**: A capability is a WASM binary compiled from Rust (or any WASM-compatible language) that reads a JSON payload from stdin and writes a JSON result to stdout. It is registered in the capability registry via a bundle manifest and invoked by the runtime's `WasmExecutor`.
+
+**When to use**:
+- You are building a new capability (a unit of computation)
+- The capability should be portable across execution targets (local, cloud, edge)
+- You want governance (spec, contract, digest immutability)
+
+**How it works**:
+```
+CLI request → PlacementRouter → WasmExecutor → WASM binary (stdin/stdout) → RuntimeTrace
+```
+
+**Entry point**: [`docs/wasm-agent-authoring-guide.md`](wasm-agent-authoring-guide.md)
+
+---
+
+### 2. MCP Surface (Agent/LLM Discovery and Invocation)
+
+**What**: The `traverse-mcp` crate exposes a Model Context Protocol server over stdio. It provides tools that LLMs and AI agents can call to discover registered capabilities, inspect their contracts, and execute them — without knowing the CLI.
+
+**MCP tools exposed**:
+| Tool | Description |
+|------|-------------|
+| `discover_capabilities` | List capabilities matching an intent or filter |
+| `get_capability` | Inspect a specific capability contract |
+| `list_events` | List events in the event catalog |
+| `get_event` | Inspect a specific event contract |
+| `execute_capability` | Execute a capability by ID with a JSON input |
+| `get_trace` | Retrieve a trace by ID |
+
+**When to use**:
+- An LLM or AI agent needs to discover what capabilities are available
+- You are integrating Traverse with Claude, GPT, or another tool-use enabled model
+- You want the model to drive capability selection rather than hard-coding IDs
+
+**How it works**:
+```
+LLM tool call → MCP stdio server → traverse-mcp → traverse-runtime → WasmExecutor
+```
+
+**Entry point**: [`docs/mcp-stdio-server.md`](mcp-stdio-server.md)
+
+**Important**: In v0.1, `traverse-mcp` is a stdio binary server. Agents cannot link it as a library — they must communicate via the MCP wire protocol. See [#310](https://github.com/enricopiovesan/Traverse/issues/310) for the planned library API.
+
+---
+
+### 3. Browser Adapter (Live Streaming to a Frontend)
+
+**What**: The browser adapter (`traverse-cli browser-adapter serve`) starts a local HTTP server that streams runtime state events and execution traces to a browser client over SSE (Server-Sent Events) or WebSocket. It enables a React or web frontend to display live Traverse execution state.
+
+**When to use**:
+- You are building a UI that shows live capability execution status
+- You want to stream `RuntimeTrace` updates to a browser in real time
+- You are building the `youaskm3` shell or a similar consumer app
+
+**How it works**:
+```
+Browser client → HTTP/SSE → browser-adapter server → traverse-runtime subscription → state events
+```
+
+**Entry point**: [`docs/browser-adapter.md`](browser-adapter.md)
+
+**Important**: The browser adapter delivers events only to actively connected clients. There is no replay for late-connecting clients in v0.1. See [#312](https://github.com/enricopiovesan/Traverse/issues/312).
+
+---
+
+## How the Three Models Interact
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Your Application                        │
+│                                                             │
+│  ┌──────────┐    ┌─────────────┐    ┌──────────────────┐   │
+│  │  CLI /   │    │  MCP tools  │    │  Browser UI      │   │
+│  │  Scripts │    │  (LLM use)  │    │  (React/Web)     │   │
+│  └────┬─────┘    └──────┬──────┘    └────────┬─────────┘   │
+│       │                 │                    │              │
+└───────┼─────────────────┼────────────────────┼─────────────┘
+        │                 │                    │
+        ▼                 ▼                    ▼
+┌───────────────────────────────────────────────────────────┐
+│                  traverse-runtime                         │
+│  PlacementRouter → WasmExecutor → RuntimeTrace            │
+│  EventBroker → subscriptions                              │
+└───────────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─────────────────────┐
+│  WASM Capabilities  │
+│  (stdin/stdout JSON)│
+└─────────────────────┘
+```
+
+All three surfaces drive the same runtime. A CLI invocation, an MCP tool call, and a browser-triggered execution all go through `PlacementRouter` and produce a `RuntimeTrace`.
+
+---
+
+## Decision Guide
+
+| If you are building... | Use |
+|------------------------|-----|
+| A new capability (unit of computation) | WASM capability + contract |
+| An LLM integration that needs to discover and call capabilities | MCP surface |
+| A web UI that shows live execution status | Browser adapter |
+| A CI pipeline or script that invokes capabilities | CLI (`traverse-cli expedition execute`) |
+| An autonomous agent that needs to register and invoke capabilities programmatically | CLI with `--json` (planned, [#305](https://github.com/enricopiovesan/Traverse/issues/305)) or MCP |
+| A multi-capability workflow | Workflow contract + registry traversal |
+
+---
+
+## Related Docs
+
+- [`docs/wasm-agent-authoring-guide.md`](wasm-agent-authoring-guide.md) — write a WASM capability
+- [`docs/mcp-stdio-server.md`](mcp-stdio-server.md) — MCP server setup
+- [`docs/browser-adapter.md`](browser-adapter.md) — browser adapter and streaming
+- [`docs/workflow-composition-guide.md`](workflow-composition-guide.md) — chain capabilities
+- [`quickstart.md`](../quickstart.md) — first browser-consumption flow

--- a/docs/capability-contract-authoring-guide.md
+++ b/docs/capability-contract-authoring-guide.md
@@ -203,3 +203,154 @@ cargo test -p traverse-contracts
 - [`docs/wasm-agent-authoring-guide.md`](wasm-agent-authoring-guide.md)
 - [`docs/wasm-microservice-authoring-guide.md`](wasm-microservice-authoring-guide.md)
 
+---
+
+## Authoring a Capability Contract From Scratch (#286)
+
+### Minimal working template
+
+The following is the smallest valid `contract.json` you can author. Every field is required unless marked optional.
+
+```json
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "examples.hello-world.say-hello",
+  "namespace": "examples.hello-world",
+  "name": "say-hello",
+  "version": "0.1.0",
+  "lifecycle": "active",
+  "service_type": "stateless",
+  "artifact_type": "native",
+  "description": "Greets a named subject and returns the greeting string.",
+  "input_schema": {
+    "type": "object",
+    "required": ["subject"],
+    "properties": {
+      "subject": { "type": "string", "description": "Name to greet" }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["greeting"],
+    "properties": {
+      "greeting": { "type": "string", "description": "The greeting message" }
+    }
+  },
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": { "kind": "wasi-command", "command": "run" },
+    "preferred_targets": ["local"],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "provenance": {
+    "spec_refs": ["002-capability-contracts"],
+    "exception_refs": []
+  }
+}
+```
+
+### Field-by-field explanation
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `kind` | Yes | Always `"capability_contract"` |
+| `schema_version` | Yes | Always `"1.0.0"` in v0.x |
+| `id` | Yes | Must equal `namespace + "." + name` |
+| `namespace` | Yes | Dot-separated domain path (e.g. `"examples.hello-world"`) |
+| `name` | Yes | Short identifier within the namespace |
+| `version` | Yes | Semver `MAJOR.MINOR.PATCH` — immutable once registered |
+| `lifecycle` | Yes | Start with `"draft"` until ready, then `"active"` (see Lifecycle section) |
+| `service_type` | Yes | See service_type reference below |
+| `artifact_type` | Yes | `"native"` for WASM binaries, `"wasm"` for explicit WASM-only |
+| `description` | Yes | Human-readable summary of what the capability does |
+| `input_schema` | Yes | JSON Schema object describing the input payload |
+| `output_schema` | Yes | JSON Schema object describing the output payload |
+| `execution` | Yes | Binary format, entrypoint, targets, constraints |
+| `provenance.spec_refs` | Yes | Must include `"002-capability-contracts"` |
+| `provenance.exception_refs` | Yes | Empty array unless `host_api_access: exception_required` |
+
+### Optional fields
+
+| Field | Description |
+|-------|-------------|
+| `emits` | Array of event contract IDs this capability may publish at runtime |
+| `consumes` | Array of event contract IDs this capability subscribes to |
+| `preconditions` | Documentation-only assertions that must hold before invocation (not enforced) |
+| `postconditions` | Documentation-only assertions that must hold after invocation (not enforced) |
+| `side_effects` | Description of observable side effects beyond the output schema |
+
+### `emits` and `consumes` — connecting to event contracts
+
+The `emits` array declares which events this capability may publish via `broker.publish()` at runtime. The runtime validates that the emitted event type is declared here; publishing an undeclared event type causes an `EventError::PolicyViolation`.
+
+```json
+"emits": ["examples.hello-world.greeted"],
+"consumes": []
+```
+
+See [`docs/event-contract-authoring-guide.md`](event-contract-authoring-guide.md) for how to define the event contract itself.
+
+### `preconditions` and `postconditions` — documentation only
+
+These fields hold assertions about the state of the world before and after capability execution:
+
+```json
+"preconditions": [
+  { "id": "pre-001", "description": "Subject name must be non-empty" }
+],
+"postconditions": [
+  { "id": "post-001", "description": "Greeting string is non-empty and contains the subject name" }
+]
+```
+
+**These are not enforced by the runtime in v0.x.** The runtime does not evaluate preconditions before execution or postconditions after. They are purely documentation — useful for human review, spec coverage, and future tooling. State this explicitly to consumers of your contract.
+
+---
+
+## `service_type` Reference (#295)
+
+| Value | Meaning | Runtime implications |
+|-------|---------|---------------------|
+| `"stateless"` | Each invocation is independent; no state persists between calls | Runtime may freely re-invoke in any order; no session affinity required |
+| `"stateful"` | The capability maintains internal state across invocations | Runtime must respect session affinity if applicable; state management is the author's responsibility |
+| `"idempotent"` | Repeated invocation with identical inputs produces identical outputs with no side effects | Runtime may safely retry on transient failure |
+
+**All expedition and hello-world examples use `"stateless"`**, which is the correct value for pure-computation WASM capabilities that receive all state through their input JSON.
+
+Use `"stateful"` only for capabilities that explicitly manage a persistent resource (e.g. a database connection, file handle, or accumulated session). Document the state lifecycle in `description`.
+
+---
+
+## Validate Before Registering (#298)
+
+Before opening a PR or registering a contract, run the spec-alignment gate against your contract:
+
+```bash
+# From repo root
+bash scripts/ci/spec_alignment_check.sh
+
+# Full repository check (includes contract schema validation)
+bash scripts/ci/repository_checks.sh
+```
+
+If you want to validate a single contract file's JSON structure locally:
+
+```bash
+cargo run -p traverse-cli -- bundle inspect contracts/path/to/your/bundle/manifest.json
+```
+
+The bundle inspect command will surface any structural issues (missing required fields, unknown values) before you attempt registration.
+
+Common validation errors and fixes:
+
+| Error | Fix |
+|-------|-----|
+| `missing required field 'service_type'` | Add `"service_type": "stateless"` to the contract root |
+| `missing required field 'artifact_type'` | Add `"artifact_type": "native"` to the contract root |
+| `host_api_access: exception_required but no exception_refs` | Add at least one entry to `provenance.exception_refs` |
+| `id does not match namespace.name` | Set `id` to exactly `namespace + "." + name` |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -113,3 +113,21 @@ This reference was checked against the live CLI behavior with:
 It should also remain consistent with:
 
 - `bash scripts/ci/repository_checks.sh`
+
+## Federation Commands (Not Yet Implemented)
+
+The `federation` command family appears in the CLI codebase as a planned surface but is **not yet fully implemented** in v0.1. The following subcommands are listed here for completeness but should not be used in production:
+
+| Subcommand              | Status           |
+|-------------------------|------------------|
+| `federation peers`      | Partial — peer listing and status only |
+| `federation sync`       | Partial — manual sync trigger only |
+| `federation status`     | Partial — peer sync summary only |
+
+Automatic federation sync, conflict resolution, and the central federation coordinator are tracked in:
+- [#236 Automatic federation sync after peer registration](https://github.com/enricopiovesan/Traverse/issues/236)
+- [#237 Central federation coordinator](https://github.com/enricopiovesan/Traverse/issues/237)
+- [#238 Federation conflict auto-resolution policy](https://github.com/enricopiovesan/Traverse/issues/238)
+- [#239 Streaming federation sync transport](https://github.com/enricopiovesan/Traverse/issues/239)
+
+Do not build workflows that depend on federation behavior until these issues are resolved.

--- a/docs/event-contract-authoring-guide.md
+++ b/docs/event-contract-authoring-guide.md
@@ -59,6 +59,49 @@ This is a minimal event contract you can copy, edit, and validate locally.
     "source": "greenfield",
     "author": "your-handle",
     "created_at": "2026-04-18T00:00:00Z"
+This guide shows how to author a valid event contract for Traverse, connect it to a capability contract, and validate it locally.
+- [`contracts/examples/expedition/events/expedition-objective-captured/contract.json`](../contracts/examples/expedition/events/expedition-objective-captured/contract.json)
+- [`specs/003-event-contracts/spec.md`](../specs/003-event-contracts/spec.md)
+- [`docs/event-publishing-tutorial.md`](event-publishing-tutorial.md)
+---
+## Minimal Annotated Template
+Place your event contract at a path that follows the convention:
+```
+contracts/<domain>/events/<event-name>/contract.json
+```
+  "kind": "event_contract",              // must be exactly "event_contract"
+  "schema_version": "1.0.0",            // must be "1.0.0" in v0.1
+  "id": "acme.orders.order-placed",     // must equal namespace.name exactly
+  "namespace": "acme.orders",           // dot-separated lowercase kebab-case
+  "name": "order-placed",               // lowercase kebab-case
+  "version": "1.0.0",                   // semver MAJOR.MINOR.PATCH
+  "lifecycle": "active",                // use "draft" until validation passes
+  "owner": {
+    "team": "orders-team",
+    "contact": "orders@example.com"
+  "summary": "An order has been placed and is ready for fulfillment.",
+  "description": "Emitted by the place-order capability after all order fields pass validation and the order is durably recorded.",
+    "schema": {                          // JSON Schema describing the event payload
+      "required": ["order_id", "placed_at"],
+      "properties": {
+        "order_id":  { "type": "string" },
+        "placed_at": { "type": "string", "format": "date-time" }
+      }
+    "compatibility": "backward-compatible"  // "backward-compatible" or "breaking"
+    "domain": "acme",
+    "bounded_context": "orders",
+    "event_type": "domain",             // "domain", "integration", or "command"
+    "tags": ["orders", "placement"]
+    {
+      "capability_id": "acme.orders.place-order",
+      "version": "1.0.0"
+    }
+  "subscribers": [],                    // optional; list known consumers
+  "policies": [],
+  "tags": ["orders", "example"],
+    "source": "greenfield",             // "greenfield", "brownfield-extracted", "ai-generated", "ai-assisted"
+    "author": "your-github-username",
+    "created_at": "2026-04-17T00:00:00Z"
   },
   "evidence": []
 }
@@ -122,3 +165,133 @@ cargo run -p traverse-cli -- bundle register <path-to-manifest.json>
 - Forgetting to update `publishers` when the emitting capability version changes.
 - Treating `tags` as a stability boundary. They are discoverability metadata, not identity.
 
+---
+## Required Fields
+| Field | Type | Rule |
+|---|---|---|
+| `kind` | string | must be `event_contract` |
+| `schema_version` | string | must be `1.0.0` |
+| `id` | string | must equal `namespace.name` exactly |
+| `namespace` | string | dot-separated lowercase kebab-case |
+| `name` | string | lowercase kebab-case |
+| `version` | string | semver `MAJOR.MINOR.PATCH` |
+| `lifecycle` | string | one of `draft`, `active`, `deprecated`, `retired`, `archived` |
+| `owner.team` | string | stable ownership identifier |
+| `owner.contact` | string | non-empty contact |
+| `summary` | string | 10–200 characters; one meaningful business event description |
+| `description` | string | at least 20 characters |
+| `payload.schema` | object | JSON Schema-compatible object describing the payload shape |
+| `payload.compatibility` | string | `backward-compatible` or `breaking` |
+| `classification.domain` | string | domain name |
+| `classification.bounded_context` | string | bounded context within the domain |
+| `classification.event_type` | string | `domain`, `integration`, or `command` |
+| `publishers` | array | at least one capability declared as publisher |
+| `publishers[].capability_id` | string | must reference a registered capability |
+| `publishers[].version` | string | semver |
+| `provenance.source` | string | one of `greenfield`, `brownfield-extracted`, `ai-generated`, `ai-assisted` |
+| `provenance.author` | string | GitHub username or team handle |
+| `provenance.created_at` | string | ISO 8601 timestamp |
+| `subscribers` | array | required; may be empty |
+| `policies` | array | required; may be empty |
+| `tags` | array | required; may be empty |
+| `evidence` | array | required; may be empty |
+---
+## Connecting to a Capability Contract
+Events and capabilities are connected through the `emits` and `consumes` arrays in the capability contract and the `publishers` and `subscribers` arrays in the event contract.
+### Emitting capability
+The capability that fires the event declares it in its `emits` array:
+```json
+"emits": [
+  {
+    "event_id": "acme.orders.order-placed",
+    "version": "1.0.0"
+  }
+]
+The event contract's `publishers` array must list that same capability:
+```json
+"publishers": [
+  {
+    "capability_id": "acme.orders.place-order",
+    "version": "1.0.0"
+  }
+]
+The spec-alignment gate checks that every event contract in `contracts/` references at least one registered publisher.
+### Consuming capability
+A capability that subscribes to the event declares it in its `consumes` array:
+```json
+"consumes": [
+  {
+    "event_id": "acme.orders.order-placed",
+    "version": "1.0.0"
+  }
+]
+Optionally, list it in the event contract's `subscribers` array for documentation and impact analysis:
+```json
+"subscribers": [
+  {
+    "capability_id": "acme.fulfillment.start-fulfillment",
+    "version": "1.0.0"
+  }
+]
+---
+## How to Validate Locally
+Run the CLI inspect command against your event contract:
+cargo run -p traverse-cli -- event inspect contracts/path/to/event-name/contract.json
+Expected output includes `id`, `version`, `lifecycle`, publisher count, and subscriber count. Any structural error is printed to stderr with a non-zero exit code.
+Then run the full spec-alignment gate:
+bash scripts/ci/spec_alignment_check.sh
+bash scripts/ci/repository_checks.sh
+---
+## The Same Event from Three Perspectives
+The following example traces the `expedition.planning.expedition-objective-captured` event through its full lifecycle: contract declaration, runtime emission, and subscriber registration. This corresponds to the pattern described in issue #292.
+### 1. Contract declaration
+`contracts/examples/expedition/events/expedition-objective-captured/contract.json` declares:
+- `id`: `expedition.planning.expedition-objective-captured`
+- `publishers`: `expedition.planning.capture-expedition-objective@1.0.0`
+- `payload.schema`: the shape of the structured objective record
+The capability contract at `contracts/examples/expedition/capabilities/capture-expedition-objective/contract.json` mirrors this with:
+```json
+"emits": [
+  {
+    "event_id": "expedition.planning.expedition-objective-captured",
+    "version": "1.0.0"
+  }
+]
+The `emits` declaration in the capability contract is authoritative. The runtime broker constrains what `broker.publish()` may emit: **if an event type is not registered in the catalog as `Active`, `broker.publish` returns `EventError::LifecycleViolation` and the event is not delivered.**
+### 2. Runtime emission
+The emitting capability registers the event type in an `EventCatalog` with `LifecycleStatus::Active`, then publishes through the `InProcessBroker`:
+```rust
+catalog.register(EventCatalogEntry {
+    event_type: "expedition.planning.expedition-objective-captured".to_owned(),
+    owner: "expedition.planning.capture-expedition-objective".to_owned(),
+    version: "1.0.0".to_owned(),
+    lifecycle_status: LifecycleStatus::Active,
+    consumer_count: 0,
+})?;
+let broker = InProcessBroker::new(catalog);
+broker.publish(TraverseEvent {
+    event_type: "expedition.planning.expedition-objective-captured".to_owned(),
+    // ... other fields matching the contract payload schema
+})?;
+### 3. Subscriber registration
+A downstream capability subscribes before the event is emitted:
+```rust
+broker.subscribe(
+    "expedition.planning.expedition-objective-captured",
+    Box::new(|event: &TraverseEvent| {
+        // handle the event payload
+    }),
+)?;
+`broker.subscribe` returns `EventError::UnregisteredEventType` if the event type is not in the catalog. Subscriptions must be registered before `broker.publish` is called — handlers registered after the event is emitted do not receive it.
+---
+- Setting `id` to anything other than `namespace.name` — the validator rejects mismatches.
+- Declaring `lifecycle: active` before the event is fully specified — use `draft` during authoring.
+- Omitting the capability from `publishers` — the spec-alignment gate flags contracts with no declared publisher.
+- Using a `payload.schema` that does not match the data actually emitted by the capability — the broker does not re-validate the schema at runtime, but CI tools do.
+- Subscribing to an event type that is not yet registered in the catalog — `broker.subscribe` returns an error.
+---
+## Related Documents
+- [`docs/event-publishing-tutorial.md`](event-publishing-tutorial.md) — end-to-end tutorial for emitting and subscribing to events
+- [`specs/003-event-contracts/spec.md`](../specs/003-event-contracts/spec.md) — governing spec
+- [`specs/018-event-driven-composition/spec.md`](../specs/018-event-driven-composition/spec.md) — event-driven workflow edges
+- [`docs/capability-contract-authoring-guide.md`](capability-contract-authoring-guide.md) — how `emits` connects to event contracts

--- a/docs/event-publishing-tutorial.md
+++ b/docs/event-publishing-tutorial.md
@@ -360,3 +360,52 @@ bash scripts/ci/event_driven_workflow_smoke.sh
 - [`docs/multi-thread-workflow.md`](multi-thread-workflow.md) — parallel agent workflow coordination
 - [`specs/003-event-contracts/spec.md`](../specs/003-event-contracts/spec.md) — governing spec for event contract artifacts
 - [`specs/018-event-driven-composition/spec.md`](../specs/018-event-driven-composition/spec.md) — governing spec for event-driven workflow progression
+
+---
+
+## Connecting Contract Declaration to Runtime Emission (#292)
+
+The `emits` and `consumes` fields in a capability contract are the governance bridge between what a contract declares and what the runtime enforces at execution time.
+
+### The same event from three perspectives
+
+**1. Contract declaration** — in `contracts/your-domain/capabilities/say-hello/contract.json`:
+```json
+{
+  "emits": ["examples.hello-world.greeted"],
+  "consumes": []
+}
+```
+This declares that this capability _may_ publish the `examples.hello-world.greeted` event. It is a promise to the registry.
+
+**2. Runtime emission** — inside the WASM binary or native executor:
+```rust
+let event = TraverseEvent {
+    event_type: "examples.hello-world.greeted".to_string(),
+    payload: serde_json::json!({ "subject": "Alice", "greeting": "Hello, Alice!" }),
+    // ...
+};
+broker.publish(event)?;
+```
+At runtime, `broker.publish()` checks the active event catalog. If `examples.hello-world.greeted` is not registered in the catalog, it returns `EventError::UnknownEventType`. If it _is_ registered but the capability contract does not declare it in `emits`, it returns `EventError::PolicyViolation`.
+
+**3. Subscriber registration** — a downstream capability or handler:
+```rust
+broker.subscribe("examples.hello-world.greeted", Box::new(|event| {
+    // handle the event
+}));
+```
+Subscribers are registered before execution begins. The runtime delivers published events synchronously to all registered subscribers in registration order.
+
+### What the runtime validates at each stage
+
+| Stage | Validation |
+|-------|------------|
+| Bundle registration | `emits` event IDs must exist in the event catalog |
+| Contract parse | `emits` and `consumes` must be valid event contract ID strings |
+| `broker.publish()` | Event type must be in catalog AND declared in capability's `emits` |
+| Subscription | No validation — subscribers are registered independently |
+
+### Common mistake: publishing without declaring
+
+If your capability calls `broker.publish("my.event")` but the contract does not list `"my.event"` in `emits`, the runtime returns `EventError::PolicyViolation`. Always keep `emits` in the contract in sync with `broker.publish()` calls in the implementation.

--- a/docs/registry-bundle-authoring-guide.md
+++ b/docs/registry-bundle-authoring-guide.md
@@ -1,0 +1,157 @@
+# Registry Bundle Authoring Guide
+
+A registry bundle is the unit by which capabilities, events, and workflows are registered into Traverse. Every artifact that the runtime resolves must be present in a registered bundle.
+
+Use the canonical example as a living reference:
+
+- [`examples/expedition/registry-bundle/manifest.json`](../examples/expedition/registry-bundle/manifest.json)
+- [`docs/workflow-composition-guide.md`](workflow-composition-guide.md) — step-by-step bundle creation
+
+---
+
+## Full Annotated `manifest.json` Template
+
+```json
+{
+  "bundle_id": "acme.orders.example-bundle",   // unique bundle identity; dot-separated
+  "version": "1.0.0",                          // semver MAJOR.MINOR.PATCH
+  "scope": "public",                           // "public" or "private"
+
+  "capabilities": [
+    {
+      "id": "acme.orders.place-order",         // must match the "id" field in contract.json
+      "version": "1.0.0",                      // must match the "version" field in contract.json
+      "path": "../../../contracts/acme/orders/capabilities/place-order/contract.json"
+                                               // relative path from this manifest file
+    }
+  ],
+
+  "events": [
+    {
+      "id": "acme.orders.order-placed",        // must match the "id" field in the event contract
+      "version": "1.0.0",
+      "path": "../../../contracts/acme/orders/events/order-placed/contract.json"
+    }
+  ],
+
+  "workflows": [
+    {
+      "id": "acme.orders.draft-and-confirm",   // must match the "id" field in workflow.json
+      "version": "1.0.0",
+      "path": "../../../workflows/acme/orders/draft-and-confirm/workflow.json"
+    }
+  ]
+}
+```
+
+---
+
+## Required vs Optional Fields
+
+| Field | Required | Notes |
+|---|---|---|
+| `bundle_id` | Yes | Unique identity for this bundle. Dot-separated. |
+| `version` | Yes | Semver. Bumping the version creates a new immutable bundle entry. |
+| `scope` | Yes | `public` or `private`. Public bundles are visible to all consumers; private bundles are registry-scoped. |
+| `capabilities` | Yes | May be an empty array `[]`, but the key must be present. |
+| `capabilities[].id` | Yes | Must match the `id` field in the referenced `contract.json`. |
+| `capabilities[].version` | Yes | Must match the `version` field in the referenced `contract.json`. |
+| `capabilities[].path` | Yes | Relative path from the manifest file to the contract. |
+| `events` | No | Omit the key entirely if no events are registered. An empty array is also acceptable. |
+| `events[].id` | Yes (if present) | Must match the `id` field in the event contract. |
+| `events[].version` | Yes (if present) | Must match the `version` field in the event contract. |
+| `events[].path` | Yes (if present) | Relative path from the manifest file to the event contract. |
+| `workflows` | No | Omit the key entirely if no workflows are registered. |
+| `workflows[].id` | Yes (if present) | Must match the `id` field in the workflow definition. |
+| `workflows[].version` | Yes (if present) | Must match the `version` field in the workflow definition. |
+| `workflows[].path` | Yes (if present) | Relative path from the manifest file to the workflow definition. |
+
+---
+
+## How Capabilities, Events, and Workflows Are Referenced
+
+The bundle manifest is a pointer document. It does not embed contract content — it references the canonical artifact files by relative path.
+
+When the CLI loads a bundle:
+
+1. It reads each contract at the given path.
+2. It validates the `id` and `version` declared in the manifest entry against the `id` and `version` inside the artifact file. A mismatch causes a hard validation error.
+3. It registers each artifact into the in-memory capability registry, event registry, and workflow registry respectively.
+4. It validates inter-artifact references: a workflow that references a capability version checks that the capability is present in the loaded set; an event edge in a workflow checks that the event contract is registered.
+
+Paths are resolved relative to the directory containing `manifest.json`, not relative to the repository root. The canonical expedition bundle uses `../../../contracts/...` because the manifest lives three directory levels below the root.
+
+---
+
+## How to Add a New Capability
+
+1. Create the capability contract at the canonical path:
+
+   ```
+   contracts/<domain>/capabilities/<name>/contract.json
+   ```
+
+2. Add an entry to the bundle manifest:
+
+   ```json
+   {
+     "id": "<namespace>.<name>",
+     "version": "1.0.0",
+     "path": "../../../contracts/<domain>/capabilities/<name>/contract.json"
+   }
+   ```
+
+3. If the capability emits events, add the corresponding event contract entries to `events`.
+
+4. If the capability participates in a workflow, ensure the workflow definition lists it as a node.
+
+5. Validate the bundle before registering (see below).
+
+---
+
+## Bundle Validation Command
+
+**Inspect** (validates and prints a summary without modifying registries):
+
+```bash
+cargo run -p traverse-cli -- bundle inspect \
+  examples/your-bundle/registry-bundle/manifest.json
+```
+
+Expected output includes `bundle_id`, `version`, `scope`, the count of discovered artifacts, and the individual capability/event/workflow ids.
+
+**Register** (loads into in-memory registries for the current session):
+
+```bash
+cargo run -p traverse-cli -- bundle register \
+  examples/your-bundle/registry-bundle/manifest.json
+```
+
+Expected output includes `bundle_id`, `version`, `scope`, registered counts per type, and a summary record per registered artifact.
+
+**Spec-alignment gate** (must pass before opening a PR):
+
+```bash
+bash scripts/ci/spec_alignment_check.sh
+bash scripts/ci/repository_checks.sh
+```
+
+---
+
+## Common Mistakes
+
+- **Path not relative to manifest** — a path that is correct relative to the repository root but not relative to the manifest directory will fail with a file-not-found error at load time. Always compute paths relative to the manifest file's parent directory.
+- **`id`/`version` mismatch between manifest and artifact** — the loader validates that the declared `id` and `version` in the manifest entry match the `id` and `version` inside the artifact file. Copying an entry without updating one of these fields is the most common cause of this error.
+- **Missing event entries for capabilities that emit** — if a capability declares `emits` but the event contract is not in the bundle, the spec-alignment gate will flag the missing publisher reference.
+- **Workflow references a capability not in the bundle** — the workflow registration validator checks that every `capability_id` referenced in a node is present in the registered capability set. Add all required capability entries to the bundle before registering the workflow.
+- **Re-registering the same `(bundle_id, version)` with different content** — once a bundle version is registered with a given digest, it cannot be changed. Bump the `version` field to register updated content.
+
+---
+
+## Related Documents
+
+- [`docs/workflow-composition-guide.md`](workflow-composition-guide.md) — end-to-end bundle creation walkthrough
+- [`docs/capability-contract-authoring-guide.md`](capability-contract-authoring-guide.md) — how to write the capability contracts referenced in the bundle
+- [`docs/event-contract-authoring-guide.md`](event-contract-authoring-guide.md) — how to write the event contracts referenced in the bundle
+- [`docs/workflow-contract-authoring-guide.md`](workflow-contract-authoring-guide.md) — how to write the workflow definitions referenced in the bundle
+- [`docs/cli-reference.md`](cli-reference.md) — full CLI command reference

--- a/docs/tutorial-index.md
+++ b/docs/tutorial-index.md
@@ -21,7 +21,6 @@ Use it in sequence unless you already know the slice you need:
 1. [README.md](../README.md)
 2. [docs/getting-started.md](getting-started.md)
 3. [docs/capability-contract-authoring-guide.md](capability-contract-authoring-guide.md)
-<<<<<<< HEAD
 4. [docs/workflow-composition-guide.md](workflow-composition-guide.md)
 5. [docs/event-publishing-tutorial.md](event-publishing-tutorial.md)
 6. [quickstart.md](../quickstart.md)
@@ -43,7 +42,6 @@ Use it in sequence unless you already know the slice you need:
 22. [docs/project-management.md](project-management.md)
 23. [docs/troubleshooting.md](troubleshooting.md)
 24. [docs/adr/README.md](adr/README.md)
-=======
 4. [docs/event-contract-authoring-guide.md](event-contract-authoring-guide.md)
 5. [docs/workflow-composition-guide.md](workflow-composition-guide.md)
 6. [docs/event-publishing-tutorial.md](event-publishing-tutorial.md)
@@ -66,7 +64,6 @@ Use it in sequence unless you already know the slice you need:
 23. [docs/project-management.md](project-management.md)
 24. [docs/troubleshooting.md](troubleshooting.md)
 25. [docs/adr/README.md](adr/README.md)
->>>>>>> main
 
 ## How To Read It
 
@@ -80,3 +77,13 @@ If your goal is documentation hygiene, onboarding, or process work, finish with 
 
 If any step fails while you are following this sequence, jump to [docs/troubleshooting.md](troubleshooting.md) before guessing.
 
+## Reference Docs (Authoring and Architecture)
+
+These docs are not part of the linear onboarding sequence but are essential references when authoring new capabilities, contracts, or agents:
+
+- [docs/architecture-execution-models.md](architecture-execution-models.md) — WASM, MCP, and browser adapter: when to use each
+- [docs/capability-contract-authoring-guide.md](capability-contract-authoring-guide.md) — full field reference, authoring steps, constraint and lifecycle tables
+- [docs/event-contract-authoring-guide.md](event-contract-authoring-guide.md) — how to author an event contract from scratch
+- [docs/workflow-contract-authoring-guide.md](workflow-contract-authoring-guide.md) — node/edge model, direct vs event edges, authoring steps
+- [docs/registry-bundle-authoring-guide.md](registry-bundle-authoring-guide.md) — how to author a bundle manifest for a new domain
+- [docs/wasm-agent-authoring-guide.md](wasm-agent-authoring-guide.md) — stub vs. real implementation, build-fixture.sh, model_dependencies

--- a/docs/wasm-agent-authoring-guide.md
+++ b/docs/wasm-agent-authoring-guide.md
@@ -68,3 +68,111 @@ That smoke path confirms the guide points at the governed template, the approved
 - treating the example as a general microservice instead of a governed agent package
 - forgetting to link the agent package to a workflow reference
 - changing the binary digest without rebuilding the fixture
+
+---
+
+## Template Stub vs. Real Implementation (#289)
+
+The package template at `examples/templates/executable-capability-package/src/implementation.rs` contains a minimal stub:
+
+```rust
+pub fn run() -> &'static str { "" }
+```
+
+This is a placeholder **not a starting point for logic**. A real WASM agent reads a JSON payload from stdin, processes it, and writes a JSON result to stdout. The expedition agent (`crates/traverse-expedition-wasm/src/main.rs`) is the canonical reference for a complete implementation.
+
+### Minimal real WASM agent
+
+```rust
+use std::io::{self, Read, Write};
+
+fn main() {
+    // Read entire stdin as JSON input
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input).unwrap_or_default();
+
+    let request: serde_json::Value = serde_json::from_str(&input)
+        .unwrap_or(serde_json::Value::Null);
+
+    // Process — replace with your logic
+    let subject = request
+        .get("subject")
+        .and_then(|v| v.as_str())
+        .unwrap_or("world");
+
+    let output = serde_json::json!({ "greeting": format!("Hello, {}!", subject) });
+
+    // Write JSON result to stdout
+    let _ = io::stdout().write_all(output.to_string().as_bytes());
+}
+```
+
+The stdin/stdout JSON I/O contract is documented in [`docs/wasm-io-contract.md`](wasm-io-contract.md).
+
+### Building for WASM
+
+```bash
+cargo build \
+  --manifest-path examples/your-agent/Cargo.toml \
+  --target wasm32-wasip1 \
+  --release
+```
+
+The output binary is at `target/wasm32-wasip1/release/your-agent.wasm`.
+
+---
+
+## `build-fixture.sh` Scripts (#299)
+
+Example agents include a `build-fixture.sh` script (e.g. `examples/hello-world/say-hello-agent/build-fixture.sh`). This script:
+
+1. Compiles the WASM binary from source using `cargo build --target wasm32-wasip1`
+2. Copies the output to a deterministic `fixture/` path inside the example directory
+3. Updates the expected SHA-256 digest in the agent's `manifest.json`
+
+**Why fixtures matter**: The capability registry enforces immutability — once a version is registered, its digest must not change. If you rebuild a WASM binary and the digest changes, re-registration of the same version will fail with `ImmutableVersionConflict`. Fixtures ensure the checked-in binary and digest are always in sync.
+
+**Do all agents need one?** Only agents with integration tests or CI smoke paths. If your agent is only used locally and not part of the CI smoke path, you do not need a fixture script. But any agent included in `scripts/ci/` smoke paths must have a deterministic fixture.
+
+### Minimal `build-fixture.sh` template
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+AGENT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MANIFEST="$AGENT_DIR/manifest.json"
+
+# Build the WASM binary
+cargo build \
+  --manifest-path "$AGENT_DIR/Cargo.toml" \
+  --target wasm32-wasip1 \
+  --release 2>&1
+
+# Copy to fixture location
+mkdir -p "$AGENT_DIR/fixture"
+cp "target/wasm32-wasip1/release/$(basename "$AGENT_DIR").wasm" \
+   "$AGENT_DIR/fixture/agent.wasm"
+
+# Print the new digest for manual update of manifest.json
+shasum -a 256 "$AGENT_DIR/fixture/agent.wasm"
+echo "Update manifest.json binary.digest with the value above."
+```
+
+---
+
+## `model_dependencies` (#296)
+
+Agent manifests may declare `model_dependencies` — abstract interface names that describe which language model interfaces the agent relies on:
+
+```json
+"model_dependencies": [
+  "expedition-intent-interpretation-v1"
+]
+```
+
+**What they are**: Named contracts for LLM interface behaviour (e.g. "given this prompt format, return this JSON shape"). They are abstract — not tied to a specific model provider.
+
+**How the runtime uses them**: In v0.1, `model_dependencies` are **documentation-only**. The runtime records them in the agent manifest but does not resolve or inject a model implementation automatically. The agent is responsible for calling the appropriate model API inside its WASM binary.
+
+**How to declare a new interface**: Choose a name that describes the capability + version (e.g. `"my-domain-classification-v1"`). Document the expected prompt format and output schema in a companion markdown file alongside the agent. There is no central interface registry in v0.1; naming is by convention.

--- a/docs/workflow-contract-authoring-guide.md
+++ b/docs/workflow-contract-authoring-guide.md
@@ -1,0 +1,243 @@
+# Workflow Contract Authoring Guide
+
+This guide shows how to author a valid workflow contract from scratch, register it, and validate it locally.
+
+Use the checked-in examples as living references:
+
+- [`workflows/examples/expedition/plan-expedition/workflow.json`](../workflows/examples/expedition/plan-expedition/workflow.json)
+- [`workflows/examples/hello-world/say-hello/workflow.json`](../workflows/examples/hello-world/say-hello/workflow.json)
+- [`specs/007-workflow-registry-traversal/spec.md`](../specs/007-workflow-registry-traversal/spec.md)
+- [`docs/workflow-composition-guide.md`](workflow-composition-guide.md)
+
+---
+
+## Node/Edge Model
+
+A workflow in Traverse is a directed graph of capability invocations connected by typed edges.
+
+```
+workflow input
+      |
+      v
+ [node: capture]  ──direct──>  [node: enrich]  ──event──>  [node: assemble]
+      |                                                           |
+  to_workflow_state                                          to_workflow_state
+      |                                                           |
+      v                                                           v
+ workflow state                                           workflow output
+```
+
+Key concepts:
+
+- **node** — maps to one registered capability version. Each node reads from workflow input or workflow state and writes its output back to workflow state.
+- **edge** — connects two nodes. Either `direct` (immediate, sequential) or `event` (triggered by a governed event emission).
+- **start\_node** — exactly one. The runtime always begins traversal here.
+- **terminal\_nodes** — one or more. Traversal ends when one of these nodes completes.
+- **workflow state** — the accumulator that carries values produced by upstream nodes to downstream nodes.
+
+The runtime is deterministic: it does not choose paths or apply heuristics. Every transition must be declared before execution starts.
+
+---
+
+## Minimal Two-Node Annotated Workflow
+
+Place your workflow at:
+
+```
+workflows/<domain>/<workflow-name>/workflow.json
+```
+
+```json
+{
+  "kind": "workflow_definition",          // must be exactly "workflow_definition"
+  "schema_version": "1.0.0",             // must be "1.0.0" in v0.1
+  "id": "acme.orders.draft-and-confirm", // must equal namespace.name
+  "name": "draft-and-confirm",           // lowercase kebab-case
+  "version": "1.0.0",                    // semver MAJOR.MINOR.PATCH
+  "lifecycle": "active",                 // use "draft" during authoring
+  "owner": {
+    "team": "orders-team",
+    "contact": "orders@example.com"
+  },
+  "summary": "Draft an order and confirm it in a two-step deterministic workflow.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": ["cart_id", "customer_id"],
+      "properties": {
+        "cart_id":     { "type": "string" },
+        "customer_id": { "type": "string" }
+      }
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": ["order_id", "confirmation_code"],
+      "properties": {
+        "order_id":          { "type": "string" },
+        "confirmation_code": { "type": "string" }
+      }
+    }
+  },
+  "nodes": [
+    {
+      "node_id": "draft_order",                         // unique within this workflow
+      "capability_id": "acme.orders.draft-order",       // must match a registered capability id
+      "capability_version": "1.0.0",                    // must match registered version
+      "input": {
+        "from_workflow_input": ["cart_id", "customer_id"]  // fields taken from workflow input or state
+      },
+      "output": {
+        "to_workflow_state": ["order_id"]               // fields written to workflow state
+      }
+    },
+    {
+      "node_id": "confirm_order",
+      "capability_id": "acme.orders.confirm-order",
+      "capability_version": "1.0.0",
+      "input": {
+        "from_workflow_input": ["order_id"]             // "order_id" was written by draft_order above
+      },
+      "output": {
+        "to_workflow_state": ["order_id", "confirmation_code"]
+      }
+    }
+  ],
+  "edges": [
+    {
+      "edge_id": "draft_to_confirm",   // unique within this workflow
+      "from": "draft_order",           // node_id of the source node
+      "to": "confirm_order",           // node_id of the destination node
+      "trigger": "direct"              // "direct" or "event"
+    }
+  ],
+  "start_node": "draft_order",        // must reference a node_id in "nodes"
+  "terminal_nodes": ["confirm_order"],// must reference node_ids in "nodes"
+  "tags": ["orders", "example"],
+  "governing_spec": "007-workflow-registry-traversal"  // must be this exact string
+}
+```
+
+---
+
+## Direct vs Event Edge
+
+### Direct edge
+
+The runtime advances immediately when the source node completes successfully.
+
+```json
+{
+  "edge_id": "draft_to_confirm",
+  "from": "draft_order",
+  "to": "confirm_order",
+  "trigger": "direct"
+}
+```
+
+Use `direct` for purely sequential flows where the downstream node does not depend on an event being emitted.
+
+### Event edge
+
+The runtime waits for the source node to emit a specific governed event before advancing to the destination node.
+
+```json
+{
+  "edge_id": "draft_to_confirm",
+  "from": "draft_order",
+  "to": "confirm_order",
+  "trigger": "event",
+  "event": {
+    "event_id": "acme.orders.order-drafted",
+    "version": "1.0.0"
+  }
+}
+```
+
+For an event edge to pass validation:
+
+1. The event contract `acme.orders.order-drafted@1.0.0` must be registered in the registry.
+2. The source capability (`acme.orders.draft-order`) must declare the event in its `emits` array.
+
+Event-driven edge semantics are governed by spec `018-event-driven-composition`.
+
+---
+
+## Data Flow Between Nodes
+
+Values move between nodes through **workflow state**:
+
+1. The source node's `output.to_workflow_state` names the fields it writes.
+2. The destination node's `input.from_workflow_input` names the fields it reads.
+
+The runtime merges fields into a single flat state map as each node completes. A node reads from that map — it does not matter whether the value came from the original workflow input or from an upstream node.
+
+If a required field is missing from state when a node starts, the runtime returns a structured failure rather than proceeding with incomplete input.
+
+---
+
+## Start and Terminal Nodes
+
+`start_node` is the single entry point. The runtime always begins at this node.
+
+`terminal_nodes` is the list of exit points. When any terminal node completes successfully, the workflow is considered done and the runtime returns its output.
+
+Rules:
+
+- `start_node` must reference a `node_id` in `nodes`.
+- Every entry in `terminal_nodes` must reference a `node_id` in `nodes`.
+- In v0.1, cycles are not permitted. Every node may appear only in one path from `start_node` to a terminal node.
+
+---
+
+## Validate and Register
+
+**Inspect the workflow** (validates structure without modifying state):
+
+```bash
+cargo run -p traverse-cli -- workflow inspect \
+  workflows/path/to/your-workflow/workflow.json
+```
+
+**Register through a bundle** (required before the workflow can be executed):
+
+Create a registry bundle manifest that includes the workflow and all capability contracts it references. Then:
+
+```bash
+cargo run -p traverse-cli -- bundle inspect \
+  examples/your-bundle/registry-bundle/manifest.json
+
+cargo run -p traverse-cli -- bundle register \
+  examples/your-bundle/registry-bundle/manifest.json
+```
+
+See [`docs/workflow-composition-guide.md`](workflow-composition-guide.md) for the full bundle manifest shape.
+
+**Run the spec-alignment gate** before opening a PR:
+
+```bash
+bash scripts/ci/spec_alignment_check.sh
+bash scripts/ci/repository_checks.sh
+```
+
+---
+
+## Common Mistakes
+
+- **`governing_spec` mismatch** — the field must equal exactly `007-workflow-registry-traversal`. Any other value causes registration failure with `InvalidLiteral`.
+- **Capability not registered** — the workflow references a `capability_id` that does not exist in the registry at the declared version. Register the bundle (which includes the capabilities) before inspecting the workflow.
+- **`from_workflow_input` references an undeclared field** — if a node expects a field that was never written to workflow state by an upstream node, runtime execution fails with a missing-input error. Verify the output `to_workflow_state` of the upstream node produces the field the downstream node expects.
+- **Event edge without matching `emits`** — an event edge requires the source capability to declare the event in its `emits` array. The registration validator checks this.
+- **Cycles in the graph** — v0.1 does not allow cycles. Use predicates on event edges for conditional branching rather than loops.
+- **`ImmutableVersionConflict` on re-registration** — once a `(id, version)` triple is registered with a content digest, it cannot be updated. Bump the `version` field to a new semver value when you need to change the workflow.
+
+---
+
+## Related Documents
+
+- [`docs/workflow-composition-guide.md`](workflow-composition-guide.md) — full two-capability worked example
+- [`docs/capability-contract-authoring-guide.md`](capability-contract-authoring-guide.md) — how to write the capabilities referenced in nodes
+- [`docs/event-contract-authoring-guide.md`](event-contract-authoring-guide.md) — how to write event contracts for event edges
+- [`specs/007-workflow-registry-traversal/spec.md`](../specs/007-workflow-registry-traversal/spec.md) — governing spec
+- [`specs/018-event-driven-composition/spec.md`](../specs/018-event-driven-composition/spec.md) — event-driven edge semantics


### PR DESCRIPTION
## Summary
- Add `docs/workflow-contract-authoring-guide.md` — node/edge model, direct vs event edges, authoring steps (#288)
- Add `docs/registry-bundle-authoring-guide.md` — annotated manifest template, required fields, common mistakes (#290)
- Add `docs/architecture-execution-models.md` — WASM/MCP/browser adapter explained with decision guide (#297)
- Extend `docs/capability-contract-authoring-guide.md` — from-scratch tutorial, service_type table, preconditions clarification, validate section (#286 supplement, #295, #298, #304)
- Extend `docs/event-contract-authoring-guide.md` — emits/consumes end-to-end section (#292 supplement)
- Extend `docs/wasm-agent-authoring-guide.md` — stub vs. real, build-fixture.sh, model_dependencies (#289, #296, #299)
- Extend `docs/event-publishing-tutorial.md` — emits/consumes three-perspective walkthrough (#292)
- Update `docs/cli-reference.md` — mark federation commands as not yet implemented with issue links (#294)
- Update `docs/tutorial-index.md` — add Reference Docs section linking all new authoring guides

Note: #286 (capability contract guide) and #287 (event contract guide) were completed by Codex in PRs #322/#323. The extensions in this PR are additive only.

## Governing Spec
- 001-foundation-v0-1
- 002-capability-contracts
- 003-event-contracts
- 007-workflow-registry-traversal
- 015-capability-discovery-mcp
- 017-ai-agent-packaging
- 025-wasm-executor-adapter

## Project Item
- Closes #288
- Closes #289
- Closes #290
- Closes #292
- Closes #294
- Closes #295
- Closes #296
- Closes #297
- Closes #298
- Closes #299
- Closes #301
- Closes #304
- Tracked in Project 1

## Validation
- bash scripts/ci/repository_checks.sh — passed
- bash scripts/ci/spec_alignment_check.sh — passes with declared specs above