### PR TITLE
feat(specs): add governing specs 029-031 (observability, security, supply chain)

### DIFF
--- a/specs/029-integrated-observability/spec.md
+++ b/specs/029-integrated-observability/spec.md
@@ -1,0 +1,166 @@
+# Feature Specification: Integrated Observability (OTel Traces, Logs, Metrics)
+
+**Feature Branch**: `029-integrated-observability`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Observability layer for `traverse-runtime` and `traverse-mcp`, covering OpenTelemetry signal export, W3C Trace Context propagation, attribute naming conventions, and deterministic test-mode identifiers.
+
+## Purpose
+
+This spec defines the integrated observability model for Traverse.
+
+It narrows the broad intent of "OTel-compatible telemetry" into a concrete, testable set of requirements covering:
+
+- emitting distributed traces (spans) for all runtime execution paths
+- propagating W3C Trace Context across runtime request objects, event publication envelopes, and browser adapter subscriptions
+- exporting structured log records with trace correlation
+- emitting named metrics for execution counts, latency, and error rates
+- pluggable OTLP export without vendor lock-in
+- a deterministic seeded identifier mode for CI and snapshot testing
+
+Compliance tiers are defined explicitly: distributed traces are REQUIRED for v0 compliance; structured logs and metrics are STANDARDIZED (testable and spec-governed) but optional for v0 compliance. All three signals are written as first-class requirements to support progressive adoption.
+
+This spec does not define a UI or visualization layer. It governs only signal generation and export.
+
+## User Scenarios and Testing
+
+### User Story 1 - Full Execution Trace Visible in Standard OTel Backend (Priority: P1)
+
+As an agent submitting a capability execution request, I want to receive an OTLP-compatible trace showing all spans from request intake to execution completion so that I can diagnose slow or failing executions without Traverse-specific tooling.
+
+**Why this priority**: Distributed tracing is the primary observability primitive for request-oriented systems. Without it, no cross-service correlation is possible and execution failures are opaque.
+
+**Independent Test**: Submit one valid runtime request end-to-end, capture the OTLP export, and verify that a root span and all child spans are present with correct parent-child relationships, attribute names, and status codes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid runtime request is submitted, **When** the runtime processes the request through discovery, selection, and execution, **Then** a root span is created for the request and child spans are created for each named execution phase, each carrying at least the required `traverse.*` attributes.
+2. **Given** a completed span tree, **When** it is exported via OTLP, **Then** the export payload is parseable by any standards-compliant OTel collector without custom schema extensions.
+3. **Given** a request that fails at any phase, **When** the span for that phase is closed, **Then** the span status is set to `ERROR` and the span records the error classification as a structured event, not only in unstructured log output.
+
+### User Story 2 - Standard Attribute Names Enable Backend Filter/Search Without Custom Parsers (Priority: P1)
+
+As a team integrating Traverse with Jaeger or Grafana, I want to filter and search traces using standard OTel semantic convention attribute names so that I do not need to write custom parsers or know Traverse internals.
+
+**Why this priority**: Non-standard attribute names break every OTel-aware backend query and defeat the purpose of adopting the OTel specification.
+
+**Independent Test**: Run several requests with varying capability IDs and intents, export spans to a test collector, and verify that every span's attribute keys conform to OTel semantic conventions or the `traverse.` namespace prefix rule and that no ad hoc keys appear.
+
+**Acceptance Scenarios**:
+
+1. **Given** a span for a capability execution phase, **When** the span attributes are enumerated, **Then** every key either maps to a defined OTel semantic convention or begins with the `traverse.` namespace prefix.
+2. **Given** a trace filtered by `traverse.capability.id` in a standard OTel backend, **When** the filter is applied, **Then** all spans related to that capability are returned without custom index configuration.
+3. **Given** spans for both success and failure cases, **When** their attribute sets are compared, **Then** the same attribute keys are present (error spans carry additional error attributes, never different base keys).
+
+### User Story 3 - Structured Log Records Carry Trace Correlation IDs (Priority: P2)
+
+As an operator enabling log export, I want to receive structured log records with trace and span IDs so that logs from Traverse are joinable with trace data in any OTel-aware log management system.
+
+**Why this priority**: Log-trace correlation is a standard expectation in production observability stacks. Without it, logs and traces are disconnected silos.
+
+**Independent Test**: Enable log export, run a request, capture the exported log records, and verify each record carries a valid `trace_id` and `span_id` matching the enclosing span in the concurrent trace.
+
+**Acceptance Scenarios**:
+
+1. **Given** a runtime execution that emits at least one internal log record, **When** log export is enabled, **Then** each exported log record includes `trace_id` and `span_id` fields matching the OTel log data model.
+2. **Given** a log record emitted during a failure, **When** it is exported, **Then** the severity is set to `ERROR` or higher and the `traverse.error.classification` attribute is present.
+3. **Given** log export is disabled, **When** the runtime runs, **Then** no export errors are raised and internal log records are silently dropped without affecting trace export.
+
+### User Story 4 - OTLP Export Endpoint Configurable Without Code Changes (Priority: P2)
+
+As an SRE deploying Traverse to production, I want to configure the OTLP export endpoint through configuration alone so that I can point telemetry at any collector without recompiling Traverse.
+
+**Why this priority**: Configuration-driven export is the minimum bar for production operability. Code changes for endpoint configuration are a deployment blocker.
+
+**Independent Test**: Start the runtime with an OTLP endpoint set only via config (not baked in), submit a request, and verify spans arrive at the configured collector. Change the endpoint in config and verify spans route to the new target after restart.
+
+**Acceptance Scenarios**:
+
+1. **Given** an OTLP endpoint specified in the runtime config, **When** the runtime starts, **Then** the OTel SDK is initialized with that endpoint without any code change.
+2. **Given** the OTLP endpoint is unreachable, **When** the runtime processes requests, **Then** export failures are logged internally but do not propagate as errors to the caller or cause request failures.
+3. **Given** no OTLP endpoint is configured, **When** the runtime starts, **Then** telemetry is collected in-process but silently dropped (no-op exporter) without error.
+
+## Edge Cases
+
+- WASM boundary: spans MUST propagate correctly when execution crosses into a WASM module; the W3C `traceparent` header MUST be injected into the WASM execution context before invocation and extracted from the WASM response envelope after completion.
+- Browser context: W3C Trace Context carrier MUST function for in-browser subscriptions; the carrier extraction logic MUST handle the absence of HTTP headers by falling back to the subscription envelope.
+- Offline/air-gapped: OTLP export failures MUST NOT crash the runtime; the export path is fire-and-forget with a bounded retry budget; exhausted retries MUST be counted in the `traverse.telemetry.export.dropped_total` metric.
+- Test mode: seeded deterministic IDs MUST produce stable trace IDs and span IDs for identical input sequences, enabling snapshot-style assertions in CI.
+- Missing `traceparent` on inbound request: the runtime MUST create a new root span rather than failing the request.
+- Concurrent requests: span context MUST not leak between concurrent execution threads or async tasks.
+- Very high attribute cardinality (e.g., large input payloads): attribute values MUST be truncated to a bounded length rather than dropped entirely; truncation MUST be recorded as a span event.
+
+## Functional Requirements
+
+- **FR-001**: The runtime MUST create an OTel root span for every runtime request at the point of request intake, before any discovery or validation logic runs.
+- **FR-002**: The runtime MUST create child spans for each named execution phase: request validation, capability discovery, candidate evaluation, capability selection, execution, contract output validation, and request completion.
+- **FR-003**: Every span MUST carry the `traverse.request.id` and `traverse.execution.id` attributes on all child spans.
+- **FR-004**: Every span MUST carry `traverse.capability.id` and `traverse.capability.version` attributes once a capability has been selected.
+- **FR-005**: Span and log attribute keys MUST either conform to an OTel semantic convention or begin with the `traverse.` namespace prefix; no ad hoc or vendor-specific key names are permitted.
+- **FR-006**: The runtime MUST set span status to `OK` on success and `ERROR` on any failure, and MUST attach the error classification as a structured span event.
+- **FR-007**: The runtime MUST propagate W3C Trace Context (`traceparent` / `tracestate`) as a carrier field on outbound runtime request objects, event publication envelopes, and browser adapter subscription payloads.
+- **FR-008**: The runtime MUST extract W3C Trace Context from inbound carriers (runtime request, event envelope, subscription) and resume the parent span when a valid `traceparent` is present.
+- **FR-009**: When no inbound `traceparent` is present, the runtime MUST start a new root span rather than failing the request.
+- **FR-010**: Span IDs and trace IDs MUST be generated using the OTel SDK default (random) in production mode.
+- **FR-011**: The runtime MUST support a deterministic seeded ID mode, toggled by a config flag, that produces stable trace IDs and span IDs for identical input sequences; this mode MUST be restricted to test and CI contexts.
+- **FR-012**: The runtime MUST export all three OTel signals (traces, logs, metrics) via OTLP over gRPC or HTTP, selectable via config.
+- **FR-013**: The OTLP export endpoint, protocol (gRPC or HTTP), and TLS settings MUST be fully configurable without code changes.
+- **FR-014**: The runtime MUST support a no-op exporter mode when no OTLP endpoint is configured; no-op mode MUST collect spans in-process and silently drop them.
+- **FR-015**: OTLP export failures MUST NOT propagate as errors to the request caller; the export path is fire-and-forget with a configurable bounded retry budget.
+- **FR-016**: Exhausted OTLP export retries MUST increment the `traverse.telemetry.export.dropped_total` metric counter.
+- **FR-017**: The runtime MUST emit at least the following named metrics: `traverse.request.count` (counter), `traverse.request.duration_ms` (histogram), `traverse.request.error.count` (counter), `traverse.capability.execution.count` (counter), `traverse.capability.execution.duration_ms` (histogram).
+- **FR-018**: Structured log records emitted during request processing MUST carry `trace_id` and `span_id` fields conforming to the OTel log data model when log export is enabled.
+- **FR-019**: The runtime MUST never include JWT access tokens or raw credential material in any span attribute, log record, or metric label; only the derived `subject_id`, `actor_id`, and token reference hash are permitted.
+- **FR-020**: Span attribute values exceeding the configured maximum length MUST be truncated and a span event MUST be recorded indicating truncation occurred.
+- **FR-021**: The observability initialization MUST complete before the runtime accepts the first request; partial initialization MUST cause startup failure.
+- **FR-022**: The runtime MUST expose the current OTel SDK configuration (endpoint, protocol, signal enablement) as a structured config dump accessible to operators without process restart.
+
+## Non-Functional Requirements
+
+- **NFR-001 Compliance Tiers**: Distributed traces are REQUIRED for v0 spec compliance; structured logs and metrics are STANDARDIZED and testable but optional for v0 compliance gate passage.
+- **NFR-002 Determinism**: In seeded test mode, trace IDs and span IDs MUST be byte-identical across runs given the same seed and input sequence, enabling snapshot assertions.
+- **NFR-003 Vendor Neutrality**: No vendor SDK, proprietary exporter, or third-party tracing library beyond the canonical OTel Rust SDK is permitted; OTLP is the only required export protocol.
+- **NFR-004 Performance**: Span creation and attribute attachment MUST not add more than 1 ms of overhead per request under normal operating conditions; the OTel SDK sampling configuration MUST be respected.
+- **NFR-005 Testability**: The telemetry layer MUST be injectable with a test exporter that captures spans and log records in-memory for assertion without a live OTLP collector.
+- **NFR-006 Isolation**: Span context MUST be scoped to the request; context MUST NOT leak between concurrent requests regardless of async executor scheduling.
+- **NFR-007 WASM Safety**: W3C Trace Context carrier injection and extraction for WASM boundaries MUST be defined at the WASM execution adapter level so that WASM modules do not need to depend on the OTel SDK directly.
+- **NFR-008 Failure Tolerance**: The observability subsystem MUST tolerate OTLP endpoint unavailability, export timeout, and serialization errors without affecting the runtime request path.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: Raw credential material (JWT, private keys, secrets) MUST NEVER appear in any exported span, log record, or metric label; this gate MUST be enforced by automated test.
+- **QG-002**: Every runtime request MUST produce a root span and at least one child span; requests that produce no telemetry MUST fail the observability unit test suite.
+- **QG-003**: Span attribute key naming MUST be validated by an automated lint rule that rejects any key not matching an OTel semantic convention or the `traverse.` prefix pattern.
+- **QG-004**: The deterministic seeded ID mode MUST be explicitly gated to test/CI config and MUST NOT be activatable in a production configuration file.
+- **QG-005**: OTLP export failures MUST NOT surface as request errors; any test that shows a dropped export causing a request error MUST block merge.
+- **QG-006**: 100% automated line coverage MUST be maintained for span creation, context propagation, carrier injection/extraction, and seeded ID generation logic.
+
+## Key Entities
+
+- **OTel Root Span**: The top-level span created at request intake that parents all phase spans for one runtime execution attempt.
+- **Phase Span**: A child span scoped to a single named execution phase (validation, discovery, selection, execution, etc.).
+- **W3C Trace Context Carrier**: The structured field set (`traceparent`, `tracestate`) injected into or extracted from runtime request objects, event envelopes, and subscription payloads.
+- **Seeded ID Mode**: A runtime configuration mode that replaces the OTel SDK's random ID generator with a deterministic seeded generator for CI and snapshot testing.
+- **OTLP Exporter**: The pluggable export adapter that forwards OTel signals to a collector via gRPC or HTTP; no-op when unconfigured.
+- **Traverse Metric**: A named OTel metric instrument (counter or histogram) under the `traverse.*` namespace covering request throughput, latency, and error rates.
+- **Log Record**: An OTel-structured log entry emitted during request processing, carrying `trace_id` and `span_id` for correlation.
+- **Token Reference Hash**: A non-secret stable hash of a JWT used for correlation in telemetry without exposing credential material.
+
+## Success Criteria
+
+- **SC-001**: A valid runtime request produces a complete, OTLP-exportable span tree with correct parent-child relationships and `traverse.*` attributes on all spans.
+- **SC-002**: W3C Trace Context is correctly propagated across runtime request objects, event publication envelopes, and browser adapter subscriptions, verified by round-trip extraction tests.
+- **SC-003**: OTLP export failures are absorbed silently by the runtime; no request returns an error due to a telemetry export failure.
+- **SC-004**: The deterministic seeded ID mode produces byte-identical trace IDs and span IDs across test runs for the same seed, confirmed by snapshot assertions.
+- **SC-005**: No span, log record, or metric label contains raw credential material; automated tests enforce this gate.
+- **SC-006**: All required metrics (`traverse.request.count`, `traverse.request.duration_ms`, `traverse.request.error.count`, `traverse.capability.execution.count`, `traverse.capability.execution.duration_ms`) are emitted and captured by the in-memory test exporter.
+
+## Out of Scope
+
+- Visualization UI or tracing dashboards
+- Proprietary APM agent integration (Datadog, New Relic, Dynatrace)
+- Sampling strategy configuration (deferred to a dedicated sampling spec)
+- Log aggregation pipeline design (only the OTel log record format is governed here)
+- Alerting or SLO definitions
+- Span-based billing or cost attribution
+- Multi-tenant trace isolation (governed by spec 030)

