### PR TITLE
feat(benchmarks): add regression gate with baseline comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ references/
 # Benchmark results — gitignored; check in manually when publishing
 benchmarks/results/*.json
 benchmarks/results/*.csv
+!benchmarks/results/baseline.json

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -34,6 +34,16 @@ Results are written to `benchmarks/results/summary.json`.
 
 See `benchmarks/results/baseline-reference.md` for the Docker comparison methodology.
 
+## Regression Gate
+
+After running `benchmarks/run.sh`, check for latency regressions against the checked-in baseline:
+
+```bash
+bash benchmarks/check-regression.sh
+```
+
+To update the baseline after an intentional change: `bash benchmarks/update-baseline.sh`
+
 ## See Also
 
 - [`docs/benchmarks.md`](../docs/benchmarks.md) — interpretation guide

--- a/benchmarks/check-regression.sh
+++ b/benchmarks/check-regression.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BASELINE="$REPO_ROOT/benchmarks/results/baseline.json"
+SUMMARY="$REPO_ROOT/benchmarks/results/summary.json"
+THRESHOLD="${TRAVERSE_BENCH_THRESHOLD_PCT:-15}"
+
+if [[ ! -f "$BASELINE" ]]; then
+  echo "ERROR: baseline not found at $BASELINE" >&2
+  echo "Run: bash benchmarks/update-baseline.sh" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SUMMARY" ]]; then
+  echo "ERROR: summary not found at $SUMMARY" >&2
+  echo "Run: bash benchmarks/run.sh first" >&2
+  exit 1
+fi
+
+python3 - "$BASELINE" "$SUMMARY" "$THRESHOLD" <<'PYEOF'
+import json, sys
+
+baseline = json.load(open(sys.argv[1]))
+summary  = json.load(open(sys.argv[2]))
+threshold = float(sys.argv[3]) / 100.0
+
+failures = []
+
+def check(metric, b_key, s_key):
+    b = baseline[b_key]["mean"]
+    s = summary[s_key]["mean"]
+    pct = (s - b) / b if b > 0 else 0
+    status = "PASS" if pct <= threshold else "FAIL"
+    print(f"  {metric}: baseline={b}ms  current={s}ms  delta={pct*100:+.1f}%  [{status}]")
+    if pct > threshold:
+        failures.append(f"{metric} regressed by {pct*100:.1f}% (threshold {threshold*100:.0f}%)")
+
+print("=== Benchmark Regression Check ===")
+check("cold_start",   "cold_start_ms",   "cold_start_ms")
+check("steady_state", "steady_state_ms", "steady_state_ms")
+
+if failures:
+    print("\nFAIL — regressions detected:")
+    for f in failures:
+        print(f"  - {f}")
+    print("\nTo update the baseline after an intentional change:")
+    print("  bash benchmarks/update-baseline.sh")
+    sys.exit(1)
+else:
+    print("\nPASS — no regressions detected")
+PYEOF

--- a/benchmarks/results/baseline.json
+++ b/benchmarks/results/baseline.json
@@ -1,0 +1,8 @@
+{
+  "created_at": "2026-04-19T00:00:00Z",
+  "git_sha": "initial-baseline",
+  "platform": "ubuntu-latest",
+  "note": "Initial conservative baseline. Update with: bash benchmarks/update-baseline.sh",
+  "cold_start_ms": { "mean": 5000, "max": 10000 },
+  "steady_state_ms": { "mean": 2000, "max": 5000 }
+}

--- a/benchmarks/update-baseline.sh
+++ b/benchmarks/update-baseline.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SUMMARY="$REPO_ROOT/benchmarks/results/summary.json"
+BASELINE="$REPO_ROOT/benchmarks/results/baseline.json"
+
+echo "This will update the benchmark baseline."
+echo "Run 'bash benchmarks/run.sh' first to generate a fresh summary."
+echo ""
+
+if [[ ! -f "$SUMMARY" ]]; then
+  echo "No summary found. Run: bash benchmarks/run.sh" >&2
+  exit 1
+fi
+
+echo "Current summary:"
+cat "$SUMMARY"
+echo ""
+read -r -p "Update baseline with these numbers? [y/N] " confirm
+if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+  echo "Aborted."
+  exit 0
+fi
+
+python3 - "$SUMMARY" "$BASELINE" <<'PYEOF'
+import json, sys
+from datetime import datetime, timezone
+
+summary = json.load(open(sys.argv[1]))
+baseline = {
+    "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "git_sha": summary.get("git_sha", "unknown"),
+    "platform": summary.get("platform", "unknown"),
+    "note": "Updated via benchmarks/update-baseline.sh",
+    "cold_start_ms": {
+        "mean": summary["cold_start_ms"]["mean"],
+        "max": summary["cold_start_ms"]["max"]
+    },
+    "steady_state_ms": {
+        "mean": summary["steady_state_ms"]["mean"],
+        "max": summary["steady_state_ms"]["max"]
+    }
+}
+with open(sys.argv[2], "w") as f:
+    json.dump(baseline, f, indent=2)
+    f.write("\n")
+print(f"Baseline updated: {sys.argv[2]}")
+PYEOF

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -62,3 +62,18 @@ See [`docs/why-not-docker.md`](why-not-docker.md) for the full decision matrix.
 - No network calls during measurement
 - `benchmarks/results/summary.json` is gitignored — check it in manually when publishing
 - Re-run with `bash benchmarks/run.sh` to regenerate
+
+## Regression Gate
+
+`benchmarks/check-regression.sh` reads the checked-in baseline (`benchmarks/results/baseline.json`) and compares it against the current `summary.json` produced by `run.sh`.
+
+- Default threshold: 15% mean increase per metric
+- Override threshold: `TRAVERSE_BENCH_THRESHOLD_PCT=10 bash benchmarks/check-regression.sh`
+- To update the baseline after an intentional performance change: `bash benchmarks/update-baseline.sh`
+
+The gate is currently optional (not a required CI check). Run it manually before merging changes to the runtime:
+
+```bash
+bash benchmarks/run.sh
+bash benchmarks/check-regression.sh
+```


### PR DESCRIPTION
## Summary
- Added `benchmarks/check-regression.sh` — compares fresh run vs checked-in baseline, fails on >15% regression
- Added `benchmarks/update-baseline.sh` — intentional baseline update with confirmation prompt
- Added `benchmarks/results/baseline.json` — conservative initial baseline (update with real numbers after first run)
- Updated `docs/benchmarks.md` and `benchmarks/README.md` with regression gate docs

## Governing Spec
- 001-foundation-v0-1

## Project Item
- Closes #347

## Validation
- `bash scripts/ci/repository_checks.sh` passes
- `bash benchmarks/check-regression.sh` runs without error (uses conservative baseline)