### PR TITLE
feat(specs): add governing specs 035-037 (multi-agent isolation, event replay, semver resolution)

### DIFF
--- a/specs/035-multi-agent-isolation/spec.md
+++ b/specs/035-multi-agent-isolation/spec.md
@@ -1,0 +1,161 @@
+# Feature Specification: Multi-Agent Workspace Isolation
+
+**Feature Branch**: `035-multi-agent-isolation`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Isolation model for multi-agent environments in Traverse, covering workspace-keyed registry scoping, subject-based authorization, shared workspace opt-in, and admin operations. Unblocks GitHub issue #303.
+
+## Purpose
+
+This spec defines the workspace isolation model for Traverse runtime and registry operations.
+
+Without isolation, any agent registering capabilities or events into the global registry can observe and interfere with the registrations of every other agent. This is unacceptable when Traverse hosts concurrent agents for distinct principals (CI pipelines, separate teams, different environments).
+
+The isolation model introduced here:
+
+- scopes every registry operation to a `workspace_id`
+- enforces that `subject_id` (derived from the JWT per spec 030) may only access workspaces it owns or has been explicitly granted access to
+- allows teams to opt in to a shared workspace where multiple subjects collaborate
+- reserves a `system` workspace for privileged admin operations
+- preserves the existing registry and runtime API shapes while adding workspace scope as a required dimension
+
+This spec does **not** address distributed cross-process isolation, federated workspace directories, or quota enforcement. Those are future concerns.
+
+## User Scenarios and Testing
+
+### User Story 1 — Two Agents Cannot Access Each Other's Capabilities (Priority: P1)
+
+As a platform operator, I want two agents running under different subject identities to have completely separate views of the registry so that one agent cannot discover, read, or execute the other's registered capabilities.
+
+**Why this priority**: Workspace isolation is the foundational safety property of multi-agent Traverse. All other isolation features depend on it being correct.
+
+**Independent Test**: Register two agents under distinct subjects. Each registers a capability with the same capability id. Verify that a runtime request from agent A resolves only agent A's registration and that agent B's registration is invisible to agent A's resolution path.
+
+**Acceptance Scenarios**:
+
+1. **Given** two agents registered under distinct `subject_id` values, each with their own workspace, **When** agent A submits a runtime request for a capability id that both have registered, **Then** the runtime resolves only the registration in agent A's workspace and never evaluates agent B's registration.
+2. **Given** agent A attempts to list, read, or execute capabilities in a workspace owned by agent B, **When** the authorization check runs, **Then** the runtime rejects the operation with an `unauthorized_workspace` error before any registry lookup occurs.
+3. **Given** agent B's workspace is deleted, **When** agent A submits a request, **Then** agent A's runtime behavior is entirely unaffected.
+
+### User Story 2 — CI Pipeline Isolation (Priority: P1)
+
+As a CI engineer, I want pipeline runs to register capabilities under ephemeral workspace identifiers so that test registrations cannot pollute production workspaces or interfere with each other across builds.
+
+**Why this priority**: CI is the primary driver of ephemeral, high-volume capability registration. Without workspace isolation, CI registrations are a correctness hazard for production agents.
+
+**Independent Test**: Register capabilities under workspace `ci.build-001` and workspace `production`. Verify that a runtime request scoped to `production` never resolves anything registered under `ci.build-001`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a CI pipeline that registers capabilities under workspace `ci.build-NNN`, **When** a runtime request is scoped to workspace `production`, **Then** the registry returns no results from `ci.build-NNN` registrations.
+2. **Given** two concurrent CI builds using `ci.build-001` and `ci.build-002`, **When** both register a capability with the same id, **Then** each build's runtime resolves its own registration without conflict.
+3. **Given** the CI workspace `ci.build-001` expires or is deleted, **When** the production workspace is queried, **Then** no references to `ci.build-001` registrations are visible.
+
+### User Story 3 — Shared Workspace for Team Collaboration (Priority: P2)
+
+As a team lead, I want to declare a workspace as shared so that multiple authenticated agents within my team can register and execute capabilities in the same namespace.
+
+**Why this priority**: Some legitimate multi-agent workflows require collaboration within one registry namespace. Shared workspaces must be an explicit opt-in, not a default.
+
+**Independent Test**: Create a shared workspace. Register two different subjects as members. Verify each subject can register and execute capabilities in the workspace and that a third non-member subject is rejected.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workspace declared `shared: true` with two member subjects, **When** either subject registers a capability in that workspace, **Then** both subjects can discover and execute it via runtime requests scoped to that workspace.
+2. **Given** a shared workspace with two members, **When** a third subject not in the member list submits a request scoped to the shared workspace, **Then** the runtime rejects the operation with `unauthorized_workspace`.
+3. **Given** a shared workspace, **When** one member deregisters a capability, **Then** the other member immediately loses the ability to resolve that capability from the workspace.
+
+### User Story 4 — Admin Workspace for System Operations (Priority: P2)
+
+As a platform administrator, I want to use a privileged token to list all workspaces and inspect their metadata via the reserved `system` workspace so that I can audit multi-agent usage without needing individual workspace access.
+
+**Why this priority**: Administrative visibility is required for operations, debugging, and compliance without compromising per-workspace isolation.
+
+**Independent Test**: Issue a request scoped to `system` with a JWT carrying a privileged role claim. Verify the response lists all active workspaces. Issue the same request with a non-privileged token and verify rejection.
+
+**Acceptance Scenarios**:
+
+1. **Given** a JWT with a privileged role claim, **When** the caller submits a request scoped to workspace `system`, **Then** the runtime returns a list of all active workspaces with their metadata.
+2. **Given** a JWT without a privileged role claim, **When** the caller attempts any operation scoped to workspace `system`, **Then** the runtime rejects the request with `insufficient_privileges`.
+3. **Given** a new workspace is created by an agent, **When** an admin lists workspaces via the `system` scope, **Then** the new workspace appears in the listing with accurate metadata.
+
+## Edge Cases
+
+- `subject_id` derived from an expired JWT — the runtime MUST reject the request without consulting cached identity state; no stale identity may be used for authorization.
+- `workspace_id` that is an empty string or contains only whitespace — reject at the validation boundary with a `workspace_id_invalid` error before any registry operation.
+- Concurrent creation of the same workspace by two agents — idempotent; workspace creation is keyed on `workspace_id` and the second creation attempt returns the existing workspace without error.
+- A legacy-style request that omits `workspace_id` entirely — reject with a `workspace_id_required` migration error containing a pointer to the migration guide; do not silently default to a global scope.
+- A subject attempting to create a workspace it already owns — idempotent; return the existing workspace.
+- A shared workspace with zero members — treat as inaccessible; no subject can access it until at least one member is added.
+- The `system` workspace cannot be deleted, renamed, or declared `shared: true` — any such attempt MUST be rejected with `reserved_workspace`.
+- A request that references a workspace id that does not exist — reject with `workspace_not_found` before any registry lookup.
+
+## Functional Requirements
+
+- **FR-001**: Every registry API operation (capability registration, deregistration, lookup, event registration, workflow registration) MUST accept `workspace_id` as a required field.
+- **FR-002**: The runtime MUST enforce that `workspace_id` is present and non-empty on every incoming request before executing any business logic; absence MUST produce a `workspace_id_required` error.
+- **FR-003**: The runtime MUST validate `workspace_id` is a non-empty, non-whitespace string of at most 128 characters consisting of alphanumeric characters, hyphens, dots, and underscores only.
+- **FR-004**: Every registry lookup MUST be scoped to the provided `workspace_id` and MUST NOT return results from any other workspace unless the requesting subject has explicit shared-workspace access.
+- **FR-005**: The runtime MUST derive `subject_id` from the validated JWT on every request and MUST NOT accept a caller-supplied `subject_id`.
+- **FR-006**: The runtime MUST verify that the `subject_id` derived from the JWT is the owner of the referenced `workspace_id` or is a declared member of a shared workspace before executing any registry operation.
+- **FR-007**: Authorization failure MUST produce an `unauthorized_workspace` error and MUST NOT leak any workspace metadata, capability names, or event names from the rejected workspace.
+- **FR-008**: Workspace creation MUST be idempotent — submitting a create request for an existing `workspace_id` owned by the same subject MUST return the existing workspace without modifying it.
+- **FR-009**: A workspace MUST support a `shared` boolean flag; default value is `false`; a workspace owner MAY set `shared: true` to enable multi-subject access.
+- **FR-010**: When `shared: true`, the workspace owner MUST provide an explicit member list of `subject_id` values; the runtime MUST enforce that only listed subjects can access the workspace.
+- **FR-011**: Two workspaces MAY register capabilities with the same capability id without conflict; the registry MUST distinguish registrations by `(workspace_id, capability_id)` composite key.
+- **FR-012**: The `system` workspace_id MUST be reserved; the runtime MUST reject any attempt to create, delete, rename, or modify the `system` workspace by a non-privileged caller.
+- **FR-013**: Operations scoped to the `system` workspace MUST require a JWT carrying a privileged role claim; requests without the privileged claim MUST be rejected with `insufficient_privileges`.
+- **FR-014**: The `system` workspace MUST support a `list_workspaces` operation that returns all active workspace metadata (ids, owners, shared flag, member count, creation timestamp).
+- **FR-015**: JWT expiry MUST be re-validated on every request; the runtime MUST NOT use a cached `subject_id` from a previous request once the JWT has expired.
+- **FR-016**: Registry state mutations (registration, deregistration, membership changes) within one workspace MUST be immediately visible to all subjects with access to that workspace on subsequent requests.
+- **FR-017**: Concurrent creation of the same workspace by two agents MUST be handled atomically; exactly one creation wins and the other receives the existing workspace; neither request MUST see an error.
+- **FR-018**: The runtime MUST emit a structured workspace audit event for each workspace creation, deletion, membership change, and authorization failure.
+- **FR-019**: Workspace deletion MUST atomically deregister all capabilities, events, and workflows associated with that workspace.
+- **FR-020**: The runtime MUST propagate `workspace_id` through all internal execution contexts so that trace artifacts and state events are labelled with the workspace scope.
+
+## Non-Functional Requirements
+
+- **NFR-001 Correctness**: Cross-workspace data leakage MUST be treated as a critical defect; no registry query path may return results from a workspace not matching the resolved scope.
+- **NFR-002 Determinism**: Authorization decisions and workspace lookup results MUST be deterministic for the same JWT, workspace state, and request input.
+- **NFR-003 Performance**: Workspace authorization and registry scoping MUST add no more than one additional indexed lookup per request compared to the pre-isolation baseline.
+- **NFR-004 Testability**: Workspace isolation, authorization enforcement, shared workspace access, and system workspace privilege checks MUST each be independently testable without requiring a running JWT issuer.
+- **NFR-005 Auditability**: Every authorization failure and workspace mutation MUST produce a structured, machine-readable audit event suitable for compliance review.
+- **NFR-006 Compatibility**: The addition of `workspace_id` MUST be a versioned, semver-disciplined breaking change; legacy clients without `workspace_id` MUST receive a `workspace_id_required` error rather than silent degradation.
+- **NFR-007 Maintainability**: Workspace resolution, authorization enforcement, and scoped registry lookup MUST be implemented as clearly separated concerns within `traverse-runtime` and `traverse-registry`.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: No registry read or write operation MAY return or modify data from a workspace that the caller does not own or have explicit shared access to; any such cross-workspace access is a blocker defect.
+- **QG-002**: JWT expiry MUST be checked on every inbound request; stale identity MUST never be used to authorize a workspace operation.
+- **QG-003**: Authorization failures MUST NOT leak workspace metadata, capability names, or event names from the rejected workspace in any error response or audit trail visible to the unauthorized caller.
+- **QG-004**: 100% automated line coverage is required for workspace authorization, scoped registry lookup, shared workspace access enforcement, and system workspace privilege checks.
+- **QG-005**: Workspace isolation behavior MUST align with this governing spec and fail the spec-alignment CI gate when drift occurs.
+
+## Key Entities
+
+- **Workspace**: A named, subject-owned scope within the Traverse registry. All registry objects (capabilities, events, workflows) belong to exactly one workspace.
+- **workspace_id**: The stable string identifier for a workspace. Required on all API calls. Validated for format at the request boundary.
+- **subject_id**: The identity of the caller, derived from the validated JWT. The runtime MUST derive this value; callers MUST NOT supply it directly.
+- **Workspace Member**: A `subject_id` explicitly granted access to a shared workspace by the workspace owner.
+- **Shared Workspace**: A workspace declared `shared: true` with an explicit member list. Multiple subjects may register and execute capabilities within a shared workspace.
+- **System Workspace**: The reserved `system` workspace_id. Supports privileged administrative operations. Cannot be created, deleted, or modified by unprivileged callers.
+- **Workspace Audit Event**: A structured event emitted on workspace creation, deletion, membership change, or authorization failure.
+
+## Success Criteria
+
+- **SC-001**: Two agents under distinct subject identities cannot observe each other's registry registrations when each operates within its own workspace.
+- **SC-002**: A runtime request that omits `workspace_id` is rejected with `workspace_id_required` before any registry lookup occurs.
+- **SC-003**: A shared workspace correctly grants access to all declared members and rejects all non-members.
+- **SC-004**: The `system` workspace rejects unprivileged callers and returns a correct workspace listing to privileged callers.
+- **SC-005**: Concurrent workspace creation with the same `workspace_id` is idempotent and produces no error for either caller.
+- **SC-006**: 100% automated line coverage is achieved for all workspace isolation and authorization paths.
+
+## Out of Scope
+
+- Distributed cross-process workspace federation
+- Workspace quota enforcement (capability count limits, event volume limits)
+- Workspace billing or usage metering
+- JWT issuance or key management (handled by the identity layer per spec 030)
+- Workspace templates or cloning
+- Role-based access control within a workspace (fine-grained per-capability permissions)
+- Cross-workspace capability sharing without shared workspace declaration

--- a/specs/036-event-subscription-replay/spec.md
+++ b/specs/036-event-subscription-replay/spec.md
@@ -1,0 +1,165 @@
+# Feature Specification: Event Subscription and Replay
+
+**Feature Branch**: `036-event-subscription-replay`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Event delivery model for Traverse covering at-least-once subscription, cursor-based replay, bounded buffer retention, backpressure handling, and browser adapter compatibility. Unblocks GitHub issues #308 and #312.
+
+## Purpose
+
+This spec defines the subscription and replay model for Traverse event delivery.
+
+The existing event registry (spec 003) defines event schemas and emitter contracts. This spec defines how consumers subscribe to event streams, how they recover from disconnections using cursors, and how the broker handles bounded retention and backpressure.
+
+The model introduced here:
+
+- delivers events to subscribers with at-least-once semantics and stable per-subscription ordering
+- assigns opaque server-side cursors so late-joining or reconnecting subscribers can replay missed events
+- bounds the broker's event buffer by a configurable `retention_window`; events outside the window are not guaranteed replayable
+- requires callers to handle duplicates by providing stable `event_id` values on all emitted events
+- supports both in-process Rust consumers and browser-hosted consumers via the existing browser adapter
+- explicitly defers distributed cross-process delivery to a future spec
+
+This spec does **not** define workflow orchestration triggers, fan-out routing topology, or persistent event log storage beyond the retention window.
+
+## User Scenarios and Testing
+
+### User Story 1 — Reconnecting Subscriber Replays Missed Events (Priority: P1)
+
+As a platform developer, I want a subscriber that disconnects and reconnects to receive all events it missed during the disconnection interval so that transient network or process interruptions do not cause silent event loss.
+
+**Why this priority**: Replay on reconnect is the foundational recovery property. Without it, subscribers must treat every disconnection as a potential data loss event.
+
+**Independent Test**: Subscribe to `CapabilityExecuted` events. Record the cursor after receiving the first batch. Disconnect. Emit three more events. Reconnect with the recorded cursor. Verify the subscriber receives all three missed events in emission order, with no duplicates if event_ids are unique.
+
+**Acceptance Scenarios**:
+
+1. **Given** a subscriber that recorded a cursor `C` before disconnecting, **When** it reconnects and provides `C` as `from_cursor`, **Then** the broker delivers all events emitted after `C` in the order they were emitted.
+2. **Given** a subscriber replaying from cursor `C`, **When** the replay includes events the subscriber already processed before disconnect, **Then** the subscriber receives those events again (at-least-once) and is responsible for idempotent handling using `event_id`.
+3. **Given** a cursor that references a point within the active retention window, **When** the subscriber reconnects, **Then** the broker begins delivery from that cursor without error.
+
+### User Story 2 — Two Independent Subscribers Receive Ordered Copies (Priority: P1)
+
+As a platform developer, I want two agents subscribing to the same event type to each receive an independent, ordered copy of all events so that event consumption by one agent does not affect the other.
+
+**Why this priority**: Independent delivery is required for fan-out use cases where multiple agents react to the same runtime events.
+
+**Independent Test**: Create two subscriptions to the same event type. Emit five events. Verify each subscription receives all five events in emission order independently.
+
+**Acceptance Scenarios**:
+
+1. **Given** two active subscriptions to the same event type, **When** an event is emitted, **Then** both subscriptions receive the event in their respective ordered streams.
+2. **Given** subscriber A acknowledges and advances past an event, **When** subscriber B has not yet received that event, **Then** subscriber B still receives the event without loss.
+3. **Given** subscriber A is slow and has a large undelivered backlog, **When** subscriber B is fast, **Then** subscriber B's delivery is not blocked or slowed by subscriber A's state.
+
+### User Story 3 — Browser App Late-Join Replay (Priority: P2)
+
+As a browser application developer, I want to connect after a capability has executed and replay from cursor 0 so that the browser UI can reconstruct state from the beginning of the retention window.
+
+**Why this priority**: Browser adapters are a first-class consumer of Traverse events. Late-join replay is essential for UI state reconstruction.
+
+**Independent Test**: Emit a `CapabilityExecuted` event. Connect a browser subscriber using `from_cursor: "0"`. Verify the subscriber receives the event despite connecting after emission.
+
+**Acceptance Scenarios**:
+
+1. **Given** a browser subscriber that connects with `from_cursor: "0"`, **When** events exist within the retention window, **Then** the subscriber receives those events from the beginning of the available buffer.
+2. **Given** a browser subscriber connected via the existing browser adapter, **When** the broker delivers events, **Then** the delivery mechanism is compatible with the browser adapter's message framing.
+3. **Given** a browser subscriber replaying from cursor 0 with no events in the buffer, **When** the broker evaluates the subscription, **Then** it returns an empty stream (not an error) and the subscription remains active for future events.
+
+### User Story 4 — Operator Configures Retention Window (Priority: P2)
+
+As a platform operator, I want to configure the broker's retention window to a value appropriate for my compliance requirements so that events are replayable for the required duration.
+
+**Why this priority**: The default retention window of 5 minutes is insufficient for compliance use cases that require longer replay windows.
+
+**Independent Test**: Configure `retention_window` to 30 minutes. Emit an event. Wait 6 minutes. Connect a new subscriber with `from_cursor: "0"`. Verify the event is still replayable.
+
+**Acceptance Scenarios**:
+
+1. **Given** a broker configured with `retention_window: 30m`, **When** an event was emitted 20 minutes ago, **Then** a new subscriber can replay that event using a cursor within the retention window.
+2. **Given** a broker configured with `retention_window: 30m`, **When** an event was emitted 35 minutes ago, **Then** a subscriber requesting replay from a cursor referencing that event receives a `cursor_expired` error.
+3. **Given** a broker with `retention_window` modified at runtime, **When** the new window is shorter than the previous one, **Then** events outside the new window are immediately ineligible for replay.
+
+## Edge Cases
+
+- Cursor from a buffer window that has expired — return a `cursor_expired` error with the expiry timestamp; MUST NOT deliver a silent empty stream as if no events had been emitted.
+- Subscriber that disconnects with an unbounded backlog — the broker drops oldest un-delivered events from that subscription's queue; on reconnect the subscriber receives a `backlog_dropped` advisory followed by the oldest available event.
+- Two events emitted with identical `event_id` values — the second event MUST be discarded by the broker; MUST NOT deliver a duplicate to any subscriber.
+- Subscription created for an event type with no registered emitter — valid operation; the broker creates an empty active subscription and delivers events if an emitter registers later.
+- A subscriber advancing a cursor that it has already advanced past — idempotent; the broker treats cursor advancement as monotonic and ignores non-advancing cursor updates.
+- Retention window set to zero or a negative duration — reject at configuration validation with `invalid_retention_window`; do not silently default.
+- Broker receives an event with a missing or empty `event_id` — reject the emission with `event_id_required`; do not assign a broker-generated id silently.
+- A subscription's delivery queue reaches capacity before any events are dropped — the broker MUST emit a `subscription_backpressure` warning event to the operator audit channel before dropping.
+
+## Functional Requirements
+
+- **FR-001**: The broker MUST support named subscriptions; each subscription is identified by a `subscription_id` and targets one event type.
+- **FR-002**: The broker MUST deliver events to all active subscriptions for a given event type; delivery to one subscription MUST NOT depend on the delivery state of any other subscription.
+- **FR-003**: Events delivered to a given subscription MUST be ordered by emission time; the broker MUST not reorder events within a subscription's delivery queue.
+- **FR-004**: The broker MUST assign an opaque server-side cursor to each event at emission time; cursors MUST be stable and monotonically increasing within the broker's buffer.
+- **FR-005**: A subscription request MAY include a `from_cursor` field; when present the broker MUST deliver all events emitted after that cursor in order before delivering new events.
+- **FR-006**: When `from_cursor` is absent, the broker MUST deliver only events emitted after the subscription was created; no historical replay occurs.
+- **FR-007**: Every emitted event MUST carry a stable `event_id`; the broker MUST reject emission requests that omit or provide an empty `event_id`.
+- **FR-008**: The broker MUST detect duplicate `event_id` values within the retention window; a duplicate event MUST be silently discarded and MUST NOT be delivered to any subscriber.
+- **FR-009**: The broker MUST enforce an at-least-once delivery guarantee; it MUST NOT drop events from active subscriptions with available queue capacity.
+- **FR-010**: The broker MUST bound each subscription's delivery queue; when a subscription's queue is full, the broker MUST drop the oldest un-delivered events and MUST record the drop count.
+- **FR-011**: On reconnect with a cursor that falls within a dropped range, the broker MUST deliver a `backlog_dropped` advisory to the subscriber before resuming delivery from the oldest available event.
+- **FR-012**: The broker MUST enforce a configurable `retention_window` (minimum: 1 minute, default: 5 minutes, no maximum enforced by spec); events older than the window are ineligible for replay.
+- **FR-013**: When a subscriber provides a `from_cursor` that references a point outside the retention window, the broker MUST return a `cursor_expired` error and MUST NOT deliver a silent empty stream.
+- **FR-014**: The cursor value `"0"` MUST be treated as a request to replay from the beginning of the available retention window.
+- **FR-015**: Subscriptions MUST be independent of workspace_id isolation per spec 035; a subscriber MUST only receive events emitted within its authorized workspace.
+- **FR-016**: The broker MUST support in-process Rust consumers and browser-hosted consumers via the existing browser adapter without requiring distinct subscription APIs.
+- **FR-017**: Subscription creation for an event type with no registered emitter MUST succeed and return an empty active subscription; this is not an error condition.
+- **FR-018**: The broker MUST emit a `subscription_backpressure` warning to the operator audit channel when a subscription's queue reaches 80% of capacity.
+- **FR-019**: The broker MUST emit a `subscription_backlog_dropped` audit event recording the subscription id, drop count, oldest available cursor, and timestamp whenever events are dropped.
+- **FR-020**: The `retention_window` MUST be validatable at configuration load time; a zero or negative value MUST produce an `invalid_retention_window` error and MUST prevent broker startup.
+- **FR-021**: The broker MUST support subscription cancellation; cancelled subscriptions MUST be removed from the delivery set and their queues freed.
+- **FR-022**: The broker MUST preserve cursor semantics across broker restarts within the retention window; cursors issued before a restart MUST remain valid if the referenced events are within the window.
+
+## Non-Functional Requirements
+
+- **NFR-001 Ordering**: Event ordering within a subscription MUST be deterministic and based on emission order; no subscriber-visible reordering is permitted.
+- **NFR-002 Idempotency**: All emitted events MUST carry stable `event_id` values; the broker MUST enforce this at the emission boundary so consumers can safely deduplicate.
+- **NFR-003 Bounded Memory**: The broker MUST not accumulate unbounded state; both the retention buffer and per-subscription queues MUST be bounded by configuration.
+- **NFR-004 Testability**: Subscription delivery, cursor replay, duplicate suppression, backpressure handling, and retention expiry MUST each be independently testable without a running network stack.
+- **NFR-005 Browser Compatibility**: The subscription framing and cursor protocol MUST be compatible with the existing browser adapter without requiring adapter changes in this spec.
+- **NFR-006 Observability**: Backpressure events, dropped events, cursor expiry, and subscription lifecycle changes MUST each produce structured audit events suitable for operator monitoring.
+- **NFR-007 Determinism**: For the same broker state and sequence of emissions, subscription delivery order and cursor assignments MUST be deterministic and reproducible in tests.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: A `cursor_expired` error MUST be returned when the caller references a cursor outside the retention window; a silent empty stream is a blocker defect.
+- **QG-002**: Events with duplicate `event_id` values MUST be discarded and MUST NOT be delivered to any subscriber; duplicate delivery via the broker is a blocker defect.
+- **QG-003**: Backpressure-induced event drops MUST be recorded in the structured audit log and MUST produce a `backlog_dropped` advisory to the subscriber on reconnect; silent drops are a blocker defect.
+- **QG-004**: 100% automated line coverage is required for subscription creation, cursor replay, duplicate suppression, backpressure handling, and retention expiry logic.
+- **QG-005**: Event subscription and replay behavior MUST align with this governing spec and fail the spec-alignment CI gate when drift occurs.
+
+## Key Entities
+
+- **Subscription**: A named, subject-scoped registration of interest in a specific event type. Identified by `subscription_id`. Maintains an ordered delivery queue and a current delivery cursor.
+- **subscription_id**: The stable identifier for a subscription, server-assigned at creation time.
+- **Event Cursor**: An opaque, monotonically increasing server-assigned string attached to each event at emission time. Used by subscribers to identify their position in the event stream.
+- **from_cursor**: The cursor value provided by a subscriber on connect or reconnect to request replay from a specific position. The value `"0"` requests replay from the start of the retention window.
+- **event_id**: A stable, caller-supplied identifier for an emitted event. Used by the broker to detect and discard duplicate emissions. Required on all emitted events.
+- **Retention Window**: The configurable duration for which the broker guarantees event replayability. Default: 5 minutes. Events older than the window may not be replayable.
+- **Delivery Queue**: The per-subscription bounded buffer holding events awaiting delivery. When full, the broker drops the oldest un-delivered events and records the drop.
+- **Backlog Dropped Advisory**: A structured advisory delivered to a subscriber on reconnect when events were dropped from its queue due to backpressure during disconnection.
+
+## Success Criteria
+
+- **SC-001**: A subscriber that reconnects with a valid cursor receives all missed events in emission order with no broker-induced gaps.
+- **SC-002**: Two independent subscribers to the same event type each receive a complete, ordered, independent copy of all emitted events.
+- **SC-003**: A `cursor_expired` error is returned for any cursor referencing a point outside the active retention window; no silent empty stream is ever returned in its place.
+- **SC-004**: Duplicate `event_id` events are silently discarded at the broker and never delivered to any subscriber.
+- **SC-005**: Backpressure-induced drops produce both an operator audit event and a subscriber advisory; no drop is silent.
+- **SC-006**: 100% automated line coverage is achieved for all subscription, cursor, duplicate suppression, and backpressure paths.
+
+## Out of Scope
+
+- Distributed cross-process event delivery (multi-node brokers, Kafka-style fan-out)
+- Persistent event log storage beyond the in-memory retention window
+- Workflow orchestration triggers driven by event subscriptions
+- Event schema versioning and migration
+- Per-subscription replay authorization beyond workspace isolation (spec 035)
+- Event fan-out routing topology configuration
+- Dead-letter queues for persistently failing subscribers

