### PR TITLE
feat(#368): contractual enforcement gate (spec 040)

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -14,6 +14,7 @@ use std::fs;
 use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use traverse_contracts::ViolationRecord;
 use traverse_contracts::{
     EventContract, EventValidationContext, parse_event_contract, validate_event_contract,
 };
@@ -1658,19 +1659,6 @@ fn load_registered_bundle(manifest_path: &Path) -> Result<RegisteredBundle, CliE
     let mut event_records = Vec::new();
     let mut workflow_records = Vec::new();
 
-    for capability in &bundle.capabilities {
-        let request = build_capability_registration(&bundle, capability)?;
-        let outcome = capability_registry.register(request).map_err(|f| {
-            let msg = render_registry_failure(f.clone());
-            map_registry_failure(&f, msg)
-        })?;
-        capability_records.push(format_capability_record(
-            &outcome.record.id,
-            &outcome.record.version,
-            outcome.record.implementation_kind,
-        ));
-    }
-
     for event in &bundle.events {
         let outcome = event_registry
             .register(EventRegistration {
@@ -1683,6 +1671,54 @@ fn load_registered_bundle(manifest_path: &Path) -> Result<RegisteredBundle, CliE
             })
             .map_err(|f| CliError::RegistrationConflict(render_event_registry_failure(f)))?;
         event_records.push(format!("{}@{}", outcome.record.id, outcome.record.version));
+    }
+
+    let mut gate_violations = Vec::new();
+    for capability in &bundle.capabilities {
+        for referenced in capability
+            .contract
+            .emits
+            .iter()
+            .chain(capability.contract.consumes.iter())
+        {
+            let exists = event_registry
+                .find_exact(
+                    LookupScope::PreferPrivate,
+                    &referenced.event_id,
+                    &referenced.version,
+                )
+                .is_some();
+            if !exists {
+                gate_violations.push(ViolationRecord::new(
+                    "unresolved_event_reference",
+                    capability.path.display().to_string(),
+                    format!(
+                        "capability references missing event {}@{}",
+                        referenced.event_id, referenced.version
+                    ),
+                ));
+            }
+        }
+    }
+
+    if !gate_violations.is_empty() {
+        return Err(CliError::ValidationFailed(render_violation_records(
+            "registration-time contractual enforcement gate failed",
+            &gate_violations,
+        )));
+    }
+
+    for capability in &bundle.capabilities {
+        let request = build_capability_registration(&bundle, capability)?;
+        let outcome = capability_registry.register(request).map_err(|f| {
+            let msg = render_registry_failure(f.clone());
+            map_registry_failure(&f, msg)
+        })?;
+        capability_records.push(format_capability_record(
+            &outcome.record.id,
+            &outcome.record.version,
+            outcome.record.implementation_kind,
+        ));
     }
 
     for workflow in &bundle.workflows {
@@ -1710,6 +1746,23 @@ fn load_registered_bundle(manifest_path: &Path) -> Result<RegisteredBundle, CliE
         event_records,
         workflow_records,
     })
+}
+
+fn render_violation_records(header: &str, violations: &[ViolationRecord]) -> String {
+    let mut lines = Vec::new();
+    lines.push(header.to_string());
+    let mut sorted = violations.to_vec();
+    sorted.sort_by(|a, b| {
+        (a.path.as_str(), a.violation_code.as_str())
+            .cmp(&(b.path.as_str(), b.violation_code.as_str()))
+    });
+    for v in sorted {
+        lines.push(format!(
+            "- [{}] {}: {}",
+            v.violation_code, v.path, v.message
+        ));
+    }
+    lines.join("\n")
 }
 
 fn map_registry_failure(failure: &traverse_registry::RegistryFailure, msg: String) -> CliError {

--- a/crates/traverse-contracts/src/lib.rs
+++ b/crates/traverse-contracts/src/lib.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeSet, HashSet};
 
+pub mod violations;
+pub use violations::ViolationRecord;
+
 const CAPABILITY_CONTRACT_KIND: &str = "capability_contract";
 const EVENT_CONTRACT_KIND: &str = "event_contract";
 const SUPPORTED_SCHEMA_VERSION: &str = "1.0.0";

