### PR TITLE
feat(scaffold): guided new-capability scaffold for custom capability contracts (#348)

### DIFF
--- a/docs/wasm-agent-authoring-guide.md
+++ b/docs/wasm-agent-authoring-guide.md
@@ -9,6 +9,31 @@ Use the checked-in examples as the source of truth:
 - [`examples/agents/team-readiness-agent/manifest.json`](../examples/agents/team-readiness-agent/manifest.json)
 - [`docs/wasm-io-contract.md`](wasm-io-contract.md)
 
+## From Hello World to Your First Custom Capability
+
+If you've completed the zero-to-hero path, you have a working `say-hello` agent. This section walks you from that starting point to a capability with your own interface.
+
+### Generate a capability scaffold
+
+```bash
+bash scripts/scaffold/new-capability.sh \
+  --name my-classifier \
+  --namespace acme.ml \
+  --output-dir ./my-classifier
+```
+
+This generates a complete directory with a valid contract stub, compilable Rust source, and a test request. You only need to fill in the TODOs.
+
+### What to change
+
+1. **`contract.json`** — replace `input_schema` and `output_schema` with your actual fields. The `description` field is required.
+2. **`src/main.rs`** — replace the stub logic with your computation. Read JSON from stdin, write JSON to stdout.
+3. **Build and verify** — `bash my-classifier/build-fixture.sh` compiles to WASM and prints the digest.
+
+### Common mistake
+
+Do not skip the contract edit. The runtime validates inputs and outputs against the schema before executing. A permissive schema (`additionalProperties: true`) will pass validation but defeat governance.
+
 ## Start From a Governed Package
 
 Begin with the executable capability package template, then specialize it for the new agent:

--- a/scripts/ci/new_capability_scaffold_smoke.sh
+++ b/scripts/ci/new_capability_scaffold_smoke.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="${TRAVERSE_REPO_ROOT:-$(pwd)}"
+OUT="/tmp/scaffold-smoke-$$"
+
+bash "$REPO_ROOT/scripts/scaffold/new-capability.sh" \
+  --name smoke-test \
+  --namespace ci.smoke \
+  --output-dir "$OUT"
+
+for f in contract.json Cargo.toml src/main.rs build-fixture.sh runtime-request.json; do
+  [[ -f "$OUT/$f" ]] || { echo "MISSING: $OUT/$f" >&2; exit 1; }
+done
+
+ID=$(python3 -c "import json; d=json.load(open('$OUT/contract.json')); print(d['id'])")
+[[ "$ID" == "ci.smoke.smoke-test" ]] || { echo "Wrong id: $ID" >&2; exit 1; }
+
+echo "Scaffold smoke: PASS"
+rm -rf "$OUT"

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -90,6 +90,8 @@ required_files=(
   "scripts/ci/mcp_real_agent_exercise_smoke.sh"
   "scripts/ci/project_board_audit.sh"
   "scripts/scaffold/hello_world_agent_scaffold.sh"
+  "scripts/scaffold/new-capability.sh"
+  "scripts/ci/new_capability_scaffold_smoke.sh"
   ".github/ISSUE_TEMPLATE/task.yml"
   "specs/001-foundation-v0-1/spec.md"
   "specs/001-foundation-v0-1/plan.md"
@@ -333,5 +335,8 @@ grep -q "Dedicated Traverse MCP WASM Server Model" specs/022-mcp-wasm-server/spe
 grep -q "Traverse runtime authority" specs/022-mcp-wasm-server/spec.md
 grep -q "MCP transport concerns" specs/022-mcp-wasm-server/spec.md
 grep -q "## Governing Spec" .github/pull_request_template.md
+
+echo "Running new-capability scaffold smoke..."
+TRAVERSE_REPO_ROOT="$(pwd)" bash "$(pwd)/scripts/ci/new_capability_scaffold_smoke.sh"
 
 echo "Repository checks passed."

--- a/scripts/scaffold/new-capability.sh
+++ b/scripts/scaffold/new-capability.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAME=""
+NAMESPACE=""
+OUTPUT_DIR=""
+
+usage() {
+  echo "Usage: $0 --name <name> --namespace <namespace> [--output-dir <dir>]" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)
+      NAME="$2"
+      shift 2
+      ;;
+    --namespace)
+      NAMESPACE="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+[[ -z "$NAME" ]] && { echo "Error: --name is required" >&2; usage; }
+[[ -z "$NAMESPACE" ]] && { echo "Error: --namespace is required" >&2; usage; }
+
+if ! [[ "$NAME" =~ ^[a-z0-9-]+$ ]]; then
+  echo "Error: --name must be kebab-case ([a-z0-9-] only), got: $NAME" >&2
+  exit 1
+fi
+
+if ! [[ "$NAMESPACE" =~ ^[a-z0-9][a-z0-9.-]*[a-z0-9]$|^[a-z0-9]$ ]]; then
+  echo "Error: --namespace must be dot-separated identifiers ([a-z0-9.-] only), got: $NAMESPACE" >&2
+  exit 1
+fi
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+  OUTPUT_DIR="./scaffold/${NAMESPACE}/${NAME}"
+fi
+
+mkdir -p "$OUTPUT_DIR/src"
+
+# contract.json
+cat > "$OUTPUT_DIR/contract.json" <<EOF
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "${NAMESPACE}.${NAME}",
+  "namespace": "${NAMESPACE}",
+  "name": "${NAME}",
+  "version": "0.1.0",
+  "lifecycle": "draft",
+  "service_type": "stateless",
+  "artifact_type": "native",
+  "description": "TODO: describe what this capability does.",
+  "input_schema": {
+    "type": "object",
+    "required": ["input"],
+    "properties": {
+      "input": { "type": "string", "description": "TODO: replace with your input fields" }
+    },
+    "additionalProperties": false
+  },
+  "output_schema": {
+    "type": "object",
+    "required": ["output"],
+    "properties": {
+      "output": { "type": "string", "description": "TODO: replace with your output fields" }
+    },
+    "additionalProperties": false
+  },
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": { "kind": "wasi-command", "command": "run" },
+    "preferred_targets": ["local"],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "forbidden",
+      "filesystem_access": "none"
+    }
+  },
+  "provenance": {
+    "spec_refs": ["002-capability-contracts"],
+    "exception_refs": []
+  }
+}
+EOF
+
+# Cargo.toml
+cat > "$OUTPUT_DIR/Cargo.toml" <<EOF
+[package]
+name = "${NAME}"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "${NAME}"
+path = "src/main.rs"
+
+[dependencies]
+serde_json = "1"
+EOF
+
+# src/main.rs
+cat > "$OUTPUT_DIR/src/main.rs" <<'RUST_EOF'
+use std::io::{self, Read, Write};
+
+fn main() {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input).unwrap_or_default();
+
+    let request: serde_json::Value = serde_json::from_str(&input)
+        .unwrap_or(serde_json::Value::Null);
+
+    // TODO: replace this stub with your logic
+    let input_value = request
+        .get("input")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let output = serde_json::json!({ "output": format!("processed: {}", input_value) });
+
+    let _ = io::stdout().write_all(output.to_string().as_bytes());
+}
+RUST_EOF
+
+# build-fixture.sh
+cat > "$OUTPUT_DIR/build-fixture.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+AGENT_DIR="\$(cd "\$(dirname "\$0")" && pwd)"
+NAME="${NAME}"
+
+cargo build \\
+  --manifest-path "\$AGENT_DIR/Cargo.toml" \\
+  --target wasm32-wasip1 \\
+  --release 2>&1
+
+mkdir -p "\$AGENT_DIR/fixture"
+cp "target/wasm32-wasip1/release/\${NAME}.wasm" "\$AGENT_DIR/fixture/agent.wasm"
+
+DIGEST=\$(shasum -a 256 "\$AGENT_DIR/fixture/agent.wasm" | awk '{print \$1}')
+echo "Built: \$AGENT_DIR/fixture/agent.wasm"
+echo "SHA-256: \$DIGEST"
+echo ""
+echo "Update contract.json or manifest.json binary.digest with: \$DIGEST"
+EOF
+chmod +x "$OUTPUT_DIR/build-fixture.sh"
+
+# runtime-request.json
+cat > "$OUTPUT_DIR/runtime-request.json" <<EOF
+{
+  "kind": "runtime_request",
+  "schema_version": "1.0.0",
+  "request_id": "${NAME}-test-001",
+  "intent": {
+    "capability_id": "${NAMESPACE}.${NAME}",
+    "capability_version": "0.1.0"
+  },
+  "input": { "input": "hello" },
+  "lookup": { "scope": "public_only", "allow_ambiguity": false },
+  "context": { "requested_target": "local", "caller": "scaffold-test" },
+  "governing_spec": "006-runtime-request-execution"
+}
+EOF
+
+echo ""
+echo "Scaffold created at: ${OUTPUT_DIR}"
+echo ""
+echo "Files generated:"
+echo "  contract.json         — capability contract (edit input_schema, output_schema, description)"
+echo "  Cargo.toml            — Rust package"
+echo "  src/main.rs           — WASM entry point (edit the TODO section)"
+echo "  build-fixture.sh      — builds the WASM binary and prints the digest"
+echo "  runtime-request.json  — test request for traverse-cli"
+echo ""
+echo "Next steps:"
+echo "  1. Edit src/main.rs with your capability logic"
+echo "  2. Edit contract.json: update description, input_schema, output_schema"
+echo "  3. Build: bash ${OUTPUT_DIR}/build-fixture.sh"
+echo "     (requires: rustup target add wasm32-wasip1)"
+echo "  4. Inspect: cargo run -p traverse-cli -- bundle inspect <path-to-bundle-manifest>"
+echo ""
+echo "For detailed guidance: docs/wasm-agent-authoring-guide.md"


### PR DESCRIPTION
## Summary
- Added `scripts/scaffold/new-capability.sh` — generates contract stub, Rust WASM source, Cargo.toml, build-fixture.sh, and test request from `--name`/`--namespace` args
- Added `scripts/ci/new_capability_scaffold_smoke.sh` — validates scaffold output in CI
- Extended `docs/wasm-agent-authoring-guide.md` with "From Hello World to Your First Custom Capability" section
- Wired smoke test into `scripts/ci/repository_checks.sh`

## Governing Spec
- 001-foundation-v0-1
- 002-capability-contracts
- 004-spec-alignment-gate
- 017-ai-agent-packaging
- 028-schema-alignment-gate-v02

## Project Item
- Closes #348

## Validation
- `bash scripts/ci/repository_checks.sh` passes (includes new scaffold smoke)