--- a/specs/030-security-identity-model/spec.md
+++ b/specs/030-security-identity-model/spec.md
@@ -1,0 +1,164 @@
+# Feature Specification: Security Identity Model
+
+**Feature Branch**: `030-security-identity-model`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Identity and signing layer for `traverse-runtime`, `traverse-contracts`, and `traverse-cli`, covering caller identity propagation, artifact signature verification, OIDC-style JWT handling, and safe identity derivation.
+
+## Purpose
+
+This spec defines the security identity model for Traverse.
+
+It narrows the broad intent of "authenticated execution" into a concrete, testable model covering:
+
+- canonical caller identity format (OIDC-style JWT access token)
+- safe identity derivation: `subject_id` and `actor_id` extracted from token claims, never the raw token
+- propagation of derived identity through runtime requests, execution contexts, emitted events, trace attributes, and subscription filters
+- two-tier artifact signature verification: published/governed artifacts MUST pass Ed25519 signature verification before execution; local/dev artifacts generate a visible warning and are never silently accepted
+- pluggable signing scheme: Ed25519 keypair signing as the required baseline, Sigstore (keyless, Fulcio/Rekor) as a supported alternative for published artifacts
+- token non-disclosure: JWT access tokens MUST NEVER appear in traces, logs, events, or any exported telemetry
+
+This spec does not define audit logging persistence, multi-tenant data isolation, or network-level authentication (TLS). Those are separate concerns.
+
+## User Scenarios and Testing
+
+### User Story 1 - Published WASM Module Fails Clearly on Signature Mismatch (Priority: P1)
+
+As an enterprise operator, I want a published WASM module configured with an Ed25519 signature to cause a clear, explicit execution failure when verification fails so that tampered or misconfigured artifacts are never silently executed.
+
+**Why this priority**: Silent execution of unsigned or tampered published artifacts is an unacceptable security regression. Clear failure is non-negotiable.
+
+**Independent Test**: Register a published WASM module with a valid Ed25519 signature, then submit a runtime request referencing a corrupted version of the artifact (byte-modified). Verify the runtime returns an explicit `signature_verification_failed` error and produces no execution output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a published artifact with a valid Ed25519 signature in its manifest, **When** the runtime loads the artifact and the signature is valid, **Then** execution proceeds normally with a `signature_verified` trace event recorded.
+2. **Given** a published artifact whose signature does not match its content, **When** the runtime attempts to load it, **Then** execution is rejected with a `signature_verification_failed` error before any capability logic runs.
+3. **Given** a published artifact with no signature in its manifest, **When** the runtime encounters it, **Then** execution is rejected with a `missing_signature` error — never silently passed.
+
+### User Story 2 - Local/Dev Module Produces Visible Warning, Not Silent Pass (Priority: P1)
+
+As a developer running Traverse locally, I want to receive a visible warning when a module has no signature in dev mode so that I know the module is unverified without the runtime blocking my workflow.
+
+**Why this priority**: Silent acceptance of unsigned dev artifacts creates a false sense of security and risks developers shipping unsigned artifacts to production by accident.
+
+**Independent Test**: Run the runtime in dev mode with an unsigned local module. Verify that a `WARNING: unverified_artifact` message is emitted to stderr and to the runtime trace before execution proceeds, and that the warning is machine-readable (structured field, not only plain text).
+
+**Acceptance Scenarios**:
+
+1. **Given** a local/dev artifact with no signature and dev mode enabled, **When** the runtime loads it, **Then** a structured warning is emitted (to stderr and as a trace event) containing the artifact path and identity before execution proceeds.
+2. **Given** a local/dev artifact with no signature and dev mode enabled, **When** execution completes, **Then** the execution result carries a `warnings` field listing the unverified artifact.
+3. **Given** dev mode is disabled (i.e., production mode), **When** the runtime encounters an unsigned local artifact, **Then** execution is rejected with `missing_signature`, identical to the published artifact path.
+
+### User Story 3 - Emitted Events Carry subject_id Without Exposing Raw Token (Priority: P2)
+
+As an authenticated user whose JWT is passed to traverse-cli, I want all emitted events to carry my `subject_id` without exposing the raw token so that downstream consumers can filter and audit events by identity without access to credentials.
+
+**Why this priority**: Token leakage via event streams is a confidentiality failure. Derived identifiers are the correct propagation primitive.
+
+**Independent Test**: Pass a valid JWT to traverse-cli, execute a capability, and capture all emitted events. Verify that no event payload contains the raw JWT string and that every event carries `subject_id` matching the `sub` claim of the JWT.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid JWT passed as caller identity, **When** the runtime derives identity, **Then** `subject_id` is set to the `sub` claim value and `actor_id` is set to the `act.sub` claim value (or omitted if absent).
+2. **Given** a derived `subject_id`, **When** events are emitted during execution, **Then** every event envelope includes `subject_id` and (when present) `actor_id` as top-level fields.
+3. **Given** any execution path (success or failure), **When** the runtime trace is exported, **Then** the raw JWT string does not appear in any span attribute, log record, event payload, or metric label.
+
+### User Story 4 - Sigstore Verification Usable in CI/CD Without Private Key Management (Priority: P2)
+
+As an operator using Sigstore for published artifact verification in a CI/CD pipeline, I want keyless verification to work when Rekor is reachable so that I do not need to manage Ed25519 private keys in the pipeline.
+
+**Why this priority**: Keyless signing reduces key management burden for CI-published artifacts and is the industry direction for supply chain security.
+
+**Independent Test**: Sign a WASM module artifact using Sigstore (Fulcio/Rekor), configure Traverse with `signing_scheme = "sigstore"`, submit a runtime request referencing the artifact, and verify successful verification. Then simulate Rekor unavailability and verify the runtime fails with `sigstore_unreachable` rather than silently passing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a published artifact signed via Sigstore and Rekor is reachable, **When** the runtime verifies it, **Then** verification succeeds and a `sigstore_verified` trace event is recorded.
+2. **Given** a published artifact signed via Sigstore and Rekor is unreachable, **When** the runtime attempts verification, **Then** execution is rejected with `sigstore_unreachable` — never silently passed.
+3. **Given** Sigstore is configured but the artifact carries an Ed25519 signature instead, **When** verification runs, **Then** the runtime falls back to Ed25519 verification rather than failing; the signing scheme used is recorded in the trace.
+
+## Edge Cases
+
+- Token expiry during long-running execution: the runtime MUST detect token expiry at the point of identity derivation (request intake); mid-execution expiry MUST NOT cause silent identity loss — the originally derived `subject_id` is pinned for the full execution lifecycle.
+- Multi-tenant requests: two concurrent requests with different `subject_id` values MUST NOT share execution context, emitted event envelope, or span attributes; identity fields MUST be scoped to the request.
+- Sigstore Rekor unreachable for published artifact verification: the runtime MUST reject the artifact with `sigstore_unreachable` rather than falling back to unsigned execution.
+- Offline environments where keyless (Sigstore) verification is impossible: operators MUST be able to configure Ed25519-only mode as the fallback; Sigstore MUST NOT be the only verification path.
+- JWT with missing or malformed `sub` claim: the runtime MUST reject the token with `invalid_identity` rather than deriving a null `subject_id`.
+- Artifact manifest lists a signature but the signature file is missing from the artifact bundle: the runtime MUST treat this as `signature_verification_failed`, not `missing_signature`.
+- Duplicate `subject_id` across distinct physical users (hash collisions or shared service accounts): out of scope for this spec; the runtime treats `subject_id` as opaque.
+
+## Functional Requirements
+
+- **FR-001**: The runtime MUST accept an OIDC-style JWT access token as the canonical caller identity input at the runtime request boundary.
+- **FR-002**: The runtime MUST derive `subject_id` from the JWT `sub` claim and `actor_id` from the JWT `act.sub` claim (RFC 8693 token exchange) before any capability logic runs.
+- **FR-003**: When the JWT `sub` claim is absent or malformed, the runtime MUST reject the request with `invalid_identity` before discovery.
+- **FR-004**: The raw JWT string MUST NEVER appear in any span attribute, log record, event envelope, metric label, or structured trace output; only `subject_id`, `actor_id`, and the token reference hash are permitted in telemetry.
+- **FR-005**: The runtime MUST compute a stable token reference hash (SHA-256 of the raw JWT bytes, hex-encoded) for correlation purposes only; this hash MUST be documented as non-secret but also non-reversible.
+- **FR-006**: `subject_id` and `actor_id` MUST propagate through: runtime request → execution context → emitted event envelopes → trace span attributes → subscription filter payloads.
+- **FR-007**: The runtime MUST implement two-tier artifact signature verification: "Published/Governed" artifacts MUST pass signature verification before execution; local/dev artifacts generate a structured warning and are allowed-but-warned in dev mode only.
+- **FR-008**: "Published/Governed" is defined as any artifact referenced by an entry in `contracts/` or `specs/governance/approved-specs.json`.
+- **FR-009**: The runtime MUST support Ed25519 keypair signing as the required baseline verification scheme; Ed25519 public keys MUST be stored in the artifact manifest, not in runtime config.
+- **FR-010**: The runtime MUST support Sigstore (Fulcio/Rekor) as an additional verification scheme for published artifacts; the signing scheme is selected per-artifact based on the manifest field `signing_scheme`.
+- **FR-011**: When Sigstore is configured and Rekor is unreachable, the runtime MUST reject the artifact with `sigstore_unreachable`; no fallback to unsigned execution is permitted.
+- **FR-012**: In production mode, unsigned artifacts (regardless of source classification) MUST be rejected with `missing_signature`; dev mode allows-but-warns unsigned local artifacts.
+- **FR-013**: Dev mode MUST be explicitly configured and MUST NOT be the default; production mode is the default.
+- **FR-014**: Every signature verification outcome (verified, failed, missing, sigstore_unreachable) MUST be recorded as a structured trace event on the artifact loading span.
+- **FR-015**: The runtime MUST pin the derived `subject_id` and `actor_id` for the full lifecycle of an execution attempt; mid-execution token expiry MUST NOT alter the pinned identity.
+- **FR-016**: Subscription filters MUST support filtering by `subject_id`; the filter MUST be evaluated against the derived identity field in the event envelope, not against the raw token.
+- **FR-017**: The CLI (`traverse-cli`) MUST accept a JWT via a dedicated flag or environment variable and MUST pass the derived identity (not the raw token) to the runtime.
+- **FR-018**: The contracts layer MUST define a canonical identity context schema (`subject_id: String`, `actor_id: Option<String>`, `token_reference_hash: String`) used uniformly across runtime request, event envelope, and execution context.
+- **FR-019**: The runtime MUST expose a machine-readable verification report for each artifact load attempt, accessible via the execution trace.
+- **FR-020**: Multi-tenant isolation MUST be enforced at the request scope: identity fields from one request MUST NOT be readable from a concurrent request's execution context.
+
+## Non-Functional Requirements
+
+- **NFR-001 Token Non-Disclosure**: The raw JWT MUST be zeroed from memory immediately after identity derivation and MUST NOT be retained in any heap-allocated structure beyond the derivation phase.
+- **NFR-002 Determinism**: Ed25519 signature verification MUST be deterministic; the same artifact and public key MUST always produce the same pass/fail result.
+- **NFR-003 Auditability**: Every signature verification outcome and every identity derivation event MUST be recorded in the execution trace with enough detail to reconstruct who ran what and what was verified.
+- **NFR-004 Testability**: The signing verification layer MUST be injectable with test fixtures (test keypairs, mock Sigstore responses) for 100% automated coverage without live Rekor access.
+- **NFR-005 Offline Operability**: Ed25519 verification MUST work fully offline; Sigstore is explicitly allowed to require network access, and operators in offline environments MUST configure Ed25519-only mode.
+- **NFR-006 Pluggability**: The verification scheme is selected per-artifact via the manifest field; adding a new scheme MUST NOT require changes to core runtime dispatch logic.
+- **NFR-007 Separation of Concerns**: Identity derivation, signature verification, and identity propagation MUST be implemented as distinct, independently testable modules within their respective crates.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: Raw JWT strings MUST NEVER appear in exported telemetry, events, or logs; an automated test MUST scan all export sinks for JWT patterns and fail the suite if any are found.
+- **QG-002**: Unsigned published artifacts MUST NEVER execute silently in any mode; automated tests MUST cover the `missing_signature` rejection path for published artifact classification.
+- **QG-003**: Local/dev unsigned artifacts MUST emit a structured (machine-readable) warning before execution in dev mode; a plain-text-only warning without a structured field MUST fail the quality gate.
+- **QG-004**: Sigstore Rekor unavailability MUST cause rejection, not silent pass; an automated test using a mock unreachable Rekor MUST verify this behavior.
+- **QG-005**: Identity context (`subject_id`, `actor_id`, token reference hash) MUST propagate consistently across all four propagation boundaries (runtime request, execution context, event envelope, subscription filter); a cross-boundary propagation test is REQUIRED.
+- **QG-006**: 100% automated line coverage MUST be maintained for identity derivation, signature verification dispatch, dev-mode warning emission, and propagation logic.
+
+## Key Entities
+
+- **JWT Access Token**: The OIDC-style bearer token provided by the caller as proof of identity; consumed at request intake and immediately discarded after derivation.
+- **subject_id**: The stable string identifier derived from the JWT `sub` claim; the canonical caller identity used for propagation and filtering.
+- **actor_id**: The optional string identifier derived from the JWT `act.sub` claim (RFC 8693 delegation chain); absent when the caller is not acting on behalf of another principal.
+- **Token Reference Hash**: A SHA-256 hex-encoded hash of the raw JWT bytes, used for correlation across telemetry without exposing credential material.
+- **Identity Context**: The canonical structured type (`subject_id`, `actor_id`, `token_reference_hash`) defined in `traverse-contracts` and used uniformly across the runtime boundary.
+- **Published/Governed Artifact**: Any artifact referenced by an entry in `contracts/` or `specs/governance/approved-specs.json`; subject to REQUIRED signature verification.
+- **Local/Dev Artifact**: Any artifact not referenced by a governed entry; subject to allowed-but-warned behavior in dev mode and REQUIRED rejection in production mode.
+- **Ed25519 Signing Scheme**: The baseline artifact signing scheme using Ed25519 keypairs; verifiable offline, deterministic, and required for all published artifact configurations.
+- **Sigstore Signing Scheme**: The keyless artifact signing scheme using Fulcio certificate authority and Rekor transparency log; requires network access to Rekor for verification.
+- **Verification Report**: The structured trace artifact recording the outcome of signature verification for one artifact load attempt.
+
+## Success Criteria
+
+- **SC-001**: A published WASM module with a valid Ed25519 signature executes successfully; a module with a corrupted signature is rejected with `signature_verification_failed` before execution.
+- **SC-002**: A local/dev unsigned module in dev mode produces a structured warning in the execution trace and the result `warnings` field, and then proceeds to execute.
+- **SC-003**: All emitted events for an authenticated request carry `subject_id` and no raw JWT string; automated scan of export sinks confirms zero JWT leakage.
+- **SC-004**: Sigstore verification with an unreachable Rekor produces `sigstore_unreachable` rejection; no execution output is produced.
+- **SC-005**: Identity context propagates correctly across all four boundaries (runtime request → execution context → event envelope → subscription filter) in a cross-boundary propagation test.
+- **SC-006**: 100% automated line coverage is confirmed for identity derivation, verification dispatch, dev-mode warning, and propagation modules.
+
+## Out of Scope
+
+- Audit log persistence and long-term audit trail storage
+- Multi-tenant data isolation beyond identity scoping at the request level
+- Network-level authentication (mTLS, client certificate validation)
+- Role-based access control (RBAC) or permission enforcement
+- Token refresh or OAuth 2.0 flow management
+- Key rotation procedures for Ed25519 keypairs
+- Hardware security module (HSM) integration
+- Single sign-on (SSO) federation or OIDC provider configuration

