### PR TITLE
docs(registry): document idempotent registration behavior

### DIFF
--- a/crates/traverse-registry/src/lib.rs
+++ b/crates/traverse-registry/src/lib.rs
@@ -186,6 +186,10 @@ pub struct RegistrationOutcome {
     pub artifact: CapabilityArtifactRecord,
     pub index_entry: DiscoveryIndexEntry,
     pub evidence: RegistrationEvidence,
+    /// `true` when the exact same version and digest were already in the
+    /// registry — the call was a no-op (idempotent).  `false` on first
+    /// registration of this version.
+    pub already_registered: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -283,6 +287,20 @@ impl CapabilityRegistry {
     }
 
     /// Registers a capability publication into the registry.
+    ///
+    /// # Idempotency
+    ///
+    /// Re-registering the same version with the same digest and metadata
+    /// succeeds silently and returns the existing record with
+    /// [`RegistrationOutcome::already_registered`] set to `true`.  No state
+    /// is mutated.  This means an agent that crashes after registering but
+    /// before recording the outcome can safely retry — the retry will succeed
+    /// and produce the same `RegistrationOutcome` as the original call.
+    ///
+    /// Re-registering the same version with a *different* digest or metadata
+    /// returns [`RegistryErrorCode::ImmutableVersionConflict`].  Published
+    /// versions are immutable; to ship a correction, publish a new semver
+    /// version.
     ///
     /// # Errors
     ///
@@ -393,6 +411,7 @@ impl CapabilityRegistry {
             record,
             artifact,
             index_entry,
+            already_registered: false,
         })
     }
 
@@ -501,6 +520,7 @@ impl CapabilityRegistry {
                 record: existing.clone(),
                 artifact: existing_artifact.clone(),
                 index_entry: existing_index.clone(),
+                already_registered: true,
             });
         }
 

--- a/docs/registry-bundle-authoring-guide.md
+++ b/docs/registry-bundle-authoring-guide.md
@@ -155,3 +155,46 @@ bash scripts/ci/repository_checks.sh
 - [`docs/event-contract-authoring-guide.md`](event-contract-authoring-guide.md) — how to write the event contracts referenced in the bundle
 - [`docs/workflow-contract-authoring-guide.md`](workflow-contract-authoring-guide.md) — how to write the workflow definitions referenced in the bundle
 - [`docs/cli-reference.md`](cli-reference.md) — full CLI command reference
+
+---
+
+## Registration Idempotency
+
+`CapabilityRegistry::register()` is **idempotent** when the same version and digest are submitted more than once.
+
+### Same version, same digest → succeeds silently
+
+If a capability is re-registered with the exact same contract digest and artifact metadata as the version already in the registry, the call returns the existing `RegistrationOutcome` unchanged. The `already_registered` field on the outcome is set to `true` so callers can distinguish this path from a fresh registration.
+
+No state is mutated. The operation is safe to retry any number of times.
+
+### Same version, different digest → `ImmutableVersionConflict`
+
+If the same version is submitted with a different contract digest or artifact metadata, the registry rejects it with `ImmutableVersionConflict`. Published versions are immutable. To ship a correction, publish a new semver version.
+
+### Agent retry pattern
+
+A common failure scenario: an agent registers a capability, then crashes before persisting the outcome. On restart it does not know whether registration succeeded.
+
+Recommended pattern:
+
+1. Attempt registration unconditionally.
+2. If the result is `Ok(outcome)` and `outcome.already_registered == true`, log "already registered — continuing" and proceed.
+3. If the result is `Ok(outcome)` and `outcome.already_registered == false`, this is a fresh registration — persist the outcome and proceed.
+4. If the result is `Err(ImmutableVersionConflict)`, the same version was registered with a different digest. This is a real conflict and requires human review.
+
+```rust
+match registry.register(request) {
+    Ok(outcome) if outcome.already_registered => {
+        // safe to continue — idempotent retry
+    }
+    Ok(outcome) => {
+        // first registration — persist outcome
+    }
+    Err(failure) => {
+        // surface the error
+    }
+}
+```
+
+This pattern means agents never need a separate "check-then-register" round-trip, which would introduce a TOCTOU window.


### PR DESCRIPTION
## Summary
- Documented that `CapabilityRegistry::register()` is idempotent when version + digest match
- Added `## Registration Idempotency` section to `docs/registry-bundle-authoring-guide.md`
- Added `already_registered` field to `RegistrationOutcome` for CLI distinguishing

## Governing Spec
- 005-capability-registry
- 007-workflow-registry-traversal
- 011-event-registry
- 018-event-driven-composition

## Project Item
- Closes #307

## Validation
- `cargo test --workspace` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo fmt --all --check` passes
