### PR TITLE
feat(specs): add governing specs 041-043 (workflow composition, MCP library, module dependencies)

### DIFF
--- a/specs/041-workflow-composition-api/spec.md
+++ b/specs/041-workflow-composition-api/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Workflow Composition API
+
+**Feature Branch**: `041-workflow-composition-api`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Spec slice defining the runtime and registry surface for registering, inspecting, and executing DAG-based workflows composed of capability nodes — covering JSON document format, HTTP API endpoints, CLI commands, cycle detection, and edge schema validation. Unblocks GitHub issue #309.
+
+## Purpose
+
+This spec defines the first implementation-governing slice for programmatic workflow composition in Traverse.
+
+It narrows the broad workflow concept into a concrete, testable model for:
+
+- accepting a canonical JSON workflow document at an HTTP endpoint and CLI command
+- validating the workflow graph for cycles and unresolved capability references at registration time
+- locking the workflow as an immutable versioned artifact with a content-addressable digest
+- exposing listing and inspection endpoints for registered workflows
+- executing a registered workflow as an ordered sequence of capability invocations within the existing runtime execution model
+
+This slice is intentionally limited to workspace-scoped, DAG workflows over already-registered capabilities. Event-driven orchestration, cross-workspace workflow sharing, and dynamic capability discovery during traversal are out of scope.
+
+## User Scenarios and Testing
+
+### User Story 1 — Register and Execute a Two-Step Workflow via HTTP API (Priority: P1)
+
+As an agent developer, I want to build a two-step workflow JSON document that wires capability A's output into capability B's input, register it via `POST /v1/workflows/register`, and execute it in a single request — without writing any files to disk — so that Traverse proves its first dynamic, programmatic workflow path.
+
+**Why this priority**: The canonical use case for workflow composition is agent-side programmatic authoring. Without this path there is no value in the composition API.
+
+**Independent Test**: Construct a valid two-node workflow JSON document in memory, POST it to `/v1/workflows/register`, verify a `201` response with a stable `workflow_id` and digest, then execute the workflow via the runtime request model and verify both capabilities are called in order with correct input/output mapping.
+
+**Acceptance Scenarios**:
+
+1. **Given** two registered capabilities where capability A's output schema is compatible with capability B's input schema, **When** an agent submits a valid workflow JSON document to `POST /v1/workflows/register`, **Then** the server validates the graph, resolves all capability references, and returns `201` with a stable `workflow_id` and content-addressable digest.
+2. **Given** a registered workflow, **When** a runtime request targets that workflow by `workflow_id`, **Then** the runtime executes capability A with the supplied input, maps A's output to B's input according to the declared edge mapping, executes capability B, and returns a structured execution result and trace covering both nodes.
+3. **Given** a workflow registration that would complete successfully, **When** the same workflow document is submitted a second time with the same `workflow_id` and identical content, **Then** the server returns `200` (idempotent re-registration) with the same digest.
+
+### User Story 2 — Register a File-Based Workflow via CLI (Priority: P1)
+
+As a developer, I want to run `traverse-cli workflow register my-workflow.json` to register a workflow stored in a local file — using the same HTTP API internally — so that file-based and programmatic workflows share one canonical code path.
+
+**Why this priority**: CLI-based registration is the primary developer workflow; it must be consistent with the API surface to avoid divergent behavior.
+
+**Independent Test**: Write a valid two-node workflow JSON document to a local file, invoke `traverse-cli workflow register`, verify it prints the assigned `workflow_id` and digest, then call `traverse-cli workflow inspect <id>` and verify the returned graph matches the submitted document.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid workflow JSON file on disk, **When** the developer runs `traverse-cli workflow register <path>`, **Then** the CLI reads the file, POSTs to `/v1/workflows/register`, and prints the assigned `workflow_id` and digest.
+2. **Given** a workflow file with a validation error (e.g. cycle or unresolved capability), **When** the developer runs the register command, **Then** the CLI prints the server error code and human-readable description and exits non-zero.
+3. **Given** a registered workflow, **When** the developer runs `traverse-cli workflow list`, **Then** the CLI prints a table of all workspace-scoped workflows with their ids, versions, and digests.
+
+### User Story 3 — Inspect a Registered Workflow via HTTP API (Priority: P2)
+
+As an agent or developer, I want to call `GET /v1/workflows/{id}` and receive the full graph definition including all nodes, edges, and edge mappings so that I can verify the composition before executing it.
+
+**Why this priority**: Inspection is necessary for debugging and for agents that need to confirm a workflow's structure before trusting its execution.
+
+**Independent Test**: Register a three-node workflow, then GET the workflow by id and verify the response contains all three nodes, all declared edges, all edge input/output mappings, and the registration digest.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registered workflow, **When** an agent calls `GET /v1/workflows/{id}`, **Then** the server returns the full workflow document including nodes, edges, edge mappings, registration metadata, and digest.
+2. **Given** a `workflow_id` that does not exist in the workspace, **When** an agent calls `GET /v1/workflows/{id}`, **Then** the server returns a structured `workflow_not_found` error with the requested id.
+3. **Given** multiple registered workflows, **When** an agent calls `GET /v1/workflows`, **Then** the server returns a paginated list of all workspace-scoped workflows with summary fields.
+
+### User Story 4 — Reject Cyclic and Invalid Workflow Graphs at Registration (Priority: P2)
+
+As a platform developer, I want the registry to detect and reject workflow graphs containing cycles, unresolved capability references, or edge schema mismatches at registration time — not at execution time — so that invalid workflows never enter the registry.
+
+**Why this priority**: Silent acceptance of invalid graphs would produce non-deterministic runtime failures; early rejection is the only safe model.
+
+**Independent Test**: Submit three invalid workflow documents — one with a direct cycle, one with an unresolved capability reference, and one with an edge connecting an incompatible output schema to an input schema — and verify each returns the correct structured error code.
+
+**Acceptance Scenarios**:
+
+1. **Given** a workflow document where node A declares a directed edge to node B and node B declares a directed edge back to node A, **When** the document is submitted to `POST /v1/workflows/register`, **Then** the server rejects it with `workflow_cycle_detected` and includes the cycle path in the error body.
+2. **Given** a workflow document referencing a `capability_id` not present in the workspace registry, **When** the document is submitted to `POST /v1/workflows/register`, **Then** the server rejects it with `unresolved_capability_reference` and identifies the missing capability.
+3. **Given** a workflow document where an edge maps node A's `result.count` (integer) to node B's `input.name` (string), **When** the document is submitted, **Then** the server rejects it with `edge_schema_mismatch` and identifies the incompatible field pair.
+
+## Edge Cases
+
+- Workflow references a capability not registered in the workspace — `unresolved_capability_reference` at registration time; the error body MUST identify each unresolved reference.
+- Workflow with a single node and no edges — valid; executes as a single-capability invocation with no edge mapping step.
+- Input/output type mismatch on an edge (schema incompatibility between connected nodes) — `edge_schema_mismatch` at registration; the error body MUST identify the edge and the incompatible field types.
+- Workflow `id` collision where the same `id` is submitted with a different document digest — `ImmutableVersionConflict`; same idempotency rules as capability registration.
+- Workflow document with zero nodes — `empty_workflow` validation error at registration; empty graphs are not executable and MUST be rejected before graph analysis.
+- Edge mapping references a field not present in the source node's output schema — `edge_field_not_found` at registration.
+- Workflow where all declared capabilities are present but one has been deprecated since registration — `deprecated_capability_reference` warning at execution time; behavior governed by workspace deprecation policy.
+- Concurrent registration of the same workflow `id` with different digests by two agents — the registry MUST serialize and apply the idempotency rules; one request wins, the other receives `ImmutableVersionConflict`.
+
+## Functional Requirements
+
+- **FR-001**: The registry MUST accept a workflow registration request at `POST /v1/workflows/register` whose body is a canonical JSON workflow document.
+- **FR-002**: A workflow document MUST contain a stable `workflow_id`, a `version` string, a `nodes` array, and an `edges` array; all fields are required.
+- **FR-003**: Each node in a workflow document MUST reference a `capability_id` and `capability_version` that are registered in the workspace at the time of workflow registration.
+- **FR-004**: Each edge in a workflow document MUST declare a `source_node`, `source_output_field`, `target_node`, and `target_input_field`.
+- **FR-005**: The registry MUST perform a topological sort of the workflow graph at registration time to detect directed cycles; any cycle MUST cause registration failure with `workflow_cycle_detected` and a cycle path in the error body.
+- **FR-006**: The registry MUST validate that every `capability_id` referenced in the workflow `nodes` array is present in the workspace registry at the time of registration; any unresolved reference MUST cause registration failure with `unresolved_capability_reference`.
+- **FR-007**: The registry MUST validate that the output schema field referenced by each edge's `source_output_field` is compatible with the input schema field referenced by each edge's `target_input_field`; schema incompatibility MUST cause registration failure with `edge_schema_mismatch`.
+- **FR-008**: On successful registration the registry MUST assign a content-addressable digest to the workflow document and store it immutably.
+- **FR-009**: Re-registration of a workflow with the same `workflow_id` and identical digest MUST be accepted idempotently and return the existing registration record.
+- **FR-010**: Re-registration of a workflow with the same `workflow_id` and a different digest MUST be rejected with `ImmutableVersionConflict`.
+- **FR-011**: The registry MUST expose `GET /v1/workflows` returning a paginated list of all workspace-scoped registered workflows with summary fields including `workflow_id`, `version`, `digest`, and `registered_at`.
+- **FR-012**: The registry MUST expose `GET /v1/workflows/{id}` returning the full workflow document, all node records, all edge records, edge mappings, and registration metadata for the identified workflow.
+- **FR-013**: `GET /v1/workflows/{id}` MUST return a structured `workflow_not_found` error when the `id` does not exist in the workspace.
+- **FR-014**: The CLI MUST expose `traverse-cli workflow register <path>` which reads a JSON workflow file and POSTs to `/v1/workflows/register` using the same HTTP client as other CLI commands.
+- **FR-015**: The CLI MUST expose `traverse-cli workflow list` which calls `GET /v1/workflows` and renders results in a tabular format.
+- **FR-016**: The CLI MUST expose `traverse-cli workflow inspect <id>` which calls `GET /v1/workflows/{id}` and renders the full graph definition.
+- **FR-017**: The runtime MUST support targeting a registered workflow by `workflow_id` in a runtime request.
+- **FR-018**: When a runtime request targets a workflow, the runtime MUST execute capability nodes in topological order derived from the registered graph.
+- **FR-019**: The runtime MUST apply the declared edge field mappings to route each node's output into the subsequent node's input before execution.
+- **FR-020**: The runtime MUST validate each node's input against its capability's contract input schema before executing that node.
+- **FR-021**: The runtime MUST validate each node's output against its capability's contract output schema after executing that node and before applying edge mappings.
+- **FR-022**: The runtime MUST emit state events and produce a structured trace that covers all nodes in the workflow execution, not just the first.
+- **FR-023**: Workflow documents MUST be workspace-scoped; a workflow registered in workspace A MUST NOT be visible or executable in workspace B.
+- **FR-024**: A workflow document with zero nodes MUST be rejected at registration with `empty_workflow`.
+
+## Non-Functional Requirements
+
+- **NFR-001 Determinism**: Graph traversal order, topological sort, edge mapping application, state event ordering, and trace generation MUST be deterministic for the same workflow graph and input.
+- **NFR-002 Explainability**: Registration failures MUST include structured error bodies identifying the exact validation failure, affected node or edge, and — for cycles — the full cycle path.
+- **NFR-003 Immutability**: Once a workflow is registered with a given `workflow_id` and digest, its document MUST be immutable; modification requires a new version.
+- **NFR-004 Testability**: Cycle detection, edge schema validation, topological sort, and node execution sequencing MUST be independently testable at unit level without a running HTTP server.
+- **NFR-005 Compatibility**: The canonical workflow JSON document format MUST be versionable and suitable for semver discipline; breaking changes to the schema require a new spec.
+- **NFR-006 Portability**: Workflow execution MUST use the existing runtime placement abstraction so that future remote and browser placements work without changes to the workflow model.
+- **NFR-007 Workspace Isolation**: Workflow registration, listing, inspection, and execution MUST be strictly workspace-scoped with no cross-workspace leakage.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: Cycle detection MUST run at registration time and MUST NOT be deferred to execution time; cyclic graphs MUST never enter the registry.
+- **QG-002**: Every workflow registration validation failure MUST return a structured error code and human-readable message; generic HTTP 500 responses for validation errors are not acceptable.
+- **QG-003**: The CLI MUST delegate all business logic to the HTTP API; no standalone validation logic may live only in the CLI.
+- **QG-004**: Core workflow validation logic (cycle detection, edge schema validation, capability reference resolution) MUST reach 100% automated line coverage.
+- **QG-005**: Workflow execution MUST use the runtime's existing contract validation path for each node; bypassing input/output schema validation for workflow-executed capabilities is not acceptable.
+
+## Key Entities
+
+- **Workflow Document**: The canonical JSON artifact defining a workflow's `workflow_id`, `version`, nodes, and edges. This is a governed artifact type with the same immutability rules as capability contracts.
+- **Workflow Node**: A member of a workflow's `nodes` array that references a registered capability by `capability_id` and `capability_version`.
+- **Workflow Edge**: A member of a workflow's `edges` array that declares a directed data-flow connection between two nodes, including source and target field mappings.
+- **Workflow Registration Record**: The immutable registry entry created on successful registration, containing the workflow document, digest, and registration metadata.
+- **Workflow Execution Trace**: The structured trace artifact produced by the runtime for a workflow execution; covers all nodes rather than a single capability.
+- **Edge Field Mapping**: The runtime operation that reads a named field from a node's output and writes it to a named field in the subsequent node's input before that node executes.
+
+## Success Criteria
+
+- **SC-001**: A two-node workflow can be registered via `POST /v1/workflows/register` and executed end-to-end with correct input/output field routing and a trace covering both nodes.
+- **SC-002**: Registration of a cyclic workflow graph fails at registration time with `workflow_cycle_detected` and a cycle path; the workflow is not stored.
+- **SC-003**: Registration of a workflow with an unresolved capability reference fails with `unresolved_capability_reference`; the workflow is not stored.
+- **SC-004**: `GET /v1/workflows/{id}` returns the full graph document for a registered workflow; unknown ids return a structured `workflow_not_found` error.
+- **SC-005**: `traverse-cli workflow register`, `list`, and `inspect` work correctly against a live server and produce consistent output with the HTTP API.
+- **SC-006**: Core workflow validation logic reaches 100% automated line coverage under the protected coverage gate.
+
+## Out of Scope
+
+- Event-driven or reactive workflow triggers
+- Cross-workspace workflow sharing or federation
+- Workflow versioning beyond the immutable `workflow_id`+digest model
+- Conditional branching, loops, or fan-out/fan-in within a workflow graph
+- Dynamic capability discovery during workflow traversal
+- Workflow rollback or compensating transactions
+- Remote or distributed placement for workflow node execution
+- Workflow scheduling or deferred execution