--- a/crates/traverse-contracts/src/violations.rs
+++ b/crates/traverse-contracts/src/violations.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+
+/// Stable, machine-readable representation of a governed contract violation.
+///
+/// Governed by spec 040-contractual-enforcement-gate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ViolationRecord {
+    pub violation_code: String,
+    pub path: String,
+    pub message: String,
+}
+
+impl ViolationRecord {
+    #[must_use]
+    pub fn new(
+        violation_code: impl Into<String>,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            violation_code: violation_code.into(),
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ViolationRecord;
+
+    #[test]
+    fn violation_record_new_round_trips_through_json() {
+        let record = ViolationRecord::new("missing_required_field", "$.id", "id is required");
+        let json = serde_json::to_string(&record);
+        assert!(json.is_ok(), "serialize must succeed: {json:?}");
+        let json = json.unwrap_or_default();
+
+        let decoded = serde_json::from_str::<ViolationRecord>(&json);
+        assert!(decoded.is_ok(), "deserialize must succeed: {decoded:?}");
+        let decoded = decoded.unwrap_or_else(|_| record.clone());
+        assert_eq!(decoded, record);
+    }
+}

--- a/crates/traverse-mcp/src/lib.rs
+++ b/crates/traverse-mcp/src/lib.rs
@@ -517,7 +517,8 @@ fn map_runtime_error(code: RuntimeErrorCode, message: &str) -> McpError {
         RuntimeErrorCode::CapabilityAmbiguous => McpErrorCode::AmbiguousMatch,
         RuntimeErrorCode::CapabilityNotRunnable
         | RuntimeErrorCode::PlacementUnsupported
-        | RuntimeErrorCode::OutputValidationFailed => McpErrorCode::ValidationFailed,
+        | RuntimeErrorCode::OutputValidationFailed
+        | RuntimeErrorCode::ContractViolation => McpErrorCode::ValidationFailed,
         RuntimeErrorCode::ExecutionFailed => McpErrorCode::ExecutionFailed,
     };
     McpError {

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -1012,6 +1012,7 @@ where
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     fn execute_selected(
         &self,
         attempt: AttemptContext,

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -12,7 +12,9 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use std::fmt;
-use traverse_contracts::{ExecutionTarget, HostApiAccess, Lifecycle, NetworkAccess};
+use traverse_contracts::{
+    ExecutionTarget, HostApiAccess, Lifecycle, NetworkAccess, ViolationRecord,
+};
 use traverse_registry::{
     CapabilityRegistration, CapabilityRegistry, DiscoveryQuery, ImplementationKind, LookupScope,
     RegistrationOutcome, RegistryFailure, RegistryScope, ResolutionError, ResolvedCapability,
@@ -555,6 +557,7 @@ pub enum RuntimeErrorCode {
     ArtifactMissing,
     ExecutionFailed,
     OutputValidationFailed,
+    ContractViolation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1024,6 +1027,32 @@ where
             selection,
         };
         let requested_target = context.attempt.request.context.requested_target;
+
+        if contains_drafts_segment(&selected.record.contract_path) {
+            let violation = ViolationRecord::new(
+                "draft_artifact_not_executable",
+                selected.record.contract_path.clone(),
+                "draft artifacts are quarantined under drafts/ and must not be executable",
+            );
+            let error = runtime_error(
+                RuntimeErrorCode::ContractViolation,
+                "draft artifacts are not executable",
+                json!({"violations": [violation]}),
+            );
+            return pre_execution_failure_outcome(
+                context,
+                PreExecutionFailure {
+                    artifact_ref: Some(selected.record.artifact_ref.clone()),
+                    failure_reason: ExecutionFailureReason::ArtifactNotRunnable,
+                    placement: placement_not_attempted(
+                        requested_target,
+                        PlacementDecisionReason::SelectionNotReached,
+                    ),
+                    error,
+                },
+            );
+        }
+
         let placement = match resolve_placement(requested_target) {
             Ok(placement) => placement,
             Err(error) => {
@@ -2029,6 +2058,12 @@ fn content_digest(value: &Value) -> String {
         hash = hash.wrapping_mul(0x0000_0001_0000_01b3);
     }
     format!("0.1.0:{hash:016x}")
+}
+
+fn contains_drafts_segment(path: &str) -> bool {
+    path.replace('\\', "/")
+        .split('/')
+        .any(|segment| segment == "drafts")
 }
 
 struct AttemptContext {

--- a/crates/traverse-runtime/src/router/mod.rs
+++ b/crates/traverse-runtime/src/router/mod.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use serde_json::Value;
-use traverse_contracts::{CapabilityContract, ServiceType};
+use traverse_contracts::{CapabilityContract, ServiceType, ViolationRecord};
 
 use crate::{
     events::types::{EventBroker, TraverseEvent},
@@ -66,6 +66,8 @@ pub enum RouterError {
     ExecutorNotFound(String),
     /// The selected executor returned an error.
     ExecutionFailed(String),
+    /// Execution violated a governed contract (aggregate violations).
+    ContractViolation(Vec<ViolationRecord>),
     /// The trace store lock was poisoned.
     TraceLockPoisoned,
 }
@@ -76,6 +78,9 @@ impl std::fmt::Display for RouterError {
             Self::PlacementFailed(e) => write!(f, "placement failed: {e:?}"),
             Self::ExecutorNotFound(t) => write!(f, "no executor registered for artifact type: {t}"),
             Self::ExecutionFailed(msg) => write!(f, "execution failed: {msg}"),
+            Self::ContractViolation(violations) => {
+                write!(f, "contract violation: {} violation(s)", violations.len())
+            }
             Self::TraceLockPoisoned => write!(f, "trace store lock is poisoned"),
         }
     }
@@ -169,10 +174,39 @@ impl PlacementRouter {
             Err(e) => return Err(RouterError::ExecutionFailed(format!("{e}"))),
         };
 
+        // --- Step 3.5: Execution-time contractual enforcement gate ---
+        let mut violations = Vec::new();
+        if request.contract.service_type == ServiceType::Subscribable
+            && !request.emitted_events.is_empty()
+        {
+            for event in &request.emitted_events {
+                let declared =
+                    request.contract.emits.iter().any(|decl| {
+                        decl.event_id == event.event_type && decl.version == event.version
+                    });
+                if !declared {
+                    violations.push(ViolationRecord::new(
+                        "undeclared_event_emission",
+                        &request.capability_id,
+                        format!(
+                            "capability emitted undeclared event {}@{}",
+                            event.event_type, event.version
+                        ),
+                    ));
+                }
+            }
+        }
+
+        let outcome = if violations.is_empty() {
+            outcome
+        } else {
+            TraceOutcome::Failure
+        };
+
         // --- Step 4: Write trace ---
         let (trace_id, time) = new_trace_id_and_time();
 
-        let public_entry = PublicTraceEntry::new(
+        let mut public_entry = PublicTraceEntry::new(
             trace_id.clone(),
             request.capability_id.clone(),
             placement_target_str,
@@ -180,6 +214,7 @@ impl PlacementRouter {
             duration_ms,
             time,
         );
+        public_entry.violations.clone_from(&violations);
 
         let input_str = serde_json::to_string(&request.input).unwrap_or_default();
         let output_str = serde_json::to_string(&output).unwrap_or_default();
@@ -192,6 +227,10 @@ impl PlacementRouter {
                 .lock()
                 .map_err(|_| RouterError::TraceLockPoisoned)?;
             store.insert(public_entry, Some(private_entry));
+        }
+
+        if !violations.is_empty() {
+            return Err(RouterError::ContractViolation(violations));
         }
 
         // --- Step 5: Publish events for Subscribable capabilities ---

--- a/crates/traverse-runtime/src/trace/public.rs
+++ b/crates/traverse-runtime/src/trace/public.rs
@@ -1,6 +1,7 @@
 //! Public (CloudEvents-formatted) trace entry.
 
 use serde::{Deserialize, Serialize};
+use traverse_contracts::ViolationRecord;
 
 /// Outcome of a capability execution recorded in the public trace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -34,6 +35,9 @@ pub struct PublicTraceEntry {
     pub outcome: TraceOutcome,
     /// Wall-clock duration of the execution in milliseconds.
     pub duration_ms: u64,
+    /// Aggregate contractual enforcement violations (if any).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub violations: Vec<ViolationRecord>,
 }
 
 impl PublicTraceEntry {
@@ -58,6 +62,7 @@ impl PublicTraceEntry {
             placement_target,
             outcome,
             duration_ms,
+            violations: Vec::new(),
         }
     }
 }

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::{Value, json};
 use traverse_contracts::{
-    BinaryFormat, CapabilityContract, Condition, Entrypoint, EntrypointKind, Execution,
-    ExecutionConstraints, ExecutionTarget, FilesystemAccess, HostApiAccess, Lifecycle,
+    BinaryFormat, CapabilityContract, Condition, Entrypoint, EntrypointKind, EventReference,
+    Execution, ExecutionConstraints, ExecutionTarget, FilesystemAccess, HostApiAccess, Lifecycle,
     NetworkAccess, Owner, Provenance, ProvenanceSource, SchemaContainer, ServiceType, SideEffect,
     SideEffectKind,
 };
@@ -318,6 +318,10 @@ fn subscribable_capability_publishes_events() -> Result<(), String> {
     // Subscribable contract
     let mut contract = base_contract(ServiceType::Subscribable);
     contract.event_trigger = Some("dev.traverse.router.test.triggered".to_string());
+    contract.emits = vec![EventReference {
+        event_id: event_type.to_string(),
+        version: "1.0.0".to_string(),
+    }];
 
     let request = RouterRequest {
         capability_id: "router.tests.subject".to_string(),
@@ -337,6 +341,58 @@ fn subscribable_capability_publishes_events() -> Result<(), String> {
         .map_err(|e| e.to_string())?;
     assert_eq!(poll.events.len(), 1, "one event must be delivered");
     assert_eq!(poll.events[0].event.event_type, event_type);
+
+    Ok(())
+}
+
+#[test]
+fn undeclared_event_emission_fails_execution_and_is_recorded() -> Result<(), String> {
+    let trace_store = Arc::new(Mutex::new(TraceStore::new()));
+    let event_type = "dev.traverse.router.test.undeclared";
+    let broker = broker_with_event(event_type)?;
+    let broker_arc: Arc<dyn EventBroker> = broker;
+
+    let router = make_router_with_native(
+        json!({ "done": true }),
+        Arc::clone(&trace_store),
+        Arc::clone(&broker_arc),
+    );
+
+    let mut contract = base_contract(ServiceType::Subscribable);
+    contract.event_trigger = Some("dev.traverse.router.test.triggered".to_string());
+    contract.emits = Vec::new();
+
+    let request = RouterRequest {
+        capability_id: "router.tests.subject".to_string(),
+        artifact_type: ArtifactType::Native,
+        contract,
+        target_hint: Some(ExecutionTarget::Local),
+        runtime_snapshot: idle_snapshot(),
+        input: json!({}),
+        executor_capability: native_executor_capability("router.tests.subject"),
+        emitted_events: vec![sample_event(event_type)],
+    };
+
+    let err = must_err(router.execute(request), "expected contract violation")?;
+    assert!(
+        matches!(err, RouterError::ContractViolation(_)),
+        "expected ContractViolation, got {err:?}"
+    );
+
+    let store = trace_store
+        .lock()
+        .map_err(|_| "trace store lock poisoned".to_string())?;
+    let traces = store.list_public(Some("router.tests.subject"));
+    assert!(
+        traces.iter().any(|trace| {
+            trace.outcome == traverse_runtime::trace::TraceOutcome::Failure
+                && trace
+                    .violations
+                    .iter()
+                    .any(|v| v.violation_code == "undeclared_event_emission")
+        }),
+        "expected a failure trace entry with undeclared_event_emission"
+    );
 
     Ok(())
 }
@@ -389,10 +445,16 @@ fn stateless_capability_does_not_publish_events() -> Result<(), String> {
 fn router_error_display_covers_all_variants() {
     use traverse_runtime::router::RouterError;
 
+    use traverse_contracts::ViolationRecord;
     let cases: Vec<RouterError> = vec![
         RouterError::PlacementFailed(PlacementError::NoEligibleTarget),
         RouterError::ExecutorNotFound("Wasm".to_string()),
         RouterError::ExecutionFailed("test failure".to_string()),
+        RouterError::ContractViolation(vec![ViolationRecord::new(
+            "undeclared_event_emission",
+            "test.cap",
+            "test message",
+        )]),
         RouterError::TraceLockPoisoned,
     ];
 

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -253,6 +253,36 @@ fn rejects_non_runnable_candidates_before_execution() {
 }
 
 #[test]
+fn rejects_draft_contract_paths_before_execution() {
+    let mut draft = registration(
+        RegistryScope::Private,
+        "content.comments.create-comment-draft",
+        "1.0.0",
+        Lifecycle::Active,
+    );
+    draft.contract_path =
+        "drafts/contracts/content.comments.create-comment-draft/1.0.0/contract.json".to_string();
+
+    let runtime = Runtime::new(registry_with(vec![draft]), EchoExecutor);
+    let outcome = runtime.execute(base_request_exact());
+
+    assert_eq!(
+        outcome.result.error.as_ref().map(|error| error.code),
+        Some(RuntimeErrorCode::ContractViolation)
+    );
+    assert!(outcome.result.error.is_some(), "error must be present");
+    let details = outcome
+        .result
+        .error
+        .as_ref()
+        .map_or_else(|| json!({}), |error| error.details.clone());
+    assert_eq!(
+        details["violations"][0]["violation_code"],
+        "draft_artifact_not_executable"
+    );
+}
+
+#[test]
 fn rejects_non_runtime_lifecycle_candidates() {
     let runtime = Runtime::new(
         registry_with(vec![registration(

--- a/scripts/ci/contractual_enforcement_gate.sh
+++ b/scripts/ci/contractual_enforcement_gate.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+default_repo_root="$(cd "${script_dir}/../.." && pwd)"
+repo_root="${TRAVERSE_REPO_ROOT:-${default_repo_root}}"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+manifest_path="${tmp_dir}/governed-artifacts-manifest.json"
+
+# Build a synthetic bundle manifest that includes every governed artifact under
+# contracts/ and workflows/, excluding the top-level drafts/ quarantine.
+python3 - "${repo_root}" "${manifest_path}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+manifest_path = Path(sys.argv[2])
+
+violations: list[dict[str, str]] = []
+
+def record(code: str, path: str, message: str) -> None:
+    violations.append({"violation_code": code, "path": path, "message": message})
+
+def load_json(path: Path):
+    try:
+        return json.loads(path.read_text())
+    except Exception as exc:
+        record("invalid_json", str(path), f"failed to parse JSON: {exc}")
+        return None
+
+def is_quarantined(path: Path) -> bool:
+    # drafts/ is a top-level quarantine directory. Ignore it entirely in CI-time validation.
+    return "drafts" in path.parts
+
+capabilities = []
+events = []
+
+contracts_root = repo_root / "contracts"
+if contracts_root.is_dir():
+    for path in sorted(contracts_root.rglob("contract.json")):
+        if is_quarantined(path):
+            continue
+        obj = load_json(path)
+        if obj is None:
+            continue
+        kind = obj.get("kind")
+        if kind == "capability_contract":
+            target = capabilities
+        elif kind == "event_contract":
+            target = events
+        else:
+            record("invalid_kind", str(path), f"unsupported contract kind: {kind!r}")
+            continue
+
+        cid = obj.get("id")
+        ver = obj.get("version")
+        if not cid:
+            record("missing_required_field", f"{path}:$.id", "contract id is required")
+            continue
+        if not ver:
+            record("missing_required_field", f"{path}:$.version", "contract version is required")
+            continue
+        target.append({"id": cid, "version": ver, "path": str(path)})
+
+workflows = []
+workflows_root = repo_root / "workflows"
+if workflows_root.is_dir():
+    for path in sorted(workflows_root.rglob("workflow.json")):
+        if is_quarantined(path):
+            continue
+        obj = load_json(path)
+        if obj is None:
+            continue
+        wid = obj.get("id")
+        wver = obj.get("version")
+        if not wid:
+            record("missing_required_field", f"{path}:$.id", "workflow id is required")
+            continue
+        if not wver:
+            record("missing_required_field", f"{path}:$.version", "workflow version is required")
+            continue
+        workflows.append({"id": wid, "version": wver, "path": str(path)})
+
+if violations:
+    payload = {"status": "failed", "violations": violations}
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    sys.exit(2)
+
+manifest = {
+    "bundle_id": "traverse.ci.governed-artifacts",
+    "version": "0.0.0",
+    "scope": "public",
+    "capabilities": capabilities,
+    "events": events,
+    "workflows": workflows,
+}
+manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+PY
+
+# Run the registration-time gate over the full local artifact tree (which includes
+# referential integrity checks like capability -> event references and workflow graph validity).
+cargo run -p traverse-cli -- bundle register "${manifest_path}"
+
+echo "Contractual enforcement gate passed."
+

--- a/scripts/ci/rust_checks.sh
+++ b/scripts/ci/rust_checks.sh
@@ -6,4 +6,6 @@ cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 
+bash scripts/ci/contractual_enforcement_gate.sh
+
 echo "Rust checks passed."


### PR DESCRIPTION
## Outcome
Implements spec 040 contractual enforcement at CI-time, registration-time, and execution-time.

## Governing Spec
- `040-contractual-enforcement-gate`
- `001-foundation-v0-1`

## Project Item
- Closes #368

## Validation
- `bash scripts/ci/rust_checks.sh`
- `bash scripts/ci/contractual_enforcement_gate.sh`
