### PR TITLE
feat: event subscription replay cursor (spec 036)

### DIFF
--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -1,28 +1,85 @@
 //! Synchronous in-process event broker.
 //!
-//! Governed by spec 026-event-broker.
+//! Governed by spec 026-event-broker and spec 036-event-subscription-replay.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet, VecDeque},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use super::{
     catalog::EventCatalog,
-    types::{EventBroker, EventError, LifecycleStatus, TraverseEvent},
+    types::{
+        BrokerEvent, EventBroker, EventCursor, EventError, LifecycleStatus, Subscription,
+        SubscriptionId, SubscriptionPoll, TraverseEvent,
+    },
 };
 
-/// Subscriber handler type alias.
-type SubscriberFn = Box<dyn Fn(&TraverseEvent) + Send + Sync>;
+/// Clock abstraction used by the broker for retention pruning.
+pub trait BrokerClock: Send + Sync {
+    fn now(&self) -> std::time::SystemTime;
+}
+
+#[derive(Debug)]
+pub struct SystemClock;
+
+impl BrokerClock for SystemClock {
+    fn now(&self) -> std::time::SystemTime {
+        std::time::SystemTime::now()
+    }
+}
+
+/// Broker runtime configuration.
+#[derive(Debug, Clone)]
+pub struct BrokerConfig {
+    pub retention_window: Duration,
+    pub max_queue_len: usize,
+}
+
+impl Default for BrokerConfig {
+    fn default() -> Self {
+        Self {
+            retention_window: Duration::from_secs(5 * 60),
+            max_queue_len: 1024,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BufferedEvent {
+    cursor: u64,
+    published_at: std::time::SystemTime,
+    event: TraverseEvent,
+}
+
+#[derive(Debug)]
+struct SubscriptionState {
+    subscription_id: SubscriptionId,
+    event_type: String,
+    cursor: u64,
+    queue: VecDeque<BufferedEvent>,
+}
+
+#[derive(Debug, Default)]
+struct BrokerState {
+    next_subscription: u64,
+    next_cursor: HashMap<String, u64>,
+    buffers: HashMap<String, VecDeque<BufferedEvent>>,
+    seen_event_ids: HashMap<String, HashSet<String>>,
+    subscriptions: HashMap<SubscriptionId, SubscriptionState>,
+}
 
 /// Synchronous, in-memory implementation of [`EventBroker`].
 ///
-/// Handlers are called synchronously inside [`publish`](Self::publish) on the
-/// caller's thread.  The catalog is consulted on every publish to enforce
-/// lifecycle rules.
+/// The broker stores a bounded retention buffer per event type and maintains a
+/// bounded delivery queue per subscription. Subscribers poll for events using a
+/// broker-issued subscription id and a cursor.
 pub struct InProcessBroker {
     catalog: Arc<EventCatalog>,
-    subscribers: Mutex<HashMap<String, Vec<SubscriberFn>>>,
+    config: BrokerConfig,
+    clock: Arc<dyn BrokerClock>,
+    state: Mutex<BrokerState>,
 }
 
 impl std::fmt::Debug for InProcessBroker {
@@ -33,13 +90,150 @@ impl std::fmt::Debug for InProcessBroker {
 
 impl InProcessBroker {
     /// Create a new broker backed by the given catalog.
-    #[must_use]
-    pub fn new(catalog: Arc<EventCatalog>) -> Self {
-        Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EventError::InvalidRetentionWindow`] when the provided configuration is invalid.
+    pub fn new(catalog: Arc<EventCatalog>) -> Result<Self, EventError> {
+        Self::with_clock(catalog, BrokerConfig::default(), Arc::new(SystemClock))
+    }
+
+    /// Create a broker with explicit configuration and clock.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EventError::InvalidRetentionWindow`] when the provided configuration is invalid.
+    pub fn with_clock(
+        catalog: Arc<EventCatalog>,
+        config: BrokerConfig,
+        clock: Arc<dyn BrokerClock>,
+    ) -> Result<Self, EventError> {
+        if config.retention_window == Duration::from_secs(0) {
+            return Err(EventError::InvalidRetentionWindow(
+                "retention_window must be > 0".to_string(),
+            ));
+        }
+        if config.max_queue_len == 0 {
+            return Err(EventError::InvalidRetentionWindow(
+                "max_queue_len must be > 0".to_string(),
+            ));
+        }
+
+        Ok(Self {
             catalog,
-            subscribers: Mutex::new(HashMap::new()),
+            config,
+            clock,
+            state: Mutex::new(BrokerState::default()),
+        })
+    }
+}
+
+fn parse_cursor(raw: &str) -> Result<u64, EventError> {
+    let trimmed = raw.trim();
+    if trimmed == "0" {
+        return Ok(0);
+    }
+    trimmed.parse::<u64>().map_err(|_| {
+        EventError::InvalidCursor("cursor must be \"0\" or a base-10 unsigned integer".to_string())
+    })
+}
+
+fn cursor_to_string(cursor: u64) -> EventCursor {
+    cursor.to_string()
+}
+
+fn enqueue_with_drop_oldest(
+    queue: &mut VecDeque<BufferedEvent>,
+    max_len: usize,
+    item: BufferedEvent,
+) {
+    while queue.len() >= max_len {
+        let _ = queue.pop_front();
+    }
+    queue.push_back(item);
+}
+
+fn prune_expired(
+    state: &mut BrokerState,
+    event_type: &str,
+    retention_window: Duration,
+    now: std::time::SystemTime,
+) {
+    let buffer = state.buffers.entry(event_type.to_string()).or_default();
+    let mut oldest_retained_cursor = None;
+    while let Some(front) = buffer.front() {
+        let age = now
+            .duration_since(front.published_at)
+            .unwrap_or(Duration::from_secs(0));
+        if age <= retention_window {
+            oldest_retained_cursor = Some(front.cursor);
+            break;
+        }
+
+        if let Some(expired) = buffer.pop_front() {
+            if let Some(ids) = state.seen_event_ids.get_mut(event_type) {
+                let _ = ids.remove(&expired.event.id);
+            }
+        } else {
+            break;
         }
     }
+
+    let Some(oldest_cursor) = oldest_retained_cursor else {
+        // Buffer is empty after pruning; nothing to sync.
+        return;
+    };
+
+    // Sync per-subscription queues so they don't deliver events that are no longer retained.
+    for sub in state.subscriptions.values_mut() {
+        if sub.event_type != event_type {
+            continue;
+        }
+        while let Some(front) = sub.queue.front() {
+            if front.cursor >= oldest_cursor {
+                break;
+            }
+            let _ = sub.queue.pop_front();
+        }
+        if sub.cursor != 0 && sub.cursor < oldest_cursor.saturating_sub(1) {
+            // Cursor is now outside the retention window; keep it as-is so poll can surface cursor_expired.
+        }
+    }
+}
+
+fn validate_from_cursor(
+    state: &BrokerState,
+    event_type: &str,
+    from_cursor: u64,
+) -> Result<(), EventError> {
+    if from_cursor == 0 {
+        return Ok(());
+    }
+
+    let last_cursor = state.next_cursor.get(event_type).copied().unwrap_or(0);
+    if let Some(buffer) = state.buffers.get(event_type)
+        && let Some(front) = buffer.front()
+    {
+        let oldest_ok = front.cursor.saturating_sub(1);
+        if from_cursor < oldest_ok {
+            return Err(EventError::CursorExpired {
+                event_type: event_type.to_string(),
+                oldest_available_cursor: cursor_to_string(oldest_ok),
+            });
+        }
+        return Ok(());
+    }
+
+    // If the buffer is empty but we have published events before, treat cursors behind the last
+    // observed cursor as expired to avoid silent gaps.
+    if last_cursor > 0 && from_cursor < last_cursor {
+        return Err(EventError::CursorExpired {
+            event_type: event_type.to_string(),
+            oldest_available_cursor: cursor_to_string(last_cursor),
+        });
+    }
+
+    Ok(())
 }
 
 impl EventBroker for InProcessBroker {
@@ -71,64 +265,195 @@ impl EventBroker for InProcessBroker {
             }
         }
 
-        let subs = self
-            .subscribers
-            .lock()
-            .map_err(|_| EventError::LifecycleViolation("subscriber lock poisoned".to_owned()))?;
+        let now = self.clock.now();
 
-        if let Some(handlers) = subs.get(&event.event_type) {
-            for handler in handlers {
-                handler(&event);
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
+
+        prune_expired(
+            &mut state,
+            &event.event_type,
+            self.config.retention_window,
+            now,
+        );
+
+        let seen = state
+            .seen_event_ids
+            .entry(event.event_type.clone())
+            .or_default();
+        if seen.contains(&event.id) {
+            // Duplicate emissions are silently discarded.
+            return Ok(());
+        }
+        seen.insert(event.id.clone());
+
+        let next = state
+            .next_cursor
+            .entry(event.event_type.clone())
+            .or_insert(0);
+        *next = next.saturating_add(1);
+        let cursor = *next;
+
+        let buffered = BufferedEvent {
+            cursor,
+            published_at: now,
+            event: event.clone(),
+        };
+
+        state
+            .buffers
+            .entry(event.event_type.clone())
+            .or_default()
+            .push_back(buffered.clone());
+
+        for sub in state.subscriptions.values_mut() {
+            if sub.event_type != event.event_type {
+                continue;
             }
+            enqueue_with_drop_oldest(&mut sub.queue, self.config.max_queue_len, buffered.clone());
         }
 
         Ok(())
     }
 
-    /// Register `handler` to receive events of `event_type`.
+    /// Create a subscription for `event_type` starting from `from_cursor`.
     ///
     /// The event type must already be registered in the catalog.
     ///
     /// # Errors
     ///
     /// Returns [`EventError::UnregisteredEventType`] if the event type is not catalogued.
-    fn subscribe(
-        &self,
-        event_type: &str,
-        handler: Box<dyn Fn(&TraverseEvent) + Send + Sync>,
-    ) -> Result<(), EventError> {
-        // Verify the type exists in the catalog before accepting the subscription.
+    fn subscribe(&self, event_type: &str, from_cursor: &str) -> Result<Subscription, EventError> {
         if self.catalog.get(event_type).is_none() {
             return Err(EventError::UnregisteredEventType(event_type.to_owned()));
         }
+
+        let from_cursor = parse_cursor(from_cursor)?;
+
+        let now = self.clock.now();
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
+
+        prune_expired(&mut state, event_type, self.config.retention_window, now);
+
+        validate_from_cursor(&state, event_type, from_cursor)?;
 
         self.catalog.increment_consumer_count(event_type);
 
-        let mut subs = self
-            .subscribers
-            .lock()
-            .map_err(|_| EventError::LifecycleViolation("subscriber lock poisoned".to_owned()))?;
+        state.next_subscription = state.next_subscription.saturating_add(1);
+        let subscription_id = format!("sub-{}", state.next_subscription);
 
-        subs.entry(event_type.to_owned()).or_default().push(handler);
-        Ok(())
+        let mut queue = VecDeque::new();
+        if let Some(buffer) = state.buffers.get(event_type) {
+            for item in buffer {
+                if from_cursor == 0 || item.cursor > from_cursor {
+                    enqueue_with_drop_oldest(&mut queue, self.config.max_queue_len, item.clone());
+                }
+            }
+        }
+
+        state.subscriptions.insert(
+            subscription_id.clone(),
+            SubscriptionState {
+                subscription_id: subscription_id.clone(),
+                event_type: event_type.to_string(),
+                cursor: from_cursor,
+                queue,
+            },
+        );
+
+        Ok(Subscription {
+            subscription_id,
+            event_type: event_type.to_string(),
+            cursor: cursor_to_string(from_cursor),
+        })
     }
 
-    /// Remove all subscribers for `event_type`.
+    /// Poll a subscription for up to `max_events`.
     ///
     /// # Errors
     ///
-    /// Returns [`EventError::UnregisteredEventType`] if the event type is not catalogued.
-    fn unsubscribe(&self, event_type: &str) -> Result<(), EventError> {
-        if self.catalog.get(event_type).is_none() {
-            return Err(EventError::UnregisteredEventType(event_type.to_owned()));
+    fn poll(
+        &self,
+        subscription_id: &str,
+        max_events: usize,
+    ) -> Result<SubscriptionPoll, EventError> {
+        let now = self.clock.now();
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
+
+        let (event_type, cursor) = match state.subscriptions.get(subscription_id) {
+            Some(sub) => (sub.event_type.clone(), sub.cursor),
+            None => {
+                return Err(EventError::SubscriptionNotFound(
+                    subscription_id.to_string(),
+                ));
+            }
+        };
+
+        prune_expired(&mut state, &event_type, self.config.retention_window, now);
+
+        validate_from_cursor(&state, &event_type, cursor)?;
+
+        if max_events == 0 {
+            return Ok(SubscriptionPoll {
+                subscription_id: subscription_id.to_string(),
+                event_type: event_type.clone(),
+                cursor: cursor_to_string(cursor),
+                events: Vec::new(),
+            });
         }
 
-        let mut subs = self
-            .subscribers
-            .lock()
-            .map_err(|_| EventError::LifecycleViolation("subscriber lock poisoned".to_owned()))?;
+        let Some(subscription) = state.subscriptions.get_mut(subscription_id) else {
+            return Err(EventError::SubscriptionNotFound(
+                subscription_id.to_string(),
+            ));
+        };
 
-        subs.remove(event_type);
+        let mut out = Vec::new();
+        let mut delivered_cursor = subscription.cursor;
+        for _ in 0..max_events {
+            let Some(item) = subscription.queue.pop_front() else {
+                break;
+            };
+            delivered_cursor = item.cursor;
+            out.push(BrokerEvent {
+                cursor: cursor_to_string(item.cursor),
+                event: item.event,
+            });
+        }
+        subscription.cursor = delivered_cursor;
+
+        Ok(SubscriptionPoll {
+            subscription_id: subscription.subscription_id.clone(),
+            event_type: subscription.event_type.clone(),
+            cursor: cursor_to_string(subscription.cursor),
+            events: out,
+        })
+    }
+
+    /// Cancel a subscription.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EventError::SubscriptionNotFound`] if the subscription id is unknown.
+    fn cancel(&self, subscription_id: &str) -> Result<(), EventError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
+
+        if state.subscriptions.remove(subscription_id).is_none() {
+            return Err(EventError::SubscriptionNotFound(
+                subscription_id.to_string(),
+            ));
+        }
         Ok(())
     }
 }

--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -161,21 +161,18 @@ fn prune_expired(
 ) {
     let buffer = state.buffers.entry(event_type.to_string()).or_default();
     let mut oldest_retained_cursor = None;
-    while let Some(front) = buffer.front() {
+    while let Some(front) = buffer.pop_front() {
         let age = now
             .duration_since(front.published_at)
             .unwrap_or(Duration::from_secs(0));
         if age <= retention_window {
             oldest_retained_cursor = Some(front.cursor);
+            buffer.push_front(front);
             break;
         }
 
-        if let Some(expired) = buffer.pop_front() {
-            if let Some(ids) = state.seen_event_ids.get_mut(event_type) {
-                let _ = ids.remove(&expired.event.id);
-            }
-        } else {
-            break;
+        if let Some(ids) = state.seen_event_ids.get_mut(event_type) {
+            let _ = ids.remove(&front.event.id);
         }
     }
 
@@ -348,11 +345,14 @@ impl EventBroker for InProcessBroker {
         let subscription_id = format!("sub-{}", state.next_subscription);
 
         let mut queue = VecDeque::new();
-        if let Some(buffer) = state.buffers.get(event_type) {
-            for item in buffer {
-                if from_cursor == 0 || item.cursor > from_cursor {
-                    enqueue_with_drop_oldest(&mut queue, self.config.max_queue_len, item.clone());
-                }
+        for item in state
+            .buffers
+            .get(event_type)
+            .into_iter()
+            .flat_map(|buffer| buffer.iter())
+        {
+            if from_cursor == 0 || item.cursor > from_cursor {
+                enqueue_with_drop_oldest(&mut queue, self.config.max_queue_len, item.clone());
             }
         }
 
@@ -388,33 +388,40 @@ impl EventBroker for InProcessBroker {
             .lock()
             .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
 
-        let (event_type, cursor) = match state.subscriptions.get(subscription_id) {
-            Some(sub) => (sub.event_type.clone(), sub.cursor),
-            None => {
-                return Err(EventError::SubscriptionNotFound(
-                    subscription_id.to_string(),
-                ));
-            }
-        };
+        let mut subscription = state
+            .subscriptions
+            .remove(subscription_id)
+            .ok_or_else(|| EventError::SubscriptionNotFound(subscription_id.to_string()))?;
+        let event_type = subscription.event_type.clone();
+        let cursor = subscription.cursor;
 
         prune_expired(&mut state, &event_type, self.config.retention_window, now);
 
         validate_from_cursor(&state, &event_type, cursor)?;
 
+        if let Some(buffer) = state.buffers.get(&event_type)
+            && let Some(oldest_cursor) = buffer.front().map(|e| e.cursor)
+        {
+            while let Some(front) = subscription.queue.front() {
+                if front.cursor >= oldest_cursor {
+                    break;
+                }
+                let _ = subscription.queue.pop_front();
+            }
+        }
+
         if max_events == 0 {
+            let cursor_str = cursor_to_string(subscription.cursor);
+            state
+                .subscriptions
+                .insert(subscription.subscription_id.clone(), subscription);
             return Ok(SubscriptionPoll {
                 subscription_id: subscription_id.to_string(),
-                event_type: event_type.clone(),
-                cursor: cursor_to_string(cursor),
+                event_type,
+                cursor: cursor_str,
                 events: Vec::new(),
             });
         }
-
-        let Some(subscription) = state.subscriptions.get_mut(subscription_id) else {
-            return Err(EventError::SubscriptionNotFound(
-                subscription_id.to_string(),
-            ));
-        };
 
         let mut out = Vec::new();
         let mut delivered_cursor = subscription.cursor;
@@ -430,10 +437,17 @@ impl EventBroker for InProcessBroker {
         }
         subscription.cursor = delivered_cursor;
 
+        let subscription_id_value = subscription.subscription_id.clone();
+        let event_type_value = subscription.event_type.clone();
+        let cursor_value = cursor_to_string(subscription.cursor);
+        state
+            .subscriptions
+            .insert(subscription.subscription_id.clone(), subscription);
+
         Ok(SubscriptionPoll {
-            subscription_id: subscription.subscription_id.clone(),
-            event_type: subscription.event_type.clone(),
-            cursor: cursor_to_string(subscription.cursor),
+            subscription_id: subscription_id_value,
+            event_type: event_type_value,
+            cursor: cursor_value,
             events: out,
         })
     }
@@ -455,5 +469,406 @@ impl EventBroker for InProcessBroker {
             ));
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+    #![allow(clippy::panic)]
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use crate::events::catalog::EventCatalogEntry;
+
+    fn cursor_expired_oldest(err: &EventError) -> Option<String> {
+        if let EventError::CursorExpired {
+            oldest_available_cursor,
+            ..
+        } = err
+        {
+            Some(oldest_available_cursor.clone())
+        } else {
+            None
+        }
+    }
+
+    fn make_catalog(event_type: &str, status: LifecycleStatus) -> Arc<EventCatalog> {
+        let catalog = Arc::new(EventCatalog::new());
+        catalog
+            .register(EventCatalogEntry {
+                event_type: event_type.to_string(),
+                owner: "cap.test".to_string(),
+                version: "1.0.0".to_string(),
+                lifecycle_status: status,
+                consumer_count: 0,
+            })
+            .expect("catalog register must succeed");
+        catalog
+    }
+
+    fn sample_event(event_type: &str, id: &str) -> TraverseEvent {
+        TraverseEvent {
+            id: id.to_string(),
+            source: "traverse-runtime/cap.test".to_string(),
+            event_type: event_type.to_string(),
+            datacontenttype: "application/json".to_string(),
+            time: "2026-04-08T00:00:00Z".to_string(),
+            data: serde_json::json!({}),
+            owner: "cap.test".to_string(),
+            version: "1.0.0".to_string(),
+            lifecycle_status: LifecycleStatus::Active,
+        }
+    }
+
+    #[test]
+    fn broker_debug_impl_is_accessible() {
+        let catalog = make_catalog("dev.traverse.debug", LifecycleStatus::Active);
+        let broker = InProcessBroker::new(catalog).expect("broker must be created");
+        let rendered = format!("{broker:?}");
+        assert!(rendered.contains("InProcessBroker"));
+    }
+
+    #[test]
+    fn invalid_max_queue_len_is_rejected() {
+        let catalog = make_catalog("dev.traverse.invalid", LifecycleStatus::Active);
+        let err = InProcessBroker::with_clock(
+            catalog,
+            BrokerConfig {
+                retention_window: Duration::from_secs(1),
+                max_queue_len: 0,
+            },
+            Arc::new(SystemClock),
+        )
+        .expect_err("max_queue_len=0 must be rejected");
+        assert!(matches!(err, EventError::InvalidRetentionWindow(_)));
+    }
+
+    #[test]
+    fn invalid_cursor_is_rejected() {
+        let catalog = make_catalog("dev.traverse.cursor", LifecycleStatus::Active);
+        let broker = InProcessBroker::new(catalog).expect("broker must be created");
+        let err = broker
+            .subscribe("dev.traverse.cursor", "not-a-cursor")
+            .expect_err("invalid cursor must fail");
+        assert!(matches!(err, EventError::InvalidCursor(_)));
+    }
+
+    #[test]
+    fn publish_rejects_deprecated_and_draft_event_types() {
+        let deprecated = InProcessBroker::new(make_catalog(
+            "dev.traverse.deprecated",
+            LifecycleStatus::Deprecated,
+        ))
+        .expect("broker must be created");
+        let err = deprecated
+            .publish(sample_event("dev.traverse.deprecated", "evt-001"))
+            .expect_err("deprecated publish must fail");
+        assert!(matches!(err, EventError::LifecycleViolation(_)));
+
+        let draft =
+            InProcessBroker::new(make_catalog("dev.traverse.draft", LifecycleStatus::Draft))
+                .expect("broker must be created");
+        let err = draft
+            .publish(sample_event("dev.traverse.draft", "evt-001"))
+            .expect_err("draft publish must fail");
+        assert!(matches!(err, EventError::LifecycleViolation(_)));
+    }
+
+    #[test]
+    fn broker_lock_poisoning_surfaces_lifecycle_violation() {
+        let broker =
+            InProcessBroker::new(make_catalog("dev.traverse.poison", LifecycleStatus::Active))
+                .expect("broker must be created");
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = broker.state.lock().unwrap();
+            panic!("poison lock");
+        }));
+
+        let err = broker
+            .publish(sample_event("dev.traverse.poison", "evt-001"))
+            .expect_err("poisoned publish must fail");
+        assert!(matches!(err, EventError::LifecycleViolation(_)));
+
+        let err = broker
+            .subscribe("dev.traverse.poison", "0")
+            .expect_err("poisoned subscribe must fail");
+        assert!(matches!(err, EventError::LifecycleViolation(_)));
+
+        let err = broker
+            .poll("sub-1", 1)
+            .expect_err("poisoned poll must fail");
+        assert!(matches!(err, EventError::LifecycleViolation(_)));
+
+        let err = broker
+            .cancel("sub-1")
+            .expect_err("poisoned cancel must fail");
+        assert!(matches!(err, EventError::LifecycleViolation(_)));
+    }
+
+    #[derive(Debug)]
+    struct ManualClock(std::sync::Mutex<std::time::SystemTime>);
+
+    impl ManualClock {
+        fn new(now: std::time::SystemTime) -> Self {
+            Self(std::sync::Mutex::new(now))
+        }
+
+        fn advance(&self, by: Duration) {
+            if let Ok(mut guard) = self.0.lock()
+                && let Some(next) = guard.checked_add(by)
+            {
+                *guard = next;
+            }
+        }
+
+        fn set(&self, now: std::time::SystemTime) {
+            if let Ok(mut guard) = self.0.lock() {
+                *guard = now;
+            }
+        }
+    }
+
+    impl BrokerClock for ManualClock {
+        fn now(&self) -> std::time::SystemTime {
+            self.0
+                .lock()
+                .ok()
+                .map_or(std::time::SystemTime::UNIX_EPOCH, |guard| *guard)
+        }
+    }
+
+    #[test]
+    fn clock_regression_does_not_break_retention_pruning() {
+        let clock = Arc::new(ManualClock::new(std::time::SystemTime::UNIX_EPOCH));
+        let broker = InProcessBroker::with_clock(
+            make_catalog("dev.traverse.clock", LifecycleStatus::Active),
+            BrokerConfig {
+                retention_window: Duration::from_secs(60),
+                max_queue_len: 16,
+            },
+            clock.clone(),
+        )
+        .expect("broker must be created");
+
+        clock.set(std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(10));
+        broker
+            .publish(sample_event("dev.traverse.clock", "evt-001"))
+            .expect("publish must succeed");
+
+        // Move time backwards to force duration_since() to hit the error path.
+        clock.set(std::time::SystemTime::UNIX_EPOCH);
+        broker
+            .publish(sample_event("dev.traverse.clock", "evt-002"))
+            .expect("publish must succeed");
+    }
+
+    #[test]
+    fn publish_pruning_syncs_subscription_queues_and_skips_other_event_types() {
+        let catalog = Arc::new(EventCatalog::new());
+        catalog
+            .register(EventCatalogEntry {
+                event_type: "dev.traverse.a".to_string(),
+                owner: "cap.test".to_string(),
+                version: "1.0.0".to_string(),
+                lifecycle_status: LifecycleStatus::Active,
+                consumer_count: 0,
+            })
+            .expect("register must succeed");
+        catalog
+            .register(EventCatalogEntry {
+                event_type: "dev.traverse.b".to_string(),
+                owner: "cap.test".to_string(),
+                version: "1.0.0".to_string(),
+                lifecycle_status: LifecycleStatus::Active,
+                consumer_count: 0,
+            })
+            .expect("register must succeed");
+
+        let clock = Arc::new(ManualClock::new(std::time::SystemTime::UNIX_EPOCH));
+        let broker = InProcessBroker::with_clock(
+            catalog,
+            BrokerConfig {
+                retention_window: Duration::from_secs(5),
+                max_queue_len: 64,
+            },
+            clock.clone(),
+        )
+        .expect("broker must be created");
+
+        let sub_a = broker
+            .subscribe("dev.traverse.a", "1")
+            .expect("subscribe must succeed");
+        let sub_b = broker
+            .subscribe("dev.traverse.b", "0")
+            .expect("subscribe must succeed");
+
+        broker
+            .publish(sample_event("dev.traverse.a", "evt-001"))
+            .expect("publish must succeed");
+        clock.advance(Duration::from_secs(1));
+        broker
+            .publish(sample_event("dev.traverse.a", "evt-002"))
+            .expect("publish must succeed");
+        clock.advance(Duration::from_secs(1));
+        broker
+            .publish(sample_event("dev.traverse.a", "evt-003"))
+            .expect("publish must succeed");
+
+        // Jump forward so evt-001 and evt-002 are outside retention; evt-003 is retained.
+        clock.advance(Duration::from_secs(5));
+        broker
+            .publish(sample_event("dev.traverse.a", "evt-004"))
+            .expect("publish must succeed");
+
+        let err = broker
+            .poll(&sub_a.subscription_id, 10)
+            .expect_err("poll must surface cursor_expired after retention pruning");
+        let oldest_available_cursor = cursor_expired_oldest(&err).expect("must be cursor_expired");
+
+        let sub_a_resumed = broker
+            .subscribe("dev.traverse.a", &oldest_available_cursor)
+            .expect("subscribe must succeed");
+        let poll_a = broker
+            .poll(&sub_a_resumed.subscription_id, 10)
+            .expect("poll must succeed");
+        assert!(
+            poll_a
+                .events
+                .first()
+                .is_some_and(|e| e.event.id == "evt-003"),
+            "queue must resume from oldest retained event"
+        );
+
+        let poll_b = broker
+            .poll(&sub_b.subscription_id, 10)
+            .expect("poll must succeed");
+        assert!(
+            poll_b.events.is_empty(),
+            "event_type mismatch must not enqueue"
+        );
+
+        // Also cover the non-cursor_expired branch in the extraction logic above.
+        let other_err = broker
+            .poll("sub-missing", 10)
+            .expect_err("poll must fail when subscription is missing");
+        assert!(cursor_expired_oldest(&other_err).is_none());
+    }
+
+    #[test]
+    fn subscribe_replays_events_from_existing_buffer() {
+        let clock = Arc::new(ManualClock::new(std::time::SystemTime::UNIX_EPOCH));
+        let broker = InProcessBroker::with_clock(
+            make_catalog("dev.traverse.replay", LifecycleStatus::Active),
+            BrokerConfig {
+                retention_window: Duration::from_secs(5),
+                max_queue_len: 64,
+            },
+            clock,
+        )
+        .expect("broker must be created");
+
+        broker
+            .publish(sample_event("dev.traverse.replay", "evt-001"))
+            .expect("publish must succeed");
+
+        let sub = broker
+            .subscribe("dev.traverse.replay", "0")
+            .expect("subscribe must succeed");
+        let poll = broker
+            .poll(&sub.subscription_id, 10)
+            .expect("poll must succeed");
+        assert_eq!(poll.events.len(), 1);
+        assert_eq!(poll.events[0].event.id, "evt-001");
+    }
+
+    #[test]
+    fn subscribe_rejects_cursor_expired_when_buffer_non_empty() {
+        let clock = Arc::new(ManualClock::new(std::time::SystemTime::UNIX_EPOCH));
+        let broker = InProcessBroker::with_clock(
+            make_catalog("dev.traverse.expire", LifecycleStatus::Active),
+            BrokerConfig {
+                retention_window: Duration::from_secs(5),
+                max_queue_len: 64,
+            },
+            clock.clone(),
+        )
+        .expect("broker must be created");
+
+        for i in 1..=5 {
+            broker
+                .publish(sample_event("dev.traverse.expire", &format!("evt-{i:03}")))
+                .expect("publish must succeed");
+            clock.advance(Duration::from_secs(1));
+        }
+
+        // Advance so only the last event remains within retention.
+        clock.advance(Duration::from_secs(5));
+
+        let err = broker
+            .subscribe("dev.traverse.expire", "1")
+            .expect_err("subscribe must fail with cursor_expired");
+        assert!(matches!(err, EventError::CursorExpired { .. }));
+    }
+
+    #[test]
+    fn poll_with_zero_max_events_returns_empty() {
+        let broker =
+            InProcessBroker::new(make_catalog("dev.traverse.poll0", LifecycleStatus::Active))
+                .expect("broker must be created");
+        let sub = broker
+            .subscribe("dev.traverse.poll0", "0")
+            .expect("subscribe must succeed");
+        let poll = broker
+            .poll(&sub.subscription_id, 0)
+            .expect("poll must succeed");
+        assert!(poll.events.is_empty());
+    }
+
+    #[test]
+    fn poll_prunes_subscription_queue_based_on_retention() {
+        let clock = Arc::new(ManualClock::new(std::time::SystemTime::UNIX_EPOCH));
+        let broker = InProcessBroker::with_clock(
+            make_catalog("dev.traverse.pollprune", LifecycleStatus::Active),
+            BrokerConfig {
+                retention_window: Duration::from_secs(5),
+                max_queue_len: 64,
+            },
+            clock.clone(),
+        )
+        .expect("broker must be created");
+
+        let sub = broker
+            .subscribe("dev.traverse.pollprune", "0")
+            .expect("subscribe must succeed");
+
+        broker
+            .publish(sample_event("dev.traverse.pollprune", "evt-001"))
+            .expect("publish must succeed");
+        clock.advance(Duration::from_secs(4));
+        broker
+            .publish(sample_event("dev.traverse.pollprune", "evt-002"))
+            .expect("publish must succeed");
+
+        // Advance so evt-001 is outside retention but evt-002 is retained.
+        clock.advance(Duration::from_secs(3));
+
+        let poll = broker
+            .poll(&sub.subscription_id, 10)
+            .expect("poll must succeed");
+        assert_eq!(poll.events.len(), 1);
+        assert_eq!(poll.events[0].event.id, "evt-002");
+    }
+
+    #[test]
+    fn cancel_unknown_subscription_returns_not_found() {
+        let broker = InProcessBroker::new(make_catalog(
+            "dev.traverse.cancel-miss",
+            LifecycleStatus::Active,
+        ))
+        .expect("broker must be created");
+        let err = broker.cancel("sub-missing").expect_err("cancel must fail");
+        assert!(matches!(err, EventError::SubscriptionNotFound(_)));
     }
 }

--- a/crates/traverse-runtime/src/events/catalog.rs
+++ b/crates/traverse-runtime/src/events/catalog.rs
@@ -102,3 +102,66 @@ impl Default for EventCatalog {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+    #![allow(clippy::panic)]
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    fn active_entry(event_type: &str) -> EventCatalogEntry {
+        EventCatalogEntry {
+            event_type: event_type.to_string(),
+            owner: "cap.test".to_string(),
+            version: "1.0.0".to_string(),
+            lifecycle_status: LifecycleStatus::Active,
+            consumer_count: 0,
+        }
+    }
+
+    #[test]
+    fn catalog_debug_impl_is_accessible() {
+        let catalog = EventCatalog::new();
+        let rendered = format!("{catalog:?}");
+        assert!(rendered.contains("EventCatalog"));
+    }
+
+    #[test]
+    fn duplicate_registration_returns_lifecycle_violation() {
+        let catalog = EventCatalog::new();
+        catalog
+            .register(active_entry("dev.traverse.dup"))
+            .expect("register must succeed");
+        let err = catalog
+            .register(active_entry("dev.traverse.dup"))
+            .expect_err("duplicate must fail");
+        assert!(matches!(err, EventError::LifecycleViolation(_)));
+    }
+
+    #[test]
+    fn list_returns_empty_when_lock_is_poisoned() {
+        let catalog = EventCatalog::new();
+        catalog
+            .register(active_entry("dev.traverse.poison"))
+            .expect("register must succeed");
+
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = catalog.entries.lock().unwrap();
+            panic!("poison");
+        }));
+
+        let entries = catalog.list();
+        assert!(
+            entries.is_empty(),
+            "poisoned lock must result in default empty list"
+        );
+    }
+
+    #[test]
+    fn default_catalog_is_empty() {
+        let catalog = EventCatalog::default();
+        assert!(catalog.list().is_empty());
+    }
+}

--- a/crates/traverse-runtime/src/events/mod.rs
+++ b/crates/traverse-runtime/src/events/mod.rs
@@ -1,11 +1,14 @@
 //! In-process event system for Traverse.
 //!
-//! Governed by spec 026-event-broker.
+//! Governed by spec 026-event-broker and spec 036-event-subscription-replay.
 
 pub mod broker;
 pub mod catalog;
 pub mod types;
 
-pub use broker::InProcessBroker;
+pub use broker::{BrokerClock, BrokerConfig, InProcessBroker, SystemClock};
 pub use catalog::{EventCatalog, EventCatalogEntry};
-pub use types::{EventBroker, EventError, LifecycleStatus, TraverseEvent};
+pub use types::{
+    BrokerEvent, EventBroker, EventCursor, EventError, LifecycleStatus, Subscription,
+    SubscriptionId, SubscriptionPoll, TraverseEvent,
+};

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -1,6 +1,6 @@
 //! Core types for the in-process event system.
 //!
-//! Governed by spec 026-event-broker.
+//! Governed by spec 026-event-broker and spec 036-event-subscription-replay.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -45,6 +45,17 @@ pub enum EventError {
     LifecycleViolation(String),
     /// Attempted to publish an event type not registered in the catalog.
     UnregisteredEventType(String),
+    /// Cursor string could not be parsed.
+    InvalidCursor(String),
+    /// The requested cursor is outside the active retention window.
+    CursorExpired {
+        event_type: String,
+        oldest_available_cursor: String,
+    },
+    /// Subscription id is unknown or was cancelled.
+    SubscriptionNotFound(String),
+    /// Broker was configured with an invalid retention window.
+    InvalidRetentionWindow(String),
 }
 
 impl std::fmt::Display for EventError {
@@ -52,6 +63,16 @@ impl std::fmt::Display for EventError {
         match self {
             Self::LifecycleViolation(msg) => write!(f, "lifecycle violation: {msg}"),
             Self::UnregisteredEventType(t) => write!(f, "unregistered event type: {t}"),
+            Self::InvalidCursor(msg) => write!(f, "invalid cursor: {msg}"),
+            Self::CursorExpired {
+                event_type,
+                oldest_available_cursor,
+            } => write!(
+                f,
+                "cursor expired for event type '{event_type}': oldest available cursor is {oldest_available_cursor}"
+            ),
+            Self::SubscriptionNotFound(id) => write!(f, "subscription not found: {id}"),
+            Self::InvalidRetentionWindow(msg) => write!(f, "invalid retention window: {msg}"),
         }
     }
 }
@@ -68,21 +89,63 @@ pub trait EventBroker: Send + Sync {
     /// or [`EventError::LifecycleViolation`] if the catalog entry is not `Active`.
     fn publish(&self, event: TraverseEvent) -> Result<(), EventError>;
 
-    /// Register a subscriber for a given event type.
+    /// Create a subscription for the given `event_type` starting from `from_cursor`.
+    ///
+    /// `from_cursor` is an opaque cursor string previously returned by [`poll`](Self::poll).
+    /// The special value `"0"` requests replay from the start of the active retention window.
     ///
     /// # Errors
     ///
-    /// Returns [`EventError::UnregisteredEventType`] if the event type is not in the catalog.
-    fn subscribe(
-        &self,
-        event_type: &str,
-        handler: Box<dyn Fn(&TraverseEvent) + Send + Sync>,
-    ) -> Result<(), EventError>;
+    /// Returns [`EventError::UnregisteredEventType`] if the event type is not in the catalog,
+    /// [`EventError::InvalidCursor`] if the cursor string is malformed, or
+    /// [`EventError::CursorExpired`] if the cursor is outside the retention window.
+    fn subscribe(&self, event_type: &str, from_cursor: &str) -> Result<Subscription, EventError>;
 
-    /// Remove all subscribers for a given event type.
+    /// Poll a subscription for up to `max_events`.
     ///
     /// # Errors
     ///
-    /// Returns [`EventError::UnregisteredEventType`] if the event type is not in the catalog.
-    fn unsubscribe(&self, event_type: &str) -> Result<(), EventError>;
+    /// Returns [`EventError::SubscriptionNotFound`] if the subscription id is unknown or cancelled.
+    fn poll(
+        &self,
+        subscription_id: &str,
+        max_events: usize,
+    ) -> Result<SubscriptionPoll, EventError>;
+
+    /// Cancel a subscription and free all associated queues.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EventError::SubscriptionNotFound`] if the subscription id is unknown.
+    fn cancel(&self, subscription_id: &str) -> Result<(), EventError>;
+}
+
+/// A broker-issued event cursor string.
+pub type EventCursor = String;
+
+/// A broker-assigned subscription identifier.
+pub type SubscriptionId = String;
+
+/// Event delivered by the broker, carrying a cursor for replay.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BrokerEvent {
+    pub cursor: EventCursor,
+    pub event: TraverseEvent,
+}
+
+/// A broker subscription handle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Subscription {
+    pub subscription_id: SubscriptionId,
+    pub event_type: String,
+    pub cursor: EventCursor,
+}
+
+/// Result of polling a subscription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionPoll {
+    pub subscription_id: SubscriptionId,
+    pub event_type: String,
+    pub cursor: EventCursor,
+    pub events: Vec<BrokerEvent>,
 }

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -149,3 +149,28 @@ pub struct SubscriptionPoll {
     pub cursor: EventCursor,
     pub events: Vec<BrokerEvent>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_error_display_covers_all_variants() {
+        let cases: Vec<EventError> = vec![
+            EventError::LifecycleViolation("x".to_string()),
+            EventError::UnregisteredEventType("t".to_string()),
+            EventError::InvalidCursor("c".to_string()),
+            EventError::CursorExpired {
+                event_type: "evt".to_string(),
+                oldest_available_cursor: "7".to_string(),
+            },
+            EventError::SubscriptionNotFound("sub-1".to_string()),
+            EventError::InvalidRetentionWindow("bad".to_string()),
+        ];
+
+        for err in cases {
+            let rendered = err.to_string();
+            assert!(!rendered.is_empty());
+        }
+    }
+}

--- a/crates/traverse-runtime/tests/event_broker_tests.rs
+++ b/crates/traverse-runtime/tests/event_broker_tests.rs
@@ -1,8 +1,11 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use traverse_runtime::events::{
-    EventBroker, EventCatalog, EventCatalogEntry, EventError, InProcessBroker, LifecycleStatus,
-    TraverseEvent,
+    BrokerClock, BrokerConfig, EventBroker, EventCatalog, EventCatalogEntry, EventError,
+    InProcessBroker, LifecycleStatus, TraverseEvent,
 };
 
 fn active_entry(event_type: &str) -> EventCatalogEntry {
@@ -15,13 +18,13 @@ fn active_entry(event_type: &str) -> EventCatalogEntry {
     }
 }
 
-fn sample_event(event_type: &str) -> TraverseEvent {
+fn sample_event(event_type: &str, id: &str, time: &str) -> TraverseEvent {
     TraverseEvent {
-        id: uuid::Uuid::new_v4().to_string(),
+        id: id.to_string(),
         source: "traverse-runtime/cap.test".to_string(),
         event_type: event_type.to_string(),
         datacontenttype: "application/json".to_string(),
-        time: "2026-04-08T00:00:00Z".to_string(),
+        time: time.to_string(),
         data: serde_json::json!({}),
         owner: "cap.test".to_string(),
         version: "1.0.0".to_string(),
@@ -34,87 +37,353 @@ fn broker_with_active(event_type: &str) -> Result<InProcessBroker, String> {
     catalog
         .register(active_entry(event_type))
         .map_err(|e| e.to_string())?;
-    Ok(InProcessBroker::new(catalog))
+    InProcessBroker::new(catalog).map_err(|e| e.to_string())
+}
+
+#[derive(Debug)]
+struct ManualClock(std::sync::Mutex<SystemTime>);
+
+impl ManualClock {
+    fn new(now: SystemTime) -> Self {
+        Self(std::sync::Mutex::new(now))
+    }
+
+    fn advance(&self, by: Duration) {
+        if let Ok(mut guard) = self.0.lock()
+            && let Some(next) = guard.checked_add(by)
+        {
+            *guard = next;
+        }
+    }
+}
+
+impl BrokerClock for ManualClock {
+    fn now(&self) -> SystemTime {
+        self.0
+            .lock()
+            .ok()
+            .map_or(SystemTime::UNIX_EPOCH, |guard| *guard)
+    }
 }
 
 #[test]
-fn publish_to_active_event_type_delivers_to_subscriber() -> Result<(), String> {
+fn publish_to_active_event_type_is_pollable_by_subscription() -> Result<(), String> {
     let broker = broker_with_active("dev.traverse.test.happened")?;
-    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-    let received_clone = Arc::clone(&received);
+    let sub = broker
+        .subscribe("dev.traverse.test.happened", "0")
+        .map_err(|e| e.to_string())?;
 
     broker
-        .subscribe(
+        .publish(sample_event(
             "dev.traverse.test.happened",
-            Box::new(move |event| {
-                if let Ok(mut v) = received_clone.lock() {
-                    v.push(event.event_type.clone());
-                }
-            }),
-        )
+            "evt-001",
+            "2026-04-08T00:00:00Z",
+        ))
+        .map_err(|e| e.to_string())?;
+
+    let poll = broker
+        .poll(&sub.subscription_id, 10)
+        .map_err(|e| e.to_string())?;
+    assert_eq!(poll.events.len(), 1);
+    assert_eq!(poll.events[0].event.id, "evt-001");
+    assert_eq!(poll.cursor, "1");
+    Ok(())
+}
+
+#[test]
+fn late_join_subscribe_replays_from_cursor_zero() -> Result<(), String> {
+    let broker = broker_with_active("dev.traverse.test.happened")?;
+
+    broker
+        .publish(sample_event(
+            "dev.traverse.test.happened",
+            "evt-001",
+            "2026-04-08T00:00:00Z",
+        ))
+        .map_err(|e| e.to_string())?;
+
+    let sub = broker
+        .subscribe("dev.traverse.test.happened", "0")
+        .map_err(|e| e.to_string())?;
+    let poll = broker
+        .poll(&sub.subscription_id, 10)
+        .map_err(|e| e.to_string())?;
+    assert_eq!(poll.events.len(), 1);
+    assert_eq!(poll.events[0].event.id, "evt-001");
+    Ok(())
+}
+
+#[test]
+fn reconnect_replays_events_after_cursor() -> Result<(), String> {
+    let broker = broker_with_active("dev.traverse.test.happened")?;
+
+    let sub1 = broker
+        .subscribe("dev.traverse.test.happened", "0")
         .map_err(|e| e.to_string())?;
 
     broker
-        .publish(sample_event("dev.traverse.test.happened"))
+        .publish(sample_event(
+            "dev.traverse.test.happened",
+            "evt-001",
+            "2026-04-08T00:00:00Z",
+        ))
+        .map_err(|e| e.to_string())?;
+    broker
+        .publish(sample_event(
+            "dev.traverse.test.happened",
+            "evt-002",
+            "2026-04-08T00:00:01Z",
+        ))
         .map_err(|e| e.to_string())?;
 
-    let got = received.lock().map_err(|e| format!("lock poisoned: {e}"))?;
-    assert_eq!(got.len(), 1);
-    assert_eq!(got[0], "dev.traverse.test.happened");
+    let poll1 = broker
+        .poll(&sub1.subscription_id, 10)
+        .map_err(|e| e.to_string())?;
+    assert_eq!(poll1.events.len(), 2);
+    let cursor = poll1.cursor;
+
+    broker
+        .publish(sample_event(
+            "dev.traverse.test.happened",
+            "evt-003",
+            "2026-04-08T00:00:02Z",
+        ))
+        .map_err(|e| e.to_string())?;
+    broker
+        .publish(sample_event(
+            "dev.traverse.test.happened",
+            "evt-004",
+            "2026-04-08T00:00:03Z",
+        ))
+        .map_err(|e| e.to_string())?;
+    broker
+        .publish(sample_event(
+            "dev.traverse.test.happened",
+            "evt-005",
+            "2026-04-08T00:00:04Z",
+        ))
+        .map_err(|e| e.to_string())?;
+
+    let sub2 = broker
+        .subscribe("dev.traverse.test.happened", &cursor)
+        .map_err(|e| e.to_string())?;
+    let poll2 = broker
+        .poll(&sub2.subscription_id, 10)
+        .map_err(|e| e.to_string())?;
+
+    assert_eq!(poll2.events.len(), 3);
+    assert_eq!(poll2.events[0].event.id, "evt-003");
+    assert_eq!(poll2.events[2].event.id, "evt-005");
     Ok(())
 }
 
 #[test]
-fn publishing_deprecated_event_returns_lifecycle_violation() -> Result<(), String> {
+fn two_subscribers_receive_independent_ordered_streams() -> Result<(), String> {
+    let broker = broker_with_active("dev.traverse.test.happened")?;
+
+    let a = broker
+        .subscribe("dev.traverse.test.happened", "0")
+        .map_err(|e| e.to_string())?;
+    let b = broker
+        .subscribe("dev.traverse.test.happened", "0")
+        .map_err(|e| e.to_string())?;
+
+    for i in 1..=5 {
+        broker
+            .publish(sample_event(
+                "dev.traverse.test.happened",
+                &format!("evt-{i:03}"),
+                "2026-04-08T00:00:00Z",
+            ))
+            .map_err(|e| e.to_string())?;
+    }
+
+    let poll_a = broker
+        .poll(&a.subscription_id, 10)
+        .map_err(|e| e.to_string())?;
+    let poll_b = broker
+        .poll(&b.subscription_id, 10)
+        .map_err(|e| e.to_string())?;
+    assert_eq!(poll_a.events.len(), 5);
+    assert_eq!(poll_b.events.len(), 5);
+    assert_eq!(poll_a.events[0].event.id, "evt-001");
+    assert_eq!(poll_b.events[4].event.id, "evt-005");
+    Ok(())
+}
+
+#[test]
+fn cursor_expired_is_returned_when_cursor_is_outside_retention_window() -> Result<(), String> {
     let catalog = Arc::new(EventCatalog::new());
     catalog
-        .register(EventCatalogEntry {
-            event_type: "dev.traverse.old.event".to_string(),
-            owner: "cap.test".to_string(),
-            version: "1.0.0".to_string(),
-            lifecycle_status: LifecycleStatus::Deprecated,
-            consumer_count: 0,
-        })
+        .register(active_entry("dev.traverse.retained"))
         .map_err(|e| e.to_string())?;
-    let broker = InProcessBroker::new(catalog);
 
-    let result = broker.publish(sample_event("dev.traverse.old.event"));
-    assert!(
-        matches!(result, Err(EventError::LifecycleViolation(_))),
-        "expected LifecycleViolation, got {result:?}"
-    );
+    let clock = Arc::new(ManualClock::new(SystemTime::UNIX_EPOCH));
+    let broker_clock: Arc<dyn BrokerClock> = clock.clone();
+    let config = BrokerConfig {
+        retention_window: Duration::from_secs(10),
+        max_queue_len: 64,
+    };
+
+    let broker = InProcessBroker::with_clock(Arc::clone(&catalog), config, broker_clock)
+        .map_err(|e| e.to_string())?;
+
+    for i in 1..=5 {
+        broker
+            .publish(sample_event(
+                "dev.traverse.retained",
+                &format!("evt-{i:03}"),
+                "2026-04-08T00:00:00Z",
+            ))
+            .map_err(|e| e.to_string())?;
+        clock.advance(Duration::from_secs(1));
+    }
+
+    // Advance beyond retention window so all buffered events are pruned.
+    clock.advance(Duration::from_secs(60));
+
+    let Err(err) = broker.subscribe("dev.traverse.retained", "1") else {
+        return Err("expected subscribe to fail with cursor_expired".to_string());
+    };
+    match err {
+        EventError::CursorExpired {
+            event_type,
+            oldest_available_cursor,
+        } => {
+            assert_eq!(event_type, "dev.traverse.retained");
+            assert_eq!(oldest_available_cursor, "5");
+        }
+        other => return Err(format!("expected CursorExpired, got {other:?}")),
+    }
+
     Ok(())
 }
 
 #[test]
-fn publishing_draft_event_returns_lifecycle_violation() -> Result<(), String> {
+fn bounded_queue_drops_oldest_when_over_capacity() -> Result<(), String> {
     let catalog = Arc::new(EventCatalog::new());
     catalog
-        .register(EventCatalogEntry {
-            event_type: "dev.traverse.draft.event".to_string(),
-            owner: "cap.test".to_string(),
-            version: "1.0.0".to_string(),
-            lifecycle_status: LifecycleStatus::Draft,
-            consumer_count: 0,
-        })
+        .register(active_entry("dev.traverse.backpressure"))
         .map_err(|e| e.to_string())?;
-    let broker = InProcessBroker::new(catalog);
 
-    let result = broker.publish(sample_event("dev.traverse.draft.event"));
-    assert!(matches!(result, Err(EventError::LifecycleViolation(_))));
+    let broker = InProcessBroker::with_clock(
+        Arc::clone(&catalog),
+        BrokerConfig {
+            retention_window: Duration::from_secs(60),
+            max_queue_len: 2,
+        },
+        Arc::new(traverse_runtime::events::SystemClock),
+    )
+    .map_err(|e| e.to_string())?;
+
+    let sub = broker
+        .subscribe("dev.traverse.backpressure", "0")
+        .map_err(|e| e.to_string())?;
+
+    broker
+        .publish(sample_event(
+            "dev.traverse.backpressure",
+            "evt-001",
+            "2026-04-08T00:00:00Z",
+        ))
+        .map_err(|e| e.to_string())?;
+    broker
+        .publish(sample_event(
+            "dev.traverse.backpressure",
+            "evt-002",
+            "2026-04-08T00:00:01Z",
+        ))
+        .map_err(|e| e.to_string())?;
+    broker
+        .publish(sample_event(
+            "dev.traverse.backpressure",
+            "evt-003",
+            "2026-04-08T00:00:02Z",
+        ))
+        .map_err(|e| e.to_string())?;
+
+    let poll = broker
+        .poll(&sub.subscription_id, 10)
+        .map_err(|e| e.to_string())?;
+    assert_eq!(poll.events.len(), 2);
+    assert_eq!(poll.events[0].event.id, "evt-002");
+    assert_eq!(poll.events[1].event.id, "evt-003");
     Ok(())
 }
 
 #[test]
-fn publishing_unregistered_event_type_returns_error() {
-    let catalog = Arc::new(EventCatalog::new());
-    let broker = InProcessBroker::new(catalog);
+fn duplicate_event_ids_are_discarded() -> Result<(), String> {
+    let broker = broker_with_active("dev.traverse.dedup")?;
+    let sub = broker
+        .subscribe("dev.traverse.dedup", "0")
+        .map_err(|e| e.to_string())?;
 
-    let result = broker.publish(sample_event("dev.traverse.unknown.event"));
+    broker
+        .publish(sample_event(
+            "dev.traverse.dedup",
+            "dup-001",
+            "2026-04-08T00:00:00Z",
+        ))
+        .map_err(|e| e.to_string())?;
+    broker
+        .publish(sample_event(
+            "dev.traverse.dedup",
+            "dup-001",
+            "2026-04-08T00:00:01Z",
+        ))
+        .map_err(|e| e.to_string())?;
+
+    let poll = broker
+        .poll(&sub.subscription_id, 10)
+        .map_err(|e| e.to_string())?;
+    assert_eq!(poll.events.len(), 1);
+    Ok(())
+}
+
+#[test]
+fn cancel_removes_subscription_and_prevents_polling() -> Result<(), String> {
+    let broker = broker_with_active("dev.traverse.cancel")?;
+    let sub = broker
+        .subscribe("dev.traverse.cancel", "0")
+        .map_err(|e| e.to_string())?;
+
+    broker
+        .cancel(&sub.subscription_id)
+        .map_err(|e| e.to_string())?;
+
+    let Err(err) = broker.poll(&sub.subscription_id, 1) else {
+        return Err("expected poll to fail after cancel".to_string());
+    };
+    assert!(matches!(err, EventError::SubscriptionNotFound(_)));
+    Ok(())
+}
+
+#[test]
+fn subscribe_to_unregistered_event_type_returns_error() -> Result<(), String> {
+    let catalog = Arc::new(EventCatalog::new());
+    let broker = InProcessBroker::new(catalog).map_err(|e| e.to_string())?;
+    let result = broker.subscribe("dev.traverse.missing", "0");
     assert!(
         matches!(result, Err(EventError::UnregisteredEventType(_))),
         "expected UnregisteredEventType, got {result:?}"
     );
+    Ok(())
+}
+
+#[test]
+fn publishing_unregistered_event_type_returns_error() -> Result<(), String> {
+    let catalog = Arc::new(EventCatalog::new());
+    let broker = InProcessBroker::new(catalog).map_err(|e| e.to_string())?;
+    let result = broker.publish(sample_event(
+        "dev.traverse.unknown.event",
+        "evt-001",
+        "2026-04-08T00:00:00Z",
+    ));
+    assert!(
+        matches!(result, Err(EventError::UnregisteredEventType(_))),
+        "expected UnregisteredEventType, got {result:?}"
+    );
+    Ok(())
 }
 
 #[test]
@@ -123,13 +392,13 @@ fn catalog_consumer_count_increments_on_subscribe() -> Result<(), String> {
     catalog
         .register(active_entry("dev.traverse.counted"))
         .map_err(|e| e.to_string())?;
-    let broker = InProcessBroker::new(Arc::clone(&catalog));
+    let broker = InProcessBroker::new(Arc::clone(&catalog)).map_err(|e| e.to_string())?;
 
-    broker
-        .subscribe("dev.traverse.counted", Box::new(|_| {}))
+    let _ = broker
+        .subscribe("dev.traverse.counted", "0")
         .map_err(|e| e.to_string())?;
-    broker
-        .subscribe("dev.traverse.counted", Box::new(|_| {}))
+    let _ = broker
+        .subscribe("dev.traverse.counted", "0")
         .map_err(|e| e.to_string())?;
 
     let entry = catalog
@@ -140,158 +409,18 @@ fn catalog_consumer_count_increments_on_subscribe() -> Result<(), String> {
 }
 
 #[test]
-fn list_event_types_returns_all_catalog_entries() -> Result<(), String> {
+fn invalid_retention_window_is_rejected() -> Result<(), String> {
     let catalog = Arc::new(EventCatalog::new());
-    catalog
-        .register(active_entry("dev.traverse.a"))
-        .map_err(|e| e.to_string())?;
-    catalog
-        .register(active_entry("dev.traverse.b"))
-        .map_err(|e| e.to_string())?;
-
-    let entries = catalog.list();
-    assert_eq!(entries.len(), 2);
+    let err = InProcessBroker::with_clock(
+        catalog,
+        BrokerConfig {
+            retention_window: Duration::from_secs(0),
+            max_queue_len: 1,
+        },
+        Arc::new(traverse_runtime::events::SystemClock),
+    )
+    .err()
+    .ok_or_else(|| "expected invalid retention window to be rejected".to_string())?;
+    assert!(matches!(err, EventError::InvalidRetentionWindow(_)));
     Ok(())
-}
-
-#[test]
-fn no_raw_event_data_in_catalog_entry() -> Result<(), String> {
-    let catalog = Arc::new(EventCatalog::new());
-    catalog
-        .register(active_entry("dev.traverse.secret"))
-        .map_err(|e| e.to_string())?;
-
-    let entry = catalog
-        .get("dev.traverse.secret")
-        .ok_or_else(|| "entry not found in catalog".to_string())?;
-    let serialized = serde_json::to_string(&entry).unwrap_or_default();
-    // Catalog entry must have no `.data` field at all
-    assert!(
-        !serialized.contains("\"data\""),
-        "catalog entry must not contain a data field: {serialized}"
-    );
-    Ok(())
-}
-
-#[test]
-fn unsubscribe_removes_all_handlers_for_event_type() -> Result<(), String> {
-    let broker = broker_with_active("dev.traverse.removable")?;
-    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-    let received_clone = Arc::clone(&received);
-
-    broker
-        .subscribe(
-            "dev.traverse.removable",
-            Box::new(move |event| {
-                if let Ok(mut v) = received_clone.lock() {
-                    v.push(event.id.clone());
-                }
-            }),
-        )
-        .map_err(|e| e.to_string())?;
-
-    broker
-        .unsubscribe("dev.traverse.removable")
-        .map_err(|e| e.to_string())?;
-    broker
-        .publish(sample_event("dev.traverse.removable"))
-        .map_err(|e| e.to_string())?;
-
-    assert!(
-        received
-            .lock()
-            .map_err(|e| format!("lock poisoned: {e}"))?
-            .is_empty(),
-        "no events should be delivered after unsubscribe"
-    );
-    Ok(())
-}
-
-#[test]
-fn subscribe_to_unregistered_event_type_returns_error() {
-    let catalog = Arc::new(EventCatalog::new());
-    let broker = InProcessBroker::new(catalog);
-
-    let result = broker.subscribe("dev.traverse.missing", Box::new(|_| {}));
-    assert!(
-        matches!(result, Err(EventError::UnregisteredEventType(_))),
-        "expected UnregisteredEventType, got {result:?}"
-    );
-}
-
-#[test]
-fn unsubscribe_from_unregistered_event_type_returns_error() {
-    let catalog = Arc::new(EventCatalog::new());
-    let broker = InProcessBroker::new(catalog);
-
-    let result = broker.unsubscribe("dev.traverse.missing");
-    assert!(
-        matches!(result, Err(EventError::UnregisteredEventType(_))),
-        "expected UnregisteredEventType, got {result:?}"
-    );
-}
-
-#[test]
-fn register_duplicate_event_type_returns_lifecycle_violation() -> Result<(), String> {
-    let catalog = EventCatalog::new();
-    catalog
-        .register(active_entry("dev.traverse.dup"))
-        .map_err(|e| e.to_string())?;
-
-    let result = catalog.register(active_entry("dev.traverse.dup"));
-    assert!(
-        matches!(result, Err(EventError::LifecycleViolation(_))),
-        "expected LifecycleViolation for duplicate, got {result:?}"
-    );
-    Ok(())
-}
-
-#[test]
-fn event_catalog_default_is_empty() {
-    let catalog = EventCatalog::default();
-    assert!(catalog.list().is_empty());
-}
-
-#[test]
-fn event_error_display_lifecycle_violation() {
-    let err = EventError::LifecycleViolation("test reason".to_string());
-    assert_eq!(err.to_string(), "lifecycle violation: test reason");
-}
-
-#[test]
-fn event_error_display_unregistered_event_type() {
-    let err = EventError::UnregisteredEventType("dev.traverse.unknown".to_string());
-    assert_eq!(
-        err.to_string(),
-        "unregistered event type: dev.traverse.unknown"
-    );
-}
-
-#[test]
-fn in_process_broker_debug_format() -> Result<(), String> {
-    let broker = broker_with_active("dev.traverse.debug.test")?;
-    let debug_str = format!("{broker:?}");
-    assert!(
-        debug_str.contains("InProcessBroker"),
-        "debug output should contain 'InProcessBroker': {debug_str}"
-    );
-    Ok(())
-}
-
-#[test]
-fn event_catalog_debug_format() {
-    let catalog = EventCatalog::new();
-    let debug_str = format!("{catalog:?}");
-    assert!(
-        debug_str.contains("EventCatalog"),
-        "debug output should contain 'EventCatalog': {debug_str}"
-    );
-}
-
-#[test]
-fn increment_consumer_count_on_missing_entry_is_noop() {
-    let catalog = EventCatalog::new();
-    // Should not panic — just a no-op when event type is not in catalog.
-    catalog.increment_consumer_count("dev.traverse.nonexistent");
-    assert!(catalog.list().is_empty());
 }

--- a/crates/traverse-runtime/tests/expedition_wasm_tests.rs
+++ b/crates/traverse-runtime/tests/expedition_wasm_tests.rs
@@ -167,17 +167,19 @@ fn make_broker() -> Result<Arc<dyn EventBroker>, String> {
             consumer_count: 0,
         })
         .map_err(|e| e.to_string())?;
-    Ok(Arc::new(InProcessBroker::new(catalog)))
+    Ok(Arc::new(
+        InProcessBroker::new(catalog).map_err(|e| e.to_string())?,
+    ))
 }
 
 /// Write `bytes` to a temp file and return the path.
 fn write_temp_wasm(bytes: &[u8]) -> Result<String, String> {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let path = format!(
-        "/tmp/traverse-expedition-stub-{}.wasm",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
+        "/tmp/traverse-expedition-stub-{}-{}.wasm",
+        std::process::id(),
+        n
     );
     std::fs::write(&path, bytes).map_err(|e| format!("write temp wasm: {e}"))?;
     Ok(path)

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -129,7 +129,9 @@ fn broker_with_event(event_type: &str) -> Result<Arc<InProcessBroker>, String> {
             consumer_count: 0,
         })
         .map_err(|e| e.to_string())?;
-    Ok(Arc::new(InProcessBroker::new(catalog)))
+    Ok(Arc::new(
+        InProcessBroker::new(catalog).map_err(|e| e.to_string())?,
+    ))
 }
 
 /// Build a router with a single native executor that returns `output`.
@@ -301,19 +303,8 @@ fn subscribable_capability_publishes_events() -> Result<(), String> {
     let event_type = "dev.traverse.router.test.emitted";
     let broker = broker_with_event(event_type)?;
 
-    // Track received events
-    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-    let received_clone = Arc::clone(&received);
-
-    broker
-        .subscribe(
-            event_type,
-            Box::new(move |event| {
-                if let Ok(mut v) = received_clone.lock() {
-                    v.push(event.event_type.clone());
-                }
-            }),
-        )
+    let sub = broker
+        .subscribe(event_type, "0")
         .map_err(|e| e.to_string())?;
 
     let broker_arc: Arc<dyn EventBroker> = broker;
@@ -341,9 +332,11 @@ fn subscribable_capability_publishes_events() -> Result<(), String> {
 
     router.execute(request).map_err(|e| e.to_string())?;
 
-    let events = received.lock().map_err(|_| "lock poisoned")?;
-    assert_eq!(events.len(), 1, "one event must be delivered to subscriber");
-    assert_eq!(events[0], event_type);
+    let poll = broker_arc
+        .poll(&sub.subscription_id, 10)
+        .map_err(|e| e.to_string())?;
+    assert_eq!(poll.events.len(), 1, "one event must be delivered");
+    assert_eq!(poll.events[0].event.event_type, event_type);
 
     Ok(())
 }
@@ -358,18 +351,8 @@ fn stateless_capability_does_not_publish_events() -> Result<(), String> {
     let event_type = "dev.traverse.router.test.emitted";
     let broker = broker_with_event(event_type)?;
 
-    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-    let received_clone = Arc::clone(&received);
-
-    broker
-        .subscribe(
-            event_type,
-            Box::new(move |event| {
-                if let Ok(mut v) = received_clone.lock() {
-                    v.push(event.event_type.clone());
-                }
-            }),
-        )
+    let sub = broker
+        .subscribe(event_type, "0")
         .map_err(|e| e.to_string())?;
 
     let broker_arc: Arc<dyn EventBroker> = broker;
@@ -390,11 +373,10 @@ fn stateless_capability_does_not_publish_events() -> Result<(), String> {
 
     router.execute(request).map_err(|e| e.to_string())?;
 
-    let events = received.lock().map_err(|_| "lock poisoned")?;
-    assert!(
-        events.is_empty(),
-        "stateless capability must not publish events"
-    );
+    let poll = broker_arc
+        .poll(&sub.subscription_id, 10)
+        .map_err(|e| e.to_string())?;
+    assert!(poll.events.is_empty(), "stateless must not publish events");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Implement cursor-based event subscriptions with retention + replay and bounded per-subscription queues.

## Governing Spec

- `036-event-subscription-replay`

## Project Item

- #364

## What Changed

- Contracts changed: none
- Runtime behavior changed: event broker now supports `subscribe(event_type, from_cursor)`, `poll(subscription_id, max_events)`, `cancel(subscription_id)`; events are retained for a configurable retention window with cursor-based replay and duplicate `event_id` suppression; per-subscription queues are bounded with drop-oldest behavior
- Compatibility impact: breaking change to `EventBroker` subscription API
- ADR needed or linked: none

## Validation

- [x] `bash scripts/ci/rust_checks.sh`

## Notes

Closes #364