### PR TITLE
feat(specs): add governing specs 032-034 (data access, HTTP API, registration)

### DIFF
--- a/specs/032-universal-data-access/spec.md
+++ b/specs/032-universal-data-access/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Universal Data Access
+
+**Feature Branch**: `032-universal-data-access`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Offline-first state access layer for capabilities running across browser, edge, and cloud environments, covering the `DataStore` trait, schema validation, deterministic conflict resolution, and sync lifecycle.
+
+## Purpose
+
+This spec defines the universal data access layer for Traverse capabilities.
+
+It narrows the broad capability portability intent into a concrete, testable model for:
+
+- providing capabilities with a uniform `DataStore` trait regardless of execution environment
+- validating reads and writes against a schema declared in the capability contract
+- resolving offline conflicts deterministically using Lamport clock ordering
+- triggering explicit sync on reconnect without corrupting already-persisted local state
+- supporting pluggable storage adapters (browser IndexedDB, cloud KV, local SQLite) that conform to the same trait
+
+This slice does **not** define distributed replication topology or background sync scheduling. It is intentionally limited to the trait boundary, contract schema declaration, Lamport-clock conflict resolution, and reconnect-triggered sync so the data access control plane can be built and verified before replication policy is added.
+
+## User Scenarios and Testing
+
+### User Story 1 - Write and Read Capability State Offline Then Merge On Reconnect (Priority: P1)
+
+As a capability developer, I want my capability to store state via the `DataStore` trait while offline and have that state automatically merged on reconnect so that the same capability implementation runs correctly in the browser and the cloud without environment-specific code.
+
+**Why this priority**: Without a portable, offline-safe data access layer, capabilities cannot be authored once and deployed anywhere — the core portability promise of Traverse breaks.
+
+**Independent Test**: Register a capability with a declared state schema; write state offline via a local adapter; simulate reconnect; verify the runtime triggers sync and the merged state reflects the Lamport-clock winner deterministically.
+
+**Acceptance Scenarios**:
+
+1. **Given** a capability with a declared state schema and a local adapter configured, **When** the capability writes state while offline, **Then** the write succeeds locally, is stamped with a Lamport clock value, and is not lost when the adapter returns to connected mode.
+2. **Given** two offline instances that each wrote the same key with different values, **When** the runtime triggers sync on reconnect, **Then** the key with the higher Lamport clock value wins and the merged state is identical on both instances.
+3. **Given** a reconnect event, **When** the runtime initiates sync, **Then** it does not corrupt already-committed local writes regardless of sync outcome.
+
+### User Story 2 - Validate Capability Writes Against Declared State Schema (Priority: P1)
+
+As a platform developer, I want the runtime to reject capability writes that do not match the declared state schema so that malformed state never reaches the storage adapter.
+
+**Why this priority**: Schema-validated writes are a non-negotiable correctness guarantee; without them, corrupt state can silently propagate across environments.
+
+**Independent Test**: Declare a state schema in a capability contract; submit a write that violates the schema; verify the runtime rejects the write with a structured validation error before the adapter is called.
+
+**Acceptance Scenarios**:
+
+1. **Given** a capability contract with a declared typed JSON state schema, **When** the capability attempts to write a value that violates the schema, **Then** the runtime rejects the write with a structured `schema_validation_error` and does not invoke the adapter.
+2. **Given** a valid write that conforms to the schema, **When** the runtime processes the write, **Then** the adapter is invoked and the write succeeds.
+3. **Given** a capability that declares no state schema (read-only or stateless), **When** any write is attempted, **Then** the runtime rejects the write with a `no_state_schema_declared` error.
+
+### User Story 3 - Resolve Conflict on Same Logical Timestamp Deterministically (Priority: P2)
+
+As a platform developer, I want Lamport clock tie-breaks to be deterministic so that two instances merging the same state always converge to the same result.
+
+**Why this priority**: Non-deterministic conflict resolution breaks the portability and reproducibility guarantees of Traverse.
+
+**Independent Test**: Produce two writes with identical Lamport clock values and different payloads; trigger merge; verify the runtime always resolves the tie in the same direction using the defined tie-break rule.
+
+**Acceptance Scenarios**:
+
+1. **Given** two writes to the same key with equal Lamport clock values, **When** the runtime merges them, **Then** it applies the canonical tie-break rule (lexicographic order of writer identity) and always selects the same winner.
+2. **Given** a tie-break resolution, **When** the merged state is inspected, **Then** it records which writer won and the Lamport clock value used.
+
+### User Story 4 - Swap Storage Adapter Without Changing Capability Implementation (Priority: P2)
+
+As an operator, I want to configure a cloud KV adapter instead of local SQLite without touching the capability contract or implementation so that the same capability artifact runs on different infrastructure.
+
+**Why this priority**: Adapter portability is a second-class but important concern; it must be validated before the data access layer ships.
+
+**Independent Test**: Instantiate the same capability with two different adapters (local SQLite stub and cloud KV stub); verify both adapters satisfy the `DataStore` trait contract and produce identical read/write results for the same inputs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a capability configured with a cloud KV adapter, **When** the capability writes state, **Then** the write is routed to the cloud KV adapter without any change to the capability source.
+2. **Given** adapter failure during a sync operation, **When** the sync fails, **Then** already-committed local state is intact and the runtime surfaces a structured sync error without data loss.
+
+## Edge Cases
+
+- Conflict on identical Lamport clock value — tie-break MUST use a deterministic, documented secondary rule (lexicographic writer identity).
+- State schema evolution: new optional fields added to the schema MUST be readable by capabilities written against the old schema without error.
+- Adapter failure mid-sync MUST leave already-written local state intact; partial remote writes MUST be rolled back or marked incomplete.
+- Capabilities that declare no state schema MUST be rejected at write time with a clear error; reads return empty.
+- A Lamport clock overflow (exceeding `u64::MAX`) MUST be handled without silent wraparound.
+- A write to a key not declared in the state schema MUST be rejected even if the value is otherwise valid JSON.
+- Sync triggered when no remote adapter is configured MUST fail with a clear `no_remote_adapter` error, not a panic.
+- Read of a key that has never been written MUST return a typed empty/absent result, not an error.
+
+## Functional Requirements
+
+- **FR-001**: The runtime MUST expose a `DataStore` trait that capabilities use for all state reads and writes; capabilities MUST NOT access storage implementations directly.
+- **FR-002**: The `DataStore` trait MUST support at minimum the operations: `read(key) -> Result<Value>`, `write(key, value) -> Result<()>`, `delete(key) -> Result<()>`, and `list_keys() -> Result<Vec<Key>>`.
+- **FR-003**: Every write through the `DataStore` MUST be stamped with a Lamport clock value maintained by the runtime, not by the capability.
+- **FR-004**: The runtime MUST validate every write against the typed JSON schema declared in the capability contract before invoking the adapter.
+- **FR-005**: The runtime MUST reject any write whose value does not conform to the declared state schema and MUST return a structured `schema_validation_error` without invoking the adapter.
+- **FR-006**: Capabilities that declare no state schema MUST receive a `no_state_schema_declared` error on any write attempt.
+- **FR-007**: The state schema MUST be declared as a typed JSON schema field in the capability contract; its presence is required for any capability that writes state.
+- **FR-008**: The runtime MUST support at least three storage adapters: local SQLite, browser IndexedDB, and cloud KV; all adapters MUST implement the `DataStore` trait.
+- **FR-009**: The active storage adapter MUST be selected by operator configuration and MUST NOT require changes to the capability contract or implementation.
+- **FR-010**: The conflict resolution default MUST be last-write-wins by Lamport clock; the runtime MUST select the entry with the higher Lamport clock value when merging concurrent writes.
+- **FR-011**: When two conflicting writes carry identical Lamport clock values, the runtime MUST apply a deterministic tie-break: lexicographic ordering of the writer identity field.
+- **FR-012**: Custom merge functions MAY be declared in the capability contract as an extension point; when declared, the runtime MUST invoke the custom merge function instead of last-write-wins.
+- **FR-013**: Sync MUST be triggered explicitly by the runtime on reconnect; background sync is not required in this slice.
+- **FR-014**: The runtime MUST NOT corrupt already-committed local state when sync fails; adapter failure during sync MUST leave the pre-sync local state intact.
+- **FR-015**: The runtime MUST surface sync failures as structured errors containing the adapter identity, failure reason, and the list of keys that were not synced.
+- **FR-016**: Schema evolution MUST support adding new optional fields to the state schema without breaking capabilities written against the previous schema version.
+- **FR-017**: Reads of keys that have never been written MUST return a typed absent result; they MUST NOT return an error.
+- **FR-018**: The runtime MUST record merge decisions in a structured merge trace that includes key, winning value, Lamport clock values of all candidates, and the resolution rule applied.
+- **FR-019**: Lamport clock values MUST be `u64`; the runtime MUST detect and reject any increment that would overflow `u64::MAX` rather than wrapping.
+- **FR-020**: The `DataStore` trait boundary MUST be stable and semver-versioned; breaking changes MUST increment the governing spec version.
+
+## Non-Functional Requirements
+
+- **NFR-001 Determinism**: Conflict resolution, tie-breaking, and merge trace generation MUST be deterministic for the same set of concurrent writes and writer identities.
+- **NFR-002 Portability**: The `DataStore` trait MUST compile to WASM target without adapter-specific native dependencies leaking through the trait boundary.
+- **NFR-003 Correctness**: Schema validation MUST occur on every write path; there MUST be no code path that bypasses validation and reaches the adapter.
+- **NFR-004 Testability**: The conflict resolution logic, schema validation, and Lamport clock management MUST be testable independently of any concrete adapter implementation.
+- **NFR-005 Adapter Isolation**: Adapter failures MUST be isolated from the capability execution path; a failing adapter MUST surface as a structured error, not a panic.
+- **NFR-006 Explainability**: Every merge decision MUST produce a machine-readable merge trace artifact that is stable enough for future audit and MCP consumption.
+- **NFR-007 Compatibility**: State schema declarations in capability contracts MUST be versionable and subject to semver discipline.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: Writes MUST NEVER reach a storage adapter without passing schema validation; any code path that bypasses validation is a spec violation.
+- **QG-002**: Conflict resolution MUST be deterministic; non-deterministic tie-break behavior is a blocking defect.
+- **QG-003**: Adapter failure during sync MUST NOT corrupt local state; data loss from a sync failure is a blocking defect.
+- **QG-004**: Core data access logic (validation, Lamport clock management, conflict resolution) MUST reach 100% automated line coverage.
+- **QG-005**: The `DataStore` trait boundary MUST be verified against the governing spec before merge; drift from the declared interface is a blocking CI failure.
+
+## Key Entities
+
+- **DataStore Trait**: The uniform Rust trait exposed by the runtime for all capability state access; implemented by concrete storage adapters.
+- **State Schema**: A typed JSON schema declared in the capability contract that defines the valid shape of all values the capability may write.
+- **Lamport Clock**: A monotonic logical timestamp maintained by the runtime per writer identity, used to order concurrent writes for conflict resolution.
+- **Storage Adapter**: A concrete implementation of the `DataStore` trait targeting a specific backend (local SQLite, browser IndexedDB, cloud KV).
+- **Merge Trace**: A structured artifact recording the inputs, resolution rule, and winner for one conflict merge operation.
+- **Sync Trigger**: The runtime-initiated operation that propagates offline-written state to the remote adapter on reconnect.
+- **Writer Identity**: A stable identifier scoped to an offline instance used as the secondary tie-break key when Lamport clocks collide.
+- **Custom Merge Function**: An optional capability-declared extension point that overrides the default last-write-wins conflict resolution strategy.
+
+## Success Criteria
+
+- **SC-001**: A capability reads and writes state through the `DataStore` trait in both local and cloud adapter configurations without any environment-specific code in the capability.
+- **SC-002**: A write that violates the declared state schema is rejected before the adapter is called and returns a structured error.
+- **SC-003**: Two offline instances with conflicting writes converge to the same merged state deterministically after sync.
+- **SC-004**: Adapter failure during sync leaves all previously committed local writes intact and surfaces a structured error.
+- **SC-005**: Core data access logic reaches 100% automated line coverage under the protected coverage gate.
+
+## Out of Scope
+
+- Background sync scheduling and sync policy configuration
+- Multi-hop replication topology across more than two instances
+- Conflict resolution strategies beyond last-write-wins and custom merge functions
+- Encryption at rest or transport-layer security for adapter communication
+- Fine-grained per-key access control within a single capability
+- CRDT-based merge semantics
+- Schema migration tooling for breaking schema changes