--- a/specs/042-mcp-library-surface/spec.md
+++ b/specs/042-mcp-library-surface/spec.md
@@ -1,0 +1,153 @@
+# Feature Specification: MCP Library Surface
+
+**Feature Branch**: `042-mcp-library-surface`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Spec slice defining the refactoring of `traverse-mcp` into a dual-surface crate: a public Rust library API callable by agents without MCP wire protocol, and a thin stdio server binary that wraps the library. Covers public function signatures, `McpToolRegistry`, semver stability guarantees, and embedding rules. Unblocks GitHub issue #310.
+
+## Purpose
+
+This spec defines the implementation-governing slice for exposing `traverse-mcp` as a first-class Rust library.
+
+It narrows the intent into a concrete, testable model for:
+
+- restructuring `traverse-mcp` so that its tool handler logic lives in a library crate, not only in the stdio binary
+- exposing a public, semver-stable API surface (`discover_capabilities`, `get_capability`, `execute_capability`, `McpToolRegistry`)
+- making the existing stdio MCP server a thin binary wrapper over the library
+- allowing Rust agents to call tool handler functions directly without MCP wire protocol
+- allowing third-party MCP servers to embed `McpToolRegistry` and re-export Traverse's tools as part of a larger tool surface
+
+This slice does not change the MCP wire protocol, the tool schemas, or the underlying runtime execution behavior. It is a structural refactoring that adds a library surface without removing the binary surface.
+
+## User Scenarios and Testing
+
+### User Story 1 — Rust Agent Calls Library Functions Directly (Priority: P1)
+
+As a Rust agent developer, I want to import `traverse_mcp` as a library dependency and call `execute_capability()` directly — without spawning a subprocess or implementing MCP stdio — so that I can integrate Traverse capabilities into my agent without the overhead of process management or wire protocol parsing.
+
+**Why this priority**: Direct library access is the primary value of this spec. Without it, Rust agents must spawn a subprocess, which is fragile and not consistent with Rust-native integration patterns.
+
+**Independent Test**: Write a Rust binary that adds `traverse_mcp` as a `[dependencies]` entry, calls `discover_capabilities()`, selects a known capability from the returned list, and calls `execute_capability()` with a valid input — verifying the result without invoking the stdio server.
+
+**Acceptance Scenarios**:
+
+1. **Given** a compiled Rust agent that imports `traverse_mcp`, **When** the agent calls `discover_capabilities()`, **Then** the function returns the same capability list as the `tools/list` MCP method would return for the same runtime state.
+2. **Given** a compiled Rust agent that imports `traverse_mcp`, **When** the agent calls `execute_capability(id, version, input)` with a registered capability, **Then** the function returns the same execution result as the `tools/call` MCP method would return.
+3. **Given** a compiled Rust agent that calls `execute_capability()` before the underlying runtime is initialized, **When** the call is made, **Then** the function returns `Err(TraverseMcpError::RuntimeNotInitialized)` without panicking.
+
+### User Story 2 — Existing Stdio Server Binary Continues to Work (Priority: P1)
+
+As a platform operator, I want the existing `traverse-mcp` stdio server to continue to work unchanged after the refactor — producing the same wire protocol output for the same MCP messages — so that existing MCP clients are not broken.
+
+**Why this priority**: Backward compatibility of the stdio server is non-negotiable; the refactor must be invisible to MCP protocol consumers.
+
+**Independent Test**: Run the stdio server binary before and after the refactor, send the same `tools/list` and `tools/call` MCP JSON-RPC messages, and verify the response payloads are byte-identical.
+
+**Acceptance Scenarios**:
+
+1. **Given** the refactored stdio server binary, **When** it receives a `tools/list` MCP JSON-RPC message, **Then** it returns a `tools/list` response with the same tool definitions as before the refactor.
+2. **Given** the refactored stdio server binary, **When** it receives a `tools/call` MCP JSON-RPC message for a registered capability, **Then** it returns the same result structure as before the refactor.
+3. **Given** the refactored stdio server binary running alongside a Rust agent calling library functions directly, **When** both operate against the same runtime state, **Then** neither corrupts shared state and both produce consistent results.
+
+### User Story 3 — Third-Party MCP Server Embeds McpToolRegistry (Priority: P2)
+
+As a third-party MCP server developer, I want to add `traverse_mcp` as a dependency, embed `McpToolRegistry` into my server, and re-export Traverse's `discover_capabilities` and `execute_capability` tools as part of my own tool surface — so that my server provides a superset of Traverse's MCP tools without duplicating their implementation.
+
+**Why this priority**: Composability of the MCP tool surface is the primary motivation for the registry abstraction; without it the library API does not support the embedding use case.
+
+**Independent Test**: Write a minimal Rust MCP server that creates an `McpToolRegistry`, calls `register_traverse_tools()`, adds one additional custom tool, and then calls `handle_tools_list()` — verifying the response includes both Traverse's tools and the custom tool.
+
+**Acceptance Scenarios**:
+
+1. **Given** a third-party MCP server that embeds `McpToolRegistry`, **When** it calls `register_traverse_tools()`, **Then** Traverse's `discover_capabilities` and `execute_capability` tool schemas are added to the registry.
+2. **Given** an `McpToolRegistry` with Traverse tools registered, **When** the third-party server adds an additional tool with a name that does not conflict, **Then** the registry accepts it and `handle_tools_list()` returns all tools including both Traverse and custom tools.
+3. **Given** an `McpToolRegistry` with Traverse tools registered, **When** the third-party server attempts to register a tool whose name conflicts with an already-registered Traverse tool, **Then** the registry returns `Err(McpRegistryError::ToolNameConflict)` and does not modify the existing registration.
+
+### User Story 4 — CI Integration Test Calls Library Without Stdio (Priority: P2)
+
+As a CI pipeline author, I want to import `traverse_mcp` as a library in integration tests and call `discover_capabilities()` and `execute_capability()` directly — without starting or connecting to a stdio server process — so that integration tests are faster, hermetic, and free of process lifecycle management.
+
+**Why this priority**: Testability without subprocess overhead is a concrete quality benefit of the library surface; it must work without the stdio server.
+
+**Independent Test**: Write a test in `traverse-mcp/tests/` that calls `discover_capabilities()` directly, verifies the list is non-empty, then calls `execute_capability()` for a known capability and verifies a successful result — all without launching the stdio binary.
+
+**Acceptance Scenarios**:
+
+1. **Given** the library API, **When** a test calls `discover_capabilities()` with a runtime that has registered capabilities, **Then** the function returns the complete list without stdio setup.
+2. **Given** a test that calls `execute_capability()` with a valid input, **When** the function completes, **Then** it returns a result consistent with the runtime's contract validation output.
+
+## Edge Cases
+
+- Library caller and stdio server running simultaneously against the same runtime — shared state MUST be protected by the same synchronization primitives used by the runtime; no data races are permitted.
+- Library function called before the underlying runtime is initialized — `RuntimeNotInitialized` error returned from all three public functions; no panic.
+- Breaking change to a public library function signature (name, parameters, or return type) — requires a new spec slice; existing callers MUST be migrated before the breaking change merges.
+- `McpToolRegistry` embedded in a third-party server that registers a tool with the same name as a Traverse tool — `ToolNameConflict` error at registration time; the conflicting tool is not registered.
+- `execute_capability()` called with an input that fails the capability's contract input schema — function returns a structured validation error, not a panic; the error is the same error returned by the runtime for schema violations.
+- `discover_capabilities()` called on a runtime with no registered capabilities — returns an empty list, not an error.
+- `McpToolRegistry` used after the runtime backing it has been shut down — returns `RuntimeNotInitialized` for any tool dispatch call; does not panic.
+- Library imported in a `#[cfg(test)]` context that does not initialize the full runtime — functions MUST return `RuntimeNotInitialized`, not an initialization side-effect or panic.
+
+## Functional Requirements
+
+- **FR-001**: The `traverse-mcp` crate MUST be refactored so that all tool handler logic lives in `lib.rs` (or a module tree rooted there), not only in a binary entry point.
+- **FR-002**: The `traverse-mcp` crate MUST expose `discover_capabilities()` as a public function in its library API.
+- **FR-003**: The `traverse-mcp` crate MUST expose `get_capability(id: &str, version: &str)` as a public function in its library API.
+- **FR-004**: The `traverse-mcp` crate MUST expose `execute_capability(id: &str, version: &str, input: serde_json::Value)` as a public function in its library API.
+- **FR-005**: All three public functions MUST return `Result` types with a typed `TraverseMcpError` error enum; `unwrap()` and `panic!()` are forbidden on any function call path reachable from the public API.
+- **FR-006**: `TraverseMcpError` MUST include at minimum the variants `RuntimeNotInitialized`, `CapabilityNotFound`, `InputSchemaValidationFailed`, `ExecutionFailed`, and `RegistryUnavailable`.
+- **FR-007**: The existing stdio server binary MUST be moved to `traverse-mcp/src/bin/server.rs` and MUST be a thin wrapper that calls the library functions for all MCP method handling.
+- **FR-008**: The stdio server binary MUST produce byte-identical responses to the same MCP JSON-RPC messages before and after the refactor.
+- **FR-009**: The crate MUST expose a `McpToolRegistry` struct with at minimum the methods `register_traverse_tools()`, `register_tool(tool: McpTool)`, `handle_tools_list()`, and `handle_tools_call(name: &str, arguments: serde_json::Value)`.
+- **FR-010**: `McpToolRegistry::register_tool()` MUST return `Err(McpRegistryError::ToolNameConflict)` when a tool with the same name is already registered; it MUST NOT silently overwrite the existing registration.
+- **FR-011**: `McpToolRegistry::register_traverse_tools()` MUST register Traverse's `discover_capabilities` and `execute_capability` tools into the registry.
+- **FR-012**: The public function signatures (`discover_capabilities`, `get_capability`, `execute_capability`, `McpToolRegistry` methods) MUST be considered stable under semver once merged; breaking changes require a new spec slice.
+- **FR-013**: The library functions MUST be safe to call from multiple threads simultaneously against the same runtime state; internal synchronization MUST prevent data races.
+- **FR-014**: All three public functions MUST return `Err(TraverseMcpError::RuntimeNotInitialized)` when called before the runtime is initialized, without panicking or producing undefined behavior.
+- **FR-015**: The crate's `Cargo.toml` `[lib]` section MUST be explicitly declared so that downstream crates can depend on the library without also depending on the binary.
+- **FR-016**: The crate MUST NOT expose any internal modules, types, or functions as `pub` beyond what is documented in this spec's public API surface.
+
+## Non-Functional Requirements
+
+- **NFR-001 Backward Compatibility**: The stdio server binary's MCP wire protocol behavior MUST be unchanged after refactoring; existing MCP clients MUST continue to work without modification.
+- **NFR-002 API Stability**: Public function signatures are semver-stable once merged; the library's major version MUST be incremented before any breaking signature change ships.
+- **NFR-003 Thread Safety**: All public library functions MUST be safe to call from multiple threads against the same runtime; `Send + Sync` bounds MUST be satisfied on all public types.
+- **NFR-004 Testability**: All three public tool handler functions MUST be independently testable at unit and integration level without spawning the stdio binary.
+- **NFR-005 Minimal Surface**: The public library API is limited to the three functions and `McpToolRegistry`; no additional types, modules, or functions are made public by this spec.
+- **NFR-006 No Panic Paths**: No panic, unwrap, or expect on any code path reachable from the public API; all error conditions MUST be surfaced via `Result`.
+- **NFR-007 Crate Hygiene**: `traverse-mcp` MUST compile with no warnings under `cargo build` after the refactor; all dead code introduced by the structural change MUST be removed.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: The public function signatures (`discover_capabilities`, `get_capability`, `execute_capability`) MUST NOT change after merge without a new governing spec; the CI gate MUST enforce this via the spec-alignment check.
+- **QG-002**: All three public functions MUST return typed `Result` errors; `unwrap()` is forbidden on any reachable path from the public API.
+- **QG-003**: The stdio server binary MUST pass byte-identical wire protocol tests before and after the refactor; regression in MCP protocol output is a blocking failure.
+- **QG-004**: `McpToolRegistry::register_tool()` MUST return `ToolNameConflict` on collision; silent overwrite is not acceptable.
+- **QG-005**: Core library logic MUST reach 100% automated line coverage under the protected coverage gate.
+
+## Key Entities
+
+- **Library API**: The set of public Rust functions exposed by `traverse-mcp` as a `[lib]` crate: `discover_capabilities()`, `get_capability()`, `execute_capability()`.
+- **TraverseMcpError**: The typed error enum returned by all public library functions, covering runtime initialization, capability lookup, schema validation, and execution failures.
+- **McpToolRegistry**: A struct that holds a named set of MCP tools and dispatches `tools/list` and `tools/call` requests; usable by third-party MCP servers to embed Traverse's tools.
+- **McpRegistryError**: The typed error enum returned by `McpToolRegistry` methods, including `ToolNameConflict`.
+- **Stdio Server Binary**: `traverse-mcp/src/bin/server.rs` — the thin binary wrapper that reads MCP JSON-RPC messages from stdin, dispatches to library functions, and writes responses to stdout.
+- **McpTool**: A struct representing a single MCP tool definition with a name, description, and JSON Schema for its arguments; used as the registration unit for `McpToolRegistry`.
+
+## Success Criteria
+
+- **SC-001**: A Rust binary that imports `traverse_mcp` as a library and calls `discover_capabilities()` compiles and runs successfully without spawning the stdio server.
+- **SC-002**: The stdio server binary produces byte-identical MCP wire protocol responses before and after the refactor, verified by automated regression tests.
+- **SC-003**: `McpToolRegistry` accepts Traverse tools and a non-conflicting custom tool; rejects a tool with a conflicting name with `ToolNameConflict`.
+- **SC-004**: All three public functions return `Err(RuntimeNotInitialized)` when called before runtime initialization; no panics occur in this path.
+- **SC-005**: Integration tests call `execute_capability()` directly without the stdio binary and produce results consistent with the runtime's contract validation.
+- **SC-006**: Core library logic reaches 100% automated line coverage under the protected coverage gate.
+
+## Out of Scope
+
+- Changes to the MCP wire protocol or tool schemas
+- Non-Rust library bindings (Python, TypeScript, etc.) — non-Rust agents use the HTTP API from spec 033
+- MCP authentication or authorization
+- Tool versioning within the MCP protocol surface
+- Streaming or incremental response support for `execute_capability`
+- Dynamic tool discovery or hot-reload of tools at runtime
+- Any change to the runtime execution model or capability contract format

--- a/specs/043-module-dependency-management/spec.md
+++ b/specs/043-module-dependency-management/spec.md
@@ -1,0 +1,159 @@
+# Feature Specification: Module Dependency Management
+
+**Feature Branch**: `043-module-dependency-management`
+**Created**: 2026-04-19
+**Status**: Draft
+**Input**: Spec slice defining how capabilities declare, resolve, lock, and verify inter-capability dependencies within Traverse's registry and contracts model. Covers dependency declaration in contracts, registration-time resolution using semver range matching, dependency lock records, execution-time digest verification, transitive resolution up to depth 5, circular dependency detection, and workspace-scoped resolution. Unblocks GitHub issue #338.
+
+## Purpose
+
+This spec defines the first implementation-governing slice for inter-capability dependency management in Traverse.
+
+It narrows the broad dependency concept into a concrete, testable model for:
+
+- declaring dependencies in a capability contract using a `dependencies` field
+- resolving declared dependencies against the workspace registry at registration time using semver range rules from spec 037
+- locking resolved dependencies as immutable `(id, version, digest)` tuples tied to the registering capability's version
+- verifying locked dependency digests at execution time to detect silent supply-chain drift
+- detecting and rejecting circular dependency chains at registration time
+- resolving transitive dependencies up to a fixed depth limit
+
+This slice does not define shared-workspace dependency federation, dependency updates/upgrades, or dependency graph visualization. It is intentionally limited to workspace-scoped, static resolution so the lock and verification model can be built and tested cleanly before more complex scenarios are added.
+
+## User Scenarios and Testing
+
+### User Story 1 — Capability Resolves a Satisfiable Dependency at Registration (Priority: P1)
+
+As a capability author, I want to declare `{"capability_id": "traverse.logging", "version_range": "^1.0.0"}` in my contract's `dependencies` field so that the registry resolves it to the installed version (e.g. `1.2.0`), locks the digest, and my capability can execute with full dependency availability.
+
+**Why this priority**: Dependency resolution at registration time is the foundational operation; all other dependency behaviors build on it.
+
+**Independent Test**: Register `traverse.logging` at version `1.2.0`. Then register a capability with a `dependencies` entry of `traverse.logging ^1.0.0`. Verify the registration succeeds, the returned dependency lock contains `{id: "traverse.logging", version: "1.2.0", digest: <expected>}`, and subsequent execution succeeds.
+
+**Acceptance Scenarios**:
+
+1. **Given** `traverse.logging` registered at `1.2.0` and a capability declaring `traverse.logging ^1.0.0`, **When** the capability is registered, **Then** the registry resolves `^1.0.0` to `1.2.0`, creates an immutable dependency lock record, and the registration succeeds.
+2. **Given** a successfully registered capability with a locked dependency, **When** the capability is executed, **Then** the runtime verifies the locked dependency digest matches the currently registered digest of `traverse.logging 1.2.0` and proceeds with execution.
+3. **Given** a capability contract where the `dependencies` field is absent, **When** the capability is registered, **Then** the registry treats it as having an empty dependency list and registers without error.
+
+### User Story 2 — Registration Fails for an Unsatisfiable Dependency (Priority: P1)
+
+As a capability author, I want a clear error when I declare `traverse.logging ^3.0.0` but the workspace only has `2.1.0` registered — so that I know immediately at registration time that my dependency cannot be satisfied, rather than discovering the problem at execution time.
+
+**Why this priority**: Early failure at registration time is the only safe model; silent registration of unsatisfiable dependencies would produce non-deterministic execution failures.
+
+**Independent Test**: Register `traverse.logging` at version `2.1.0`. Attempt to register a capability with `traverse.logging ^3.0.0`. Verify the registration fails with `dependency_unsatisfiable`, the error body identifies the unsatisfied dependency, and the capability is not stored.
+
+**Acceptance Scenarios**:
+
+1. **Given** `traverse.logging` registered only at `2.1.0`, **When** a capability declaring `traverse.logging ^3.0.0` is registered, **Then** the registry rejects it with `dependency_unsatisfiable` and identifies the unresolved dependency in the error body.
+2. **Given** a `dependency_unsatisfiable` failure, **When** the error is inspected, **Then** it contains the `capability_id`, the declared `version_range`, and the highest available version that did not satisfy the range.
+3. **Given** a capability with two dependencies where one is satisfiable and one is not, **When** the capability is registered, **Then** the registry fails with `dependency_unsatisfiable` and reports all unsatisfied dependencies, not just the first.
+
+### User Story 3 — Execution Fails When a Locked Dependency Digest Changes (Priority: P2)
+
+As a platform security engineer, I want execution of a capability to fail with `dependency_digest_changed` when the digest of a locked dependency has changed since registration — even if the version string is the same — so that Traverse detects silent supply-chain drift or tampering.
+
+**Why this priority**: Digest verification at execution time is the tamper-detection layer; without it, a re-registered dependency with different content would silently replace the locked version.
+
+**Independent Test**: Register `traverse.logging 1.2.0`, register a dependent capability (locking the digest), re-register `traverse.logging 1.2.0` with different content (new digest), then attempt to execute the dependent capability and verify it fails with `dependency_digest_changed` identifying the affected dependency.
+
+**Acceptance Scenarios**:
+
+1. **Given** a capability with a locked dependency on `traverse.logging 1.2.0` (digest D1), **When** `traverse.logging 1.2.0` is re-registered with a different content (digest D2), **Then** the next execution of the dependent capability fails with `dependency_digest_changed`.
+2. **Given** a `dependency_digest_changed` failure, **When** the error is inspected, **Then** it contains the dependency `capability_id`, `version`, the locked digest, and the current digest.
+3. **Given** a capability with a locked dependency whose digest has not changed, **When** the capability is executed, **Then** the digest verification step passes silently and execution proceeds normally.
+
+### User Story 4 — Circular Dependency Chain Rejected at Registration (Priority: P2)
+
+As a registry operator, I want the registry to detect and reject circular dependency chains (`A → B → A`) at registration time so that dependency resolution can never enter an infinite loop and lock records remain acyclic.
+
+**Why this priority**: Cyclic dependency graphs make resolution non-terminating and lock records meaningless; they must be rejected before entering the registry.
+
+**Independent Test**: Register capability A with a dependency on B, register B with a dependency on A. Verify B's registration fails with `circular_dependency_detected` identifying the cycle path `B → A → B`.
+
+**Acceptance Scenarios**:
+
+1. **Given** capability A registered with a dependency on B, **When** B is registered with a dependency on A, **Then** the registry detects the cycle and rejects B's registration with `circular_dependency_detected` and the cycle path in the error body.
+2. **Given** a three-node cycle `A → B → C → A`, **When** C is registered, **Then** the registry rejects it with `circular_dependency_detected` and the full cycle path.
+3. **Given** a valid DAG dependency chain `A → B → C` with no cycles, **When** all three capabilities are registered, **Then** all registrations succeed and all three lock records are created.
+
+## Edge Cases
+
+- Transitive dependency depth exceeds 5 levels — fail at registration with `max_transitive_depth_exceeded`; the error MUST identify the depth at which the limit was reached and the chain up to that point.
+- `dependencies` field absent from contract — treat as an empty dependency list; registration proceeds without dependency resolution.
+- Dependency lock record corrupted or missing at execution time — fail execution with `dependency_lock_invalid` rather than re-resolving silently; silent re-resolution could mask supply-chain drift.
+- Same capability version registered in two workspaces at different digests — workspace isolation means each workspace's lock record is independent; no cross-workspace lock comparison is performed.
+- A dependency satisfies the version range but the resolved capability has itself been deprecated — `deprecated_dependency` warning recorded in the registration result; registration is not blocked by deprecation in this slice.
+- Two capabilities in the same workspace declare the same transitive dependency at different version ranges — resolve each independently; if the resolved versions differ, each capability's lock record captures its own resolved version.
+- A dependency's `version_range` field is an invalid semver expression — fail at registration with `invalid_version_range` and identify the malformed expression.
+- A capability is registered with a `dependencies` entry that references itself — `circular_dependency_detected` at registration time; self-referential dependencies are a degenerate cycle.
+
+## Functional Requirements
+
+- **FR-001**: The capability contract schema MUST be extended with an optional `dependencies` field containing an array of `{capability_id: string, version_range: string}` objects.
+- **FR-002**: The registry MUST validate each entry in the `dependencies` array at registration time; `capability_id` MUST be a non-empty string and `version_range` MUST be a valid semver range expression.
+- **FR-003**: If the `dependencies` field is absent or an empty array, the registry MUST treat the capability as having no dependencies and complete registration without dependency resolution.
+- **FR-004**: For each declared dependency, the registry MUST perform semver range resolution against the workspace's registered capabilities using the rules defined in spec 037.
+- **FR-005**: Resolution MUST select the highest matching version within the declared range; if no registered version satisfies the range, registration MUST fail with `dependency_unsatisfiable`.
+- **FR-006**: `dependency_unsatisfiable` errors MUST identify the `capability_id`, declared `version_range`, and the highest available version that did not satisfy the range; all unsatisfied dependencies MUST be reported in one error, not one at a time.
+- **FR-007**: The registry MUST resolve transitive dependencies recursively up to a maximum depth of 5 levels; exceeding depth 5 MUST fail registration with `max_transitive_depth_exceeded` identifying the chain depth and path.
+- **FR-008**: The registry MUST detect directed cycles in the dependency graph during transitive resolution; a cycle MUST fail registration with `circular_dependency_detected` and the full cycle path in the error body.
+- **FR-009**: On successful resolution of all declared and transitive dependencies, the registry MUST write an immutable `dependency_lock` record for the registering capability containing the resolved `(capability_id, version, digest)` tuple for each dependency.
+- **FR-010**: The `dependency_lock` record MUST be tied to the registering capability's version and digest; a new capability version registration creates a new lock record independently.
+- **FR-011**: The `dependency_lock` record MUST be immutable after creation; it MUST NOT be modified when a dependency is re-registered at a different digest.
+- **FR-012**: At execution time, the runtime MUST read the `dependency_lock` record for the executing capability and verify that the current registered digest of each locked dependency matches the digest captured in the lock.
+- **FR-013**: If any locked dependency's current digest differs from the lock record's digest, execution MUST fail with `dependency_digest_changed` identifying the `capability_id`, `version`, locked digest, and current digest.
+- **FR-014**: If the `dependency_lock` record is missing or unreadable at execution time, execution MUST fail with `dependency_lock_invalid`; silent re-resolution is not permitted.
+- **FR-015**: Dependency resolution MUST be workspace-scoped; the registry MUST NOT resolve dependencies against capabilities registered in other workspaces unless those workspaces are explicitly shared (shared workspace resolution is out of scope for this slice).
+- **FR-016**: A `version_range` that is not a valid semver range expression MUST cause registration failure with `invalid_version_range` identifying the malformed expression.
+- **FR-017**: A self-referential dependency (a capability declaring itself as a dependency) MUST be detected and rejected as `circular_dependency_detected`.
+- **FR-018**: The `dependency_lock` record MUST be included in the registration response so that the caller can inspect the resolved versions and digests.
+
+## Non-Functional Requirements
+
+- **NFR-001 Determinism**: Dependency resolution, version range matching, transitive graph traversal, and lock record creation MUST be deterministic for the same workspace state and contract input.
+- **NFR-002 Atomicity**: Dependency resolution and lock record creation MUST be atomic with the capability registration; partial registrations where the capability is stored but the lock is missing MUST not occur.
+- **NFR-003 Explainability**: All dependency-related registration failures (`dependency_unsatisfiable`, `circular_dependency_detected`, `max_transitive_depth_exceeded`, `invalid_version_range`) MUST include structured error bodies with enough detail to identify and fix the problem without inspecting internal registry state.
+- **NFR-004 Testability**: Semver range resolution, cycle detection, depth limiting, and digest verification MUST be independently testable at unit level without a running registry server.
+- **NFR-005 Immutability**: Lock records MUST be immutable after creation; no mutation path may exist even under concurrent re-registration of dependencies.
+- **NFR-006 Workspace Isolation**: Dependency resolution MUST not leak across workspace boundaries; a capability in workspace A MUST NOT resolve dependencies from workspace B without explicit shared-workspace configuration (out of scope for this slice).
+- **NFR-007 Performance**: Transitive resolution up to depth 5 MUST complete within the same registration latency budget as a non-dependency registration; resolution MUST NOT perform unbounded registry scans.
+
+## Non-Negotiable Quality Standards
+
+- **QG-001**: Dependency resolution MUST fail at registration time for all invalid inputs (unsatisfiable range, cycle, depth exceeded, invalid semver); deferred detection at execution time is not acceptable.
+- **QG-002**: Digest verification MUST run on every execution of a capability with a non-empty lock record; it MUST NOT be skippable via configuration or request parameters.
+- **QG-003**: A missing or unreadable lock record at execution time MUST cause execution failure with `dependency_lock_invalid`; silent re-resolution is never acceptable.
+- **QG-004**: Core dependency resolution logic (range matching, cycle detection, depth limiting, lock creation) MUST reach 100% automated line coverage under the protected coverage gate.
+- **QG-005**: Lock records MUST be immutable after creation; any code path that mutates an existing lock record is a blocking defect.
+
+## Key Entities
+
+- **Dependency Declaration**: A `{capability_id, version_range}` object in a capability contract's `dependencies` field. Declares that the capability requires another capability within the given semver range.
+- **Dependency Lock Record**: The immutable registry artifact created at registration time containing the resolved `(capability_id, version, digest)` tuple for each declared and transitively resolved dependency. Tied to the registering capability's version and digest.
+- **Resolved Dependency**: A specific `(capability_id, version, digest)` triple produced by matching a dependency declaration's version range against the workspace registry.
+- **Transitive Dependency**: A dependency of a dependency, resolved recursively up to the configured maximum depth.
+- **Dependency Digest Verification**: The execution-time check that compares each locked dependency's digest against the currently registered digest of that dependency version. Fails execution on mismatch.
+- **Semver Range Resolution**: The process of selecting the highest registered version of a `capability_id` that satisfies the declared `version_range`, using the semver rules from spec 037.
+
+## Success Criteria
+
+- **SC-001**: A capability declaring a satisfiable dependency is registered with a populated lock record containing the resolved version and digest; execution succeeds.
+- **SC-002**: A capability declaring an unsatisfiable dependency fails registration with `dependency_unsatisfiable` identifying all unresolved dependencies; the capability is not stored.
+- **SC-003**: A capability whose locked dependency has been re-registered at a different digest fails execution with `dependency_digest_changed`; execution does not proceed to capability code.
+- **SC-004**: A circular dependency chain is detected at registration time and rejected with `circular_dependency_detected` and the cycle path; no partial lock records are created.
+- **SC-005**: A transitive dependency chain exceeding 5 levels fails with `max_transitive_depth_exceeded`; registration is rejected.
+- **SC-006**: Core dependency resolution logic reaches 100% automated line coverage under the protected coverage gate.
+
+## Out of Scope
+
+- Cross-workspace dependency resolution or federation
+- Dependency upgrade or update commands
+- Dependency graph visualization or reporting tools
+- Optional dependencies or conditional dependency activation
+- Dependency conflict resolution when two transitive chains require incompatible versions of the same capability
+- Dependency removal or capability deregistration cascading
+- Shared-workspace dependency resolution configuration
+- Dependency pinning or lockfile export for external tooling
+- Runtime dependency injection or lazy loading of dependency capabilities


### PR DESCRIPTION
## Summary
Add governing specs 041, 042, 043 to unblock issues #309, #310, #338.

Specs only — no code changes. `approved-specs.json` registration in follow-on PR.

## Governing Spec
- 004-spec-alignment-gate
- 028-schema-alignment-gate-v02

## Project Item
Closes #309
Closes #310
Closes #338

## Validation
- All three spec files follow the approved spec format (Purpose, User Stories, Edge Cases, FR/NFR/QG, Key Entities, Success Criteria, Out of Scope)
- No code changes in this PR
- Spec IDs 041-043 reserved and consistent with approved-specs.json numbering sequence