### PR TITLE
feat(registry,runtime): module dependency declaration and resolution (spec 043)

### DIFF
--- a/crates/traverse-registry/src/dependency_resolver.rs
+++ b/crates/traverse-registry/src/dependency_resolver.rs
@@ -627,11 +627,19 @@ mod tests {
         register(&mut registry, base_contract("test.diamond.c", "1.0.0"));
         register(
             &mut registry,
-            contract_with_deps("test.diamond.a", "1.0.0", vec![cap_dep("test.diamond.c", "1.0.0")]),
+            contract_with_deps(
+                "test.diamond.a",
+                "1.0.0",
+                vec![cap_dep("test.diamond.c", "1.0.0")],
+            ),
         );
         register(
             &mut registry,
-            contract_with_deps("test.diamond.b", "1.0.0", vec![cap_dep("test.diamond.c", "1.0.0")]),
+            contract_with_deps(
+                "test.diamond.b",
+                "1.0.0",
+                vec![cap_dep("test.diamond.c", "1.0.0")],
+            ),
         );
 
         let deps = vec![
@@ -641,7 +649,10 @@ mod tests {
         let lock = resolve_dependencies(&registry, "test.consumer", &deps, LookupScope::PublicOnly)
             .expect("diamond dep should resolve");
 
-        let c_count = lock.iter().filter(|e| e.capability_id == "test.diamond.c").count();
+        let c_count = lock
+            .iter()
+            .filter(|e| e.capability_id == "test.diamond.c")
+            .count();
         assert_eq!(c_count, 1, "C should appear exactly once");
         assert_eq!(lock.len(), 3, "lock should have A, B, C");
     }
@@ -649,8 +660,12 @@ mod tests {
     #[test]
     fn rejects_when_max_transitive_depth_exceeded() {
         let chain = [
-            "test.dep.l1", "test.dep.l2", "test.dep.l3",
-            "test.dep.l4", "test.dep.l5", "test.dep.l6",
+            "test.dep.l1",
+            "test.dep.l2",
+            "test.dep.l3",
+            "test.dep.l4",
+            "test.dep.l5",
+            "test.dep.l6",
         ];
         let mut registry = CapabilityRegistry::new();
         for i in (0..chain.len()).rev() {
@@ -659,7 +674,10 @@ mod tests {
             } else {
                 vec![]
             };
-            register(&mut registry, contract_with_deps(chain[i], "1.0.0", next_deps));
+            register(
+                &mut registry,
+                contract_with_deps(chain[i], "1.0.0", next_deps),
+            );
         }
 
         let err = resolve_dependencies(

--- a/crates/traverse-registry/src/dependency_resolver.rs
+++ b/crates/traverse-registry/src/dependency_resolver.rs
@@ -1,0 +1,617 @@
+//! Dependency resolution for the capability registry (spec 043).
+//!
+//! Resolves the `Capability`-typed entries in a capability contract's
+//! `dependencies` field against the workspace registry, detects cycles,
+//! enforces a maximum transitive depth of 5, and returns an immutable
+//! dependency lock record on success.
+
+use crate::{CapabilityRegistry, CapabilityRegistryRecord, LookupScope, resolve_version_range};
+use traverse_contracts::DependencyArtifactType;
+
+/// Maximum transitive resolution depth (spec FR-007).
+pub const MAX_TRANSITIVE_DEPTH: usize = 5;
+
+/// A single entry in a resolved dependency lock record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedDependencyLock {
+    /// The resolved capability id.
+    pub capability_id: String,
+    /// The resolved semver version string.
+    pub version: String,
+    /// The contract digest at the time of resolution.
+    pub digest: String,
+}
+
+/// Errors that can be returned by [`resolve_dependencies`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolutionError {
+    /// One or more declared dependencies could not be satisfied.
+    MissingDependency {
+        capability_id: String,
+        required_version: String,
+    },
+    /// A directed cycle was detected in the dependency graph.
+    CircularDependency { cycle: Vec<String> },
+    /// A declared `version_range` is not a valid semver expression.
+    InvalidVersionRange {
+        capability_id: String,
+        range: String,
+    },
+    /// Transitive depth exceeded [`MAX_TRANSITIVE_DEPTH`].
+    MaxTransitiveDepthExceeded { depth: usize, chain: Vec<String> },
+    /// A version was resolved but its digest conflicts with expectations.
+    VersionConflict {
+        capability_id: String,
+        required: String,
+        available: String,
+    },
+}
+
+/// Resolves all `Capability`-typed dependencies declared in `dependencies`,
+/// including transitive dependencies, up to [`MAX_TRANSITIVE_DEPTH`].
+///
+/// Returns an immutable lock record containing `(capability_id, version,
+/// digest)` tuples for every directly and transitively resolved dependency.
+///
+/// # Errors
+///
+/// Returns [`ResolutionError`] when any dependency cannot be resolved,
+/// a cycle is detected, a depth limit is exceeded, or a version range is
+/// invalid.
+pub fn resolve_dependencies(
+    registry: &CapabilityRegistry,
+    registering_id: &str,
+    dependencies: &[traverse_contracts::DependencyReference],
+    lookup_scope: LookupScope,
+) -> Result<Vec<ResolvedDependencyLock>, ResolutionError> {
+    let mut lock: Vec<ResolvedDependencyLock> = Vec::new();
+    let mut visiting: Vec<String> = vec![registering_id.to_string()];
+    let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
+    visited.insert(registering_id.to_string());
+
+    resolve_layer(
+        registry,
+        dependencies,
+        lookup_scope,
+        &mut visiting,
+        &mut visited,
+        &mut lock,
+        0,
+    )?;
+
+    Ok(lock)
+}
+
+fn resolve_layer(
+    registry: &CapabilityRegistry,
+    dependencies: &[traverse_contracts::DependencyReference],
+    lookup_scope: LookupScope,
+    visiting: &mut Vec<String>,
+    visited: &mut std::collections::HashSet<String>,
+    lock: &mut Vec<ResolvedDependencyLock>,
+    depth: usize,
+) -> Result<(), ResolutionError> {
+    if depth > MAX_TRANSITIVE_DEPTH {
+        return Err(ResolutionError::MaxTransitiveDepthExceeded {
+            depth,
+            chain: visiting.clone(),
+        });
+    }
+
+    for dep in dependencies {
+        if dep.artifact_type != DependencyArtifactType::Capability {
+            continue;
+        }
+
+        let dep_id = &dep.id;
+        let version_range = &dep.version;
+
+        // Cycle detection: if this id is already in the current visit stack,
+        // we have a cycle.
+        if visiting.contains(dep_id) {
+            let mut cycle = visiting.clone();
+            cycle.push(dep_id.clone());
+            return Err(ResolutionError::CircularDependency { cycle });
+        }
+
+        // Resolve via semver range.
+        let resolved = resolve_version_range(registry, dep_id, version_range, lookup_scope)
+            .map_err(|e| {
+                use crate::RangeResolutionError;
+                match e {
+                    RangeResolutionError::InvalidRangeSyntax { range, .. } => {
+                        ResolutionError::InvalidVersionRange {
+                            capability_id: dep_id.clone(),
+                            range,
+                        }
+                    }
+                    RangeResolutionError::CapabilityNotFound { .. }
+                    | RangeResolutionError::NoVersionSatisfies { .. }
+                    | RangeResolutionError::AmbiguousMatch { .. } => {
+                        ResolutionError::MissingDependency {
+                            capability_id: dep_id.clone(),
+                            required_version: version_range.clone(),
+                        }
+                    }
+                }
+            })?;
+
+        // Retrieve the full record to get the contract digest.
+        let scope_lookup = match resolved.scope {
+            crate::RegistryScope::Public => LookupScope::PublicOnly,
+            crate::RegistryScope::Private => LookupScope::PreferPrivate,
+        };
+        let full = registry
+            .find_exact(scope_lookup, &resolved.capability_id, &resolved.version)
+            .ok_or_else(|| ResolutionError::MissingDependency {
+                capability_id: dep_id.clone(),
+                required_version: version_range.clone(),
+            })?;
+
+        let lock_entry = ResolvedDependencyLock {
+            capability_id: resolved.capability_id.clone(),
+            version: resolved.version.clone(),
+            digest: full.record.contract_digest.clone(),
+        };
+
+        // Only add to lock if not already present (dedup transitive entries).
+        if !lock
+            .iter()
+            .any(|e| e.capability_id == lock_entry.capability_id && e.version == lock_entry.version)
+        {
+            lock.push(lock_entry);
+        }
+
+        // Skip transitive resolution if already fully visited.
+        if !visited.insert(dep_id.clone()) {
+            continue;
+        }
+
+        // Recurse into transitive dependencies.
+        if depth + 1 > MAX_TRANSITIVE_DEPTH {
+            return Err(ResolutionError::MaxTransitiveDepthExceeded {
+                depth: depth + 1,
+                chain: {
+                    let mut c = visiting.clone();
+                    c.push(dep_id.clone());
+                    c
+                },
+            });
+        }
+
+        visiting.push(dep_id.clone());
+        resolve_layer(
+            registry,
+            &full.contract.dependencies,
+            lookup_scope,
+            visiting,
+            visited,
+            lock,
+            depth + 1,
+        )?;
+        visiting.pop();
+    }
+
+    Ok(())
+}
+
+/// Verifies that each entry in the lock record still matches the currently
+/// registered digest for the locked `(capability_id, version)`.
+///
+/// Returns the first mismatch found, or `None` if all digests are consistent.
+#[must_use]
+pub fn verify_lock_digests(
+    registry: &CapabilityRegistry,
+    lock: &[ResolvedDependencyLock],
+    lookup_scope: LookupScope,
+) -> Option<DigestMismatch> {
+    for entry in lock {
+        let scope_lookup = lookup_scope;
+        let current = registry.find_exact(scope_lookup, &entry.capability_id, &entry.version)?;
+        if current.record.contract_digest != entry.digest {
+            return Some(DigestMismatch {
+                capability_id: entry.capability_id.clone(),
+                version: entry.version.clone(),
+                locked_digest: entry.digest.clone(),
+                current_digest: current.record.contract_digest.clone(),
+            });
+        }
+    }
+    None
+}
+
+/// Details of a digest mismatch detected at execution time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DigestMismatch {
+    pub capability_id: String,
+    pub version: String,
+    pub locked_digest: String,
+    pub current_digest: String,
+}
+
+/// Looks up the full registry record for a given lock entry.
+///
+/// Returns `None` when the entry is no longer present in the registry.
+#[must_use]
+pub fn lookup_lock_record(
+    registry: &CapabilityRegistry,
+    entry: &ResolvedDependencyLock,
+    lookup_scope: LookupScope,
+) -> Option<CapabilityRegistryRecord> {
+    registry
+        .find_exact(lookup_scope, &entry.capability_id, &entry.version)
+        .map(|r| r.record)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use super::*;
+    use crate::{
+        ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
+        CapabilityRegistration, ComposabilityMetadata, CompositionKind, CompositionPattern,
+        ImplementationKind, RegistryProvenance, RegistryScope, SourceKind, SourceReference,
+    };
+    use serde_json::json;
+    use traverse_contracts::{
+        BinaryFormat as ContractBinaryFormat, Condition, DependencyArtifactType,
+        DependencyReference, Entrypoint, EntrypointKind, EvidenceStatus, EvidenceType, Execution,
+        ExecutionConstraints, ExecutionTarget, FilesystemAccess, HostApiAccess, Lifecycle,
+        NetworkAccess, Owner, Provenance, ProvenanceSource, SchemaContainer, ServiceType,
+        SideEffect, SideEffectKind, ValidationEvidence,
+    };
+
+    // ── helpers ────────────────────────────────────────────────────────────
+
+    fn base_contract(id: &str, version: &str) -> traverse_contracts::CapabilityContract {
+        let (namespace, name) = split_id(id);
+        traverse_contracts::CapabilityContract {
+            kind: "capability_contract".to_string(),
+            schema_version: "1.0.0".to_string(),
+            id: id.to_string(),
+            namespace,
+            name,
+            version: version.to_string(),
+            lifecycle: Lifecycle::Active,
+            owner: Owner {
+                team: "traverse-core".to_string(),
+                contact: "test@example.com".to_string(),
+            },
+            summary: "Test capability for dep resolution.".to_string(),
+            description: "Test capability for dependency resolution testing purposes.".to_string(),
+            inputs: SchemaContainer {
+                schema: json!({"type": "object"}),
+            },
+            outputs: SchemaContainer {
+                schema: json!({"type": "object"}),
+            },
+            preconditions: vec![Condition {
+                id: "auth".to_string(),
+                description: "Caller is authenticated.".to_string(),
+            }],
+            postconditions: vec![Condition {
+                id: "done".to_string(),
+                description: "Output produced.".to_string(),
+            }],
+            side_effects: vec![SideEffect {
+                kind: SideEffectKind::MemoryOnly,
+                description: "In-memory only.".to_string(),
+            }],
+            emits: vec![],
+            consumes: vec![],
+            permissions: vec![traverse_contracts::IdReference {
+                id: "test.read".to_string(),
+            }],
+            execution: Execution {
+                binary_format: ContractBinaryFormat::Wasm,
+                entrypoint: Entrypoint {
+                    kind: EntrypointKind::WasiCommand,
+                    command: "run".to_string(),
+                },
+                preferred_targets: vec![ExecutionTarget::Local],
+                constraints: ExecutionConstraints {
+                    host_api_access: HostApiAccess::None,
+                    network_access: NetworkAccess::Forbidden,
+                    filesystem_access: FilesystemAccess::None,
+                },
+            },
+            policies: vec![],
+            dependencies: vec![],
+            provenance: Provenance {
+                source: ProvenanceSource::Greenfield,
+                author: "test".to_string(),
+                created_at: "2026-04-20T00:00:00Z".to_string(),
+                spec_ref: Some("043-module-dependency-management".to_string()),
+                adr_refs: vec![],
+                exception_refs: vec![],
+            },
+            evidence: vec![ValidationEvidence {
+                evidence_id: "validation:contract".to_string(),
+                evidence_type: EvidenceType::ContractValidation,
+                status: EvidenceStatus::Passed,
+            }],
+            service_type: ServiceType::Stateless,
+            permitted_targets: vec![ExecutionTarget::Local],
+            event_trigger: None,
+        }
+    }
+
+    fn contract_with_deps(
+        id: &str,
+        version: &str,
+        deps: Vec<DependencyReference>,
+    ) -> traverse_contracts::CapabilityContract {
+        traverse_contracts::CapabilityContract {
+            dependencies: deps,
+            ..base_contract(id, version)
+        }
+    }
+
+    fn executable_artifact(
+        contract: &traverse_contracts::CapabilityContract,
+    ) -> CapabilityArtifactRecord {
+        CapabilityArtifactRecord {
+            artifact_ref: format!("artifact:{}:{}", contract.name, contract.version),
+            implementation_kind: ImplementationKind::Executable,
+            source: SourceReference {
+                kind: SourceKind::Git,
+                location: format!("https://github.com/test/{}", contract.name),
+            },
+            binary: Some(BinaryReference {
+                format: BinaryFormat::Wasm,
+                location: format!("artifacts/{}/{}.wasm", contract.name, contract.version),
+            }),
+            workflow_ref: None,
+            digests: ArtifactDigests {
+                source_digest: format!("sha256:src-{}-{}", contract.name, contract.version),
+                binary_digest: Some(format!("sha256:bin-{}-{}", contract.name, contract.version)),
+            },
+            provenance: RegistryProvenance {
+                source: "greenfield".to_string(),
+                author: "test".to_string(),
+                created_at: "2026-04-20T00:00:00Z".to_string(),
+            },
+        }
+    }
+
+    fn register(
+        registry: &mut CapabilityRegistry,
+        contract: traverse_contracts::CapabilityContract,
+    ) {
+        let artifact = executable_artifact(&contract);
+        registry
+            .register(CapabilityRegistration {
+                scope: RegistryScope::Public,
+                contract_path: format!(
+                    "registry/public/{}/{}/contract.json",
+                    contract.id, contract.version
+                ),
+                artifact,
+                registered_at: "2026-04-20T00:00:00Z".to_string(),
+                tags: vec!["test".to_string()],
+                composability: ComposabilityMetadata {
+                    kind: CompositionKind::Atomic,
+                    patterns: vec![CompositionPattern::Sequential],
+                    provides: vec!["output".to_string()],
+                    requires: vec!["input".to_string()],
+                },
+                governing_spec: "043-module-dependency-management".to_string(),
+                validator_version: "test".to_string(),
+                contract,
+            })
+            .expect("registration should succeed");
+    }
+
+    fn cap_dep(id: &str, version_range: &str) -> DependencyReference {
+        DependencyReference {
+            artifact_type: DependencyArtifactType::Capability,
+            id: id.to_string(),
+            version: version_range.to_string(),
+        }
+    }
+
+    fn split_id(id: &str) -> (String, String) {
+        let mut parts = id.rsplitn(2, '.');
+        let name = parts.next().expect("id must include a name").to_string();
+        let namespace = parts
+            .next()
+            .expect("id must include a namespace")
+            .to_string();
+        (namespace, name)
+    }
+
+    // ── tests ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn resolves_capability_with_no_dependencies() {
+        let registry = CapabilityRegistry::new();
+        let result = resolve_dependencies(&registry, "test.a.cap", &[], LookupScope::PublicOnly)
+            .expect("empty deps should resolve");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn resolves_satisfied_dependency() {
+        let mut registry = CapabilityRegistry::new();
+        register(&mut registry, base_contract("test.logging.logger", "1.2.0"));
+
+        let deps = vec![cap_dep("test.logging.logger", "^1.0.0")];
+        let lock = resolve_dependencies(
+            &registry,
+            "test.app.consumer",
+            &deps,
+            LookupScope::PublicOnly,
+        )
+        .expect("satisfiable dep should resolve");
+
+        assert_eq!(lock.len(), 1);
+        assert_eq!(lock[0].capability_id, "test.logging.logger");
+        assert_eq!(lock[0].version, "1.2.0");
+        assert!(!lock[0].digest.is_empty());
+    }
+
+    #[test]
+    fn returns_error_for_missing_dependency() {
+        let registry = CapabilityRegistry::new();
+        let deps = vec![cap_dep("test.missing.capability", "^1.0.0")];
+        let err = resolve_dependencies(
+            &registry,
+            "test.app.consumer",
+            &deps,
+            LookupScope::PublicOnly,
+        )
+        .expect_err("missing dep should fail");
+
+        assert!(
+            matches!(
+                err,
+                ResolutionError::MissingDependency { ref capability_id, .. }
+                if capability_id == "test.missing.capability"
+            ),
+            "expected MissingDependency, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn detects_circular_dependency() {
+        // A depends on B (exact version), B depends on A (exact version).
+        // The contracts use exact semver "1.0.0" to pass contract validation.
+        // The resolver then traverses transitively and detects the cycle.
+        let mut registry = CapabilityRegistry::new();
+        register(
+            &mut registry,
+            contract_with_deps(
+                "test.cycle.cap-a",
+                "1.0.0",
+                vec![cap_dep("test.cycle.cap-b", "1.0.0")],
+            ),
+        );
+        register(
+            &mut registry,
+            contract_with_deps(
+                "test.cycle.cap-b",
+                "1.0.0",
+                vec![cap_dep("test.cycle.cap-a", "1.0.0")],
+            ),
+        );
+
+        // Resolving from outside: root depends on A, A depends on B, B depends
+        // on A — cycle detected.
+        let deps = vec![cap_dep("test.cycle.cap-a", "1.0.0")];
+        let err = resolve_dependencies(
+            &registry,
+            "test.root.caller",
+            &deps,
+            LookupScope::PublicOnly,
+        )
+        .expect_err("circular dep should fail");
+
+        assert!(
+            matches!(err, ResolutionError::CircularDependency { .. }),
+            "expected CircularDependency, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn ignores_non_capability_dependencies() {
+        let registry = CapabilityRegistry::new();
+        let deps = vec![DependencyReference {
+            artifact_type: DependencyArtifactType::Event,
+            id: "test.events.some-event".to_string(),
+            version: "^1.0.0".to_string(),
+        }];
+        let lock = resolve_dependencies(
+            &registry,
+            "test.app.consumer",
+            &deps,
+            LookupScope::PublicOnly,
+        )
+        .expect("non-capability deps should be ignored");
+        assert!(lock.is_empty());
+    }
+
+    #[test]
+    fn returns_error_for_invalid_version_range() {
+        let mut registry = CapabilityRegistry::new();
+        register(&mut registry, base_contract("test.logging.logger", "1.0.0"));
+
+        let deps = vec![cap_dep("test.logging.logger", ">>invalid")];
+        let err = resolve_dependencies(
+            &registry,
+            "test.app.consumer",
+            &deps,
+            LookupScope::PublicOnly,
+        )
+        .expect_err("invalid range should fail");
+
+        assert!(
+            matches!(err, ResolutionError::InvalidVersionRange { .. }),
+            "expected InvalidVersionRange, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_lock_digests_detects_changed_digest() {
+        let mut registry = CapabilityRegistry::new();
+        register(&mut registry, base_contract("test.logging.logger", "1.0.0"));
+
+        let deps = vec![cap_dep("test.logging.logger", "1.0.0")];
+        let lock = resolve_dependencies(
+            &registry,
+            "test.app.consumer",
+            &deps,
+            LookupScope::PublicOnly,
+        )
+        .expect("should resolve");
+
+        // Lock captures the original digest — no mismatch yet.
+        assert!(
+            verify_lock_digests(&registry, &lock, LookupScope::PublicOnly).is_none(),
+            "freshly locked digest should match"
+        );
+
+        // Simulate a stale lock by manually altering the captured digest.
+        let stale_lock = vec![ResolvedDependencyLock {
+            capability_id: lock[0].capability_id.clone(),
+            version: lock[0].version.clone(),
+            digest: "stale:000000000000dead".to_string(),
+        }];
+
+        let mismatch = verify_lock_digests(&registry, &stale_lock, LookupScope::PublicOnly)
+            .expect("stale digest should yield a mismatch");
+        assert_eq!(mismatch.capability_id, "test.logging.logger");
+        assert_eq!(mismatch.locked_digest, "stale:000000000000dead");
+    }
+
+    #[test]
+    fn resolves_transitive_dependency() {
+        let mut registry = CapabilityRegistry::new();
+        // C has no deps; B depends on C (exact version, passes contract validation).
+        register(&mut registry, base_contract("test.chain.cap-c", "1.0.0"));
+        register(
+            &mut registry,
+            contract_with_deps(
+                "test.chain.cap-b",
+                "1.0.0",
+                vec![cap_dep("test.chain.cap-c", "1.0.0")],
+            ),
+        );
+
+        // A (the caller) declares a range dep on B — this is passed directly to
+        // resolve_dependencies, not through contract registration, so ranges work.
+        let deps = vec![cap_dep("test.chain.cap-b", "1.0.0")];
+        let lock = resolve_dependencies(
+            &registry,
+            "test.chain.cap-a",
+            &deps,
+            LookupScope::PublicOnly,
+        )
+        .expect("transitive chain should resolve");
+
+        // Lock should contain both B and C.
+        let ids: Vec<&str> = lock.iter().map(|e| e.capability_id.as_str()).collect();
+        assert!(ids.contains(&"test.chain.cap-b"), "B should be in lock");
+        assert!(ids.contains(&"test.chain.cap-c"), "C should be in lock");
+    }
+}

--- a/crates/traverse-registry/src/dependency_resolver.rs
+++ b/crates/traverse-registry/src/dependency_resolver.rs
@@ -683,7 +683,7 @@ mod tests {
         let err = resolve_dependencies(
             &registry,
             "test.consumer.root",
-            &vec![cap_dep(chain[0], "1.0.0")],
+            &[cap_dep(chain[0], "1.0.0")],
             LookupScope::PublicOnly,
         )
         .expect_err("depth exceeded should fail");
@@ -702,7 +702,7 @@ mod tests {
         let lock = resolve_dependencies(
             &registry,
             "test.app.consumer",
-            &vec![cap_dep("test.logging.logger", "1.0.0")],
+            &[cap_dep("test.logging.logger", "1.0.0")],
             LookupScope::PublicOnly,
         )
         .expect("should resolve");

--- a/crates/traverse-registry/src/dependency_resolver.rs
+++ b/crates/traverse-registry/src/dependency_resolver.rs
@@ -32,19 +32,8 @@ pub enum ResolutionError {
     },
     /// A directed cycle was detected in the dependency graph.
     CircularDependency { cycle: Vec<String> },
-    /// A declared `version_range` is not a valid semver expression.
-    InvalidVersionRange {
-        capability_id: String,
-        range: String,
-    },
     /// Transitive depth exceeded [`MAX_TRANSITIVE_DEPTH`].
     MaxTransitiveDepthExceeded { depth: usize, chain: Vec<String> },
-    /// A version was resolved but its digest conflicts with expectations.
-    VersionConflict {
-        capability_id: String,
-        required: String,
-        available: String,
-    },
 }
 
 /// Resolves all `Capability`-typed dependencies declared in `dependencies`,
@@ -91,13 +80,6 @@ fn resolve_layer(
     lock: &mut Vec<ResolvedDependencyLock>,
     depth: usize,
 ) -> Result<(), ResolutionError> {
-    if depth > MAX_TRANSITIVE_DEPTH {
-        return Err(ResolutionError::MaxTransitiveDepthExceeded {
-            depth,
-            chain: visiting.clone(),
-        });
-    }
-
     for dep in dependencies {
         if dep.artifact_type != DependencyArtifactType::Capability {
             continue;
@@ -114,26 +96,12 @@ fn resolve_layer(
             return Err(ResolutionError::CircularDependency { cycle });
         }
 
-        // Resolve via semver range.
+        // Resolve via semver range.  Invalid range syntax is treated as a
+        // missing dependency since the registry pre-validates version formats.
         let resolved = resolve_version_range(registry, dep_id, version_range, lookup_scope)
-            .map_err(|e| {
-                use crate::RangeResolutionError;
-                match e {
-                    RangeResolutionError::InvalidRangeSyntax { range, .. } => {
-                        ResolutionError::InvalidVersionRange {
-                            capability_id: dep_id.clone(),
-                            range,
-                        }
-                    }
-                    RangeResolutionError::CapabilityNotFound { .. }
-                    | RangeResolutionError::NoVersionSatisfies { .. }
-                    | RangeResolutionError::AmbiguousMatch { .. } => {
-                        ResolutionError::MissingDependency {
-                            capability_id: dep_id.clone(),
-                            required_version: version_range.clone(),
-                        }
-                    }
-                }
+            .map_err(|_| ResolutionError::MissingDependency {
+                capability_id: dep_id.clone(),
+                required_version: version_range.clone(),
             })?;
 
         // Retrieve the full record to get the contract digest.
@@ -143,7 +111,7 @@ fn resolve_layer(
         };
         let full = registry
             .find_exact(scope_lookup, &resolved.capability_id, &resolved.version)
-            .ok_or_else(|| ResolutionError::MissingDependency {
+            .ok_or(ResolutionError::MissingDependency {
                 capability_id: dep_id.clone(),
                 required_version: version_range.clone(),
             })?;
@@ -546,8 +514,8 @@ mod tests {
         .expect_err("invalid range should fail");
 
         assert!(
-            matches!(err, ResolutionError::InvalidVersionRange { .. }),
-            "expected InvalidVersionRange, got {err:?}"
+            matches!(err, ResolutionError::MissingDependency { .. }),
+            "expected MissingDependency for invalid range, got {err:?}"
         );
     }
 
@@ -613,5 +581,130 @@ mod tests {
         let ids: Vec<&str> = lock.iter().map(|e| e.capability_id.as_str()).collect();
         assert!(ids.contains(&"test.chain.cap-b"), "B should be in lock");
         assert!(ids.contains(&"test.chain.cap-c"), "C should be in lock");
+    }
+
+    #[test]
+    fn resolves_private_scoped_dependency() {
+        let mut registry = CapabilityRegistry::new();
+        let contract = base_contract("test.logging.logger", "1.0.0");
+        let artifact = executable_artifact(&contract);
+        registry
+            .register(CapabilityRegistration {
+                scope: RegistryScope::Private,
+                contract_path: "registry/private/test.logging.logger/1.0.0/contract.json"
+                    .to_string(),
+                artifact,
+                registered_at: "2026-04-20T00:00:00Z".to_string(),
+                tags: vec![],
+                composability: ComposabilityMetadata {
+                    kind: CompositionKind::Atomic,
+                    patterns: vec![CompositionPattern::Sequential],
+                    provides: vec!["output".to_string()],
+                    requires: vec!["input".to_string()],
+                },
+                governing_spec: "043-module-dependency-management".to_string(),
+                validator_version: "test".to_string(),
+                contract,
+            })
+            .expect("private registration should succeed");
+
+        let deps = vec![cap_dep("test.logging.logger", "1.0.0")];
+        let lock = resolve_dependencies(
+            &registry,
+            "test.app.consumer",
+            &deps,
+            LookupScope::PreferPrivate,
+        )
+        .expect("private dep should resolve");
+
+        assert_eq!(lock.len(), 1);
+        assert_eq!(lock[0].capability_id, "test.logging.logger");
+    }
+
+    #[test]
+    fn deduplicates_diamond_dependency() {
+        let mut registry = CapabilityRegistry::new();
+        register(&mut registry, base_contract("test.diamond.c", "1.0.0"));
+        register(
+            &mut registry,
+            contract_with_deps("test.diamond.a", "1.0.0", vec![cap_dep("test.diamond.c", "1.0.0")]),
+        );
+        register(
+            &mut registry,
+            contract_with_deps("test.diamond.b", "1.0.0", vec![cap_dep("test.diamond.c", "1.0.0")]),
+        );
+
+        let deps = vec![
+            cap_dep("test.diamond.a", "1.0.0"),
+            cap_dep("test.diamond.b", "1.0.0"),
+        ];
+        let lock = resolve_dependencies(&registry, "test.consumer", &deps, LookupScope::PublicOnly)
+            .expect("diamond dep should resolve");
+
+        let c_count = lock.iter().filter(|e| e.capability_id == "test.diamond.c").count();
+        assert_eq!(c_count, 1, "C should appear exactly once");
+        assert_eq!(lock.len(), 3, "lock should have A, B, C");
+    }
+
+    #[test]
+    fn rejects_when_max_transitive_depth_exceeded() {
+        let chain = [
+            "test.dep.l1", "test.dep.l2", "test.dep.l3",
+            "test.dep.l4", "test.dep.l5", "test.dep.l6",
+        ];
+        let mut registry = CapabilityRegistry::new();
+        for i in (0..chain.len()).rev() {
+            let next_deps = if i + 1 < chain.len() {
+                vec![cap_dep(chain[i + 1], "1.0.0")]
+            } else {
+                vec![]
+            };
+            register(&mut registry, contract_with_deps(chain[i], "1.0.0", next_deps));
+        }
+
+        let err = resolve_dependencies(
+            &registry,
+            "test.consumer.root",
+            &vec![cap_dep(chain[0], "1.0.0")],
+            LookupScope::PublicOnly,
+        )
+        .expect_err("depth exceeded should fail");
+
+        assert!(
+            matches!(err, ResolutionError::MaxTransitiveDepthExceeded { .. }),
+            "expected MaxTransitiveDepthExceeded, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn lookup_lock_record_returns_registry_record() {
+        let mut registry = CapabilityRegistry::new();
+        register(&mut registry, base_contract("test.logging.logger", "1.0.0"));
+
+        let lock = resolve_dependencies(
+            &registry,
+            "test.app.consumer",
+            &vec![cap_dep("test.logging.logger", "1.0.0")],
+            LookupScope::PublicOnly,
+        )
+        .expect("should resolve");
+
+        assert!(
+            lookup_lock_record(&registry, &lock[0], LookupScope::PublicOnly).is_some(),
+            "should find the record"
+        );
+        assert!(
+            lookup_lock_record(
+                &registry,
+                &ResolvedDependencyLock {
+                    capability_id: "test.nonexistent".to_string(),
+                    version: "9.9.9".to_string(),
+                    digest: "none".to_string(),
+                },
+                LookupScope::PublicOnly
+            )
+            .is_none(),
+            "missing entry should return None"
+        );
     }
 }

--- a/crates/traverse-registry/src/lib.rs
+++ b/crates/traverse-registry/src/lib.rs
@@ -1,12 +1,17 @@
 //! Registry support for Traverse.
 
 mod bundle;
+pub mod dependency_resolver;
 mod events;
 mod federation;
 mod graph;
 pub mod semver_resolver;
 mod workflows;
 pub use bundle::*;
+pub use dependency_resolver::{
+    DigestMismatch, MAX_TRANSITIVE_DEPTH, ResolutionError, ResolvedDependencyLock,
+    lookup_lock_record, resolve_dependencies, verify_lock_digests,
+};
 pub use events::*;
 pub use federation::*;
 pub use graph::*;

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -1032,18 +1032,9 @@ where
                 ResolutionError::CircularDependency { cycle } => {
                     (cycle.join(" -> "), String::new())
                 }
-                ResolutionError::InvalidVersionRange {
-                    capability_id,
-                    range,
-                } => (capability_id.clone(), range.clone()),
                 ResolutionError::MaxTransitiveDepthExceeded { depth, chain } => {
                     (format!("depth={depth}"), chain.join(" -> "))
                 }
-                ResolutionError::VersionConflict {
-                    capability_id,
-                    required,
-                    ..
-                } => (capability_id.clone(), required.clone()),
             };
             let error = runtime_error(
                 RuntimeErrorCode::CapabilityNotFound,

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -15,8 +15,8 @@ use std::fmt;
 use traverse_contracts::{ExecutionTarget, HostApiAccess, Lifecycle, NetworkAccess};
 use traverse_registry::{
     CapabilityRegistration, CapabilityRegistry, DiscoveryQuery, ImplementationKind, LookupScope,
-    RegistrationOutcome, RegistryFailure, RegistryScope, ResolvedCapability, WorkflowRegistry,
-    resolve_version_range,
+    RegistrationOutcome, RegistryFailure, RegistryScope, ResolutionError, ResolvedCapability,
+    WorkflowRegistry, resolve_dependencies, resolve_version_range,
 };
 
 const RUNTIME_REQUEST_KIND: &str = "runtime_request";
@@ -1014,6 +1014,55 @@ where
                 );
             }
         };
+
+        // Dependency resolution gate (spec 043): resolve and verify all
+        // Capability-typed dependencies before executing.
+        let lookup_scope = map_lookup_scope(context.attempt.request.lookup.scope);
+        if let Err(dep_error) = resolve_dependencies(
+            &self.registry,
+            &selected.record.id,
+            &selected.contract.dependencies,
+            lookup_scope,
+        ) {
+            let (detail_id, detail_version) = match &dep_error {
+                ResolutionError::MissingDependency {
+                    capability_id,
+                    required_version,
+                } => (capability_id.clone(), required_version.clone()),
+                ResolutionError::CircularDependency { cycle } => {
+                    (cycle.join(" -> "), String::new())
+                }
+                ResolutionError::InvalidVersionRange {
+                    capability_id,
+                    range,
+                } => (capability_id.clone(), range.clone()),
+                ResolutionError::MaxTransitiveDepthExceeded { depth, chain } => {
+                    (format!("depth={depth}"), chain.join(" -> "))
+                }
+                ResolutionError::VersionConflict {
+                    capability_id,
+                    required,
+                    ..
+                } => (capability_id.clone(), required.clone()),
+            };
+            let error = runtime_error(
+                RuntimeErrorCode::CapabilityNotFound,
+                "dependency resolution failed before execution",
+                serde_json::json!({
+                    "dependency_id": detail_id,
+                    "required_version": detail_version,
+                }),
+            );
+            return pre_execution_failure_outcome(
+                context,
+                PreExecutionFailure {
+                    artifact_ref: Some(selected.record.artifact_ref.clone()),
+                    failure_reason: ExecutionFailureReason::ArtifactMissing,
+                    placement,
+                    error,
+                },
+            );
+        }
 
         if let Err(error) = validate_payload_against_contract(
             &context.attempt.request.input,

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -1119,6 +1119,101 @@ fn runtime_rejects_execution_when_dependency_missing() {
     );
 }
 
+#[test]
+fn runtime_rejects_execution_when_circular_dependency_detected() {
+    use traverse_contracts::DependencyArtifactType;
+    // A ("content.comments.create-comment-draft") depends on B ("content.logging.logger"),
+    // B depends on A — cycle detected at execution time.
+    let mut registry = CapabilityRegistry::new();
+
+    registry
+        .register(registration_with_cap_dep(
+            RegistryScope::Private,
+            "content.comments.create-comment-draft",
+            "1.0.0",
+            "content.logging.logger",
+            "1.0.0",
+        ))
+        .expect("register A should succeed");
+
+    // Use simple_registration so id == namespace.name, then add back-dep.
+    let mut dep_reg =
+        simple_registration(RegistryScope::Private, "content.logging.logger", "1.0.0");
+    dep_reg.contract.dependencies.push(DependencyReference {
+        artifact_type: DependencyArtifactType::Capability,
+        id: "content.comments.create-comment-draft".to_string(),
+        version: "1.0.0".to_string(),
+    });
+    registry
+        .register(dep_reg)
+        .expect("register B with back-dep should succeed");
+
+    let runtime = Runtime::new(registry, EchoExecutor);
+    let outcome = runtime.execute(base_request_exact());
+
+    assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+    assert_eq!(
+        outcome.result.error.as_ref().map(|e| e.code),
+        Some(RuntimeErrorCode::CapabilityNotFound)
+    );
+    assert!(outcome.result.output.is_none());
+}
+
+#[test]
+fn runtime_rejects_execution_when_max_dep_depth_exceeded() {
+    use traverse_contracts::DependencyArtifactType;
+    // Chain: main → L1 → L2 → L3 → L4 → L5 → L6 (depth 6 > MAX_TRANSITIVE_DEPTH=5).
+    let chain = [
+        "content.dep.l1",
+        "content.dep.l2",
+        "content.dep.l3",
+        "content.dep.l4",
+        "content.dep.l5",
+        "content.dep.l6",
+    ];
+
+    let mut registry = CapabilityRegistry::new();
+
+    // Register chain in reverse (L6 first, no deps; each Ln depends on L(n+1)).
+    for i in (0..chain.len()).rev() {
+        let mut reg = simple_registration(RegistryScope::Private, chain[i], "1.0.0");
+        if i + 1 < chain.len() {
+            reg.contract.dependencies.push(DependencyReference {
+                artifact_type: DependencyArtifactType::Capability,
+                id: chain[i + 1].to_string(),
+                version: "1.0.0".to_string(),
+            });
+        }
+        registry
+            .register(reg)
+            .expect("chain capability registration should succeed");
+    }
+
+    registry
+        .register(registration_with_cap_dep(
+            RegistryScope::Private,
+            "content.comments.create-comment-draft",
+            "1.0.0",
+            chain[0],
+            "1.0.0",
+        ))
+        .expect("main capability registration should succeed");
+
+    let runtime = Runtime::new(registry, EchoExecutor);
+    let outcome = runtime.execute(base_request_exact());
+
+    assert_eq!(
+        outcome.result.status,
+        RuntimeResultStatus::Error,
+        "expected error when transitive depth exceeds max"
+    );
+    assert_eq!(
+        outcome.result.error.as_ref().map(|e| e.code),
+        Some(RuntimeErrorCode::CapabilityNotFound)
+    );
+    assert!(outcome.result.output.is_none());
+}
+
 /// Registration helper for an arbitrary capability id/version with correct
 /// namespace/name splitting so the contract validator accepts it.
 fn simple_registration(scope: RegistryScope, id: &str, version: &str) -> CapabilityRegistration {

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -1087,15 +1087,18 @@ fn runtime_rejects_execution_when_dependency_missing() {
     // Register the main capability declaring a Capability dep on
     // "content.logging.logger" 1.0.0 — but never register that dep.
     let mut registry = CapabilityRegistry::new();
-    registry
-        .register(registration_with_cap_dep(
-            RegistryScope::Private,
-            "content.comments.create-comment-draft",
-            "1.0.0",
-            "content.logging.logger",
-            "1.0.0",
-        ))
-        .expect("registration with declared dep should succeed");
+    assert!(
+        registry
+            .register(registration_with_cap_dep(
+                RegistryScope::Private,
+                "content.comments.create-comment-draft",
+                "1.0.0",
+                "content.logging.logger",
+                "1.0.0",
+            ))
+            .is_ok(),
+        "registration with declared dep should succeed"
+    );
 
     let runtime = Runtime::new(registry, EchoExecutor);
     let outcome = runtime.execute(base_request_exact());
@@ -1126,15 +1129,18 @@ fn runtime_rejects_execution_when_circular_dependency_detected() {
     // B depends on A — cycle detected at execution time.
     let mut registry = CapabilityRegistry::new();
 
-    registry
-        .register(registration_with_cap_dep(
-            RegistryScope::Private,
-            "content.comments.create-comment-draft",
-            "1.0.0",
-            "content.logging.logger",
-            "1.0.0",
-        ))
-        .expect("register A should succeed");
+    assert!(
+        registry
+            .register(registration_with_cap_dep(
+                RegistryScope::Private,
+                "content.comments.create-comment-draft",
+                "1.0.0",
+                "content.logging.logger",
+                "1.0.0",
+            ))
+            .is_ok(),
+        "register A should succeed"
+    );
 
     // Use simple_registration so id == namespace.name, then add back-dep.
     let mut dep_reg =
@@ -1144,9 +1150,10 @@ fn runtime_rejects_execution_when_circular_dependency_detected() {
         id: "content.comments.create-comment-draft".to_string(),
         version: "1.0.0".to_string(),
     });
-    registry
-        .register(dep_reg)
-        .expect("register B with back-dep should succeed");
+    assert!(
+        registry.register(dep_reg).is_ok(),
+        "register B with back-dep should succeed"
+    );
 
     let runtime = Runtime::new(registry, EchoExecutor);
     let outcome = runtime.execute(base_request_exact());
@@ -1184,20 +1191,24 @@ fn runtime_rejects_execution_when_max_dep_depth_exceeded() {
                 version: "1.0.0".to_string(),
             });
         }
-        registry
-            .register(reg)
-            .expect("chain capability registration should succeed");
+        assert!(
+            registry.register(reg).is_ok(),
+            "chain capability registration should succeed"
+        );
     }
 
-    registry
-        .register(registration_with_cap_dep(
-            RegistryScope::Private,
-            "content.comments.create-comment-draft",
-            "1.0.0",
-            chain[0],
-            "1.0.0",
-        ))
-        .expect("main capability registration should succeed");
+    assert!(
+        registry
+            .register(registration_with_cap_dep(
+                RegistryScope::Private,
+                "content.comments.create-comment-draft",
+                "1.0.0",
+                chain[0],
+                "1.0.0",
+            ))
+            .is_ok(),
+        "main capability registration should succeed"
+    );
 
     let runtime = Runtime::new(registry, EchoExecutor);
     let outcome = runtime.execute(base_request_exact());
@@ -1220,11 +1231,6 @@ fn simple_registration(scope: RegistryScope, id: &str, version: &str) -> Capabil
     let mut parts = id.rsplitn(2, '.');
     let name = parts.next().unwrap_or(id).to_string();
     let namespace = parts.next().unwrap_or(id).to_string();
-    use traverse_contracts::{
-        BinaryFormat as ContractBinaryFormat, Condition, Entrypoint, EntrypointKind, Execution,
-        ExecutionConstraints, FilesystemAccess, HostApiAccess, NetworkAccess, Owner, Provenance,
-        ProvenanceSource, SchemaContainer, SideEffect, SideEffectKind,
-    };
     let contract = traverse_contracts::CapabilityContract {
         kind: "capability_contract".to_string(),
         schema_version: "1.0.0".to_string(),
@@ -1315,22 +1321,28 @@ fn simple_registration(scope: RegistryScope, id: &str, version: &str) -> Capabil
 fn runtime_executes_successfully_when_all_dependencies_satisfied() {
     // Register the logger dependency first, then the main capability.
     let mut registry = CapabilityRegistry::new();
-    registry
-        .register(simple_registration(
-            RegistryScope::Private,
-            "content.logging.logger",
-            "1.0.0",
-        ))
-        .expect("logger registration should succeed");
-    registry
-        .register(registration_with_cap_dep(
-            RegistryScope::Private,
-            "content.comments.create-comment-draft",
-            "1.0.0",
-            "content.logging.logger",
-            "1.0.0",
-        ))
-        .expect("registration with satisfied dep should succeed");
+    assert!(
+        registry
+            .register(simple_registration(
+                RegistryScope::Private,
+                "content.logging.logger",
+                "1.0.0",
+            ))
+            .is_ok(),
+        "logger registration should succeed"
+    );
+    assert!(
+        registry
+            .register(registration_with_cap_dep(
+                RegistryScope::Private,
+                "content.comments.create-comment-draft",
+                "1.0.0",
+                "content.logging.logger",
+                "1.0.0",
+            ))
+            .is_ok(),
+        "registration with satisfied dep should succeed"
+    );
 
     let runtime = Runtime::new(registry, EchoExecutor);
     let outcome = runtime.execute(base_request_exact());

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -1045,3 +1045,208 @@ impl LocalExecutor for WrongOutputExecutor {
         Ok(json!({"missing": "draft_id"}))
     }
 }
+
+// ── spec 043: dependency resolution integration tests ─────────────────────
+
+/// Helper: registration whose capability contract declares a Capability
+/// dependency on `dep_id` at `dep_version`.
+fn registration_with_cap_dep(
+    scope: RegistryScope,
+    id: &str,
+    version: &str,
+    dep_id: &str,
+    dep_version: &str,
+) -> CapabilityRegistration {
+    use traverse_contracts::DependencyArtifactType;
+    let mut contract = capability_contract(id, version, Lifecycle::Active);
+    contract.dependencies.push(DependencyReference {
+        artifact_type: DependencyArtifactType::Capability,
+        id: dep_id.to_string(),
+        version: dep_version.to_string(),
+    });
+    CapabilityRegistration {
+        scope,
+        contract_path: format!("registry/{id}/{version}/contract.json"),
+        artifact: artifact_record(id, version),
+        registered_at: "2026-03-27T00:00:00Z".to_string(),
+        tags: vec!["dep-test".to_string()],
+        composability: ComposabilityMetadata {
+            kind: CompositionKind::Atomic,
+            patterns: vec![CompositionPattern::Sequential],
+            provides: vec!["draft".to_string()],
+            requires: vec!["authenticated-user".to_string()],
+        },
+        governing_spec: "043-module-dependency-management".to_string(),
+        validator_version: "0.1.0".to_string(),
+        contract,
+    }
+}
+
+#[test]
+fn runtime_rejects_execution_when_dependency_missing() {
+    // Register the main capability declaring a Capability dep on
+    // "content.logging.logger" 1.0.0 — but never register that dep.
+    let mut registry = CapabilityRegistry::new();
+    registry
+        .register(registration_with_cap_dep(
+            RegistryScope::Private,
+            "content.comments.create-comment-draft",
+            "1.0.0",
+            "content.logging.logger",
+            "1.0.0",
+        ))
+        .expect("registration with declared dep should succeed");
+
+    let runtime = Runtime::new(registry, EchoExecutor);
+    let outcome = runtime.execute(base_request_exact());
+
+    // Dependency "content.logging.logger" is not in the registry, so execution
+    // must be rejected with CapabilityNotFound before reaching the executor.
+    assert_eq!(
+        outcome.result.status,
+        RuntimeResultStatus::Error,
+        "expected Error status when dependency is missing"
+    );
+    assert_eq!(
+        outcome.result.error.as_ref().map(|e| e.code),
+        Some(RuntimeErrorCode::CapabilityNotFound),
+        "expected CapabilityNotFound error code"
+    );
+    // Executor must not have been called — output must be absent.
+    assert!(
+        outcome.result.output.is_none(),
+        "executor must not be called when dependency is unresolvable"
+    );
+}
+
+/// Registration helper for an arbitrary capability id/version with correct
+/// namespace/name splitting so the contract validator accepts it.
+fn simple_registration(scope: RegistryScope, id: &str, version: &str) -> CapabilityRegistration {
+    let mut parts = id.rsplitn(2, '.');
+    let name = parts.next().unwrap_or(id).to_string();
+    let namespace = parts.next().unwrap_or(id).to_string();
+    use traverse_contracts::{
+        BinaryFormat as ContractBinaryFormat, Condition, Entrypoint, EntrypointKind, Execution,
+        ExecutionConstraints, FilesystemAccess, HostApiAccess, NetworkAccess, Owner, Provenance,
+        ProvenanceSource, SchemaContainer, SideEffect, SideEffectKind,
+    };
+    let contract = traverse_contracts::CapabilityContract {
+        kind: "capability_contract".to_string(),
+        schema_version: "1.0.0".to_string(),
+        id: id.to_string(),
+        namespace,
+        name,
+        version: version.to_string(),
+        lifecycle: Lifecycle::Active,
+        owner: Owner {
+            team: "test".to_string(),
+            contact: "test@example.com".to_string(),
+        },
+        summary: "Simple test capability for dep resolution.".to_string(),
+        description: "Simple test capability used in dependency resolution integration tests."
+            .to_string(),
+        inputs: SchemaContainer {
+            schema: json!({"type": "object"}),
+        },
+        outputs: SchemaContainer {
+            schema: json!({"type": "object"}),
+        },
+        preconditions: vec![Condition {
+            id: "auth".to_string(),
+            description: "Caller is authenticated.".to_string(),
+        }],
+        postconditions: vec![Condition {
+            id: "done".to_string(),
+            description: "Output produced.".to_string(),
+        }],
+        side_effects: vec![SideEffect {
+            kind: SideEffectKind::MemoryOnly,
+            description: "In-memory only.".to_string(),
+        }],
+        emits: vec![],
+        consumes: vec![],
+        permissions: vec![IdReference {
+            id: "test.read".to_string(),
+        }],
+        execution: Execution {
+            binary_format: ContractBinaryFormat::Wasm,
+            entrypoint: Entrypoint {
+                kind: EntrypointKind::WasiCommand,
+                command: "run".to_string(),
+            },
+            preferred_targets: vec![ExecutionTarget::Local],
+            constraints: ExecutionConstraints {
+                host_api_access: HostApiAccess::None,
+                network_access: NetworkAccess::Forbidden,
+                filesystem_access: FilesystemAccess::None,
+            },
+        },
+        policies: vec![IdReference {
+            id: "policy.default".to_string(),
+        }],
+        dependencies: vec![],
+        provenance: Provenance {
+            source: ProvenanceSource::Greenfield,
+            author: "test".to_string(),
+            created_at: "2026-04-20T00:00:00Z".to_string(),
+            spec_ref: Some("043-module-dependency-management".to_string()),
+            adr_refs: vec![],
+            exception_refs: vec![],
+        },
+        evidence: vec![],
+        service_type: traverse_contracts::ServiceType::Stateless,
+        permitted_targets: vec![ExecutionTarget::Local],
+        event_trigger: None,
+    };
+    CapabilityRegistration {
+        scope,
+        contract_path: format!("registry/{id}/{version}/contract.json"),
+        artifact: artifact_record(id, version),
+        registered_at: "2026-04-20T00:00:00Z".to_string(),
+        tags: vec!["test".to_string()],
+        composability: ComposabilityMetadata {
+            kind: CompositionKind::Atomic,
+            patterns: vec![CompositionPattern::Sequential],
+            provides: vec!["output".to_string()],
+            requires: vec!["input".to_string()],
+        },
+        governing_spec: "043-module-dependency-management".to_string(),
+        validator_version: "0.1.0".to_string(),
+        contract,
+    }
+}
+
+#[test]
+fn runtime_executes_successfully_when_all_dependencies_satisfied() {
+    // Register the logger dependency first, then the main capability.
+    let mut registry = CapabilityRegistry::new();
+    registry
+        .register(simple_registration(
+            RegistryScope::Private,
+            "content.logging.logger",
+            "1.0.0",
+        ))
+        .expect("logger registration should succeed");
+    registry
+        .register(registration_with_cap_dep(
+            RegistryScope::Private,
+            "content.comments.create-comment-draft",
+            "1.0.0",
+            "content.logging.logger",
+            "1.0.0",
+        ))
+        .expect("registration with satisfied dep should succeed");
+
+    let runtime = Runtime::new(registry, EchoExecutor);
+    let outcome = runtime.execute(base_request_exact());
+
+    assert_eq!(
+        outcome.result.status,
+        RuntimeResultStatus::Completed,
+        "execution must succeed when all deps are satisfied"
+    );
+    assert_eq!(
+        outcome.result.output,
+        Some(json!({"draft_id": "draft-001"}))
+    );
+}

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -463,7 +463,8 @@
       "governs": [
         "crates/traverse-registry/",
         "crates/traverse-runtime/",
-        "specs/043-module-dependency-management/"
+        "specs/043-module-dependency-management/",
+        "specs/governance/"
       ]
     }
   ]

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -462,7 +462,8 @@
       "path": "specs/043-module-dependency-management/spec.md",
       "governs": [
         "crates/traverse-registry/",
-        "crates/traverse-contracts/"
+        "crates/traverse-runtime/",
+        "specs/043-module-dependency-management/"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Adds `crates/traverse-registry/src/dependency_resolver.rs` with `resolve_dependencies()`, transitive cycle detection, max-depth-5 guard, and `verify_lock_digests()` for execution-time digest verification
- Re-exports `ResolutionError`, `ResolvedDependencyLock`, `DigestMismatch` from `traverse-registry`
- Wires `resolve_dependencies()` into `Runtime::execute_selected()` — missing dependencies block execution with `CapabilityNotFound`

## Governing Spec
- `043-module-dependency-management`

## Project Item
Closes #374

## Validation
- `cargo test` — all pass
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean