### PR TITLE
spec-034: Programmatic capability registration via HTTP API

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -1,14 +1,25 @@
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::{IpAddr, TcpListener, TcpStream};
-use traverse_registry::{CapabilityRegistry, DiscoveryQuery, LookupScope, WorkflowRegistry};
+use std::path::{Path, PathBuf};
+use traverse_contracts::{CapabilityContract, parse_contract};
+use traverse_registry::{
+    ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
+    CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
+    CompositionPattern, DiscoveryQuery, ImplementationKind, LookupScope, RegistryProvenance,
+    RegistryScope, SourceKind, SourceReference, WorkflowRegistry,
+};
 use traverse_runtime::{
     LocalExecutor, Runtime, RuntimeExecutionOutcome, RuntimeRequest, RuntimeResultStatus,
     parse_runtime_request,
 };
 
 const MAX_REQUEST_BODY: usize = 4 * 1024 * 1024; // 4 MiB
+const DEFAULT_WORKSPACE_ID: &str = "system";
+const PERSISTED_REGISTRY_SCHEMA_VERSION: &str = "1.0.0";
 
 /// Errors that can occur while serving the HTTP/JSON API.
 #[derive(Debug)]
@@ -34,7 +45,49 @@ pub struct ApiServerConfig<E> {
     pub allow_unauthenticated: bool,
     pub capability_registry: CapabilityRegistry,
     pub workflow_registry: WorkflowRegistry,
+    pub registry_root: PathBuf,
     pub executor: E,
+}
+
+struct ApiState<E> {
+    allow_unauthenticated: bool,
+    registry_root: PathBuf,
+    executor: E,
+    workspaces: RefCell<HashMap<String, WorkspaceState<E>>>,
+}
+
+struct WorkspaceState<E> {
+    runtime: traverse_runtime::Runtime<E>,
+    persisted: PersistedWorkspaceRegistryV1,
+    loaded_from_disk: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedWorkspaceRegistryV1 {
+    schema_version: String,
+    registrations: Vec<PersistedCapabilityRegistrationV1>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedCapabilityRegistrationV1 {
+    registry_scope: String,
+    contract: CapabilityContract,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegistrationScope {
+    WorkspacePersisted,
+    SessionEphemeral,
+}
+
+#[derive(Debug, Clone)]
+struct ApiError {
+    status: u16,
+    reason: &'static str,
+    code: &'static str,
+    message: String,
 }
 
 /// Start the HTTP/JSON API server, blocking until the listener fails.
@@ -44,7 +97,7 @@ pub struct ApiServerConfig<E> {
 /// Returns [`ServeError`] when the server cannot bind or the accept loop fails.
 pub fn serve_http_api<E>(config: ApiServerConfig<E>) -> Result<(), ServeError>
 where
-    E: LocalExecutor,
+    E: LocalExecutor + Clone,
 {
     let bind_addr = format!("0.0.0.0:{}", config.port);
     let listener = TcpListener::bind(&bind_addr)
@@ -66,14 +119,31 @@ where
     );
     let _ = std::io::stderr().flush();
 
-    // Build the runtime once; `execute` takes &self so it can be shared across connections.
-    let runtime = Runtime::new(config.capability_registry, config.executor)
-        .with_workflow_registry(config.workflow_registry);
+    let mut workspaces = HashMap::new();
+    workspaces.insert(
+        DEFAULT_WORKSPACE_ID.to_string(),
+        WorkspaceState {
+            runtime: Runtime::new(config.capability_registry, config.executor.clone())
+                .with_workflow_registry(config.workflow_registry),
+            persisted: PersistedWorkspaceRegistryV1 {
+                schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
+                registrations: Vec::new(),
+            },
+            loaded_from_disk: true,
+        },
+    );
+
+    let state = ApiState {
+        allow_unauthenticated: config.allow_unauthenticated,
+        registry_root: config.registry_root,
+        executor: config.executor,
+        workspaces: RefCell::new(workspaces),
+    };
 
     for connection in listener.incoming() {
         match connection {
             Ok(stream) => {
-                if let Err(e) = handle_connection(stream, config.allow_unauthenticated, &runtime) {
+                if let Err(e) = handle_connection(stream, &state) {
                     eprintln!("traverse-cli serve: connection error: {e}");
                 }
             }
@@ -84,14 +154,417 @@ where
     Ok(())
 }
 
+impl<E> ApiState<E>
+where
+    E: LocalExecutor + Clone,
+{
+    fn with_workspace_mut<R>(
+        &self,
+        workspace_id: &str,
+        f: impl FnOnce(&mut WorkspaceState<E>) -> Result<R, String>,
+    ) -> Result<R, String> {
+        let mut workspaces = self.workspaces.borrow_mut();
+        let entry = workspaces
+            .entry(workspace_id.to_string())
+            .or_insert_with(|| WorkspaceState {
+                runtime: Runtime::new(CapabilityRegistry::new(), self.executor.clone())
+                    .with_workflow_registry(WorkflowRegistry::new()),
+                persisted: PersistedWorkspaceRegistryV1 {
+                    schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
+                    registrations: Vec::new(),
+                },
+                loaded_from_disk: false,
+            });
+
+        if !entry.loaded_from_disk {
+            entry.persisted = load_persisted_registry(&self.registry_root, workspace_id)?;
+            for persisted in entry.persisted.registrations.clone() {
+                let registration = derive_registration(workspace_id, &persisted).map_err(|e| {
+                    format!("persisted registry contains invalid entry: {}", e.message)
+                })?;
+                let _ = entry
+                    .runtime
+                    .register_capability(registration)
+                    .map_err(render_registry_failure_as_string)?;
+            }
+            entry.loaded_from_disk = true;
+        }
+
+        f(entry)
+    }
+}
+
+fn load_persisted_registry(
+    registry_root: &Path,
+    workspace_id: &str,
+) -> Result<PersistedWorkspaceRegistryV1, String> {
+    let path = persisted_registry_path(registry_root, workspace_id);
+    if !path.exists() {
+        return Ok(PersistedWorkspaceRegistryV1 {
+            schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
+            registrations: Vec::new(),
+        });
+    }
+
+    let bytes =
+        std::fs::read(&path).map_err(|e| format!("failed to read persisted registry: {e}"))?;
+    let persisted: PersistedWorkspaceRegistryV1 = serde_json::from_slice(&bytes).map_err(|e| {
+        format!(
+            "failed to parse persisted registry at {}: {e}",
+            path.display()
+        )
+    })?;
+    Ok(persisted)
+}
+
+fn persisted_registry_path(registry_root: &Path, workspace_id: &str) -> PathBuf {
+    registry_root
+        .join("workspaces")
+        .join(workspace_id)
+        .join("capabilities.json")
+}
+
+fn persist_registry(
+    registry_root: &Path,
+    workspace_id: &str,
+    persisted: &PersistedWorkspaceRegistryV1,
+) -> Result<(), String> {
+    let path = persisted_registry_path(registry_root, workspace_id);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create persisted registry directory: {e}"))?;
+    }
+
+    let bytes = serde_json::to_vec_pretty(persisted)
+        .map_err(|e| format!("failed to serialize persisted registry: {e}"))?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &bytes)
+        .map_err(|e| format!("failed to write persisted registry temp file: {e}"))?;
+    std::fs::rename(&tmp, &path)
+        .map_err(|e| format!("failed to atomically replace persisted registry: {e}"))?;
+    Ok(())
+}
+
+fn render_registry_failure_as_string(failure: traverse_registry::RegistryFailure) -> String {
+    use std::fmt::Write as _;
+
+    let mut rendered = String::new();
+    for err in failure.errors {
+        let _ = write!(
+            &mut rendered,
+            "{:?} at {}: {}; ",
+            err.code, err.target, err.message
+        );
+    }
+    rendered
+}
+
+fn validate_workspace_id(workspace_id: &str) -> Result<(), String> {
+    if workspace_id.trim().is_empty() {
+        return Err("workspace_id must be non-empty".to_string());
+    }
+    if workspace_id.len() > 64 {
+        return Err("workspace_id must be at most 64 characters".to_string());
+    }
+    if workspace_id.contains('\0') {
+        return Err("workspace_id must not contain null bytes".to_string());
+    }
+
+    // Conservative allowlist: avoids path traversal and injection into on-disk layout.
+    for ch in workspace_id.chars() {
+        let ok = ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.');
+        if !ok {
+            return Err(
+                "workspace_id may contain only ASCII letters, digits, '-', '_', and '.'"
+                    .to_string(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn parse_registration_scope(value: Option<&Value>) -> Result<RegistrationScope, String> {
+    let Some(value) = value else {
+        return Ok(RegistrationScope::WorkspacePersisted);
+    };
+    let Some(scope) = value.as_str() else {
+        return Err("scope must be a string".to_string());
+    };
+    match scope {
+        "workspace_persisted" => Ok(RegistrationScope::WorkspacePersisted),
+        "session_ephemeral" => Ok(RegistrationScope::SessionEphemeral),
+        _ => Err("scope must be workspace_persisted or session_ephemeral".to_string()),
+    }
+}
+
+fn map_registry_failure_http(
+    failure: &traverse_registry::RegistryFailure,
+) -> (u16, &'static str, &'static str) {
+    use traverse_registry::RegistryErrorCode;
+
+    let mut has_immutable = false;
+    for err in &failure.errors {
+        if err.code == RegistryErrorCode::ImmutableVersionConflict {
+            has_immutable = true;
+        }
+    }
+
+    if has_immutable {
+        return (409, "immutable_version_conflict", "Conflict");
+    }
+
+    (422, "registration_failed", "Unprocessable Entity")
+}
+
+fn derive_registration(
+    workspace_id: &str,
+    persisted: &PersistedCapabilityRegistrationV1,
+) -> Result<CapabilityRegistration, ApiError> {
+    let registry_scope = match persisted.registry_scope.as_str() {
+        "public" => RegistryScope::Public,
+        "private" => RegistryScope::Private,
+        other => {
+            return Err(ApiError {
+                status: 422,
+                reason: "Unprocessable Entity",
+                code: "invalid_registry_scope",
+                message: format!("registry_scope must be public or private (got {other})"),
+            });
+        }
+    };
+
+    let contract = persisted.contract.clone();
+    let entrypoint = contract.execution.entrypoint.command.clone();
+    let binary_path = PathBuf::from(&entrypoint);
+    if !binary_path.exists() {
+        return Err(ApiError {
+            status: 422,
+            reason: "Unprocessable Entity",
+            code: "artifact_not_found",
+            message: format!("binary artifact not found at {entrypoint}"),
+        });
+    }
+
+    let artifact_ref = format!(
+        "workspace:{workspace_id}:{}:{}",
+        contract.id, contract.version
+    );
+    let source_digest = format!("sha256:source-{}-{}", contract.id, contract.version);
+    let binary_digest = format!("sha256:binary-{}-{}", contract.id, contract.version);
+
+    Ok(CapabilityRegistration {
+        scope: registry_scope,
+        contract_path: format!(
+            "workspaces/{workspace_id}/registry/{}/{}@{}/contract.json",
+            format!("{registry_scope:?}").to_lowercase(),
+            contract.id,
+            contract.version
+        ),
+        contract,
+        artifact: CapabilityArtifactRecord {
+            artifact_ref,
+            implementation_kind: ImplementationKind::Executable,
+            source: SourceReference {
+                kind: SourceKind::Local,
+                location: entrypoint.clone(),
+            },
+            binary: Some(BinaryReference {
+                format: BinaryFormat::Wasm,
+                location: entrypoint,
+            }),
+            workflow_ref: None,
+            digests: ArtifactDigests {
+                source_digest,
+                binary_digest: Some(binary_digest),
+            },
+            provenance: RegistryProvenance {
+                source: "programmatic_registration".to_string(),
+                author: persisted.contract.provenance.author.clone(),
+                created_at: persisted.contract.provenance.created_at.clone(),
+            },
+        },
+        registered_at: persisted.contract.provenance.created_at.clone(),
+        tags: persisted.tags.clone(),
+        composability: ComposabilityMetadata {
+            kind: CompositionKind::Atomic,
+            patterns: vec![CompositionPattern::Sequential],
+            provides: Vec::new(),
+            requires: Vec::new(),
+        },
+        governing_spec: "034-programmatic-registration".to_string(),
+        validator_version: "traverse-cli".to_string(),
+    })
+}
+
+fn parse_register_body(
+    body: &[u8],
+) -> Result<(String, RegistrationScope, PersistedCapabilityRegistrationV1), ApiError> {
+    let body_str = std::str::from_utf8(body).map_err(|e| ApiError {
+        status: 400,
+        reason: "Bad Request",
+        code: "invalid_request",
+        message: format!("request body is not valid UTF-8: {e}"),
+    })?;
+
+    let value: Value = serde_json::from_str(body_str).map_err(|e| ApiError {
+        status: 400,
+        reason: "Bad Request",
+        code: "invalid_request",
+        message: format!("invalid JSON body: {e}"),
+    })?;
+
+    let workspace_id = value
+        .get("workspace_id")
+        .and_then(|v| v.as_str())
+        .filter(|ws| !ws.trim().is_empty())
+        .ok_or_else(|| ApiError {
+            status: 400,
+            reason: "Bad Request",
+            code: "missing_workspace_id",
+            message: "workspace_id is required".to_string(),
+        })?
+        .to_string();
+
+    validate_workspace_id(&workspace_id).map_err(|msg| ApiError {
+        status: 400,
+        reason: "Bad Request",
+        code: "invalid_workspace_id",
+        message: msg,
+    })?;
+
+    let scope = parse_registration_scope(value.get("scope")).map_err(|msg| ApiError {
+        status: 422,
+        reason: "Unprocessable Entity",
+        code: "invalid_scope",
+        message: msg,
+    })?;
+
+    let contract_value = if value
+        .get("kind")
+        .and_then(|v| v.as_str())
+        .is_some_and(|k| k == "capability_contract")
+    {
+        value.clone()
+    } else if let Some(contract) = value.get("contract") {
+        contract.clone()
+    } else {
+        return Err(ApiError {
+            status: 422,
+            reason: "Unprocessable Entity",
+            code: "invalid_contract",
+            message: "expected body to be a capability contract or to contain a `contract` field"
+                .to_string(),
+        });
+    };
+
+    let contract_json = serde_json::to_string(&contract_value).map_err(|e| ApiError {
+        status: 422,
+        reason: "Unprocessable Entity",
+        code: "invalid_contract",
+        message: format!("failed to serialize contract: {e}"),
+    })?;
+
+    let contract: CapabilityContract =
+        parse_contract(&contract_json).map_err(|failure| ApiError {
+            status: 422,
+            reason: "Unprocessable Entity",
+            code: "contract_validation_failed",
+            message: format!("contract could not be parsed: {failure:?}"),
+        })?;
+
+    let registry_scope = value
+        .get("registry_scope")
+        .and_then(|v| v.as_str())
+        .unwrap_or("private")
+        .to_string();
+
+    let tags = value
+        .get("tags")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(ToString::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    Ok((
+        workspace_id,
+        scope,
+        PersistedCapabilityRegistrationV1 {
+            registry_scope,
+            contract,
+            tags,
+        },
+    ))
+}
+
+fn ensure_workspace_loaded<E: LocalExecutor + Clone>(
+    state: &ApiState<E>,
+    workspace_id: &str,
+    ws: &mut WorkspaceState<E>,
+) -> Result<(), String> {
+    if ws.loaded_from_disk {
+        return Ok(());
+    }
+
+    ws.persisted = load_persisted_registry(&state.registry_root, workspace_id)?;
+    for persisted in ws.persisted.registrations.clone() {
+        let registration = derive_registration(workspace_id, &persisted)
+            .map_err(|e| format!("persisted registry contains invalid entry: {}", e.message))?;
+        let _ = ws
+            .runtime
+            .register_capability(registration)
+            .map_err(render_registry_failure_as_string)?;
+    }
+    ws.loaded_from_disk = true;
+    Ok(())
+}
+
+fn apply_registration<E: LocalExecutor + Clone>(
+    state: &ApiState<E>,
+    workspace_id: &str,
+    scope: RegistrationScope,
+    persisted_registration: PersistedCapabilityRegistrationV1,
+    registration: CapabilityRegistration,
+) -> Result<
+    Result<traverse_registry::RegistrationOutcome, traverse_registry::RegistryFailure>,
+    String,
+> {
+    let mut workspaces = state.workspaces.borrow_mut();
+    let ws = workspaces
+        .entry(workspace_id.to_string())
+        .or_insert_with(|| WorkspaceState {
+            runtime: Runtime::new(CapabilityRegistry::new(), state.executor.clone())
+                .with_workflow_registry(WorkflowRegistry::new()),
+            persisted: PersistedWorkspaceRegistryV1 {
+                schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
+                registrations: Vec::new(),
+            },
+            loaded_from_disk: false,
+        });
+
+    ensure_workspace_loaded(state, workspace_id, ws)?;
+
+    match ws.runtime.register_capability(registration) {
+        Ok(outcome) => {
+            if scope == RegistrationScope::WorkspacePersisted && !outcome.already_registered {
+                ws.persisted.registrations.push(persisted_registration);
+                persist_registry(&state.registry_root, workspace_id, &ws.persisted)?;
+            }
+            Ok(Ok(outcome))
+        }
+        Err(failure) => Ok(Err(failure)),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Connection handler
 // ---------------------------------------------------------------------------
 
-fn handle_connection<E: LocalExecutor>(
+fn handle_connection<E: LocalExecutor + Clone>(
     mut stream: TcpStream,
-    allow_unauthenticated: bool,
-    runtime: &Runtime<E>,
+    state: &ApiState<E>,
 ) -> Result<(), String> {
     let request = read_http_request(&mut stream)?;
 
@@ -100,7 +573,7 @@ fn handle_connection<E: LocalExecutor>(
         .map(|a| a.ip())
         .unwrap_or(IpAddr::from([127, 0, 0, 1]));
 
-    if !allow_unauthenticated && !peer_ip.is_loopback() {
+    if !state.allow_unauthenticated && !peer_ip.is_loopback() {
         let has_bearer = request
             .headers
             .get("authorization")
@@ -118,8 +591,11 @@ fn handle_connection<E: LocalExecutor>(
 
     match (request.method.as_str(), request.path.as_str()) {
         ("GET", "/v1/health") => handle_health(&mut stream),
-        ("GET", "/v1/capabilities") => handle_list_capabilities(&mut stream, runtime),
-        ("POST", "/v1/capabilities/execute") => handle_execute(&mut stream, &request.body, runtime),
+        ("GET", "/v1/capabilities") => handle_list_capabilities(&mut stream, &request, state),
+        ("POST", "/v1/capabilities/register") => {
+            handle_register_capability(&mut stream, &request.body, state)
+        }
+        ("POST", "/v1/capabilities/execute") => handle_execute(&mut stream, &request, state),
         _ => write_json(
             &mut stream,
             404,
@@ -133,17 +609,27 @@ fn handle_connection<E: LocalExecutor>(
 // Route handlers (pub(crate) so tests can call them directly)
 // ---------------------------------------------------------------------------
 
-pub(crate) fn handle_health<W: Write>(w: &mut W) -> Result<(), String> {
+fn handle_health<W: Write>(w: &mut W) -> Result<(), String> {
     write_json(w, 200, "OK", &json!({"status": "ok"}))
 }
 
-pub(crate) fn handle_list_capabilities<W: Write, E: LocalExecutor>(
+fn handle_list_capabilities<W: Write, E: LocalExecutor + Clone>(
     w: &mut W,
-    runtime: &Runtime<E>,
+    request: &HttpRequest,
+    state: &ApiState<E>,
 ) -> Result<(), String> {
-    let entries = runtime
-        .capability_registry()
-        .discover(LookupScope::PreferPrivate, &DiscoveryQuery::default());
+    let workspace_id = request
+        .query
+        .get("workspace_id")
+        .map_or(DEFAULT_WORKSPACE_ID, String::as_str);
+
+    let entries = state.with_workspace_mut(workspace_id, |ws| {
+        Ok(ws
+            .runtime
+            .capability_registry()
+            .discover(LookupScope::PreferPrivate, &DiscoveryQuery::default()))
+    })?;
+
     let json_entries: Vec<Value> = entries
         .iter()
         .map(|e| {
@@ -161,11 +647,87 @@ pub(crate) fn handle_list_capabilities<W: Write, E: LocalExecutor>(
     write_json(w, 200, "OK", &Value::Array(json_entries))
 }
 
-pub(crate) fn handle_execute<W: Write, E: LocalExecutor>(
+fn handle_register_capability<W: Write, E: LocalExecutor + Clone>(
     w: &mut W,
     body: &[u8],
-    runtime: &Runtime<E>,
+    state: &ApiState<E>,
 ) -> Result<(), String> {
+    let (workspace_id, scope, persisted_registration) = match parse_register_body(body) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            return write_json(
+                w,
+                err.status,
+                err.reason,
+                &error_envelope(err.code, &err.message),
+            );
+        }
+    };
+
+    let registration = match derive_registration(&workspace_id, &persisted_registration) {
+        Ok(registration) => registration,
+        Err(err) => {
+            return write_json(
+                w,
+                err.status,
+                err.reason,
+                &error_envelope(err.code, &err.message),
+            );
+        }
+    };
+
+    match apply_registration(
+        state,
+        &workspace_id,
+        scope,
+        persisted_registration,
+        registration,
+    )? {
+        Ok(outcome) => {
+            let status = if outcome.already_registered { 200 } else { 201 };
+            write_json(
+                w,
+                status,
+                if status == 200 { "OK" } else { "Created" },
+                &json!({
+                    "workspace_id": workspace_id,
+                    "scope": match scope {
+                        RegistrationScope::WorkspacePersisted => "workspace_persisted",
+                        RegistrationScope::SessionEphemeral => "session_ephemeral",
+                    },
+                    "already_registered": outcome.already_registered,
+                    "capability": {
+                        "id": outcome.record.id,
+                        "version": outcome.record.version,
+                        "digest": outcome.record.contract_digest,
+                        "registry_scope": format!("{:?}", outcome.record.scope).to_lowercase(),
+                    }
+                }),
+            )
+        }
+        Err(failure) => {
+            let (status, code, reason) = map_registry_failure_http(&failure);
+            write_json(
+                w,
+                status,
+                reason,
+                &json!({
+                    "error": {
+                        "code": code,
+                        "message": render_registry_failure_as_string(failure),
+                    }
+                }),
+            )
+        }
+    }
+}
+
+fn handle_execute<W: Write, E: LocalExecutor + Clone>(
+    w: &mut W,
+    request: &HttpRequest,
+    state: &ApiState<E>,
+) -> Result<(), String> {
+    let body = request.body.as_slice();
     let body_str = match std::str::from_utf8(body) {
         Ok(s) => s,
         Err(e) => {
@@ -181,7 +743,7 @@ pub(crate) fn handle_execute<W: Write, E: LocalExecutor>(
         }
     };
 
-    let request: RuntimeRequest = match parse_runtime_request(body_str) {
+    let runtime_request: RuntimeRequest = match parse_runtime_request(body_str) {
         Ok(r) => r,
         Err(e) => {
             return write_json(
@@ -196,7 +758,13 @@ pub(crate) fn handle_execute<W: Write, E: LocalExecutor>(
         }
     };
 
-    let outcome: RuntimeExecutionOutcome = runtime.execute(request);
+    let workspace_id = request
+        .query
+        .get("workspace_id")
+        .map_or(DEFAULT_WORKSPACE_ID, String::as_str);
+
+    let outcome: RuntimeExecutionOutcome =
+        state.with_workspace_mut(workspace_id, |ws| Ok(ws.runtime.execute(runtime_request)))?;
 
     match serialize_outcome(&outcome) {
         Ok(body_str) => write_json_raw(w, 200, "OK", &body_str),
@@ -251,6 +819,7 @@ pub(crate) fn error_envelope(code: &str, message: &str) -> Value {
 pub(crate) struct HttpRequest {
     pub(crate) method: String,
     pub(crate) path: String,
+    pub(crate) query: HashMap<String, String>,
     pub(crate) headers: HashMap<String, String>,
     pub(crate) body: Vec<u8>,
 }
@@ -293,10 +862,11 @@ fn read_http_request(stream: &mut TcpStream) -> Result<HttpRequest, String> {
         .next()
         .ok_or_else(|| "HTTP request missing method".to_string())?
         .to_string();
-    let path = parts
+    let raw_path = parts
         .next()
         .ok_or_else(|| "HTTP request missing path".to_string())?
         .to_string();
+    let (path, query) = parse_path_and_query(&raw_path);
 
     let mut headers = HashMap::new();
     for line in lines {
@@ -332,9 +902,29 @@ fn read_http_request(stream: &mut TcpStream) -> Result<HttpRequest, String> {
     Ok(HttpRequest {
         method,
         path,
+        query,
         headers,
         body,
     })
+}
+
+fn parse_path_and_query(raw_path: &str) -> (String, HashMap<String, String>) {
+    let (path, query) = match raw_path.split_once('?') {
+        Some((path, query)) => (path, Some(query)),
+        None => (raw_path, None),
+    };
+
+    let mut params = HashMap::new();
+    if let Some(query) = query {
+        for pair in query.split('&') {
+            if pair.is_empty() {
+                continue;
+            }
+            let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+            params.insert(k.to_string(), v.to_string());
+        }
+    }
+    (path.to_string(), params)
 }
 
 fn find_header_end(bytes: &[u8]) -> Option<usize> {
@@ -535,16 +1125,67 @@ mod tests {
         }
     }
 
-    fn test_runtime_with(id: &str, version: &str) -> Runtime<TestExecutor> {
+    fn test_state_with(id: &str, version: &str) -> ApiState<TestExecutor> {
         let mut registry = CapabilityRegistry::new();
         registry
             .register(test_registration(id, version))
             .expect("test registration must succeed");
-        Runtime::new(registry, TestExecutor::ok(json!({"result": "ok"})))
+
+        let executor = TestExecutor::ok(json!({"result": "ok"}));
+        let mut workspaces = HashMap::new();
+        workspaces.insert(
+            DEFAULT_WORKSPACE_ID.to_string(),
+            WorkspaceState {
+                runtime: Runtime::new(registry, executor.clone())
+                    .with_workflow_registry(WorkflowRegistry::new()),
+                persisted: PersistedWorkspaceRegistryV1 {
+                    schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
+                    registrations: Vec::new(),
+                },
+                loaded_from_disk: true,
+            },
+        );
+
+        ApiState {
+            allow_unauthenticated: true,
+            registry_root: std::env::temp_dir().join("traverse-cli-http-api-tests"),
+            executor,
+            workspaces: RefCell::new(workspaces),
+        }
     }
 
-    fn empty_runtime() -> Runtime<TestExecutor> {
-        Runtime::new(CapabilityRegistry::new(), TestExecutor::ok(json!({})))
+    fn empty_state() -> ApiState<TestExecutor> {
+        let executor = TestExecutor::ok(json!({}));
+        let mut workspaces = HashMap::new();
+        workspaces.insert(
+            DEFAULT_WORKSPACE_ID.to_string(),
+            WorkspaceState {
+                runtime: Runtime::new(CapabilityRegistry::new(), executor.clone())
+                    .with_workflow_registry(WorkflowRegistry::new()),
+                persisted: PersistedWorkspaceRegistryV1 {
+                    schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
+                    registrations: Vec::new(),
+                },
+                loaded_from_disk: true,
+            },
+        );
+
+        ApiState {
+            allow_unauthenticated: true,
+            registry_root: std::env::temp_dir().join("traverse-cli-http-api-tests"),
+            executor,
+            workspaces: RefCell::new(workspaces),
+        }
+    }
+
+    fn make_http_request(method: &str, path: &str, body: Vec<u8>) -> HttpRequest {
+        HttpRequest {
+            method: method.to_string(),
+            path: path.to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body,
+        }
     }
 
     fn make_runtime_request_body(capability_id: &str) -> Vec<u8> {
@@ -612,9 +1253,10 @@ mod tests {
 
     #[test]
     fn capabilities_endpoint_returns_registered_capability() {
-        let runtime = test_runtime_with("test.api.do-something", "1.0.0");
+        let state = test_state_with("test.api.do-something", "1.0.0");
+        let req = make_http_request("GET", "/v1/capabilities", Vec::new());
         let mut out = Vec::new();
-        handle_list_capabilities(&mut out, &runtime).expect("list must succeed");
+        handle_list_capabilities(&mut out, &req, &state).expect("list must succeed");
 
         let status = response_status(&out);
         let body = parse_response_body(&out);
@@ -629,9 +1271,10 @@ mod tests {
 
     #[test]
     fn capabilities_endpoint_returns_empty_array_for_empty_registry() {
-        let runtime = empty_runtime();
+        let state = empty_state();
+        let req = make_http_request("GET", "/v1/capabilities", Vec::new());
         let mut out = Vec::new();
-        handle_list_capabilities(&mut out, &runtime).expect("list must succeed");
+        handle_list_capabilities(&mut out, &req, &state).expect("list must succeed");
 
         let body = parse_response_body(&out);
         assert!(body.is_array());
@@ -644,11 +1287,12 @@ mod tests {
 
     #[test]
     fn execute_endpoint_returns_completed_trace_on_success() {
-        let runtime = test_runtime_with("test.api.do-something", "1.0.0");
         let body = make_runtime_request_body("test.api.do-something");
+        let state = test_state_with("test.api.do-something", "1.0.0");
+        let req = make_http_request("POST", "/v1/capabilities/execute", body);
 
         let mut out = Vec::new();
-        handle_execute(&mut out, &body, &runtime).expect("execute must write a response");
+        handle_execute(&mut out, &req, &state).expect("execute must write a response");
 
         let status = response_status(&out);
         let resp = parse_response_body(&out);
@@ -665,11 +1309,12 @@ mod tests {
 
     #[test]
     fn execute_endpoint_returns_error_status_for_unknown_capability() {
-        let runtime = empty_runtime();
         let body = make_runtime_request_body("unknown.capability.does-not-exist");
+        let state = empty_state();
+        let req = make_http_request("POST", "/v1/capabilities/execute", body);
 
         let mut out = Vec::new();
-        handle_execute(&mut out, &body, &runtime)
+        handle_execute(&mut out, &req, &state)
             .expect("handle_execute must write a response even on runtime error");
 
         let status = response_status(&out);
@@ -685,11 +1330,15 @@ mod tests {
 
     #[test]
     fn execute_endpoint_rejects_malformed_json_body() {
-        let runtime = empty_runtime();
+        let state = empty_state();
+        let req = make_http_request(
+            "POST",
+            "/v1/capabilities/execute",
+            b"{not valid json".to_vec(),
+        );
 
         let mut out = Vec::new();
-        handle_execute(&mut out, b"{not valid json", &runtime)
-            .expect("handle_execute must write a response");
+        handle_execute(&mut out, &req, &state).expect("handle_execute must write a response");
 
         let status = response_status(&out);
         let resp = parse_response_body(&out);

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -639,6 +639,9 @@ fn run_serve(port: u16, allow_unauthenticated: bool) -> Result<(), String> {
         allow_unauthenticated,
         capability_registry: registered.capability_registry,
         workflow_registry: registered.workflow_registry,
+        registry_root: std::env::current_dir()
+            .map_err(|e| format!("failed to resolve current directory: {e}"))?
+            .join(".traverse/registry"),
         executor: ExpeditionExampleExecutor,
     };
 

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -14,8 +14,9 @@ use serde_json::{Map, Value, json};
 use std::fmt;
 use traverse_contracts::{ExecutionTarget, HostApiAccess, Lifecycle, NetworkAccess};
 use traverse_registry::{
-    CapabilityRegistry, DiscoveryQuery, ImplementationKind, LookupScope, RegistryScope,
-    ResolvedCapability, WorkflowRegistry, resolve_version_range,
+    CapabilityRegistration, CapabilityRegistry, DiscoveryQuery, ImplementationKind, LookupScope,
+    RegistrationOutcome, RegistryFailure, RegistryScope, ResolvedCapability, WorkflowRegistry,
+    resolve_version_range,
 };
 
 const RUNTIME_REQUEST_KIND: &str = "runtime_request";
@@ -63,6 +64,22 @@ impl<E> Runtime<E> {
     #[must_use]
     pub fn capability_registry(&self) -> &CapabilityRegistry {
         &self.registry
+    }
+
+    /// Registers a capability into the runtime's registry.
+    ///
+    /// Returns `true` when the capability was newly registered, `false` when
+    /// the same contract digest was already present (idempotent no-op).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryFailure`] when contract validation fails or when a
+    /// different contract digest conflicts with an existing immutable version.
+    pub fn register_capability(
+        &mut self,
+        registration: CapabilityRegistration,
+    ) -> Result<RegistrationOutcome, RegistryFailure> {
+        self.registry.register(registration)
     }
 }
 

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -813,6 +813,32 @@ fn capability_registry_accessor_returns_registered_capabilities() {
     );
 }
 
+#[test]
+fn runtime_register_capability_forwards_to_registry_and_is_idempotent() {
+    let reg = CapabilityRegistry::new();
+    let mut runtime = Runtime::new(reg, EchoExecutor);
+
+    let first = runtime
+        .register_capability(registration(
+            RegistryScope::Public,
+            "content.comments.create-comment-draft",
+            "1.0.0",
+            Lifecycle::Active,
+        ))
+        .expect("first registration must succeed");
+    assert!(!first.already_registered);
+
+    let second = runtime
+        .register_capability(registration(
+            RegistryScope::Public,
+            "content.comments.create-comment-draft",
+            "1.0.0",
+            Lifecycle::Active,
+        ))
+        .expect("second registration must succeed as idempotent");
+    assert!(second.already_registered);
+}
+
 fn registry_with(registrations: Vec<CapabilityRegistration>) -> CapabilityRegistry {
     let mut registry = CapabilityRegistry::new();
     for registration in registrations {

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -818,24 +818,34 @@ fn runtime_register_capability_forwards_to_registry_and_is_idempotent() {
     let reg = CapabilityRegistry::new();
     let mut runtime = Runtime::new(reg, EchoExecutor);
 
-    let first = runtime
-        .register_capability(registration(
-            RegistryScope::Public,
-            "content.comments.create-comment-draft",
-            "1.0.0",
-            Lifecycle::Active,
-        ))
-        .expect("first registration must succeed");
+    let first_result = runtime.register_capability(registration(
+        RegistryScope::Public,
+        "content.comments.create-comment-draft",
+        "1.0.0",
+        Lifecycle::Active,
+    ));
+    assert!(
+        first_result.is_ok(),
+        "first registration must succeed: {first_result:?}"
+    );
+    let Ok(first) = first_result else {
+        return;
+    };
     assert!(!first.already_registered);
 
-    let second = runtime
-        .register_capability(registration(
-            RegistryScope::Public,
-            "content.comments.create-comment-draft",
-            "1.0.0",
-            Lifecycle::Active,
-        ))
-        .expect("second registration must succeed as idempotent");
+    let second_result = runtime.register_capability(registration(
+        RegistryScope::Public,
+        "content.comments.create-comment-draft",
+        "1.0.0",
+        Lifecycle::Active,
+    ));
+    assert!(
+        second_result.is_ok(),
+        "second registration must succeed: {second_result:?}"
+    );
+    let Ok(second) = second_result else {
+        return;
+    };
     assert!(second.already_registered);
 }
 


### PR DESCRIPTION
Closes #360.

## Governing Spec
- 033-http-json-api
- 034-programmatic-registration
- 006-runtime-request-execution

## Project Item
- GitHub Project 1: https://github.com/users/enricopiovesan/projects/1 (issue #360)

## Validation
- `cargo test`
- `bash scripts/ci/rust_checks.sh`

## Notes
- Adds `POST /v1/capabilities/register` and persists per-workspace registrations under `.traverse/registry/workspaces/<workspace_id>/capabilities.json`.