--- a/specs/037-semver-range-resolution/spec.md
+++ b/specs/037-semver-range-resolution/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Semver Range Resolution
+
+**Feature Branch**: `037-semver-range-resolution`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Version resolution model for Traverse capability lookup, covering semver range syntax, highest-satisfying-version selection, contract compatibility gating, exact-version pinning, and workspace-scoped resolution fallback. Unblocks GitHub issue #311.
+
+## Purpose
+
+This spec defines how the Traverse registry resolves a capability request that specifies a version range rather than an exact version.
+
+The existing runtime request model (spec 006) requires capability identity and an optional version. Today the runtime treats version as an exact match. This spec introduces range-based resolution so capability consumers can express compatibility constraints (e.g., `^1.0.0`) without being pinned to a specific patch release.
+
+The model introduced here:
+
+- selects the highest registered version satisfying the range, within the same major version (`^` Cargo semantics by default)
+- accepts Cargo/npm-style range syntax: `^1.2.0`, `>=1.0.0, <2.0.0`, `1.x`, `*`
+- verifies contract compatibility before accepting a resolved version
+- bypasses range logic entirely for exact-version requests
+- fails explicitly on ambiguous matches (same resolved version, different digests)
+- scopes resolution to the requesting workspace_id first with fallback to accessible shared workspaces
+
+This spec does **not** define dependency graph resolution across multiple capabilities, lock file semantics, or cross-registry federation.
+
+## User Scenarios and Testing
+
+### User Story 1 — Range Request Resolves to Highest Satisfying Version (Priority: P1)
+
+As a capability consumer, I want to request a capability using a semver range so that I automatically receive the highest compatible version registered in my workspace without updating my request each time a new patch is released.
+
+**Why this priority**: Range resolution is the primary consumer-facing feature of this spec. Without it, all callers must pin exact versions, which defeats semver compatibility discipline.
+
+**Independent Test**: Register capability `data.transform` at versions 1.0.0, 1.1.0, and 1.2.0. Submit a runtime request with range `^1.0.0`. Verify the resolver selects 1.2.0 and executes it.
+
+**Acceptance Scenarios**:
+
+1. **Given** capabilities registered at 1.0.0, 1.1.0, and 1.2.0, **When** a request specifies range `^1.0.0`, **Then** the resolver selects version 1.2.0 as the highest satisfying version.
+2. **Given** the resolver selects 1.2.0, **When** the execution trace is produced, **Then** it records the requested range, the evaluated candidates, and the selected version.
+3. **Given** a new version 1.3.0 is registered after the initial request, **When** the same range request is submitted again, **Then** the resolver now selects 1.3.0.
+
+### User Story 2 — No Satisfying Version Fails Explicitly (Priority: P1)
+
+As a capability consumer, I want to receive a clear error when no registered version satisfies my range so that I can diagnose version gaps without inspecting the registry manually.
+
+**Why this priority**: Silent fallback or wrong-version execution is a correctness hazard. Explicit failure with diagnostic information is required.
+
+**Independent Test**: Register capability `data.transform` at version 2.0.0 only. Submit a range request for `^1.0.0`. Verify the resolver returns `no_version_satisfies_range` and lists the registered versions.
+
+**Acceptance Scenarios**:
+
+1. **Given** only version 2.0.0 is registered, **When** a request specifies range `^1.0.0`, **Then** the resolver fails with `no_version_satisfies_range` and includes the registered versions and the requested range in the error.
+2. **Given** a `no_version_satisfies_range` failure, **When** the runtime trace is produced, **Then** it records the range, the evaluated candidates, and the reason no candidate was selected.
+3. **Given** a `no_version_satisfies_range` error, **When** the error is inspected, **Then** it does not expose versions from other workspaces.
+
+### User Story 3 — Ambiguous Match Fails Explicitly (Priority: P2)
+
+As a platform operator, I want the resolver to fail explicitly when two registrations at the same resolved version have different digests so that execution is never silently routed to an unexpected artifact.
+
+**Why this priority**: Silent tie-breaking between different artifacts at the same version is a security and correctness risk.
+
+**Independent Test**: Register two entries for capability `data.transform` at version 1.2.0 with different artifact digests. Submit a range request for `^1.0.0`. Verify the resolver returns `ambiguous_match` and lists both registrations.
+
+**Acceptance Scenarios**:
+
+1. **Given** two registrations for the same capability id and version with different digests, **When** a range resolves to that version, **Then** the resolver fails with `ambiguous_match` and lists both registrations.
+2. **Given** an `ambiguous_match` failure, **When** the trace is produced, **Then** it records the matched candidates and the reason no selection was made.
+3. **Given** one of the two ambiguous registrations is deregistered, **When** the range request is resubmitted, **Then** the resolver succeeds and selects the remaining registration.
+
+### User Story 4 — Exact Version Bypasses Range Logic (Priority: P2)
+
+As a capability consumer requiring deterministic execution, I want to pin an exact version so that range resolution logic is bypassed entirely and the named version is executed directly.
+
+**Why this priority**: Exact pinning is necessary for reproducible builds, integration tests, and compliance scenarios.
+
+**Independent Test**: Register capability `data.transform` at versions 1.0.0, 1.1.0, 1.2.0. Submit a request pinning exact version `1.0.0`. Verify that 1.0.0 is executed and that no range evaluation occurs.
+
+**Acceptance Scenarios**:
+
+1. **Given** versions 1.0.0, 1.1.0, and 1.2.0 are registered, **When** a request specifies exact version `1.0.0`, **Then** the resolver selects 1.0.0 directly without evaluating a range.
+2. **Given** a request with exact version `1.0.0`, **When** version 1.0.0 is not registered, **Then** the resolver fails with `capability_not_found` (not `no_version_satisfies_range`).
+3. **Given** an exact version request, **When** the execution trace is produced, **Then** it records that no range evaluation occurred and that the exact version was used.
+
+## Edge Cases
+
+- Malformed semver range string (e.g., `^abc`, `>=1.0.x.y`) — reject at parse time with `invalid_range_syntax` error containing the malformed input; do not attempt partial evaluation.
+- Empty registry for the requested capability id — fail with `capability_not_found` before evaluating any range; do not return `no_version_satisfies_range` for a non-existent capability.
+- Range `*` (any version) — valid; the resolver selects the highest registered version across all major versions in the workspace.
+- Pre-release versions (e.g., `1.0.0-alpha.1`, `2.0.0-rc.3`) — excluded from range resolution unless the request explicitly opts in with a `include_prerelease: true` flag; a range of `*` does not include pre-release versions by default.
+- Range request where workspace has no registrations but a shared workspace does — the resolver MUST attempt shared workspace fallback before failing; if the shared workspace satisfies the range, it MUST be used.
+- Contract compatibility check fails for the highest satisfying version — the resolver MUST NOT silently fall back to a lower version; it MUST fail with `contract_incompatible` and report the failed version.
+- Two registrations at the same version with identical digests — treat as the same registration (idempotent); select it without ambiguity error.
+- Range `>=2.0.0, <2.0.0` (empty intersection) — reject at parse time with `invalid_range_syntax`; an unsatisfiable range is a parse error, not a resolution error.
+
+## Functional Requirements
+
+- **FR-001**: The runtime MUST accept a `version_range` field on capability execution requests as an alternative to an exact `version` field; the two fields are mutually exclusive.
+- **FR-002**: When `version_range` is provided, the resolver MUST parse it using Cargo/npm semver range semantics supporting: `^`, `~`, `>=`, `<=`, `>`, `<`, `x` wildcards, `*`, and compound ranges with `,`.
+- **FR-003**: The resolver MUST reject a malformed `version_range` at parse time with `invalid_range_syntax` before performing any registry lookup.
+- **FR-004**: When a valid `version_range` is provided, the resolver MUST collect all registered versions of the requested capability id within the requesting workspace and evaluate each against the range.
+- **FR-005**: The resolver MUST select the highest version among all versions satisfying the range; in the case of `^`-style ranges, only versions within the same major version MUST be considered.
+- **FR-006**: Pre-release versions MUST be excluded from range evaluation unless the request includes `include_prerelease: true`.
+- **FR-007**: Before accepting the resolved version as the selected candidate, the resolver MUST verify that the resolved capability's contract id and contract version are compatible with the dependency declaration in the requesting capability's contract.
+- **FR-008**: If the contract compatibility check fails for the highest satisfying version, the resolver MUST fail with `contract_incompatible` and MUST NOT silently evaluate lower versions.
+- **FR-009**: When no registered version satisfies the range, the resolver MUST fail with `no_version_satisfies_range` and MUST include the requested range and the list of registered versions in the error detail.
+- **FR-010**: When the requested capability id has no registrations at all in the resolved scope, the resolver MUST fail with `capability_not_found` rather than `no_version_satisfies_range`.
+- **FR-011**: When multiple registrations exist at the same resolved version with different artifact digests, the resolver MUST fail with `ambiguous_match` listing all conflicting registrations.
+- **FR-012**: Two registrations at the same version with identical artifact digests MUST be treated as one registration; the resolver MUST select it without raising `ambiguous_match`.
+- **FR-013**: When `version` (exact) is provided instead of `version_range`, the resolver MUST bypass range evaluation entirely and look up the exact registration; if not found, fail with `capability_not_found`.
+- **FR-014**: Resolution MUST be scoped to the requesting `workspace_id` first (per spec 035); if no satisfying version exists in the primary workspace and the workspace has declared shared workspace access, the resolver MUST evaluate shared workspaces in declaration order.
+- **FR-015**: Resolution MUST NOT cross workspace boundaries without explicit shared workspace declaration; cross-workspace resolution without authorization is a blocker defect.
+- **FR-016**: The range `*` MUST be treated as matching any registered version (excluding pre-release unless opted in); the resolver MUST select the highest registered version.
+- **FR-017**: The resolver MUST produce a structured resolution trace recording: requested range or exact version, candidate versions evaluated, workspace(s) searched, selected version, and failure classification if applicable.
+- **FR-018**: The resolution trace MUST be included in the parent runtime execution trace (spec 006) as a nested artifact.
+- **FR-019**: The resolver MUST be deterministic: the same registry state, workspace scope, and version range MUST always produce the same selected version.
+- **FR-020**: All resolver error types (`invalid_range_syntax`, `capability_not_found`, `no_version_satisfies_range`, `ambiguous_match`, `contract_incompatible`) MUST be machine-readable, stable error codes suitable for programmatic handling.
+
+## Non-Functional Requirements
+
+- **NFR-001 Determinism**: For the same registry state and version range input, the resolver MUST always select the same version. Non-deterministic version selection is a blocker defect.
+- **NFR-002 Explainability**: Every resolution outcome — success or failure — MUST produce a structured trace recording the evaluated candidates and the selection rationale.
+- **NFR-003 Performance**: Range evaluation MUST complete in O(n log n) time or better with respect to the number of registered versions for a given capability id.
+- **NFR-004 Testability**: Range parsing, candidate evaluation, version selection, contract compatibility checking, ambiguity detection, and workspace fallback MUST each be independently testable without a running registry.
+- **NFR-005 Compatibility**: `version_range` and `version` fields MUST be mutually exclusive and versionable under semver discipline; adding range support MUST NOT break existing exact-version callers.
+- **NFR-006 Correctness**: Pre-release exclusion, `^` major-version pinning, and `*` wildcard semantics MUST match Cargo semver crate behavior exactly; no custom divergence is permitted.
+- **NFR-007 Maintainability**: Range parsing, candidate collection, version selection, contract compatibility gating, and workspace fallback MUST be clearly separated concerns within `traverse-registry`.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: Non-deterministic version selection (same inputs, different outputs) is a blocker defect; the resolver MUST be deterministic for all range types.
+- **QG-002**: Cross-workspace resolution without explicit shared workspace access is a blocker defect; workspace isolation from spec 035 MUST be respected at all resolution boundaries.
+- **QG-003**: `capability_not_found` MUST be returned for non-existent capability ids; `no_version_satisfies_range` MUST NOT be returned when the capability id itself is absent.
+- **QG-004**: 100% automated line coverage is required for range parsing, candidate selection, ambiguity detection, contract compatibility gating, and workspace fallback.
+- **QG-005**: Semver range resolution behavior MUST align with this governing spec and fail the spec-alignment CI gate when drift occurs.
+
+## Key Entities
+
+- **Version Range**: A semver range expression provided on a capability execution request in place of an exact version. Parsed using Cargo/npm semver semantics.
+- **Resolved Version**: The single registered version selected by the resolver as the highest version satisfying the requested range within the authorized workspace scope.
+- **Candidate Version Set**: The set of all registered versions for a given capability id within the resolved workspace scope, evaluated against the requested range.
+- **Exact Version Request**: A capability execution request that specifies an exact version string rather than a range. Bypasses all range evaluation; fails with `capability_not_found` if the exact version is absent.
+- **Contract Compatibility Check**: The verification step that confirms the resolved capability's contract id and contract version are compatible with what the requesting capability declared as a dependency. Runs before the resolved version is accepted.
+- **Ambiguous Match**: The error condition raised when two or more registrations exist at the same resolved version with different artifact digests. Requires operator intervention to resolve.
+- **Resolution Trace**: The structured artifact produced by the resolver recording the range input, candidate evaluation, workspace search path, selected version, and failure classification. Embedded in the parent runtime execution trace.
+- **include_prerelease**: An optional boolean flag on a version range request. When `true`, pre-release versions are included in candidate evaluation. Default: `false`.
+
+## Success Criteria
+
+- **SC-001**: A range request resolves to the highest satisfying version in the workspace; the resolution trace records all evaluated candidates and the selected version.
+- **SC-002**: A range with no satisfying version returns `no_version_satisfies_range` with the requested range and registered version list in the error detail.
+- **SC-003**: An ambiguous match (same version, different digests) returns `ambiguous_match` listing all conflicting registrations; execution is never silently routed to one of them.
+- **SC-004**: An exact version request bypasses range logic entirely; the resolution trace records that no range evaluation occurred.
+- **SC-005**: A malformed range string is rejected at parse time with `invalid_range_syntax` before any registry lookup.
+- **SC-006**: 100% automated line coverage is achieved for all range parsing, selection, ambiguity detection, contract compatibility, and workspace fallback paths.
+
+## Out of Scope
+
+- Dependency graph resolution across multiple capabilities (lock file semantics)
+- Cross-registry federation or external registry lookup
+- Version yanking or deprecation markers
+- Automatic range widening or narrowing on conflict
+- Semver pre-release comparison ordering beyond Cargo crate semantics
+- Range resolution for event contracts or workflow definitions (capability contracts only in this spec)
+- UI or CLI tooling for range debugging


### PR DESCRIPTION
## Summary
Add governing specs 035, 036, 037 to unblock issues #303, #308, #312, #311.

Specs only — no code changes. `approved-specs.json` registration in follow-on PR.

## Governing Spec
- 004-spec-alignment-gate
- 028-schema-alignment-gate-v02

## Project Item
Closes #303
Closes #308
Closes #312
Closes #311

## Validation
- All three spec files follow the approved spec format (Purpose, User Stories, Edge Cases, FR/NFR/QG, Key Entities, Success Criteria, Out of Scope)
- No code changes in this PR
- Spec IDs 035-037 reserved and consistent with approved-specs.json numbering sequence