### PR TITLE
feat(specs): add governing specs 038-040 (WASM insulation, connectors, contractual gate)

### DIFF
--- a/specs/038-wasi-host-insulation/spec.md
+++ b/specs/038-wasi-host-insulation/spec.md
@@ -1,0 +1,158 @@
+# Feature Specification: WASI Host Insulation and Traverse Host ABI
+
+**Feature Branch**: `038-wasi-host-insulation`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Stable host-function boundary for WASM modules compiled for Traverse, insulating module authors from WASI churn and establishing an independently versioned Traverse Host ABI. Governs `crates/traverse-runtime/` and `Cargo.toml`. Unblocks GitHub issue #330.
+
+## Purpose
+
+This spec defines the Traverse Host ABI — a stable, versioned set of host functions that WASM modules call at runtime. The ABI is the sole sanctioned surface between a Traverse WASM module and the host runtime. It insulates module authors from changes in the underlying WASI implementation: a module compiled against ABI v1 continues to execute correctly after the host upgrades or replaces its WASI layer.
+
+The primary compilation target for v0 is `wasm32-wasip1` (WASI Preview 1). This spec restricts v0 to that target only and defines the forward migration path to the Component Model / WASI Preview 2 as a separate adapter-layer strategy. No dual-target support is introduced in v0.
+
+The host-function categories covered by ABI v1 are:
+
+- **stdio**: structured input delivery and structured output capture
+- **environment queries**: capability identity, declared version, and runtime-injected configuration
+- **execution metadata**: trace context injection, execution-id propagation
+
+This spec establishes how ABI versioning, load-time import validation, and the Component Model migration path are governed so that the boundary remains stable as the underlying WASI implementation evolves.
+
+## User Scenarios and Testing
+
+### User Story 1 — Module Stability Across Host Upgrades (Priority: P1)
+
+As a WASM module author, I want a module compiled with Traverse Host ABI v1 to continue running correctly after the host runtime upgrades its WASI p1 implementation so that I never need to recompile a published module due to host-side WASI churn.
+
+**Why this priority**: ABI stability is the primary contract that allows the Traverse ecosystem to distribute compiled WASM artifacts independent of the host runtime release cycle.
+
+**Independent Test**: Compile a module targeting ABI v1. Simulate a host upgrade by swapping the underlying WASI p1 implementation. Verify the module executes correctly and produces identical output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a WASM module compiled against Traverse Host ABI v1 and a host runtime that has been upgraded to a newer WASI p1 implementation, **When** the module is loaded and executed, **Then** the runtime applies the ABI v1 compatibility layer and the module executes without modification.
+2. **Given** a host runtime reporting ABI v1 and a module that imports only `traverse_host::*` symbols, **When** the module is loaded, **Then** the import validation gate passes without error.
+3. **Given** a host runtime that has promoted to ABI v2, **When** a v1 module is loaded, **Then** the runtime applies the shim path described under FR-009 and execution proceeds.
+
+### User Story 2 — Enforced Import Boundary (Priority: P1)
+
+As a platform maintainer, I want module authors to import only `traverse_host::*` functions and never directly import raw WASI syscalls so that the ABI boundary is enforced by the runtime, not by convention.
+
+**Why this priority**: Without a load-time enforcement gate, any module can silently bypass the insulation layer, making ABI versioning meaningless.
+
+**Independent Test**: Build a WASM module that imports one raw WASI function not in the ABI whitelist. Attempt to load it in the Traverse runtime. Verify the load fails with `unauthorized_host_import` and the module is never executed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a WASM module that imports a raw WASI syscall not present in the ABI v1 whitelist, **When** the runtime attempts to load the module, **Then** load fails immediately with error code `unauthorized_host_import` before any module code executes.
+2. **Given** a WASM module that imports only ABI-whitelisted functions, **When** the runtime loads the module, **Then** load succeeds and execution proceeds normally.
+3. **Given** a module load failure due to `unauthorized_host_import`, **When** the runtime produces a trace, **Then** the trace records the specific import symbol that triggered the violation.
+
+### User Story 3 — Component Model Migration Path (Priority: P2)
+
+As a platform maintainer, I want to add Component Model / WASI Preview 2 support behind an adapter layer so that existing ABI v1 modules receive compatibility without recompilation.
+
+**Why this priority**: Locking the platform to WASI Preview 1 indefinitely is not acceptable; the migration path must be specified before v1 artifacts are published at scale.
+
+**Independent Test**: With the adapter-layer strategy documented, verify a test harness can load a WASI p1 module through the adapter layer against a p2 host without modification to the module.
+
+**Acceptance Scenarios**:
+
+1. **Given** a future host runtime that implements the adapter-layer strategy defined in this spec, **When** an ABI v1 module is loaded, **Then** the adapter translates ABI v1 imports to their p2 equivalents without requiring module recompilation.
+2. **Given** a platform upgrade that introduces Component Model support, **When** new modules are compiled targeting ABI v2, **Then** they coexist with ABI v1 modules in the same registry without conflict.
+3. **Given** the adapter layer fails to translate a specific ABI v1 import, **When** the failure is detected at load time, **Then** the runtime returns `abi_adapter_failure` with the untranslatable symbol identified.
+
+### User Story 4 — CI Import Whitelist Verification (Priority: P2)
+
+As a CI engineer, I want a deterministic job that verifies compiled WASM modules do not import host functions outside the Traverse Host ABI whitelist so that unauthorized imports are caught before artifacts are published.
+
+**Why this priority**: Runtime load-time rejection is the last line of defense; CI verification prevents unauthorized modules from ever reaching distribution.
+
+**Independent Test**: Run the CI verification job against a known-bad WASM binary containing a prohibited import. Verify the job fails and reports the violating symbol.
+
+**Acceptance Scenarios**:
+
+1. **Given** a CI pipeline that runs the ABI whitelist verification job, **When** a compiled WASM artifact contains only whitelisted imports, **Then** the job exits with status 0.
+2. **Given** a CI pipeline that runs the ABI whitelist verification job, **When** a compiled WASM artifact contains at least one non-whitelisted import, **Then** the job exits non-zero and reports each violating symbol.
+3. **Given** multiple compiled WASM artifacts submitted together, **When** the CI job runs, **Then** it validates all artifacts and reports all violations in a single structured output before exiting.
+
+## Edge Cases
+
+- Module imports a raw WASI function not in the ABI whitelist — reject at load time with `unauthorized_host_import`; module code must never execute
+- ABI v1 module loaded on a host that has advanced to ABI v2 — compatibility shim applies transparently; no error surfaced to the module
+- ABI v2 module loaded on a host that only supports ABI v1 — reject at load time with `unsupported_abi_version`; module must declare its minimum required ABI version
+- Host function panics or traps inside the WASM execution context — caught by the runtime trap handler and surfaced as a structured `ExecutionFailure`; the host process must never crash
+- Malformed or truncated WASM binary — caught at the binary parse phase before import validation; error returned as `malformed_wasm_artifact`
+- Module declares an ABI version string that does not match any known ABI version — reject at load time with `unknown_abi_version`
+- Module imports an ABI function that exists in v1 but has changed signature in v2 — adapter layer must detect the signature mismatch and return `abi_signature_mismatch`
+- Two modules loaded concurrently both fail ABI validation — each failure is independent and both are reported without interference
+
+## Functional Requirements
+
+- **FR-001**: The runtime MUST define a versioned "Traverse Host ABI" as the sole sanctioned surface through which WASM modules invoke host capabilities.
+- **FR-002**: Traverse Host ABI v1 MUST include the following function categories: stdio (structured input delivery, structured output capture), environment queries (capability id, declared version, runtime-injected configuration), and execution metadata (trace context injection, execution-id propagation).
+- **FR-003**: The ABI version MUST be independently versioned using a semver-compatible scheme separate from the Traverse runtime version and the WASI implementation version.
+- **FR-004**: Every WASM module MUST declare its target ABI version as a custom section or export in the binary before load-time validation occurs.
+- **FR-005**: The runtime MUST maintain a machine-readable ABI whitelist that enumerates all permitted import symbols for each supported ABI version.
+- **FR-006**: The runtime MUST perform import validation against the ABI whitelist for every WASM module at load time, before any module code is executed.
+- **FR-007**: If a WASM module imports any symbol not present in the whitelisted set for its declared ABI version, the runtime MUST reject the load with error code `unauthorized_host_import` and include the violating symbol in the error detail.
+- **FR-008**: The runtime MUST NOT execute any module code after a load-time validation failure.
+- **FR-009**: When a module declares ABI v1 and the host supports ABI v2, the runtime MUST apply an ABI compatibility shim that translates v1 import calls to their v2 equivalents without requiring module recompilation.
+- **FR-010**: When a module declares an ABI version higher than the maximum supported by the host, the runtime MUST reject the load with `unsupported_abi_version`.
+- **FR-011**: Host function implementations MUST catch all WASM traps and runtime panics originating within the module execution context and surface them as structured `ExecutionFailure` results without crashing the host process.
+- **FR-012**: The stdio category of ABI v1 MUST provide deterministic functions for delivering structured JSON input to a module and capturing structured JSON output from a module.
+- **FR-013**: The environment query category of ABI v1 MUST provide read-only access to the capability id, declared contract version, and runtime-injected configuration; the module MUST NOT be able to modify these values.
+- **FR-014**: The execution metadata category of ABI v1 MUST allow the runtime to inject a trace context and execution-id into the module before execution begins.
+- **FR-015**: The ABI whitelist MUST be stored as a versioned, machine-readable artifact co-located with the runtime source and subject to the spec-alignment CI gate.
+- **FR-016**: A CI verification job MUST be defined that validates compiled WASM artifacts against the ABI whitelist and fails with non-zero exit status when any prohibited import is detected.
+- **FR-017**: The migration path to WASI Preview 2 / Component Model MUST be documented in this spec as an adapter-layer strategy: a future spec introduces ABI v2 targeting the Component Model; existing v1 modules are served through a published adapter without recompilation.
+- **FR-018**: The v0 implementation MUST use `wasm32-wasip1` as the sole compilation target; no dual-target or Component Model support is introduced in this spec.
+- **FR-019**: Load-time errors produced by ABI validation MUST be machine-readable, carry a stable `error_code`, and include sufficient path and symbol information to identify the violating artifact without manual inspection.
+- **FR-020**: The runtime MUST expose the supported ABI version range so that tooling and registry consumers can query it without loading a module.
+
+## Non-Functional Requirements
+
+- **NFR-001 Stability**: The Traverse Host ABI version MUST evolve independently of the WASI implementation; a WASI p1 implementation swap MUST NOT require ABI version bumps or module recompilation.
+- **NFR-002 Determinism**: ABI whitelist validation MUST be deterministic for the same module binary and ABI version; identical inputs MUST produce identical validation outcomes.
+- **NFR-003 Isolation**: Host function implementations MUST be isolated from capability state such that one module's host function invocations cannot observe or modify another module's execution context.
+- **NFR-004 Testability**: ABI whitelist validation logic, shim application logic, and host function trap handling MUST each be independently testable with 100% automated line coverage.
+- **NFR-005 Observability**: Every load-time ABI validation failure MUST be surfaced in the runtime trace; the absence of an ABI validation step in the trace for a loaded module MUST be treated as a gate failure.
+- **NFR-006 Forward Compatibility**: ABI whitelist additions in a minor version increment MUST be backward compatible; removals MUST only occur in a major version increment with a defined migration window.
+- **NFR-007 Portability**: The ABI design MUST not encode assumptions about the host operating system beyond what `wasm32-wasip1` guarantees, preserving future portability to browser and edge hosts.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: A WASM module that imports any symbol outside the ABI whitelist MUST be rejected at load time and MUST never execute any code.
+- **QG-002**: Every load-time ABI validation failure MUST produce a machine-readable error with a stable `error_code` and the violating symbol identified.
+- **QG-003**: Host function trap handling MUST catch all traps and surface them as structured `ExecutionFailure`; the host process MUST NOT crash due to a module trap.
+- **QG-004**: ABI whitelist validation, shim logic, and host function implementations MUST reach 100% automated line coverage under the quality gate.
+- **QG-005**: The ABI whitelist artifact MUST be subject to the spec-alignment CI gate; drift between the spec-declared ABI function set and the whitelist artifact MUST block merge.
+
+## Key Entities
+
+- **Traverse Host ABI**: The versioned, whitelist-governed set of host functions that WASM modules import; the sole sanctioned boundary between module code and the host runtime.
+- **ABI Whitelist**: The machine-readable per-version enumeration of all permitted import symbols; stored as a versioned artifact co-located with the runtime source.
+- **ABI Version**: An independently versioned semver-compatible identifier assigned to each published Traverse Host ABI revision; declared by modules as a custom section or export.
+- **ABI Compatibility Shim**: The host-side adapter that translates import calls from an older ABI version to the current implementation without requiring module recompilation.
+- **Load-Time Import Validation**: The gate that runs against every WASM module binary before any module code executes; compares declared imports against the ABI whitelist.
+- **Host Function Category**: A logical grouping of related ABI functions (stdio, environment queries, execution metadata) that defines the functional scope of ABI v1.
+- **Adapter-Layer Strategy**: The forward migration approach in which a future ABI v2 targets the Component Model; v1 modules are served through a published adapter without recompilation.
+
+## Success Criteria
+
+- **SC-001**: A WASM module compiled against Traverse Host ABI v1 executes correctly on a host that has upgraded its WASI p1 implementation without any modification to the module binary.
+- **SC-002**: A WASM module importing any symbol outside the ABI whitelist is rejected at load time with `unauthorized_host_import` before any module code executes.
+- **SC-003**: A host function trap or panic inside the WASM execution context is caught and surfaced as a structured `ExecutionFailure` without crashing the host process.
+- **SC-004**: The CI ABI whitelist verification job fails with non-zero exit and identifies all violating symbols when presented with a module containing prohibited imports.
+- **SC-005**: ABI whitelist validation, shim application, and host function trap handling each reach 100% automated line coverage under the quality gate.
+
+## Out of Scope
+
+- WASI Preview 2 / Component Model implementation (defined as a follow-on spec via the adapter-layer strategy)
+- Dual-target compilation (wasm32-wasip1 and Component Model in the same v0 build)
+- Browser or edge host adapters
+- Module signing or integrity verification
+- Custom user-defined host functions outside the three ABI v1 categories
+- WASM module caching or artifact distribution
+- Network or remote execution of WASM modules