--- a/specs/033-http-json-api/spec.md
+++ b/specs/033-http-json-api/spec.md
@@ -1,0 +1,159 @@
+# Feature Specification: HTTP JSON API
+
+**Feature Branch**: `033-http-json-api`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: HTTP+JSON external adapter for Traverse, covering `traverse-cli serve`, endpoint definitions, authentication tiers, wire format, versioning, and error envelope for v0 synchronous request/response.
+
+## Purpose
+
+This spec defines the HTTP JSON API for Traverse.
+
+It narrows the broad transport-agnostic runtime intent into a concrete, testable model for:
+
+- embedding an HTTP/1.1 server in `traverse-cli` via a `serve` subcommand
+- exposing a versioned `/v1/` endpoint surface for capability execution, listing, registration, and health
+- enforcing a tiered authentication model that is safe by default for loopback and requires Bearer JWT for non-loopback or production bindings
+- producing structured JSON error envelopes for all failure paths
+- maintaining wire format and versioning discipline suitable for semver governance
+
+This slice does **not** define async or streaming execution, WebSocket transport, or `/v2/` endpoint shapes. It is intentionally limited to synchronous request/response over HTTP/1.1 so the external API surface can be verified before async patterns are introduced.
+
+## User Scenarios and Testing
+
+### User Story 1 - Execute a Capability via HTTP POST from Any Language (Priority: P1)
+
+As a capability developer, I want to run `traverse-cli serve` and submit a capability execution request via `curl` or any HTTP client so that Traverse is usable from any language without the Rust SDK.
+
+**Why this priority**: Without an HTTP boundary, Traverse is only accessible from Rust callers; the HTTP API is the primary cross-language integration surface.
+
+**Independent Test**: Start `traverse-cli serve`; register one capability; submit `POST /v1/capabilities/execute` with a valid JSON body; verify the response contains a structured trace and result with HTTP 200.
+
+**Acceptance Scenarios**:
+
+1. **Given** the server is running with a registered capability, **When** a client sends `POST /v1/capabilities/execute` with a valid JSON body, **Then** the server returns HTTP 200 with a JSON body containing a trace and result.
+2. **Given** a request body that fails runtime contract validation, **When** the server processes it, **Then** it returns HTTP 422 with a `{"error": {"code": "...", "message": "..."}}` envelope.
+3. **Given** a request that causes an ambiguous match, **When** the server processes it, **Then** it returns HTTP 409 with an error envelope listing all matching candidates.
+
+### User Story 2 - Call the HTTP API from a Browser Application (Priority: P1)
+
+As a browser application developer, I want to call `POST /v1/capabilities/execute` over HTTP from a JavaScript client so that Traverse capabilities are usable from browser-hosted agents.
+
+**Why this priority**: Browser integration is a named consumer of this API surface and must be verified before the API is considered stable.
+
+**Independent Test**: Simulate a browser-originated HTTP request (including CORS preflight); verify the server responds correctly to both preflight and the actual POST.
+
+**Acceptance Scenarios**:
+
+1. **Given** a browser client sends an OPTIONS preflight to `/v1/capabilities/execute`, **When** the server processes it, **Then** it returns the correct CORS headers for the configured allowed origins.
+2. **Given** a browser client sends `POST /v1/capabilities/execute` with content-type `application/json`, **When** the server processes it, **Then** it returns a JSON response with correct content-type and a structured trace.
+
+### User Story 3 - Require Bearer JWT for Non-Loopback Bindings (Priority: P2)
+
+As an operator, I want the server to require a Bearer JWT for any non-loopback binding so that production deployments are not accidentally exposed without authentication.
+
+**Why this priority**: The tiered auth model is a safety-critical design decision; unauthenticated production access is a blocking security defect.
+
+**Independent Test**: Start `traverse-cli serve --bind 0.0.0.0:8080`; submit a request without an `Authorization` header; verify the server returns HTTP 401.
+
+**Acceptance Scenarios**:
+
+1. **Given** the server is bound to a non-loopback address, **When** a client sends a request without an `Authorization: Bearer <token>` header, **Then** the server returns HTTP 401 with a structured error envelope.
+2. **Given** the server is bound to a non-loopback address and the client provides a valid JWT, **When** the server processes the request, **Then** it authorizes the request and returns the normal response.
+3. **Given** `--allow-unauthenticated` is set on a non-loopback binding, **When** the server starts, **Then** it logs a clearly visible warning that the binding is unsafe.
+
+### User Story 4 - Health Check Returns 200 Without Credentials (Priority: P2)
+
+As an operator, I want `GET /v1/health` to return 200 without credentials so that load balancers and orchestrators can probe liveness without managing tokens.
+
+**Why this priority**: Health probes are infrastructure-level; requiring auth on a health endpoint breaks standard orchestration patterns.
+
+**Independent Test**: Start the server with auth required; send `GET /v1/health` without any `Authorization` header; verify HTTP 200 with a JSON liveness body.
+
+**Acceptance Scenarios**:
+
+1. **Given** the server is running with Bearer JWT auth required, **When** a client sends `GET /v1/health` without any `Authorization` header, **Then** the server returns HTTP 200 with a JSON body indicating liveness.
+2. **Given** the server is running, **When** `GET /v1/health` is called, **Then** the response includes at minimum `{"status": "ok"}` and a server version field.
+
+## Edge Cases
+
+- Concurrent requests: the server MUST handle multiple simultaneous requests without corrupting shared registry state.
+- Large request payloads exceeding the configured maximum (default 8MB) MUST be rejected with HTTP 413 before body parsing.
+- Auth token expiry during a long-running synchronous execution: the request is already authorized at intake; mid-execution expiry MUST NOT abort the in-progress execution.
+- Bind failure (port already in use) MUST produce a clear error message to stderr and exit with a non-zero code.
+- Request body that is not valid JSON MUST return HTTP 400 with a structured error envelope, not an unhandled panic.
+- Missing `Content-Type: application/json` header on POST endpoints MUST return HTTP 415.
+- Unknown endpoint paths MUST return HTTP 404 with a structured error envelope.
+- Server started with `--bind` on a non-loopback address without `--allow-unauthenticated` and without a JWT signing key configured MUST fail at startup with a clear configuration error.
+
+## Functional Requirements
+
+- **FR-001**: `traverse-cli` MUST expose a `serve` subcommand that starts a long-running HTTP/1.1 server process.
+- **FR-002**: The server MUST bind to `127.0.0.1:8080` by default; the bind address and port MUST be configurable via `--bind` flag.
+- **FR-003**: All endpoints MUST be versioned under the `/v1/` URL prefix.
+- **FR-004**: The server MUST expose `POST /v1/capabilities/execute` accepting a JSON body and returning a runtime trace and result.
+- **FR-005**: The server MUST expose `GET /v1/capabilities` returning a JSON array of registered capabilities.
+- **FR-006**: The server MUST expose `POST /v1/capabilities/register` accepting a capability contract JSON body and registering the capability.
+- **FR-007**: The server MUST expose `GET /v1/health` returning liveness status and server version without requiring authentication.
+- **FR-008**: All JSON responses MUST use `Content-Type: application/json`.
+- **FR-009**: All error responses MUST use the envelope `{"error": {"code": "<machine_code>", "message": "<human_readable>"}}`.
+- **FR-010**: When the server is bound to loopback (`127.0.0.1` or `::1`) with no explicit `--require-auth` flag, it MUST allow unauthenticated requests (dev mode).
+- **FR-011**: When the server is bound to any non-loopback address, it MUST require `Authorization: Bearer <jwt>` for all endpoints except `GET /v1/health`.
+- **FR-012**: When `--allow-unauthenticated` is passed on a non-loopback binding, the server MUST start but MUST emit a clearly visible startup warning.
+- **FR-013**: The server MUST validate Bearer JWTs against a configured OIDC-compatible signing key; invalid or expired tokens MUST return HTTP 401.
+- **FR-014**: Request bodies exceeding the configured maximum payload size (default 8MB, configurable via `--max-body-bytes`) MUST be rejected with HTTP 413 before full body parsing.
+- **FR-015**: Requests with `Content-Type` other than `application/json` on POST endpoints MUST be rejected with HTTP 415.
+- **FR-016**: Invalid JSON request bodies MUST return HTTP 400 with a structured error envelope.
+- **FR-017**: Bind failures MUST produce a human-readable error on stderr and exit the process with a non-zero code.
+- **FR-018**: The server MUST handle concurrent requests without corrupting registry state; registry access MUST be protected by appropriate synchronization.
+- **FR-019**: CORS headers MUST be configurable; the default MUST allow loopback origins only; non-loopback allowed origins MUST be explicitly configured.
+- **FR-020**: Unknown paths MUST return HTTP 404 with a structured error envelope.
+- **FR-021**: The `POST /v1/capabilities/execute` endpoint MUST delegate to the same runtime execution path used by `traverse-cli run`; it MUST NOT implement a separate execution path.
+
+## Non-Functional Requirements
+
+- **NFR-001 Safety**: Non-loopback bindings MUST require explicit auth configuration; the server MUST NOT silently default to unauthenticated on non-loopback bindings.
+- **NFR-002 Determinism**: The HTTP layer MUST not alter the determinism of the runtime execution path; same request body MUST produce the same trace and result.
+- **NFR-003 Portability**: The HTTP server implementation MUST be decoupled from the runtime core; `traverse-runtime` MUST remain a library crate with no HTTP dependency.
+- **NFR-004 Testability**: Endpoint handler logic MUST be testable without a live TCP listener; integration tests MUST test via in-process HTTP client.
+- **NFR-005 Compatibility**: The `/v1/` wire format MUST be stable and semver-versioned; breaking changes MUST be introduced under `/v2/` and MUST NOT modify `/v1/` response shapes.
+- **NFR-006 Observability**: The server MUST log each inbound request with method, path, response status, and latency in a structured format.
+- **NFR-007 Startup Correctness**: The server MUST validate its own configuration at startup and fail fast with a clear error if any required configuration is missing or invalid.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: Auth bypass on non-loopback bindings MUST be impossible without the explicit `--allow-unauthenticated` flag; any code path that allows unauthenticated non-loopback access without this flag is a spec violation.
+- **QG-002**: All error responses MUST use the structured envelope; free-form error strings or unhandled panics surfacing as HTTP 500 are blocking defects.
+- **QG-003**: The HTTP endpoint handlers MUST delegate to `traverse-runtime` without duplicating execution logic; code duplication between `traverse-cli run` and `traverse-cli serve` execution paths is a spec violation.
+- **QG-004**: Core handler logic MUST reach 100% automated line coverage.
+- **QG-005**: The server MUST pass all endpoint contract tests before merge; deviations from the declared wire format are blocking CI failures.
+
+## Key Entities
+
+- **HTTP Server**: The embedded HTTP/1.1 server process started by `traverse-cli serve`.
+- **Endpoint**: A versioned HTTP route under `/v1/` that accepts JSON requests and returns JSON responses.
+- **Auth Tier**: The authentication policy applied based on bind address — dev mode (loopback, no auth) or production mode (non-loopback, Bearer JWT required).
+- **Error Envelope**: The canonical JSON error response shape `{"error": {"code": "...", "message": "..."}}` used by all error responses.
+- **Bearer JWT**: A JSON Web Token presented in the `Authorization` header for production-mode authentication, validated against a configured OIDC-compatible signing key.
+- **Max Payload**: The configurable upper bound on request body size; requests exceeding this limit are rejected with HTTP 413.
+- **CORS Configuration**: The set of allowed origins for cross-origin requests; defaults to loopback only.
+- **Wire Format**: The stable JSON request and response shapes versioned under `/v1/`.
+
+## Success Criteria
+
+- **SC-001**: A developer runs `traverse-cli serve`, registers a capability, and executes it via `curl` or any HTTP client without using the Rust SDK.
+- **SC-002**: A non-loopback binding without `--allow-unauthenticated` rejects all non-health requests without a valid Bearer JWT.
+- **SC-003**: `GET /v1/health` returns HTTP 200 with a liveness payload regardless of auth configuration.
+- **SC-004**: A request with a payload exceeding the configured maximum is rejected with HTTP 413 before body parsing completes.
+- **SC-005**: Core endpoint handler logic reaches 100% automated line coverage.
+
+## Out of Scope
+
+- Asynchronous or streaming execution (request/response is synchronous in v0)
+- WebSocket or Server-Sent Events transport
+- `/v2/` endpoint shapes
+- Fine-grained role-based access control beyond the dev/production auth tier
+- TLS termination (assumed to be handled by a reverse proxy)
+- API rate limiting
+- OpenAPI/Swagger schema generation
+- Multi-tenant isolation at the HTTP layer