--- a/specs/031-supply-chain-hardening/spec.md
+++ b/specs/031-supply-chain-hardening/spec.md
@@ -1,0 +1,166 @@
+# Feature Specification: Supply Chain Hardening
+
+**Feature Branch**: `031-supply-chain-hardening`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Supply chain security layer for `scripts/ci/`, `.github/workflows/`, and `Cargo.toml`, covering SBOM generation, reproducible builds, SLSA provenance, artifact checksum verification, and nightly supply-chain CI checks.
+
+## Purpose
+
+This spec defines the supply chain hardening model for Traverse.
+
+It narrows the broad intent of "artifact integrity and provenance" into a concrete, testable set of requirements covering:
+
+- SBOM generation in CycloneDX format for each release using `cargo cyclonedx` or equivalent
+- reproducible builds: `Cargo.lock` committed, no timestamps in binary artifacts, byte-identical output across runs on the same platform
+- SLSA Level 1 provenance for v0: a signed build provenance statement linking a source commit to a produced artifact
+- artifact checksum (SHA-256) included in every artifact manifest, verified by the runtime before execution
+- a `traverse-cli artifact verify` subcommand returning structured pass/fail evidence
+- a nightly CI workflow running SBOM generation, checksum validation, and signature presence checks for governed artifacts
+
+This spec governs CI scripts, GitHub Actions workflows, and top-level `Cargo.toml` workspace settings. It does not define runtime execution logic (governed by spec 006) or the security identity model (governed by spec 030), though it shares the same signing scheme (Ed25519 baseline, Sigstore for published artifacts).
+
+## User Scenarios and Testing
+
+### User Story 1 - CLI Artifact Verification Returns Structured Pass/Fail with Evidence (Priority: P1)
+
+As a security team member, I want to run `traverse-cli artifact verify <path>` and receive a structured pass/fail result with explicit evidence (signature status, checksum match, provenance statement) so that I can verify artifact integrity without reading internal implementation details.
+
+**Why this priority**: A verifiable CLI command is the primary trust boundary for enterprise consumers. Without it, integrity claims cannot be independently checked.
+
+**Independent Test**: Sign and checksum a WASM artifact, place it at a known path, run `traverse-cli artifact verify <path>`, and assert the structured output contains `signature_status: verified`, `checksum_status: matched`, and a `provenance` block with a valid source commit reference.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid, signed, checksummed artifact with a provenance statement, **When** `traverse-cli artifact verify <path>` is run, **Then** the command exits with code 0 and outputs a structured JSON report with `overall_status: passed` and per-check evidence fields.
+2. **Given** an artifact whose SHA-256 checksum does not match the manifest, **When** `traverse-cli artifact verify <path>` is run, **Then** the command exits with a non-zero code and the report includes `checksum_status: mismatch` with the expected and actual hash values.
+3. **Given** an artifact with no provenance statement, **When** `traverse-cli artifact verify <path>` is run, **Then** the command exits with a non-zero code and the report includes `provenance_status: missing`; the report MUST NOT suppress the other check results.
+
+### User Story 2 - CI Pipeline Fails on Published Artifact Checksum Mismatch (Priority: P1)
+
+As a CI pipeline operator, I want the CI build to fail when a published artifact's checksum does not match its manifest entry so that compromised or accidentally modified artifacts are caught before deployment.
+
+**Why this priority**: Checksum gating at CI is the last automated line of defense before a modified artifact reaches production.
+
+**Independent Test**: In a CI test environment, modify a single byte in a governed WASM artifact binary without updating its manifest checksum, trigger the supply-chain CI workflow, and verify the workflow step fails with an explicit checksum mismatch error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a governed artifact with a mismatched SHA-256 checksum, **When** the nightly supply-chain CI workflow runs, **Then** the checksum validation step fails with an explicit error naming the artifact path and the expected versus actual hash.
+2. **Given** all governed artifacts with matching checksums, **When** the nightly supply-chain CI workflow runs, **Then** the checksum validation step passes and a machine-readable summary is written to the workflow artifact store.
+3. **Given** a new WASM module added to the repo without a manifest entry, **When** the nightly workflow runs, **Then** the workflow emits a warning step (not a hard failure) indicating the artifact lacks a manifest entry, and the overall job fails to prompt the developer to register it.
+
+### User Story 3 - Enterprise Consumer Can Independently Verify SBOM and Provenance (Priority: P2)
+
+As an enterprise consumer downloading a Traverse release, I want to independently verify the SBOM and provenance attestation so that I can satisfy my organization's software composition analysis requirements without trusting the Traverse release pipeline blindly.
+
+**Why this priority**: Publicly verifiable provenance and SBOM are table-stakes for enterprise software procurement and compliance programs.
+
+**Independent Test**: Download a release package, extract the included CycloneDX SBOM and SLSA provenance statement, verify the SBOM lists all direct and transitive Rust dependencies with accurate version metadata, and verify the provenance statement links the correct source commit SHA to the release artifact hash.
+
+**Acceptance Scenarios**:
+
+1. **Given** a published Traverse release archive, **When** the CycloneDX SBOM is extracted and parsed by a standards-compliant SBOM tool, **Then** all direct and transitive Cargo dependencies are present with correct package names, versions, and license identifiers.
+2. **Given** a published release SLSA Level 1 provenance statement, **When** it is inspected, **Then** it contains the source commit SHA, the build system identifier, the artifact SHA-256, and a build invocation reference.
+3. **Given** a release where the source commit SHA in the provenance does not match the artifact, **When** an independent verification tool checks the provenance, **Then** the mismatch is detectable without Traverse-specific tooling.
+
+### User Story 4 - Nightly CI Warns on WASM Module Missing Signature (Priority: P2)
+
+As a developer who has added a new WASM module, I want the nightly CI to warn me that the module is missing a signature so that I am not surprised by a verification failure when the module is promoted to governed status.
+
+**Why this priority**: Early warning reduces the cost of fixing supply chain gaps compared to discovering them at promotion or production deployment.
+
+**Independent Test**: Add an unsigned WASM module to the repo, trigger the nightly supply-chain CI workflow, and verify the workflow emits a structured warning listing the module path and `signature_status: missing` without failing the overall job for ungoverned artifacts.
+
+**Acceptance Scenarios**:
+
+1. **Given** an ungoverned WASM module with no signature in its manifest, **When** the nightly workflow runs the signature presence check, **Then** the check emits a structured warning step output listing the module path and `signature_status: missing`.
+2. **Given** a governed WASM module with no signature, **When** the nightly workflow runs, **Then** the signature presence check FAILS the job (not a warning) with an explicit error naming the governed artifact.
+3. **Given** all governed modules have valid signatures, **When** the nightly workflow runs, **Then** the signature presence check passes and a summary report is written to the workflow artifact store.
+
+## Edge Cases
+
+- Reproducible build failures on different Rust toolchain versions: the reproducible build gate MUST pin the toolchain version in `rust-toolchain.toml`; builds on a different toolchain version are explicitly not required to be byte-identical and the CI gate MUST document this constraint.
+- SBOM accuracy for transitive dependencies: `cargo cyclonedx` MUST be run with the `--all-features` flag to capture conditional dependency trees; the nightly CI MUST fail if the generated SBOM lists zero transitive dependencies (indicates tool misconfiguration).
+- Partial provenance (some artifacts signed, some not): the verification report MUST enumerate each artifact's individual status; an overall `partial_provenance` status MUST be surfaced rather than silently passing or failing the whole set.
+- Cargo.lock missing from the repository: the CI gate MUST detect a missing or `.gitignore`d `Cargo.lock` and fail with an explicit error.
+- Artifact manifest checksum computed with a non-SHA-256 algorithm: the runtime MUST reject manifests with unsupported checksum algorithms rather than silently skipping verification.
+- SLSA provenance statement signed by a key not in the trusted keystore: verification MUST fail with `provenance_key_untrusted` rather than `provenance_missing`.
+- Race condition in nightly SBOM generation when a dependency is updated between the lock file read and the SBOM write: the CI script MUST use the committed `Cargo.lock` as the authoritative input, not a freshly resolved lock.
+
+## Functional Requirements
+
+- **FR-001**: `Cargo.lock` MUST be committed to the repository and MUST NOT be listed in `.gitignore`; the nightly CI MUST fail if `Cargo.lock` is absent or excluded.
+- **FR-002**: The top-level `Cargo.toml` workspace MUST configure `[workspace.metadata.cyclonedx]` to enable `cargo cyclonedx` SBOM generation with all features enabled.
+- **FR-003**: The nightly CI workflow MUST run `cargo cyclonedx` (or a pinned equivalent) and write a CycloneDX-format SBOM to the workflow artifact store as `traverse-sbom.cdx.json`.
+- **FR-004**: The generated SBOM MUST list all direct and transitive Cargo dependencies with package name, version, and license identifier.
+- **FR-005**: The nightly CI workflow MUST fail if the generated SBOM lists zero transitive dependencies.
+- **FR-006**: Every release artifact MUST include a SHA-256 checksum in its manifest under the field `checksum_sha256`.
+- **FR-007**: The runtime MUST verify the SHA-256 checksum of every artifact against the manifest value before execution; a mismatch MUST cause rejection with `checksum_mismatch`.
+- **FR-008**: The nightly CI workflow MUST verify the SHA-256 checksum for every governed artifact and fail the job when any checksum mismatches.
+- **FR-009**: Artifact signing MUST use the same scheme as spec 030: Ed25519 keypair as the required baseline, Sigstore (Fulcio/Rekor) as an additional supported scheme for published artifacts.
+- **FR-010**: The nightly CI workflow MUST run a signature presence check for all governed artifacts and fail the job when any governed artifact is missing a signature.
+- **FR-011**: The nightly CI workflow MUST emit a structured warning (not a hard failure) for ungoverned artifacts missing a signature.
+- **FR-012**: The release build pipeline MUST produce a SLSA Level 1 provenance statement for each release artifact; the statement MUST include: source commit SHA, build system identifier, artifact SHA-256, and build invocation reference.
+- **FR-013**: The provenance statement MUST be included in the release archive alongside the artifact and the SBOM.
+- **FR-014**: Builds MUST be byte-identical across runs on the same platform and toolchain version; the `rust-toolchain.toml` file MUST pin the exact Rust toolchain version used for release builds.
+- **FR-015**: Release binaries MUST NOT embed build timestamps or other non-deterministic metadata; CI MUST verify byte-identity by hashing the build output of two identical inputs and asserting SHA-256 equality.
+- **FR-016**: The `traverse-cli` MUST implement an `artifact verify <path>` subcommand that outputs a structured JSON report containing: `overall_status`, `signature_status`, `checksum_status`, `provenance_status`, and per-check evidence fields.
+- **FR-017**: `traverse-cli artifact verify` MUST exit with code 0 only when all checks pass; any single check failure MUST produce a non-zero exit code.
+- **FR-018**: The `artifact verify` report MUST enumerate all checks even when an early check fails; it MUST NOT short-circuit after the first failure.
+- **FR-019**: The nightly CI workflow MUST be defined as a separate GitHub Actions workflow file (`.github/workflows/supply-chain.yml`) triggered on schedule and on push to the main branch.
+- **FR-020**: The CI workflow MUST write a machine-readable supply-chain summary report to the workflow artifact store after each run, whether passing or failing.
+- **FR-021**: The `scripts/ci/` directory MUST contain a `supply_chain_check.sh` script that can be run locally to reproduce the nightly CI checks without GitHub Actions infrastructure.
+- **FR-022**: Artifact manifest files MUST reject unsupported checksum algorithm identifiers with an explicit `unsupported_checksum_algorithm` error rather than silently skipping verification.
+
+## Non-Functional Requirements
+
+- **NFR-001 Reproducibility**: Byte-identical builds are REQUIRED on the same platform and pinned toolchain; cross-platform byte identity is explicitly not required and MUST NOT be claimed.
+- **NFR-002 Toolchain Pinning**: The exact Rust toolchain version MUST be pinned in `rust-toolchain.toml` and the CI workflow MUST use this pinned version for all release builds.
+- **NFR-003 SBOM Completeness**: The SBOM MUST cover transitive dependencies, not only direct Cargo dependencies; SBOM generation tool configuration MUST enable full dependency tree traversal.
+- **NFR-004 Provenance Level**: SLSA Level 1 is the target for v0; SLSA Level 2 (signed provenance from a hosted build platform) is deferred to a follow-on spec and MUST NOT block this spec's completion.
+- **NFR-005 Verifiability**: The SBOM and provenance artifacts MUST be parseable by standard third-party tools (e.g., `cyclonedx-cli`, `slsa-verifier`) without Traverse-specific tooling.
+- **NFR-006 Nightly Gate**: The nightly supply-chain workflow MUST complete within 15 minutes; if it exceeds this bound, the workflow MUST fail with a timeout error rather than producing a partial report.
+- **NFR-007 Local Reproducibility**: The `supply_chain_check.sh` script MUST run to completion on a developer workstation with the pinned toolchain installed, producing the same report as the CI workflow.
+- **NFR-008 Partial Provenance Surfacing**: When a release contains a mix of signed and unsigned artifacts, the overall status MUST be `partial_provenance` (not `passed` or `failed`); the report MUST enumerate each artifact's individual status.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: `Cargo.lock` MUST be present and committed; a CI check MUST explicitly verify this and fail the workflow if it is missing.
+- **QG-002**: Every governed artifact MUST have a SHA-256 checksum in its manifest; the nightly CI MUST fail for any governed artifact with a missing or malformed checksum field.
+- **QG-003**: The `traverse-cli artifact verify` command MUST output a structured JSON report for every invocation regardless of outcome; plain-text-only output without a machine-readable field MUST fail the quality gate.
+- **QG-004**: Reproducible build verification MUST be automated: the CI pipeline MUST build the same artifact twice and assert SHA-256 equality of the outputs; a single non-deterministic build MUST fail the gate.
+- **QG-005**: The nightly supply-chain workflow MUST be a first-class CI gate: a failing nightly run MUST create a GitHub issue or send a notification to the maintainers; silent failures are not acceptable.
+- **QG-006**: 100% automated line coverage MUST be maintained for `traverse-cli artifact verify` logic including checksum verification, signature dispatch, and provenance parsing.
+
+## Key Entities
+
+- **CycloneDX SBOM**: A software bill of materials in CycloneDX JSON format listing all direct and transitive Cargo dependencies with package name, version, and license identifier.
+- **SLSA Level 1 Provenance Statement**: A build provenance document linking a source commit SHA to a produced artifact SHA-256, including build system identifier and build invocation reference.
+- **Artifact Manifest**: The structured metadata file accompanying each artifact, containing `checksum_sha256`, `signing_scheme`, `signature`, and provenance reference fields.
+- **Reproducible Build**: A build process that produces byte-identical output for the same source, toolchain version, and build environment; non-deterministic elements (timestamps, PIE randomization) are explicitly excluded.
+- **Supply-Chain CI Workflow**: The nightly GitHub Actions workflow (`.github/workflows/supply-chain.yml`) running SBOM generation, checksum validation, signature presence checks, and reproducible build verification.
+- **artifact verify Command**: The `traverse-cli artifact verify <path>` subcommand that runs all supply-chain checks against a local artifact path and outputs a structured JSON report.
+- **Governed Artifact**: Any artifact referenced by an entry in `contracts/` or `specs/governance/approved-specs.json`; subject to REQUIRED checksum, signature, and provenance checks.
+- **Partial Provenance**: An overall status indicating a release contains a mix of fully verified and partially verified or unsigned artifacts.
+- **rust-toolchain.toml**: The Rust toolchain pin file that specifies the exact toolchain version used for release builds to enable reproducibility.
+
+## Success Criteria
+
+- **SC-001**: `traverse-cli artifact verify <path>` returns a structured JSON report with `overall_status: passed` for a valid, signed, checksummed artifact with a provenance statement; non-zero exit code for any check failure.
+- **SC-002**: The nightly CI workflow fails explicitly when any governed artifact's SHA-256 checksum mismatches; the failure message names the artifact path and the expected versus actual hash.
+- **SC-003**: A published Traverse release archive contains a CycloneDX SBOM listing all transitive Cargo dependencies and a SLSA Level 1 provenance statement, both parseable by standard third-party tools.
+- **SC-004**: The nightly CI workflow emits a structured warning for each ungoverned WASM module missing a signature, and fails the job for any governed module missing a signature.
+- **SC-005**: The reproducible build gate produces byte-identical output across two back-to-back builds on the same platform and pinned toolchain, verified by SHA-256 comparison in CI.
+- **SC-006**: `supply_chain_check.sh` runs to completion locally and produces a report equivalent to the nightly CI workflow output.
+
+## Out of Scope
+
+- SLSA Level 2 or higher (deferred to a follow-on spec)
+- Cross-platform byte-identical reproducible builds
+- Hardware security module (HSM) integration for signing keys
+- Binary transparency log for Traverse releases beyond SLSA provenance
+- Dependency vulnerability scanning (CVE database queries)
+- License compliance enforcement (SBOM generation is in scope; enforcement policy is not)
+- Container image supply chain hardening (Traverse ships as a Cargo workspace, not a container image in v0)
+- Automatic dependency update PRs (Dependabot configuration)


### PR DESCRIPTION
## Summary
Add governing specs 029, 030, 031 to unblock issues #329, #337, #339.

Specs only — no code changes. `approved-specs.json` registration in follow-on PR.

## Governing Spec
- 004-spec-alignment-gate
- 028-schema-alignment-gate-v02

## Project Item
Closes #329
Closes #337
Closes #339 (partial — supply chain hardening spec)

## Validation
- All three spec files follow the approved spec format (Purpose, User Stories, Edge Cases, FR/NFR/QG, Key Entities, Success Criteria, Out of Scope)
- No code changes in this PR
- Spec IDs 029-031 reserved and consistent with approved-specs.json numbering sequence