--- a/specs/039-connector-plugin-architecture/spec.md
+++ b/specs/039-connector-plugin-architecture/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Connector Plugin Architecture
+
+**Feature Branch**: `039-connector-plugin-architecture`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Plugin model that allows capabilities to declare external resource dependencies (HTTP, filesystem, environment variables) through a `ConnectorPlugin` trait and a `connector_contract.json`; connectors are registered in the Traverse registry alongside capabilities and injected at execution time. Governs `crates/traverse-contracts/` and `crates/traverse-registry/`. Unblocks GitHub issue #331.
+
+## Purpose
+
+This spec defines the Connector Plugin Architecture for Traverse — the mechanism by which capabilities declare, discover, and use external resource integrations without embedding resource-access logic inside capability modules or the runtime core.
+
+A connector is a discrete, registered artifact that satisfies a typed interface (`ConnectorPlugin` trait) and declares its identity, version, provided capabilities, required configuration, and supported placement targets via a `connector_contract.json`. Capabilities declare their connector requirements in their own contracts; the runtime wires connectors to capabilities at execution time.
+
+The execution model for v0 is hybrid:
+- The `ConnectorPlugin` trait defines a single interface for both host-native (Rust) and future WASM connectors.
+- v0 ships three host-native reference connectors: HTTP (outbound), local filesystem read, and environment variable reader.
+- A WASM connector lane is defined in the trait but not required for v0 compliance.
+
+Connectors are registered in the Traverse registry as first-class entries alongside capabilities, enabling the same discovery, versioning, and scope rules to apply. Connectors are isolated from direct capability state access; config injection flows through the runtime, never through the WASM module boundary directly.
+
+## User Scenarios and Testing
+
+### User Story 1 — Runtime HTTP Connector Wiring (Priority: P1)
+
+As a capability developer, I want to declare `connector_requirements: [{connector_id: "traverse.http", version: "^1.0.0"}]` in my capability contract so that the runtime wires the HTTP connector without me embedding HTTP logic in my WASM module.
+
+**Why this priority**: The connector wiring path is the primary value delivery of this spec; without it, capabilities cannot access external resources through the governed integration surface.
+
+**Independent Test**: Register a capability contract with a valid `connector_requirements` entry for `traverse.http`. Register the HTTP reference connector. Submit a runtime request. Verify the runtime wires the connector and executes the capability successfully.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registered capability contract declaring `connector_requirements: [{connector_id: "traverse.http", version: "^1.0.0"}]` and a registered HTTP connector satisfying that requirement, **When** the runtime resolves the capability for execution, **Then** it wires the HTTP connector and injects its config before execution begins.
+2. **Given** the HTTP connector is successfully wired, **When** execution completes, **Then** the runtime trace records the connector id, resolved version, and placement target used for injection.
+3. **Given** a capability contract referencing `traverse.http` and a runtime where the HTTP connector is not registered, **When** the capability is submitted for registration, **Then** registration fails with `missing_required_connector` before the capability is written to the registry.
+
+### User Story 2 — Missing Connector Fails at Registration (Priority: P1)
+
+As a CI engineer, I want a capability with a connector requirement that cannot be satisfied to fail at registration time so that broken capability packages never enter the registry.
+
+**Why this priority**: Fail-at-registration prevents runtime surprises; a capability that cannot be wired should never be executable.
+
+**Independent Test**: In a CI environment that registers only the environment-variable connector, attempt to register a capability declaring `traverse.http` as a required connector. Verify the registration returns `missing_required_connector`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registry that has only the environment-variable connector registered and a capability declaring a requirement for `traverse.http`, **When** the capability is submitted for registration, **Then** the registry returns `missing_required_connector` and the capability is not written.
+2. **Given** a registration failure with `missing_required_connector`, **When** the error response is inspected, **Then** it includes the unsatisfied `connector_id` and the version range that could not be resolved.
+3. **Given** the required connector is later registered and the capability is resubmitted, **When** registration is retried, **Then** it succeeds and the capability enters the registry.
+
+### User Story 3 — Third-Party Custom Connector (Priority: P2)
+
+As a third-party integrator, I want to implement a custom connector (e.g., a Postgres connector) using the `ConnectorPlugin` trait and register it without modifying the Traverse runtime so that Traverse's integration surface is extensible without core changes.
+
+**Why this priority**: Extensibility without core modification is required for Traverse to be usable as a platform, not just a single-vendor tool.
+
+**Independent Test**: Implement a minimal custom connector satisfying the `ConnectorPlugin` trait. Register it via the registry API. Register a capability that declares it as a requirement. Verify the runtime wires it and executes the capability.
+
+**Acceptance Scenarios**:
+
+1. **Given** a third-party connector implementing `ConnectorPlugin` with a valid `connector_contract.json`, **When** it is submitted to the registry, **Then** it is registered without requiring any changes to the Traverse runtime source.
+2. **Given** a registered third-party connector, **When** a capability declares a requirement for it and is registered, **Then** the requirement is satisfied and the capability enters the registry.
+3. **Given** a custom connector and a reference connector registered simultaneously, **When** a capability requires both, **Then** the runtime wires both and injects both configs before execution begins.
+
+### User Story 4 — WASM Connector Execution (Priority: P2)
+
+As a platform maintainer, I want a WASM connector to be registered and executed using the same WASM executor as capability modules so that the connector plugin model is symmetric for native and WASM implementations.
+
+**Why this priority**: Defining the WASM connector execution path in the trait now prevents architectural divergence when WASM connectors are implemented.
+
+**Independent Test**: Register a minimal WASM connector. Register a capability that requires it. Execute the capability. Verify the runtime loads and executes the WASM connector using the WASM executor, not a native code path.
+
+**Acceptance Scenarios**:
+
+1. **Given** a WASM connector registered with a valid `connector_contract.json` and a `wasm` placement target, **When** a capability requiring that connector is executed, **Then** the runtime loads the WASM connector through the WASM executor and wires its output to the capability.
+2. **Given** a WASM connector that traps during execution, **When** the trap is detected, **Then** the runtime surfaces `ConnectorError` in the capability's execution trace and fails execution without crashing the host.
+3. **Given** a WASM connector and a native connector both registered, **When** a capability requires only the native connector, **Then** the WASM connector is never loaded or executed.
+
+## Edge Cases
+
+- Connector version conflict — capability requires `^1.0.0` but registry has only `2.0.0`; fail at registration with `connector_version_incompatible`
+- Circular connector dependency — connector A declares a requirement on connector B which declares a requirement on connector A; detect at registration time and reject with `circular_connector_dependency`
+- Connector execution failure — surface as `ConnectorError` in the capability's execution trace; the trace MUST include the connector id, the failure description, and the execution step at which the failure occurred
+- Missing config fields at execution time — connector config schema declared in `connector_contract.json` is not fully satisfied by the runtime-injected config; reject before execution with `connector_config_invalid`
+- Connector registered with an invalid `connector_contract.json` — reject at connector registration time with `invalid_connector_contract` before the connector enters the registry
+- Capability declares a connector requirement with a connector_id that does not match any registered connector id prefix — fail at registration with `unknown_connector_id`
+- Two capabilities share the same connector requirement with conflicting config schemas — each capability retains its own config injection context; no merging of schemas occurs
+- Connector placement target is `wasm` but no WASM executor is available in the current runtime — reject connector registration with `unsupported_placement_target`
+
+## Functional Requirements
+
+- **FR-001**: The runtime MUST define a `ConnectorPlugin` trait as the single interface contract for all connectors, covering both host-native (Rust) and WASM connector implementations.
+- **FR-002**: Every connector MUST declare a `connector_contract.json` artifact containing at minimum: `connector_id`, `version`, `capabilities_provided` (list of capability ids the connector can serve), `required_config_schema` (JSON schema), and `supported_placement_targets`.
+- **FR-003**: Connectors MUST be registered in the Traverse registry as first-class entries, subject to the same versioning and scope rules as capability registrations.
+- **FR-004**: The registry MUST validate `connector_contract.json` structure and required fields at connector registration time, before the connector entry is written.
+- **FR-005**: Capability contracts MUST support a `connector_requirements` field as a list of objects each containing `connector_id` and `version` (semver range).
+- **FR-006**: At capability registration time, the registry MUST verify that every connector listed in `connector_requirements` is already registered and that at least one registered version satisfies the declared semver range.
+- **FR-007**: If any connector requirement cannot be satisfied at capability registration time, the registry MUST reject the capability registration with `missing_required_connector` identifying the unsatisfied `connector_id` and version range.
+- **FR-008**: If a connector requirement specifies a semver range that no registered version satisfies due to a major version mismatch, the registry MUST reject with `connector_version_incompatible`.
+- **FR-009**: The registry MUST detect circular connector dependency chains at registration time and reject with `circular_connector_dependency`.
+- **FR-010**: At capability execution time, the runtime MUST inject connector configuration into each required connector before executing the capability; configuration MUST NOT be exposed to the WASM capability module directly.
+- **FR-011**: Connector config injection MUST validate the injected config against the `required_config_schema` declared in the `connector_contract.json` before execution begins; if the config does not satisfy the schema, execution MUST be rejected with `connector_config_invalid`.
+- **FR-012**: Connectors MUST run in an execution context isolated from direct capability state; a connector MUST NOT be able to observe or modify the internal state of a capability module.
+- **FR-013**: The v0 release MUST include three host-native reference connectors: `traverse.http` (outbound HTTP), `traverse.fs.read` (local filesystem read), and `traverse.env` (environment variable reader).
+- **FR-014**: Each reference connector MUST have a corresponding `connector_contract.json` that is versioned and governed under the spec-alignment CI gate.
+- **FR-015**: Connector execution failures MUST be surfaced as `ConnectorError` in the capability's execution trace, including the connector id, failure description, and the execution step at which the failure occurred.
+- **FR-016**: The `ConnectorPlugin` trait MUST include a defined execution path for WASM connectors; the WASM path MUST use the same WASM executor as capability modules.
+- **FR-017**: WASM connector traps MUST be caught by the runtime and surfaced as `ConnectorError` without crashing the host process.
+- **FR-018**: The registry MUST expose a query interface that returns all connectors satisfying a given `connector_id` and semver range, to support both registration-time verification and runtime wiring.
+- **FR-019**: Connector registration, capability registration with connector requirements, and connector wiring at execution time MUST each produce machine-readable, trace-compatible event records.
+- **FR-020**: The runtime MUST NOT permit a capability to execute if any of its declared connector requirements are unresolved at execution time, even if they were satisfied at registration time but subsequently deregistered.
+
+## Non-Functional Requirements
+
+- **NFR-001 Isolation**: Connectors MUST be executed in a context isolated from capability state; no direct memory or state sharing between a connector and a capability module is permitted.
+- **NFR-002 Determinism**: Connector requirement resolution and version matching MUST be deterministic for the same registry state and capability contract; identical inputs MUST produce identical outcomes.
+- **NFR-003 Extensibility**: The `ConnectorPlugin` trait MUST be defined such that new connectors can be implemented and registered without modifying the Traverse runtime source.
+- **NFR-004 Testability**: Connector registration validation, version matching, config schema validation, circular dependency detection, and execution wiring MUST each be independently testable with 100% automated line coverage.
+- **NFR-005 Versioning**: Connector contracts and the `ConnectorPlugin` trait MUST be versioned under semver discipline; breaking changes MUST require a major version increment.
+- **NFR-006 Observability**: Every connector wiring step and connector execution failure MUST be recorded in the runtime execution trace with sufficient detail to diagnose failures without relying on unstructured logs.
+- **NFR-007 Config Security**: Connector configuration MUST be injected by the runtime at execution time and MUST NOT be readable by the capability WASM module; config values MUST not appear in capability execution traces.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: A capability declaring a connector requirement that cannot be satisfied MUST be rejected at registration time and MUST NOT enter the registry.
+- **QG-002**: Connector config schema validation MUST run on every execution attempt; the execution MUST be rejected if the config does not satisfy the declared schema.
+- **QG-003**: A connector execution failure MUST be surfaced as `ConnectorError` in the trace; the capability MUST fail execution and the host process MUST NOT crash.
+- **QG-004**: Circular connector dependency detection MUST run at registration time and MUST produce a machine-readable `circular_connector_dependency` error identifying the cycle.
+- **QG-005**: Connector registration validation, version matching, config schema validation, and execution wiring logic MUST reach 100% automated line coverage under the quality gate.
+
+## Key Entities
+
+- **ConnectorPlugin**: The Rust trait that defines the single interface contract for all connectors; implemented by both host-native and WASM connectors.
+- **Connector Contract**: The `connector_contract.json` artifact that declares connector identity, version, provided capabilities, required config schema, and supported placement targets.
+- **Connector Requirement**: An entry in a capability contract's `connector_requirements` list, specifying a `connector_id` and a semver version range.
+- **Connector Registry Entry**: The first-class registry record for a registered connector, subject to the same versioning and scope rules as capability entries.
+- **ConnectorError**: The structured error type emitted in the execution trace when a connector fails during execution; includes connector id, failure description, and execution step.
+- **Config Injection**: The runtime operation that delivers connector configuration to the connector at execution time, without exposing the config to the capability WASM module.
+- **Reference Connector**: One of the three v0 host-native connectors shipped with Traverse: `traverse.http`, `traverse.fs.read`, and `traverse.env`.
+
+## Success Criteria
+
+- **SC-001**: A capability declaring `traverse.http` as a connector requirement can be registered and executed; the runtime wires the HTTP connector and injects its config without the capability module accessing config directly.
+- **SC-002**: A capability with an unsatisfied connector requirement is rejected at registration time with `missing_required_connector`; it never enters the registry.
+- **SC-003**: A third-party connector implementing `ConnectorPlugin` with a valid `connector_contract.json` is registered without modifying the Traverse runtime source.
+- **SC-004**: A connector execution failure is surfaced as `ConnectorError` in the trace; the host process does not crash.
+- **SC-005**: Connector registration validation, version matching, config schema validation, circular dependency detection, and execution wiring logic each reach 100% automated line coverage.
+
+## Out of Scope
+
+- Outbound connector authentication and secret management (e.g., OAuth, mTLS)
+- Bi-directional or event-driven connectors (connectors that push data into capabilities)
+- Connector-to-connector chaining beyond circular dependency detection
+- Connector hot-reload or live deregistration while capabilities are executing
+- Remote connector execution over a network transport
+- UI or MCP surfaces for connector management
+- Connector marketplace or external distribution registry

