### PR TITLE
Define Traverse value proposition + killer use case

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,21 @@
+# Build artifacts — never index these
+target/
+*.profraw
+*.profdata
+coverage.profdata
+
+# Lock files — large, machine-generated, not useful for reasoning
+Cargo.lock
+
+# Coverage and test output
+lcov.info
+tarpaulin-report.html
+coverage/
+
+# Worktrees managed by Claude — avoid recursive indexing
+.claude/worktrees/
+
+# IDE and OS noise
+.DS_Store
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -9,9 +9,28 @@
 
 # Traverse
 
-**Business logic should be portable. Traverse makes it executable anywhere and composable with everything.**
+**Run one governed business capability across browser, edge, and cloud without rewriting it.**
 
-Traverse is a contract-driven runtime for discovering, validating, and composing portable business capabilities through events, policies, constraints, and graph-based workflows — across browser, edge, cloud, and device environments.
+Traverse is a contract-driven runtime for discovering, validating, and composing portable business capabilities through events, policies, constraints, and graph-based workflows.
+
+## Why Should I Care?
+
+Most systems are portable at the container boundary, but not at the business behavior boundary. The moment you need the same governed behavior to run in multiple hosts (browser, edge, cloud, device), you typically end up with duplicated implementations and behavior drift.
+
+Traverse is built to make the capability contract the source of truth, and make execution traceable and governed regardless of where it runs.
+
+**Killer use case (first target):** a portable knowledge workflow that runs offline in the browser and can also run in cloud/edge contexts, without splitting the business behavior into separate implementations. See: [docs/killer-use-case-portable-knowledge-app.md](docs/killer-use-case-portable-knowledge-app.md).
+
+### What’s Proven Today
+
+- A spec-governed runtime with deterministic CI gates and versioned governing specs
+- “App-consumable” release surfaces with downstream validation (see: [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) and [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md))
+
+### Who It’s For (and Not For)
+
+Traverse is for teams that must run the same governed behavior across multiple host environments and want contract-first portability, traceability, and governance.
+
+Traverse is not a replacement for Docker-orchestrated services when “portable enough” means “runs in a container in one environment”, and you do not need host-level portability or capability-level governance.
 
 This is personal research and development by [Enrico Piovesan](https://enricopiovesan.com), built to prove in code the ideas behind [Universal Microservices Architecture (UMA)](https://github.com/enricopiovesan/UMA-code-examples).
 
@@ -64,10 +83,7 @@ Use this as the human and agent navigation hub for the supported docs:
 | Follow the full onboarding sequence | [docs/tutorial-index.md](docs/tutorial-index.md) | [quickstart.md](quickstart.md) |
 | Run the first app-consumable flow | [quickstart.md](quickstart.md) | [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) |
 | Author your first capability contract | [docs/capability-contract-authoring-guide.md](docs/capability-contract-authoring-guide.md) | [docs/getting-started.md](docs/getting-started.md) |
-<<<<<<< HEAD
-=======
 | Author your first event contract | [docs/event-contract-authoring-guide.md](docs/event-contract-authoring-guide.md) | [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) |
->>>>>>> main
 | Build WASM-hosted capabilities | [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md) | [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) |
 | Integrate a downstream app like `youaskm3` | [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) | [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md) |
 | Review runtime and MCP release surfaces | [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) | [docs/packaged-traverse-mcp-server-artifact.md](docs/packaged-traverse-mcp-server-artifact.md) |

--- a/docs/killer-use-case-portable-knowledge-app.md
+++ b/docs/killer-use-case-portable-knowledge-app.md
@@ -1,0 +1,41 @@
+# Killer Use Case: Portable Knowledge Workflow (Browser + Cloud)
+
+This repository is easiest to understand when you start from a real constraint:
+
+You want one governed knowledge workflow to run:
+
+- offline in the browser (fast, private, resilient)
+- and also in cloud or edge environments (automation, sharing, federation)
+
+Most teams solve this by splitting the implementation:
+
+- one code path in the web app (often JS/TS + bespoke storage)
+- a separate service in the cloud (often a different language/runtime)
+- glue code that drifts over time, plus duplicated validation logic
+
+Traverse targets a different outcome: keep the business capability portable and governed, then swap the host around it.
+
+## What “Success” Means (Measurable)
+
+We consider this use case successful when we can demonstrate:
+
+- One capability contract and one workflow definition that run in at least two hosts.
+- Deterministic validation: the same artifacts either pass or fail in both hosts.
+- Traceability: a runtime trace that is consistent across hosts and can be consumed by downstream apps.
+
+Performance claims are tracked separately under benchmarks (see: #326).
+
+## Where to Start in This Repo
+
+- Downstream validation path: [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md)
+- Consumer release surface: [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md)
+- First app-consumable entry path: [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md)
+
+## What This Use Case Forces Us to Build Next
+
+This use case is the forcing function for several “industry standard” requirements:
+
+- Observability that works in non-traditional hosts (OpenTelemetry traces/logs) (#329)
+- A stable insulation layer as WASI/component model evolves (#330)
+- Contract enforcement that blocks invalid artifacts early (#332)
+


### PR DESCRIPTION
Fixes #324.

## What this changes
- Clarifies the top-level README value proposition and who the project is for.
- Adds a concrete killer use case doc anchored in the existing downstream youaskm3 validation path.
- Fixes unresolved merge-conflict markers in README.

## Governing Spec
- 001-foundation-v0-1

## Project Item
- #324

## Validation
- bash scripts/ci/repository_checks.sh