--- a/specs/034-programmatic-registration/spec.md
+++ b/specs/034-programmatic-registration/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Programmatic Capability Registration
+
+**Feature Branch**: `034-programmatic-registration`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Runtime capability registration via the HTTP API, covering workspace-scoped persistence, idempotency by contract digest, full contract validation at registration time, and session-ephemeral scope for one-off capabilities.
+
+## Purpose
+
+This spec defines programmatic capability registration for Traverse.
+
+It narrows the broad registry extensibility intent into a concrete, testable model for:
+
+- accepting capability contract submissions via `POST /v1/capabilities/register`
+- validating contracts fully at registration time before any persistence
+- keying the registry by (workspace_id, capability_id, version) for workspace-scoped isolation
+- making registration idempotent for the same contract digest within a workspace
+- supporting two registration scopes: `workspace_persisted` (default) and `session_ephemeral`
+- rejecting conflicting re-registrations with a deterministic `ImmutableVersionConflict` error
+
+This slice does **not** define capability artifact distribution, remote artifact fetching, or multi-workspace federation. It is intentionally limited to the registration lifecycle so the registry control plane can be built and verified before artifact management is added.
+
+## User Scenarios and Testing
+
+### User Story 1 - Register a Capability at Runtime Without a CLI Command (Priority: P1)
+
+As an agent or automation system, I want to register a capability via `POST /v1/capabilities/register` so that capabilities can be provisioned dynamically without requiring a manual CLI step.
+
+**Why this priority**: Programmatic registration is the primary mechanism for agent-driven capability provisioning; without it, Traverse cannot be used in headless or automated contexts.
+
+**Independent Test**: Send `POST /v1/capabilities/register` with a valid capability contract JSON body including a `workspace_id`; verify the capability is immediately executable via `POST /v1/capabilities/execute` without a CLI command.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid capability contract JSON body with a `workspace_id`, **When** the client sends `POST /v1/capabilities/register`, **Then** the server validates the contract, persists it under `workspace_persisted` scope, and returns HTTP 201 with the registered capability record.
+2. **Given** a successful registration, **When** the client sends `POST /v1/capabilities/execute` with a matching request, **Then** the runtime discovers and executes the newly registered capability.
+3. **Given** a capability registered under `workspace_persisted` scope, **When** the server restarts, **Then** the capability is still present in the registry and executable.
+
+### User Story 2 - Idempotent Re-registration With the Same Digest (Priority: P1)
+
+As an agent, I want re-registering the same capability with the same contract digest to succeed silently so that registration logic does not need to track whether a capability was previously registered.
+
+**Why this priority**: Idempotency is required for safe automation; without it, agents must implement their own deduplication, which leaks registry concerns into capability authors.
+
+**Independent Test**: Register a capability; register the same capability a second time with an identical contract digest; verify the server returns HTTP 200 with `already_registered: true` and does not write to persistent storage again.
+
+**Acceptance Scenarios**:
+
+1. **Given** a capability already registered under a given workspace, **When** the same contract digest is submitted for the same capability id and version, **Then** the server returns HTTP 200 with `{"already_registered": true}` and does not modify the existing registry entry.
+2. **Given** two concurrent registration requests for the same capability from two agents, **When** both requests complete, **Then** exactly one write occurs and both agents receive a success response (`already_registered: true` or HTTP 201).
+
+### User Story 3 - Session-Ephemeral Registration for One-Off Tasks (Priority: P2)
+
+As an agent, I want to register a capability with `scope: session_ephemeral` so that the capability is cleaned up automatically on server restart without requiring an explicit deregistration call.
+
+**Why this priority**: Ephemeral registrations are important for short-lived automation tasks; persistent storage of one-off capabilities wastes registry space and leaks between sessions.
+
+**Independent Test**: Register a capability with `scope: session_ephemeral`; verify it is executable in the current session; simulate server restart; verify the capability is no longer present in the registry.
+
+**Acceptance Scenarios**:
+
+1. **Given** a capability registered with `scope: session_ephemeral`, **When** the server restarts, **Then** the capability is absent from the registry and cannot be executed.
+2. **Given** a session-ephemeral capability registered in the current session, **When** the client executes it, **Then** it runs successfully within the same session.
+
+### User Story 4 - Reject Invalid Contracts Before Touching the Registry (Priority: P2)
+
+As a platform developer, I want invalid capability contracts to be rejected at registration time so that malformed contracts never reach the registry or persistent storage.
+
+**Why this priority**: Pre-persistence validation is a non-negotiable correctness guarantee; a registry containing invalid contracts can cause silent runtime failures.
+
+**Independent Test**: Submit `POST /v1/capabilities/register` with a contract body missing a required field (e.g., `service_type`); verify the server returns HTTP 422 with a structured validation error and no registry write occurs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a contract body missing required fields, **When** the client sends `POST /v1/capabilities/register`, **Then** the server returns HTTP 422 with a structured error listing each violated requirement and does not write to the registry.
+2. **Given** a contract with an invalid `artifact_type` value, **When** the client sends the registration, **Then** the server returns HTTP 422 with a machine-readable error code and the offending field path.
+3. **Given** a contract where the declared state schema is malformed JSON Schema, **When** the client sends the registration, **Then** the server returns HTTP 422 with a `malformed_state_schema` error before any persistence.
+
+## Edge Cases
+
+- Concurrent registration of the same capability from two agents simultaneously: idempotency MUST hold regardless of request interleaving; no duplicate writes and no conflicting error responses.
+- `workspace_id` missing from the request body MUST be rejected with HTTP 400 and a clear `missing_workspace_id` error before any validation proceeds.
+- Registration of a capability whose artifact is not yet present locally MUST return a structured `artifact_not_found` error; partial registration MUST NOT be persisted.
+- Version conflict: same `capability_id`, same `workspace_id`, different `version`, different digest — this is a valid new registration; same `capability_id`, same `workspace_id`, same `version`, different digest MUST return `ImmutableVersionConflict`.
+- Registration with a `workspace_id` that contains invalid characters (e.g., path separators) MUST be rejected before any file system or storage operation.
+- Re-registration attempt for a `session_ephemeral` capability after server restart MUST succeed as a fresh registration (the old entry no longer exists).
+- Contract body exceeding the HTTP max payload limit (governed by spec 033) MUST be rejected by the HTTP layer before the registry is consulted.
+
+## Functional Requirements
+
+- **FR-001**: The server MUST expose `POST /v1/capabilities/register` accepting a capability contract JSON body and a required `workspace_id` field.
+- **FR-002**: Every registration request MUST include a `workspace_id`; requests without `workspace_id` MUST be rejected with HTTP 400 and a `missing_workspace_id` error before any further processing.
+- **FR-003**: The registry MUST key each entry by the compound key `(workspace_id, capability_id, version)`; registrations in different workspaces MUST be isolated from each other.
+- **FR-004**: The server MUST fully validate the submitted contract before any write to the registry, including schema validation, required field presence, `service_type` validity, and `artifact_type` validity.
+- **FR-005**: Contracts that fail validation MUST be rejected with HTTP 422 and a structured error body listing each violated requirement; no partial registry write MUST occur.
+- **FR-006**: A malformed `state_schema` field in the contract MUST cause rejection with a `malformed_state_schema` error code before any registry write.
+- **FR-007**: When the submitted contract digest matches an existing entry for the same `(workspace_id, capability_id, version)`, the server MUST return HTTP 200 with `{"already_registered": true}` and MUST NOT perform a new write.
+- **FR-008**: When a different contract digest is submitted for an existing `(workspace_id, capability_id, version)`, the server MUST return HTTP 409 with an `ImmutableVersionConflict` error and MUST NOT overwrite the existing entry.
+- **FR-009**: Concurrent registration requests for the same key MUST be handled with correct mutual exclusion; exactly one write MUST occur and both callers MUST receive a non-error response.
+- **FR-010**: The registration request MUST include a `scope` field with valid values `workspace_persisted` (default) or `session_ephemeral`; unknown scope values MUST be rejected with HTTP 422.
+- **FR-011**: `workspace_persisted` registrations MUST be written to persistent storage and MUST survive server restarts.
+- **FR-012**: `session_ephemeral` registrations MUST be held in-memory only and MUST NOT be written to persistent storage; they MUST be absent from the registry after a server restart.
+- **FR-013**: A capability registered via this endpoint MUST be immediately discoverable and executable via `POST /v1/capabilities/execute` without requiring a separate activation step.
+- **FR-014**: `GET /v1/capabilities?workspace_id=<id>` MUST return only capabilities registered in the specified workspace; capabilities from other workspaces MUST NOT appear in the response.
+- **FR-015**: A `workspace_id` containing path separators, null bytes, or other invalid characters MUST be rejected with HTTP 400 before any storage or file system operation.
+- **FR-016**: The registration response for a new HTTP 201 registration MUST include the full registered capability record with its computed digest, scope, and workspace_id.
+- **FR-017**: Registration of a capability whose referenced artifact is not present locally MUST return HTTP 422 with an `artifact_not_found` error and MUST NOT persist a registry entry.
+- **FR-018**: The contract digest MUST be computed deterministically by the server; callers MUST NOT provide the digest as an input field.
+- **FR-019**: The registry MUST support listing capabilities filtered by `workspace_id`; the listing MUST include both `workspace_persisted` and `session_ephemeral` entries for the current session.
+- **FR-020**: All registry mutations MUST be atomic from the caller's perspective; a failed registration MUST leave the registry in its pre-request state.
+
+## Non-Functional Requirements
+
+- **NFR-001 Idempotency**: Registration MUST be idempotent for the same `(workspace_id, capability_id, version, digest)` tuple regardless of how many times or how concurrently the request is issued.
+- **NFR-002 Atomicity**: Registry writes MUST be atomic; partial writes that leave the registry in an inconsistent state are blocking defects.
+- **NFR-003 Isolation**: Registrations in one workspace MUST NOT be visible to registry lookups in another workspace.
+- **NFR-004 Testability**: Contract validation, idempotency logic, and scope handling MUST be testable independently of the HTTP transport layer.
+- **NFR-005 Determinism**: Contract digest computation MUST be deterministic; the same contract bytes MUST always produce the same digest.
+- **NFR-006 Compatibility**: The registration request and response wire format MUST be semver-versioned and stable; breaking changes require a new governing spec version.
+- **NFR-007 Fail-Fast Validation**: Contract validation MUST occur fully before any storage operation is initiated; the validation and persistence phases MUST be clearly separated.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: An invalid contract MUST NEVER reach the persistent registry; any code path that writes an unvalidated contract is a spec violation.
+- **QG-002**: Idempotency MUST hold under concurrent load; a race condition that produces duplicate registry entries or conflicting error responses is a blocking defect.
+- **QG-003**: `workspace_id` MUST be validated for illegal characters before any file system or storage operation; an injection via `workspace_id` is a blocking security defect.
+- **QG-004**: Core registration logic (validation, idempotency, scope handling, digest computation) MUST reach 100% automated line coverage.
+- **QG-005**: The registration wire format MUST be verified against the governing spec before merge; drift from the declared interface is a blocking CI failure.
+
+## Key Entities
+
+- **Registration Request**: The HTTP request body submitted to `POST /v1/capabilities/register`, containing the capability contract, `workspace_id`, and optional `scope`.
+- **Contract Digest**: A deterministic hash of the submitted capability contract, computed by the server and used as the idempotency key.
+- **Registration Key**: The compound key `(workspace_id, capability_id, version)` used to look up and store registry entries.
+- **Registration Scope**: The lifecycle policy for a registry entry — `workspace_persisted` survives restarts; `session_ephemeral` does not.
+- **ImmutableVersionConflict**: The structured error returned when a different contract digest is submitted for an already-registered `(workspace_id, capability_id, version)`.
+- **Workspace**: A named isolation boundary for capability registrations; each registration belongs to exactly one workspace.
+- **Validation Phase**: The pre-persistence step that checks schema, required fields, `service_type`, `artifact_type`, and state schema correctness before any write.
+- **Persistent Registry Storage**: The durable backend (filesystem or embedded DB) used for `workspace_persisted` entries.
+
+## Success Criteria
+
+- **SC-001**: An agent registers a capability via `POST /v1/capabilities/register` and immediately executes it via `POST /v1/capabilities/execute` without any CLI command.
+- **SC-002**: Re-registering the same capability with the same contract digest returns HTTP 200 with `already_registered: true` regardless of how many times the request is issued.
+- **SC-003**: A `session_ephemeral` registration is absent from the registry after a server restart.
+- **SC-004**: A registration request with an invalid contract is rejected with HTTP 422 before any registry write occurs.
+- **SC-005**: Core registration logic reaches 100% automated line coverage under the protected coverage gate.
+
+## Out of Scope
+
+- Capability deregistration or explicit deletion from the registry
+- Remote artifact fetching or distribution at registration time
+- Cross-workspace capability sharing or federation
+- Capability versioning migration tooling
+- Bulk registration from a manifest file
+- Webhook or event notification on registration
+- Registration of capabilities without a `workspace_id` (anonymous workspace)


### PR DESCRIPTION
## Summary
Add governing specs 032, 033, 034 to unblock issues #335, #300, #302.

Specs only — no code changes. `approved-specs.json` registration in follow-on PR.

## Governing Spec
- 004-spec-alignment-gate
- 028-schema-alignment-gate-v02

## Project Item
Closes #335
Closes #300
Closes #302

## Validation
- All three spec files follow the approved spec format (Purpose, User Stories, Edge Cases, FR/NFR/QG, Key Entities, Success Criteria, Out of Scope)
- No code changes in this PR
- Spec IDs 032-034 reserved and consistent with approved-specs.json numbering sequence