--- a/specs/040-contractual-enforcement-gate/spec.md
+++ b/specs/040-contractual-enforcement-gate/spec.md
@@ -1,0 +1,162 @@
+# Feature Specification: Contractual Enforcement Gate
+
+**Feature Branch**: `040-contractual-enforcement-gate`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Three-layer contractual validation enforced at authoring/CI-time, registration-time, and execution-time across all governed artifact directories. Introduces the draft quarantine convention, a unified violation taxonomy, and aggregate (non-fail-fast) violation reporting. Governs `scripts/ci/`, `crates/traverse-runtime/`, `crates/traverse-contracts/`, and `specs/governance/`. Unblocks GitHub issue #332.
+
+## Purpose
+
+This spec defines the Contractual Enforcement Gate — a three-layer validation architecture that prevents invalid, incomplete, or quarantine-violating artifacts from entering any governed execution path in Traverse.
+
+The three enforcement layers are:
+
+1. **Authoring/CI-time gate**: Runs in CI against all governed artifact directories (`contracts/`, `workflows/`, `specs/`, `crates/`). Fails for any validation error anywhere in those directories. No partial-pass mode.
+2. **Registration-time gate**: Runs when a capability, event, workflow, or connector is submitted to the registry. Validates the same rules as CI plus referential integrity checks (connector contracts, event type registry).
+3. **Execution-time gate**: Runs during capability execution. Validates input and output schemas against the capability contract (as established by spec 006) and additionally verifies that emitted events match the declared event catalog in the capability contract.
+
+The draft quarantine convention establishes that experimental artifacts MUST live under `drafts/` (top-level). Artifacts in `drafts/` are never executable, never referenced by production workflows or governed specs, and explicitly rejected by the runtime if an execution path attempts to reference them.
+
+All validation failures carry a unified violation record: `violation_code` (stable string), `path` (artifact path), and `message` (human-readable). All violations are collected and reported together; no fail-fast-on-first behavior is permitted.
+
+## User Scenarios and Testing
+
+### User Story 1 — CI Fails on Malformed Contract (Priority: P1)
+
+As a developer, I want CI to fail with a specific `violation_code` pointing to the exact field and file when I submit a PR with a malformed contract JSON so that I can fix the problem without guessing which artifact is invalid.
+
+**Why this priority**: Contract validation in CI is the outermost and earliest enforcement point; every developer encounters it before any other gate.
+
+**Independent Test**: Introduce a contract JSON missing a required field (`service_type`). Submit through the CI gate script. Verify the script exits non-zero and the output includes a violation record with `violation_code`, `path`, and `message` pointing to the missing field.
+
+**Acceptance Scenarios**:
+
+1. **Given** a PR that adds a contract JSON missing the required `service_type` field, **When** the CI gate runs, **Then** it exits non-zero and emits a violation record with `violation_code: "missing_required_field"`, the artifact `path`, and a `message` identifying the missing field.
+2. **Given** a PR with multiple invalid contracts in different files, **When** the CI gate runs, **Then** it collects all violations across all files and reports them in a single structured output before exiting non-zero.
+3. **Given** a PR where all contracts are valid, **When** the CI gate runs, **Then** it exits 0 with no violation records emitted.
+
+### User Story 2 — Registration Rejects Missing Required Field (Priority: P1)
+
+As an agent or developer, I want the Traverse registry to reject a capability registration that is missing `service_type` so that invalid capabilities never enter the registry, even if CI was bypassed.
+
+**Why this priority**: Registration-time validation is the second line of defense; it must be independent of CI so that programmatic registrations are also validated.
+
+**Independent Test**: Submit a capability contract missing `service_type` directly to the registry API. Verify the response carries a validation error with `violation_code`, `path`, and `message` before any registry state is modified.
+
+**Acceptance Scenarios**:
+
+1. **Given** a capability contract submitted for registration that is missing `service_type`, **When** the registry processes the submission, **Then** it returns a validation error with `violation_code: "missing_required_field"` and does not write any registry state.
+2. **Given** a capability contract with all required fields present but referencing a connector not in the registry, **When** registration is attempted, **Then** the registry returns `missing_required_connector` and does not write the capability.
+3. **Given** a capability contract that fails multiple field validations simultaneously, **When** registration is attempted, **Then** the registry returns all violations in a single error response (not just the first).
+
+### User Story 3 — Undeclared Event Emission Fails Execution (Priority: P1)
+
+As a platform operator, I want the runtime to record a `undeclared_event_emission` violation in the trace and fail execution when a capability emits an event not declared in its contract's event catalog so that event catalog drift is caught at runtime.
+
+**Why this priority**: Event catalog integrity is a contractual guarantee; silent undeclared emissions would corrupt downstream event consumers and audit trails.
+
+**Independent Test**: Deploy a capability whose implementation emits an event type not listed in its contract's `event_catalog`. Execute it. Verify the execution trace contains `undeclared_event_emission` and the execution fails.
+
+**Acceptance Scenarios**:
+
+1. **Given** a capability that emits an event type not declared in its contract's event catalog, **When** the capability executes and the event is emitted, **Then** the runtime records `undeclared_event_emission` in the trace and fails the execution.
+2. **Given** a capability that emits only events declared in its contract's event catalog, **When** execution completes, **Then** no `undeclared_event_emission` violation appears in the trace.
+3. **Given** a capability that emits two events — one declared and one undeclared — **When** execution runs, **Then** the trace records the undeclared emission specifically and still fails execution.
+
+### User Story 4 — Draft Quarantine Passes CI Without Errors (Priority: P2)
+
+As a developer, I want to place a draft contract under `drafts/` so that CI passes without validation errors and no example or governed spec references it.
+
+**Why this priority**: The draft quarantine enables safe experimentation without polluting the governed artifact space or triggering CI failures for intentionally incomplete artifacts.
+
+**Independent Test**: Place a draft contract under `drafts/contracts/`. Run the CI gate. Verify it exits 0 and the draft artifact is not subject to production-schema validation. Verify that placing a reference to the draft inside `workflows/` causes CI to fail with `draft_reference_in_production_artifact`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a draft contract placed under `drafts/contracts/`, **When** the CI gate runs, **Then** it exits 0 and does not validate the draft artifact against production schema rules.
+2. **Given** a workflow in `workflows/` that references an artifact path starting with `drafts/`, **When** the CI gate runs, **Then** it fails with `draft_reference_in_production_artifact` identifying the workflow path and the draft artifact path.
+3. **Given** the runtime is invoked with an execution request that resolves to an artifact path starting with `drafts/`, **When** the runtime processes the request, **Then** it rejects execution with `draft_artifact_not_executable` before any module code runs.
+
+## Edge Cases
+
+- Contract references an event type not in the event registry — `unresolved_event_reference` at registration time; not a CI-time error (event registry is not available at CI time)
+- Workflow references a capability that exists in the registry but belongs to a different workspace scope — `capability_not_in_scope` at registration time
+- Artifact in `drafts/` is referenced by a workflow in `workflows/` — CI fails with `draft_reference_in_production_artifact`; both the workflow path and the draft artifact path are included in the violation record
+- All violations reported in one response — both CI and registration-time gates MUST aggregate all violations and report them together, never fail-fast on the first
+- Contract JSON is syntactically valid JSON but fails schema validation on multiple fields simultaneously — all field-level violations reported in one response
+- Workflow graph contains a dangling edge reference (references a node that does not exist) — `dangling_workflow_edge` at CI time and registration time
+- Event catalog in a contract references an event type that exists in the event registry but with a different schema version — `event_schema_version_mismatch` at registration time
+- Execution-time event catalog check runs for a capability that declares an empty event catalog — any emitted event triggers `undeclared_event_emission`; no events emitted is valid
+- CI gate is run against a directory that contains no governed artifacts — gate exits 0 with no violations
+- Two contracts in the same PR both have the same `id` field — `duplicate_artifact_id` reported for both; neither is valid
+
+## Functional Requirements
+
+- **FR-001**: The Contractual Enforcement Gate MUST operate at three enforcement layers: authoring/CI-time, registration-time, and execution-time; all three layers are required and none may be omitted.
+- **FR-002**: The CI-time gate MUST scan all governed artifact directories (`contracts/`, `workflows/`, `specs/`, `crates/`) and fail for ANY validation error found anywhere in those directories; no partial-pass mode is permitted.
+- **FR-003**: At CI time, the gate MUST validate: contract JSON schema validity, required fields (`kind`, `id`, `version`, `service_type`, `artifact_type` for capability contracts), event catalog completeness (all referenced event types are defined in the local event schema files), and workflow graph validity (no dangling edge references).
+- **FR-004**: At registration time, the gate MUST perform all CI-time validations plus: referenced connector contracts must be registered, referenced event types must be present in the event registry.
+- **FR-005**: At execution time, the gate MUST validate input and output schemas against the capability contract and MUST verify that every event emitted during execution is declared in the capability contract's event catalog.
+- **FR-006**: If a capability emits an event not declared in its contract's event catalog, the runtime MUST record a `undeclared_event_emission` violation in the execution trace and MUST fail the execution.
+- **FR-007**: Every validation failure produced by any enforcement layer MUST carry a violation record containing: `violation_code` (stable string), `path` (artifact path), and `message` (human-readable description).
+- **FR-008**: All enforcement layers MUST aggregate all violations before reporting; fail-fast-on-first behavior is explicitly prohibited.
+- **FR-009**: Artifacts placed under `drafts/` (top-level directory) MUST be excluded from production schema validation by the CI-time gate.
+- **FR-010**: A workflow, governed spec, or example that references an artifact path starting with `drafts/` MUST cause the CI-time gate to fail with `draft_reference_in_production_artifact` identifying both the referencing artifact and the draft artifact path.
+- **FR-011**: The runtime MUST reject execution of any artifact whose resolved path starts with `drafts/` with error code `draft_artifact_not_executable`, before any module code is executed.
+- **FR-012**: The `violation_code` values used by the enforcement gate MUST be defined as a stable enumeration in the governing spec and MUST NOT be changed without a spec revision.
+- **FR-013**: The CI-time gate script MUST exit with non-zero status when any violation is found and exit 0 only when no violations are found.
+- **FR-014**: The CI-time gate MUST produce its violation output in a machine-readable format (JSON array of violation records) in addition to any human-readable summary.
+- **FR-015**: Registration-time validation MUST reject the entire registration request if any violation is found; no partial registration is permitted.
+- **FR-016**: The CI-time gate MUST be runnable as a standalone script (`scripts/ci/`) without requiring the Traverse registry or runtime to be running.
+- **FR-017**: Workflow graph validation at CI time MUST detect and report dangling edge references — edges that point to workflow nodes not defined in the same workflow artifact.
+- **FR-018**: Event catalog completeness validation at CI time MUST verify that every event type referenced in a capability contract's `event_catalog` field is defined in a local event schema file within the governed artifacts; unresolvable event type references at CI time MUST produce `unresolved_local_event_reference`.
+- **FR-019**: The `unresolved_event_reference` violation at registration time MUST identify the event type that is missing from the event registry.
+- **FR-020**: Duplicate `id` values across capability contracts submitted in the same registration batch MUST produce a `duplicate_artifact_id` violation for each conflicting entry.
+
+## Non-Functional Requirements
+
+- **NFR-001 Completeness**: All enforcement layers MUST report all violations before exiting or returning; partial reports that omit some violations are treated as gate failures.
+- **NFR-002 Determinism**: Given the same set of artifacts and the same registry state, each enforcement layer MUST produce the same set of violations in the same order on every run.
+- **NFR-003 Independence**: The CI-time gate MUST operate without a running registry or runtime; it MUST NOT require network access or external service availability.
+- **NFR-004 Testability**: CI-time validation logic, registration-time validation logic, execution-time event catalog checking, and draft quarantine enforcement MUST each be independently testable with 100% automated line coverage.
+- **NFR-005 Stability**: `violation_code` values MUST be stable across minor version increments; additions are permitted, changes or removals MUST require a spec revision.
+- **NFR-006 Performance**: The CI-time gate MUST complete validation of the entire governed artifact tree within a time budget suitable for standard CI pipelines (no external blocking I/O).
+- **NFR-007 Traceability**: Every violation record emitted at execution time MUST appear in the runtime execution trace with the same `violation_code`, `path`, and `message` fields used at CI and registration time.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: All three enforcement layers MUST be active and non-bypassable; no code path MAY execute a governed artifact that has not passed all applicable layers.
+- **QG-002**: Violation reporting MUST be aggregate; any enforcement layer that emits only the first violation and stops is non-compliant with this spec.
+- **QG-003**: The CI-time gate script MUST exit non-zero on any violation and MUST exit 0 only when all governed artifact directories are valid.
+- **QG-004**: A draft artifact MUST never be executable; the runtime MUST reject it with `draft_artifact_not_executable` before any module code runs.
+- **QG-005**: CI-time validation, registration-time validation, execution-time event catalog checking, and draft quarantine enforcement MUST each reach 100% automated line coverage under the quality gate.
+
+## Key Entities
+
+- **Enforcement Layer**: One of the three validation stages — authoring/CI-time, registration-time, or execution-time — each with a defined scope and set of validation rules.
+- **Violation Record**: The structured unit of a validation failure, carrying `violation_code` (stable string), `path` (artifact path), and `message` (human-readable description).
+- **Violation Code**: A stable, enumerated string identifier for a specific type of validation failure; defined in this spec and versioned with it.
+- **CI-Time Gate**: The standalone script in `scripts/ci/` that validates all governed artifact directories without requiring a running registry or runtime.
+- **Registration-Time Gate**: The validation layer that runs when an artifact is submitted to the Traverse registry; includes all CI-time rules plus referential integrity checks.
+- **Execution-Time Gate**: The validation layer that runs during capability execution; enforces input/output schema compliance and event catalog integrity.
+- **Draft Quarantine**: The convention that experimental artifacts MUST reside under `drafts/` (top-level); draft artifacts are excluded from production validation, are never executable, and must not be referenced by production artifacts.
+- **Event Catalog**: The list of event types declared in a capability contract that the capability is permitted to emit; any emission outside this list triggers `undeclared_event_emission`.
+
+## Success Criteria
+
+- **SC-001**: A PR with a malformed contract JSON fails the CI gate with a machine-readable violation record identifying the exact field and file, and the PR is blocked from merge.
+- **SC-002**: A capability registration with a missing required field is rejected by the registry with a structured violation record before any registry state is modified.
+- **SC-003**: A capability that emits an undeclared event during execution produces `undeclared_event_emission` in the execution trace and execution fails.
+- **SC-004**: A draft artifact placed under `drafts/` does not trigger CI validation errors; a workflow referencing it triggers `draft_reference_in_production_artifact`.
+- **SC-005**: All three enforcement layers aggregate all violations before reporting; no enforcement layer exits after the first violation.
+- **SC-006**: CI-time validation, registration-time validation, execution-time event catalog checking, and draft quarantine enforcement each reach 100% automated line coverage.
+
+## Out of Scope
+
+- Automated remediation or auto-fix of validation violations
+- UI or dashboard surfaces for violation reporting
+- Validation of non-governed directories outside `contracts/`, `workflows/`, `specs/`, `crates/`, and `drafts/`
+- Schema migration tooling for evolving existing contracts to new required fields
+- Enforcement of semantic correctness beyond the structural and referential rules defined in this spec
+- Cross-workspace validation (validating capability references across multiple Traverse workspaces)
+- Real-time file-watch validation during local development (CI and registration-time gates only)


### PR DESCRIPTION
## Summary
Add governing specs 038, 039, 040 to unblock issues #330, #331, #332.

Specs only — no code changes. `approved-specs.json` registration in follow-on PR.

## Governing Spec
- 004-spec-alignment-gate
- 028-schema-alignment-gate-v02

## Project Item
Closes #330
Closes #331
Closes #332

## Validation
- All three spec files follow the approved spec format (Purpose, User Stories, Edge Cases, FR/NFR/QG, Key Entities, Success Criteria, Out of Scope)
- No code changes in this PR
- Spec IDs 038-040 reserved and consistent with approved-specs.json numbering sequence