### PR TITLE
feat(041): workflow JSON composition API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,7 @@ dependencies = [
 name = "traverse-cli"
 version = "0.2.0"
 dependencies = [
+ "semver",
  "serde",
  "serde_json",
  "traverse-contracts",

--- a/contracts/examples/expedition/capabilities/assess-conditions-summary/contract.json
+++ b/contracts/examples/expedition/capabilities/assess-conditions-summary/contract.json
@@ -78,6 +78,7 @@
     "schema": {
       "type": "object",
       "required": [
+        "conditions_summary",
         "conditions_summary_id",
         "objective_id",
         "overall_rating",
@@ -105,6 +106,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "conditions_summary": {
+          "type": "object",
+          "description": "Composite conditions_summary record for downstream consumption."
         }
       }
     }

--- a/contracts/examples/expedition/capabilities/capture-expedition-objective/contract.json
+++ b/contracts/examples/expedition/capabilities/capture-expedition-objective/contract.json
@@ -71,6 +71,7 @@
     "schema": {
       "type": "object",
       "required": [
+        "objective",
         "objective_id",
         "destination",
         "target_window",
@@ -78,6 +79,10 @@
         "notes"
       ],
       "properties": {
+        "objective": {
+          "type": "object",
+          "description": "Composite expedition objective record for downstream consumption."
+        },
         "objective_id": {
           "type": "string"
         },

--- a/contracts/examples/expedition/capabilities/interpret-expedition-intent/contract.json
+++ b/contracts/examples/expedition/capabilities/interpret-expedition-intent/contract.json
@@ -87,6 +87,7 @@
     "schema": {
       "type": "object",
       "required": [
+        "interpreted_intent",
         "intent_id",
         "objective_id",
         "route_preferences",
@@ -121,6 +122,10 @@
         },
         "confidence": {
           "type": "number"
+        },
+        "interpreted_intent": {
+          "type": "object",
+          "description": "Composite interpreted_intent record for downstream consumption."
         }
       }
     }

--- a/contracts/examples/expedition/capabilities/validate-team-readiness/contract.json
+++ b/contracts/examples/expedition/capabilities/validate-team-readiness/contract.json
@@ -95,6 +95,7 @@
     "schema": {
       "type": "object",
       "required": [
+        "readiness_result",
         "readiness_result_id",
         "objective_id",
         "status",
@@ -122,6 +123,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "readiness_result": {
+          "type": "object",
+          "description": "Composite readiness_result record for downstream consumption."
         }
       }
     }

--- a/crates/traverse-cli/Cargo.toml
+++ b/crates/traverse-cli/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 traverse-contracts = { path = "../traverse-contracts" }

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -10,7 +10,8 @@ use traverse_registry::{
     ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
     CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
     CompositionPattern, DiscoveryQuery, ImplementationKind, LookupScope, RegistryProvenance,
-    RegistryScope, SourceKind, SourceReference, WorkflowRegistry,
+    RegistryScope, SourceKind, SourceReference, WorkflowDefinition, WorkflowRegistration,
+    WorkflowRegistry,
 };
 use traverse_runtime::{
     LocalExecutor, Runtime, RuntimeExecutionOutcome, RuntimeRequest, RuntimeResultStatus,
@@ -68,6 +69,8 @@ struct WorkspaceState<E> {
 struct PersistedWorkspaceRegistryV1 {
     schema_version: String,
     registrations: Vec<PersistedCapabilityRegistrationV1>,
+    #[serde(default)]
+    workflows: Vec<PersistedWorkflowRegistrationV1>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -76,6 +79,14 @@ struct PersistedCapabilityRegistrationV1 {
     contract: CapabilityContract,
     #[serde(default)]
     tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedWorkflowRegistrationV1 {
+    registry_scope: String,
+    definition: WorkflowDefinition,
+    registered_at: String,
+    validator_version: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -146,6 +157,7 @@ where
             persisted: PersistedWorkspaceRegistryV1 {
                 schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
                 registrations: Vec::new(),
+                workflows: Vec::new(),
             },
             loaded_from_disk: true,
         },
@@ -172,6 +184,110 @@ where
     Ok(())
 }
 
+/// In-process wrapper around the HTTP/JSON API handlers, used by `traverse-cli`
+/// subcommands that must delegate to the canonical server code paths.
+pub struct InProcessApi<E> {
+    state: ApiState<E>,
+}
+
+impl<E> InProcessApi<E>
+where
+    E: LocalExecutor + Clone,
+{
+    #[must_use]
+    pub fn new(config: ApiServerConfig<E>) -> Self {
+        let mut workspaces = HashMap::new();
+        workspaces.insert(
+            SYSTEM_WORKSPACE_ID.to_string(),
+            WorkspaceState {
+                runtime: Runtime::new(config.capability_registry, config.executor.clone())
+                    .with_workflow_registry(config.workflow_registry),
+                persisted: PersistedWorkspaceRegistryV1 {
+                    schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
+                    registrations: Vec::new(),
+                    workflows: Vec::new(),
+                },
+                loaded_from_disk: false,
+            },
+        );
+
+        Self {
+            state: ApiState {
+                allow_unauthenticated: config.allow_unauthenticated,
+                registry_root: config.registry_root,
+                executor: config.executor,
+                workspaces: RefCell::new(workspaces),
+            },
+        }
+    }
+
+    pub fn register_workflow(
+        &self,
+        body: Vec<u8>,
+        loopback: bool,
+    ) -> Result<(u16, Value), String> {
+        let request = HttpRequest {
+            method: "POST".to_string(),
+            path: "/v1/workflows/register".to_string(),
+            query: HashMap::new(),
+            headers: HashMap::new(),
+            body,
+        };
+        let mut out = Vec::new();
+        handle_register_workflow(&mut out, &request, &self.state, loopback)?;
+        parse_http_json_response(&out)
+    }
+
+    pub fn list_workflows(
+        &self,
+        workspace_id: &str,
+        loopback: bool,
+    ) -> Result<(u16, Value), String> {
+        let mut query = HashMap::new();
+        query.insert("workspace_id".to_string(), workspace_id.to_string());
+        let request = HttpRequest {
+            method: "GET".to_string(),
+            path: "/v1/workflows".to_string(),
+            query,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+        let mut out = Vec::new();
+        handle_list_workflows(&mut out, &request, &self.state, loopback)?;
+        parse_http_json_response(&out)
+    }
+
+    pub fn get_workflow(
+        &self,
+        workspace_id: &str,
+        workflow_id: &str,
+        version: Option<&str>,
+        loopback: bool,
+    ) -> Result<(u16, Value), String> {
+        let mut query = HashMap::new();
+        query.insert("workspace_id".to_string(), workspace_id.to_string());
+        if let Some(version) = version {
+            query.insert("version".to_string(), version.to_string());
+        }
+        let request = HttpRequest {
+            method: "GET".to_string(),
+            path: format!("/v1/workflows/{workflow_id}"),
+            query,
+            headers: HashMap::new(),
+            body: Vec::new(),
+        };
+        let mut out = Vec::new();
+        handle_get_workflow(
+            &mut out,
+            &request,
+            &self.state,
+            loopback,
+            workflow_id,
+        )?;
+        parse_http_json_response(&out)
+    }
+}
+
 impl<E> ApiState<E>
 where
     E: LocalExecutor + Clone,
@@ -190,6 +306,7 @@ where
                 persisted: PersistedWorkspaceRegistryV1 {
                     schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
                     registrations: Vec::new(),
+                    workflows: Vec::new(),
                 },
                 loaded_from_disk: false,
             });
@@ -205,11 +322,44 @@ where
                     .register_capability(registration)
                     .map_err(render_registry_failure_as_string)?;
             }
+            for persisted in entry.persisted.workflows.clone() {
+                let registration = derive_workflow_registration(workspace_id, &persisted)
+                    .map_err(|e| format!("persisted registry contains invalid workflow: {e:?}"))?;
+                let _ = entry
+                    .runtime
+                    .register_workflow(registration)
+                    .map_err(render_workflow_failure_as_string)?;
+            }
             entry.loaded_from_disk = true;
         }
 
         f(entry)
     }
+}
+
+fn parse_http_json_response(bytes: &[u8]) -> Result<(u16, Value), String> {
+    let text = std::str::from_utf8(bytes).map_err(|e| format!("response not UTF-8: {e}"))?;
+    let status_line = text
+        .lines()
+        .next()
+        .ok_or_else(|| "response missing status line".to_string())?;
+    let mut parts = status_line.split_whitespace();
+    let _proto = parts
+        .next()
+        .ok_or_else(|| "response status line missing protocol".to_string())?;
+    let status = parts
+        .next()
+        .ok_or_else(|| "response status line missing status code".to_string())?
+        .parse::<u16>()
+        .map_err(|_| "response status code is not a u16".to_string())?;
+
+    let header_end = text
+        .find("\r\n\r\n")
+        .ok_or_else(|| "response missing header terminator".to_string())?;
+    let body = &bytes[header_end + 4..];
+    let value: Value =
+        serde_json::from_slice(body).map_err(|e| format!("invalid JSON response body: {e}"))?;
+    Ok((status, value))
 }
 
 fn load_persisted_registry(
@@ -221,6 +371,7 @@ fn load_persisted_registry(
         return Ok(PersistedWorkspaceRegistryV1 {
             schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
             registrations: Vec::new(),
+            workflows: Vec::new(),
         });
     }
 
@@ -282,6 +433,33 @@ fn render_registry_failure_as_string(failure: traverse_registry::RegistryFailure
         );
     }
     rendered
+}
+
+fn render_workflow_failure_as_string(failure: traverse_registry::WorkflowFailure) -> String {
+    use std::fmt::Write as _;
+
+    let mut rendered = String::new();
+    for err in failure.errors {
+        let _ = write!(
+            &mut rendered,
+            "{:?} at {}: {}; ",
+            err.code, err.path, err.message
+        );
+    }
+    rendered
+}
+
+fn generated_registered_at() -> Result<String, ApiError> {
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| ApiError {
+            status: 500,
+            reason: "Internal Server Error",
+            code: "internal_error",
+            message: format!("failed to read system time: {e}"),
+        })?
+        .as_secs();
+    Ok(format!("unix:{now_secs}"))
 }
 
 fn validate_workspace_id(workspace_id: &str) -> Result<(), String> {
@@ -696,6 +874,145 @@ fn map_registry_failure_http(
     (422, "registration_failed", "Unprocessable Entity")
 }
 
+fn map_workflow_failure_http(
+    failure: &traverse_registry::WorkflowFailure,
+    definition: &WorkflowDefinition,
+) -> (u16, &'static str, &'static str, Option<Value>) {
+    use traverse_registry::WorkflowErrorCode;
+
+    let mut has_immutable = false;
+    let mut has_cycle = false;
+    let mut has_edge_schema_mismatch = false;
+    let mut has_missing_reference = false;
+    let mut has_empty_nodes = false;
+
+    for err in &failure.errors {
+        match err.code {
+            WorkflowErrorCode::ImmutableVersionConflict => has_immutable = true,
+            WorkflowErrorCode::DeterministicCycleNotAllowed => has_cycle = true,
+            WorkflowErrorCode::EdgeSchemaMismatch => has_edge_schema_mismatch = true,
+            WorkflowErrorCode::MissingReference => has_missing_reference = true,
+            WorkflowErrorCode::MissingRequiredField => {
+                if err.path == "$.nodes" {
+                    has_empty_nodes = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if has_immutable {
+        return (409, "immutable_version_conflict", "Conflict", None);
+    }
+
+    if has_cycle {
+        let path = find_cycle_path(definition);
+        return (
+            422,
+            "workflow_cycle_detected",
+            "Unprocessable Entity",
+            Some(json!({ "cycle_path": path })),
+        );
+    }
+
+    if has_edge_schema_mismatch {
+        return (422, "edge_schema_mismatch", "Unprocessable Entity", None);
+    }
+
+    if has_missing_reference {
+        return (
+            422,
+            "unresolved_capability_reference",
+            "Unprocessable Entity",
+            None,
+        );
+    }
+
+    if has_empty_nodes {
+        return (422, "empty_workflow", "Unprocessable Entity", None);
+    }
+
+    (422, "registration_failed", "Unprocessable Entity", None)
+}
+
+fn find_cycle_path(definition: &WorkflowDefinition) -> Vec<String> {
+    use std::collections::BTreeMap;
+
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Mark {
+        Visiting,
+        Done,
+    }
+
+    fn dfs(
+        node: &str,
+        adjacency: &std::collections::BTreeMap<String, Vec<String>>,
+        marks: &mut std::collections::BTreeMap<String, Mark>,
+        stack: &mut Vec<String>,
+    ) -> Option<Vec<String>> {
+        marks.insert(node.to_string(), Mark::Visiting);
+        stack.push(node.to_string());
+
+        if let Some(neighbors) = adjacency.get(node) {
+            for next in neighbors {
+                match marks.get(next.as_str()).copied() {
+                    Some(Mark::Visiting) => {
+                        if let Some(pos) = stack.iter().position(|v| v == next) {
+                            let mut cycle = stack[pos..].to_vec();
+                            cycle.push(next.clone());
+                            return Some(cycle);
+                        }
+                        return Some(vec![next.clone(), next.clone()]);
+                    }
+                    Some(Mark::Done) => {}
+                    None => {
+                        if let Some(found) = dfs(next, adjacency, marks, stack) {
+                            return Some(found);
+                        }
+                    }
+                }
+            }
+        }
+
+        stack.pop();
+        marks.insert(node.to_string(), Mark::Done);
+        None
+    }
+
+    let node_ids = definition
+        .nodes
+        .iter()
+        .map(|node| node.node_id.clone())
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut adjacency: BTreeMap<String, Vec<String>> = node_ids
+        .iter()
+        .map(|id| (id.clone(), Vec::new()))
+        .collect();
+
+    for edge in &definition.edges {
+        if node_ids.contains(&edge.from) && node_ids.contains(&edge.to) {
+            adjacency.entry(edge.from.clone()).or_default().push(edge.to.clone());
+        }
+    }
+
+    for neighbors in adjacency.values_mut() {
+        neighbors.sort();
+    }
+
+    let mut marks = BTreeMap::<String, Mark>::new();
+    for node in &node_ids {
+        if marks.contains_key(node) {
+            continue;
+        }
+        let mut stack = Vec::new();
+        if let Some(found) = dfs(node, &adjacency, &mut marks, &mut stack) {
+            return found;
+        }
+    }
+
+    Vec::new()
+}
+
 fn derive_registration(
     workspace_id: &str,
     persisted: &PersistedCapabilityRegistrationV1,
@@ -773,6 +1090,37 @@ fn derive_registration(
         },
         governing_spec: "034-programmatic-registration".to_string(),
         validator_version: "traverse-cli".to_string(),
+    })
+}
+
+fn derive_workflow_registration(
+    workspace_id: &str,
+    persisted: &PersistedWorkflowRegistrationV1,
+) -> Result<WorkflowRegistration, ApiError> {
+    let registry_scope = match persisted.registry_scope.as_str() {
+        "public" => RegistryScope::Public,
+        "private" => RegistryScope::Private,
+        other => {
+            return Err(ApiError {
+                status: 422,
+                reason: "Unprocessable Entity",
+                code: "invalid_registry_scope",
+                message: format!("registry_scope must be public or private (got {other})"),
+            });
+        }
+    };
+
+    Ok(WorkflowRegistration {
+        scope: registry_scope,
+        definition: persisted.definition.clone(),
+        workflow_path: format!(
+            "workspaces/{workspace_id}/workflows/{}/{}@{}/workflow.json",
+            format!("{registry_scope:?}").to_lowercase(),
+            persisted.definition.id,
+            persisted.definition.version
+        ),
+        registered_at: persisted.registered_at.clone(),
+        validator_version: persisted.validator_version.clone(),
     })
 }
 
@@ -879,6 +1227,108 @@ fn parse_register_body(
     ))
 }
 
+fn parse_workflow_register_body(
+    body: &[u8],
+) -> Result<(String, RegistrationScope, PersistedWorkflowRegistrationV1), ApiError> {
+    let body_str = std::str::from_utf8(body).map_err(|e| ApiError {
+        status: 400,
+        reason: "Bad Request",
+        code: "invalid_request",
+        message: format!("request body is not valid UTF-8: {e}"),
+    })?;
+
+    let value: Value = serde_json::from_str(body_str).map_err(|e| ApiError {
+        status: 400,
+        reason: "Bad Request",
+        code: "invalid_request",
+        message: format!("invalid JSON body: {e}"),
+    })?;
+
+    let workspace_id = value
+        .get("workspace_id")
+        .and_then(|v| v.as_str())
+        .filter(|ws| !ws.trim().is_empty())
+        .ok_or_else(|| ApiError {
+            status: 400,
+            reason: "Bad Request",
+            code: "missing_workspace_id",
+            message: "workspace_id is required".to_string(),
+        })?
+        .to_string();
+
+    validate_workspace_id(&workspace_id).map_err(|message| ApiError {
+        status: 400,
+        reason: "Bad Request",
+        code: "invalid_workspace_id",
+        message,
+    })?;
+
+    let scope = value
+        .get("scope")
+        .and_then(|v| v.as_str())
+        .unwrap_or("workspace_persisted");
+    let scope = match scope {
+        "workspace_persisted" => RegistrationScope::WorkspacePersisted,
+        "session_ephemeral" => RegistrationScope::SessionEphemeral,
+        other => {
+            return Err(ApiError {
+                status: 422,
+                reason: "Unprocessable Entity",
+                code: "invalid_scope",
+                message: format!(
+                    "scope must be workspace_persisted or session_ephemeral (got {other})"
+                ),
+            });
+        }
+    };
+
+    let registry_scope = value
+        .get("registry_scope")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| if workspace_id == SYSTEM_WORKSPACE_ID { "public" } else { "private" })
+        .to_string();
+
+    let workflow_value = value.get("workflow").ok_or_else(|| ApiError {
+        status: 400,
+        reason: "Bad Request",
+        code: "missing_workflow",
+        message: "workflow is required".to_string(),
+    })?;
+
+    let definition: WorkflowDefinition = serde_json::from_value(workflow_value.clone()).map_err(
+        |e| ApiError {
+            status: 422,
+            reason: "Unprocessable Entity",
+            code: "invalid_workflow",
+            message: format!("workflow must be a valid workflow_definition: {e}"),
+        },
+    )?;
+
+    let registered_at = match value.get("registered_at").and_then(|v| v.as_str()) {
+        Some(value) if !value.trim().is_empty() => value.to_string(),
+        _ => match generated_registered_at() {
+            Ok(value) => value,
+            Err(_) => "unix:0".to_string(),
+        },
+    };
+    let validator_version = value
+        .get("validator_version")
+        .and_then(|v| v.as_str())
+        .unwrap_or(env!("CARGO_PKG_VERSION"))
+        .to_string();
+
+    Ok((
+        workspace_id,
+        scope,
+        PersistedWorkflowRegistrationV1 {
+            registry_scope,
+            definition,
+            registered_at,
+            validator_version,
+        },
+    ))
+}
+
 fn ensure_workspace_loaded<E: LocalExecutor + Clone>(
     state: &ApiState<E>,
     workspace_id: &str,
@@ -920,6 +1370,7 @@ fn apply_registration<E: LocalExecutor + Clone>(
             persisted: PersistedWorkspaceRegistryV1 {
                 schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
                 registrations: Vec::new(),
+                workflows: Vec::new(),
             },
             loaded_from_disk: false,
         });
@@ -936,6 +1387,66 @@ fn apply_registration<E: LocalExecutor + Clone>(
         }
         Err(failure) => Ok(Err(failure)),
     }
+}
+
+#[derive(Debug, Clone)]
+struct WorkflowRegistrationHttpOutcome {
+    already_registered: bool,
+    workflow_id: String,
+    workflow_version: String,
+    digest: String,
+    registry_scope: String,
+    registered_at: String,
+}
+
+fn apply_workflow_registration<E: LocalExecutor + Clone>(
+    state: &ApiState<E>,
+    workspace_id: &str,
+    scope: RegistrationScope,
+    mut persisted: PersistedWorkflowRegistrationV1,
+) -> Result<
+    Result<WorkflowRegistrationHttpOutcome, traverse_registry::WorkflowFailure>,
+    String,
+> {
+    state.with_workspace_mut(workspace_id, |ws| {
+        let workflow_id = persisted.definition.id.clone();
+        let workflow_version = persisted.definition.version.clone();
+        let already = ws
+            .runtime
+            .workflow_registry()
+            .find_exact(LookupScope::PreferPrivate, &workflow_id, &workflow_version)
+            .is_some();
+
+        if !already && persisted.registered_at.trim().is_empty() {
+            persisted.registered_at = generated_registered_at().map_err(|e| e.message)?;
+        }
+
+        if persisted.validator_version.trim().is_empty() {
+            persisted.validator_version = env!("CARGO_PKG_VERSION").to_string();
+        }
+
+        let registration =
+            derive_workflow_registration(workspace_id, &persisted).map_err(|e| e.message)?;
+
+        match ws.runtime.register_workflow(registration) {
+            Ok(outcome) => {
+                if scope == RegistrationScope::WorkspacePersisted && !already {
+                    ws.persisted.workflows.push(persisted);
+                    persist_registry(&state.registry_root, workspace_id, &ws.persisted)?;
+                }
+
+                Ok(Ok(WorkflowRegistrationHttpOutcome {
+                    already_registered: already,
+                    workflow_id: outcome.record.id,
+                    workflow_version: outcome.record.version,
+                    digest: outcome.record.workflow_digest,
+                    registry_scope: format!("{:?}", outcome.record.scope).to_lowercase(),
+                    registered_at: outcome.record.registered_at,
+                }))
+            }
+            Err(failure) => Ok(Err(failure)),
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -980,6 +1491,19 @@ fn handle_connection<E: LocalExecutor + Clone>(
         ("POST", "/v1/capabilities/execute") => {
             handle_execute(&mut stream, &request, state, peer_ip.is_loopback())
         }
+        ("POST", "/v1/workflows/register") => {
+            handle_register_workflow(&mut stream, &request, state, peer_ip.is_loopback())
+        }
+        ("GET", "/v1/workflows") => {
+            handle_list_workflows(&mut stream, &request, state, peer_ip.is_loopback())
+        }
+        ("GET", path) if path.starts_with("/v1/workflows/") => handle_get_workflow(
+            &mut stream,
+            &request,
+            state,
+            peer_ip.is_loopback(),
+            path.trim_start_matches("/v1/workflows/"),
+        ),
         _ => write_json(
             &mut stream,
             404,
@@ -1251,6 +1775,283 @@ fn handle_execute<W: Write, E: LocalExecutor + Clone>(
             &error_envelope("internal_error", &e),
         ),
     }
+}
+
+fn handle_register_workflow<W: Write, E: LocalExecutor + Clone>(
+    w: &mut W,
+    request: &HttpRequest,
+    state: &ApiState<E>,
+    loopback: bool,
+) -> Result<(), String> {
+    let identity =
+        match subject_from_request(&request.headers, state.allow_unauthenticated, loopback) {
+            Ok(identity) => identity,
+            Err(err) => {
+                return write_json(
+                    w,
+                    err.status,
+                    err.reason,
+                    &error_envelope(err.code, &err.message),
+                );
+            }
+        };
+
+    let (workspace_id, scope, persisted) = match parse_workflow_register_body(&request.body) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            return write_json(
+                w,
+                err.status,
+                err.reason,
+                &error_envelope(err.code, &err.message),
+            );
+        }
+    };
+    let definition_for_errors = persisted.definition.clone();
+
+    let _ = match ensure_workspace_access(&state.registry_root, &workspace_id, &identity) {
+        Ok(metadata) => metadata,
+        Err(err) => {
+            return write_json(
+                w,
+                err.status,
+                err.reason,
+                &error_envelope(err.code, &err.message),
+            );
+        }
+    };
+
+    match apply_workflow_registration(state, &workspace_id, scope, persisted)? {
+        Ok(outcome) => {
+            let status = if outcome.already_registered { 200 } else { 201 };
+            write_json(
+                w,
+                status,
+                if status == 200 { "OK" } else { "Created" },
+                &json!({
+                    "workspace_id": workspace_id,
+                    "scope": match scope {
+                        RegistrationScope::WorkspacePersisted => "workspace_persisted",
+                        RegistrationScope::SessionEphemeral => "session_ephemeral",
+                    },
+                    "already_registered": outcome.already_registered,
+                    "workflow": {
+                        "id": outcome.workflow_id,
+                        "version": outcome.workflow_version,
+                        "digest": outcome.digest,
+                        "registry_scope": outcome.registry_scope,
+                        "registered_at": outcome.registered_at,
+                    }
+                }),
+            )
+        }
+        Err(failure) => {
+            let rendered = render_workflow_failure_as_string(failure.clone());
+            let (status, code, reason, extra) =
+                map_workflow_failure_http(&failure, &definition_for_errors);
+            let mut body = json!({
+                "error": {
+                    "code": code,
+                    "message": rendered,
+                }
+            });
+            if let (Some(extra), Value::Object(root)) = (extra, &mut body) {
+                root.insert("details".to_string(), extra);
+            }
+            write_json(w, status, reason, &body)
+        }
+    }
+}
+
+fn handle_list_workflows<W: Write, E: LocalExecutor + Clone>(
+    w: &mut W,
+    request: &HttpRequest,
+    state: &ApiState<E>,
+    loopback: bool,
+) -> Result<(), String> {
+    let workspace_id = match require_workspace_id_query(request) {
+        Ok(value) => value,
+        Err(err) => {
+            return write_json(
+                w,
+                err.status,
+                err.reason,
+                &error_envelope(err.code, &err.message),
+            );
+        }
+    };
+
+    let identity =
+        match subject_from_request(&request.headers, state.allow_unauthenticated, loopback) {
+            Ok(identity) => identity,
+            Err(err) => {
+                return write_json(
+                    w,
+                    err.status,
+                    err.reason,
+                    &error_envelope(err.code, &err.message),
+                );
+            }
+        };
+
+    let _ = match ensure_workspace_access(&state.registry_root, &workspace_id, &identity) {
+        Ok(metadata) => metadata,
+        Err(err) => {
+            return write_json(
+                w,
+                err.status,
+                err.reason,
+                &error_envelope(err.code, &err.message),
+            );
+        }
+    };
+
+    let entries = state.with_workspace_mut(&workspace_id, |ws| {
+        Ok(ws
+            .runtime
+            .workflow_registry()
+            .discover(LookupScope::PreferPrivate))
+    })?;
+
+    let mut json_entries = Vec::new();
+    for entry in entries {
+        let resolved = state.with_workspace_mut(&workspace_id, |ws| {
+            Ok(ws.runtime.workflow_registry().find_exact(
+                LookupScope::PreferPrivate,
+                &entry.id,
+                &entry.version,
+            ))
+        })?;
+        let digest = resolved
+            .as_ref()
+            .map(|wf| wf.record.workflow_digest.clone())
+            .unwrap_or_default();
+        let registered_at = resolved
+            .as_ref()
+            .map(|wf| wf.record.registered_at.clone())
+            .unwrap_or_default();
+        json_entries.push(json!({
+            "id": entry.id,
+            "version": entry.version,
+            "digest": digest,
+            "registered_at": registered_at,
+            "scope": format!("{:?}", entry.scope).to_lowercase(),
+            "lifecycle": format!("{:?}", entry.lifecycle).to_lowercase(),
+            "summary": entry.summary,
+            "tags": entry.tags,
+        }));
+    }
+
+    write_json(w, 200, "OK", &Value::Array(json_entries))
+}
+
+fn handle_get_workflow<W: Write, E: LocalExecutor + Clone>(
+    w: &mut W,
+    request: &HttpRequest,
+    state: &ApiState<E>,
+    loopback: bool,
+    workflow_id: &str,
+) -> Result<(), String> {
+    let workflow_id = workflow_id.trim();
+    if workflow_id.is_empty() {
+        return write_json(
+            w,
+            400,
+            "Bad Request",
+            &error_envelope("invalid_request", "workflow id must be non-empty"),
+        );
+    }
+
+    let workspace_id = match require_workspace_id_query(request) {
+        Ok(value) => value,
+        Err(err) => {
+            return write_json(
+                w,
+                err.status,
+                err.reason,
+                &error_envelope(err.code, &err.message),
+            );
+        }
+    };
+
+    let identity =
+        match subject_from_request(&request.headers, state.allow_unauthenticated, loopback) {
+            Ok(identity) => identity,
+            Err(err) => {
+                return write_json(
+                    w,
+                    err.status,
+                    err.reason,
+                    &error_envelope(err.code, &err.message),
+                );
+            }
+        };
+
+    let _ = match ensure_workspace_access(&state.registry_root, &workspace_id, &identity) {
+        Ok(metadata) => metadata,
+        Err(err) => {
+            return write_json(
+                w,
+                err.status,
+                err.reason,
+                &error_envelope(err.code, &err.message),
+            );
+        }
+    };
+
+    let version = request.query.get("version").cloned();
+    let resolved = state.with_workspace_mut(&workspace_id, |ws| {
+        let registry = ws.runtime.workflow_registry();
+        if let Some(version) = &version {
+            return Ok(registry.find_exact(
+                LookupScope::PreferPrivate,
+                workflow_id,
+                version,
+            ));
+        }
+
+        let candidates = registry
+            .discover(LookupScope::PreferPrivate)
+            .into_iter()
+            .filter(|entry| entry.id == workflow_id)
+            .collect::<Vec<_>>();
+        let mut ordered = candidates;
+        ordered.sort_by(|left, right| semver::Version::parse(&left.version)
+            .ok()
+            .cmp(&semver::Version::parse(&right.version).ok()));
+        let latest = ordered.last().cloned();
+        Ok(latest.and_then(|entry| {
+            registry.find_exact(LookupScope::PreferPrivate, &entry.id, &entry.version)
+        }))
+    })?;
+
+    let Some(resolved) = resolved else {
+        return write_json(
+            w,
+            404,
+            "Not Found",
+            &error_envelope(
+                "workflow_not_found",
+                &format!("workflow {workflow_id} was not found"),
+            ),
+        );
+    };
+
+    write_json(
+        w,
+        200,
+        "OK",
+        &json!({
+            "workflow": resolved.definition,
+            "record": {
+                "id": resolved.record.id,
+                "version": resolved.record.version,
+                "digest": resolved.record.workflow_digest,
+                "registered_at": resolved.record.registered_at,
+                "registry_scope": format!("{:?}", resolved.record.scope).to_lowercase(),
+            }
+        }),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -1629,6 +2430,7 @@ mod tests {
                 persisted: PersistedWorkspaceRegistryV1 {
                     schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
                     registrations: Vec::new(),
+                    workflows: Vec::new(),
                 },
                 loaded_from_disk: true,
             },
@@ -1657,6 +2459,7 @@ mod tests {
                 persisted: PersistedWorkspaceRegistryV1 {
                     schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
                     registrations: Vec::new(),
+                    workflows: Vec::new(),
                 },
                 loaded_from_disk: true,
             },

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -221,11 +221,7 @@ where
         }
     }
 
-    pub fn register_workflow(
-        &self,
-        body: Vec<u8>,
-        loopback: bool,
-    ) -> Result<(u16, Value), String> {
+    pub fn register_workflow(&self, body: Vec<u8>, loopback: bool) -> Result<(u16, Value), String> {
         let request = HttpRequest {
             method: "POST".to_string(),
             path: "/v1/workflows/register".to_string(),
@@ -277,13 +273,7 @@ where
             body: Vec::new(),
         };
         let mut out = Vec::new();
-        handle_get_workflow(
-            &mut out,
-            &request,
-            &self.state,
-            loopback,
-            workflow_id,
-        )?;
+        handle_get_workflow(&mut out, &request, &self.state, loopback, workflow_id)?;
         parse_http_json_response(&out)
     }
 }
@@ -984,14 +974,15 @@ fn find_cycle_path(definition: &WorkflowDefinition) -> Vec<String> {
         .iter()
         .map(|node| node.node_id.clone())
         .collect::<std::collections::BTreeSet<_>>();
-    let mut adjacency: BTreeMap<String, Vec<String>> = node_ids
-        .iter()
-        .map(|id| (id.clone(), Vec::new()))
-        .collect();
+    let mut adjacency: BTreeMap<String, Vec<String>> =
+        node_ids.iter().map(|id| (id.clone(), Vec::new())).collect();
 
     for edge in &definition.edges {
         if node_ids.contains(&edge.from) && node_ids.contains(&edge.to) {
-            adjacency.entry(edge.from.clone()).or_default().push(edge.to.clone());
+            adjacency
+                .entry(edge.from.clone())
+                .or_default()
+                .push(edge.to.clone());
         }
     }
 
@@ -1285,7 +1276,13 @@ fn parse_workflow_register_body(
     let registry_scope = value
         .get("registry_scope")
         .and_then(|v| v.as_str())
-        .unwrap_or_else(|| if workspace_id == SYSTEM_WORKSPACE_ID { "public" } else { "private" })
+        .unwrap_or_else(|| {
+            if workspace_id == SYSTEM_WORKSPACE_ID {
+                "public"
+            } else {
+                "private"
+            }
+        })
         .to_string();
 
     let workflow_value = value.get("workflow").ok_or_else(|| ApiError {
@@ -1295,14 +1292,13 @@ fn parse_workflow_register_body(
         message: "workflow is required".to_string(),
     })?;
 
-    let definition: WorkflowDefinition = serde_json::from_value(workflow_value.clone()).map_err(
-        |e| ApiError {
+    let definition: WorkflowDefinition =
+        serde_json::from_value(workflow_value.clone()).map_err(|e| ApiError {
             status: 422,
             reason: "Unprocessable Entity",
             code: "invalid_workflow",
             message: format!("workflow must be a valid workflow_definition: {e}"),
-        },
-    )?;
+        })?;
 
     let registered_at = match value.get("registered_at").and_then(|v| v.as_str()) {
         Some(value) if !value.trim().is_empty() => value.to_string(),
@@ -1404,10 +1400,7 @@ fn apply_workflow_registration<E: LocalExecutor + Clone>(
     workspace_id: &str,
     scope: RegistrationScope,
     mut persisted: PersistedWorkflowRegistrationV1,
-) -> Result<
-    Result<WorkflowRegistrationHttpOutcome, traverse_registry::WorkflowFailure>,
-    String,
-> {
+) -> Result<Result<WorkflowRegistrationHttpOutcome, traverse_registry::WorkflowFailure>, String> {
     state.with_workspace_mut(workspace_id, |ws| {
         let workflow_id = persisted.definition.id.clone();
         let workflow_version = persisted.definition.version.clone();
@@ -2003,11 +1996,7 @@ fn handle_get_workflow<W: Write, E: LocalExecutor + Clone>(
     let resolved = state.with_workspace_mut(&workspace_id, |ws| {
         let registry = ws.runtime.workflow_registry();
         if let Some(version) = &version {
-            return Ok(registry.find_exact(
-                LookupScope::PreferPrivate,
-                workflow_id,
-                version,
-            ));
+            return Ok(registry.find_exact(LookupScope::PreferPrivate, workflow_id, version));
         }
 
         let candidates = registry
@@ -2016,9 +2005,11 @@ fn handle_get_workflow<W: Write, E: LocalExecutor + Clone>(
             .filter(|entry| entry.id == workflow_id)
             .collect::<Vec<_>>();
         let mut ordered = candidates;
-        ordered.sort_by(|left, right| semver::Version::parse(&left.version)
-            .ok()
-            .cmp(&semver::Version::parse(&right.version).ok()));
+        ordered.sort_by(|left, right| {
+            semver::Version::parse(&left.version)
+                .ok()
+                .cmp(&semver::Version::parse(&right.version).ok())
+        });
         let latest = ordered.last().cloned();
         Ok(latest.and_then(|entry| {
             registry.find_exact(LookupScope::PreferPrivate, &entry.id, &entry.version)

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -1155,9 +1155,8 @@ fn workflow_inspect(
     }
 
     let workflow = response.get("workflow").cloned().unwrap_or_default();
-    serde_json::to_string_pretty(&workflow).map_err(|e| {
-        CliError::IoError(format!("failed to render workflow inspection output: {e}"))
-    })
+    serde_json::to_string_pretty(&workflow)
+        .map_err(|e| CliError::IoError(format!("failed to render workflow inspection output: {e}")))
 }
 
 fn build_in_process_api() -> Result<http_api::InProcessApi<ExpeditionExampleExecutor>, CliError> {

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -76,8 +76,17 @@ enum Command {
     TraceInspect {
         trace_path: PathBuf,
     },
-    Workflow {
+    WorkflowRegister {
         workflow_path: PathBuf,
+        workspace_id: String,
+    },
+    WorkflowList {
+        workspace_id: String,
+    },
+    WorkflowInspect {
+        workflow_id: String,
+        version: Option<String>,
+        workspace_id: String,
     },
     Serve {
         port: u16,
@@ -211,7 +220,16 @@ fn run_command(command: Command) -> Result<String, CliError> {
         } => discover_capabilities(&manifest_path, json_output),
         Command::Event { contract_path } => inspect_event(&contract_path),
         Command::TraceInspect { trace_path } => inspect_trace(&trace_path),
-        Command::Workflow { workflow_path } => inspect_workflow(&workflow_path),
+        Command::WorkflowRegister {
+            workflow_path,
+            workspace_id,
+        } => workflow_register(&workflow_path, &workspace_id),
+        Command::WorkflowList { workspace_id } => workflow_list(&workspace_id),
+        Command::WorkflowInspect {
+            workflow_id,
+            version,
+            workspace_id,
+        } => workflow_inspect(&workflow_id, version.as_deref(), &workspace_id),
     }
 }
 
@@ -239,6 +257,7 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
         (Some("agent"), Some("execute")) => parse_agent_execute_command(args),
         (Some("expedition"), Some("execute")) => parse_expedition_execute_command(args),
         (Some("capability"), Some("discover")) => parse_capability_discover_command(args),
+        (Some("workflow"), Some(_)) => parse_workflow_command(args),
         _ => parse_fixed_arity_command(args),
     }
 }
@@ -251,6 +270,8 @@ fn subcommand_help(family: Option<&str>, subcommand: Option<&str>) -> String {
         (Some("agent"), Some("inspect")) => help_agent_inspect(),
         (Some("agent"), Some("execute")) => help_agent_execute(),
         (Some("agent"), _) => help_agent(),
+        (Some("workflow"), Some("register")) => help_workflow_register(),
+        (Some("workflow"), Some("list")) => help_workflow_list(),
         (Some("workflow"), Some("inspect")) => help_workflow_inspect(),
         (Some("workflow"), _) => help_workflow(),
         (Some("expedition"), Some("execute")) => help_expedition_execute(),
@@ -370,22 +391,57 @@ fn help_agent() -> String {
         .to_string()
 }
 
-fn help_workflow_inspect() -> String {
-    "traverse-cli workflow inspect <workflow-path>
+fn help_workflow_register() -> String {
+    "traverse-cli workflow register <workflow-path> [--workspace-id <id>]
 
   Purpose:
-    Parse and summarize a workflow definition artifact. Prints the workflow id,
-    version, lifecycle, start/terminal nodes, node-to-capability mappings, and
-    edge topology.
+    Register a workflow definition via the HTTP/JSON API handler
+    (POST /v1/workflows/register). This uses the same canonical workflow
+    validation and immutability rules as the server.
 
   Required arguments:
-    <workflow-path>   Path to the workflow definition JSON file.
+    <workflow-path>       Path to the workflow definition JSON file.
 
   Optional flags:
-    --help            Print this help text.
+    --workspace-id <id>   Workspace identifier (default: system).
+    --help                Print this help text.
 
   Example:
-    traverse-cli workflow inspect workflows/examples/expedition/plan-expedition/workflow.json"
+    traverse-cli workflow register workflows/examples/hello-world/say-hello/workflow.json"
+        .to_string()
+}
+
+fn help_workflow_list() -> String {
+    "traverse-cli workflow list [--workspace-id <id>]
+
+  Purpose:
+    List registered workflows in a workspace via GET /v1/workflows.
+
+  Optional flags:
+    --workspace-id <id>   Workspace identifier (default: system).
+    --help                Print this help text.
+
+  Example:
+    traverse-cli workflow list"
+        .to_string()
+}
+
+fn help_workflow_inspect() -> String {
+    "traverse-cli workflow inspect <workflow-id> [--version <v>] [--workspace-id <id>]
+
+  Purpose:
+    Inspect a registered workflow via GET /v1/workflows/{id}.
+
+  Required arguments:
+    <workflow-id>         Workflow identifier.
+
+  Optional flags:
+    --version <v>         Workflow version (default: latest in workspace).
+    --workspace-id <id>   Workspace identifier (default: system).
+    --help                Print this help text.
+
+  Example:
+    traverse-cli workflow inspect expedition.planning.plan-expedition"
         .to_string()
 }
 
@@ -393,7 +449,9 @@ fn help_workflow() -> String {
     "traverse-cli workflow <subcommand> [options]
 
   Subcommands:
-    inspect <workflow-path>    Parse and summarize a workflow definition.
+    register <workflow-path>   Register a workflow definition.
+    list                       List registered workflows.
+    inspect <workflow-id>      Inspect a registered workflow.
 
   Run `traverse-cli workflow inspect --help` for subcommand-specific help."
         .to_string()
@@ -687,9 +745,6 @@ fn parse_fixed_arity_command(args: &[String]) -> Result<Command, String> {
         ("trace", "inspect") => Ok(Command::TraceInspect {
             trace_path: PathBuf::from(positional[3]),
         }),
-        ("workflow", "inspect") => Ok(Command::Workflow {
-            workflow_path: PathBuf::from(positional[3]),
-        }),
         _ => Err(usage()),
     }
 }
@@ -759,6 +814,38 @@ fn parse_capability_discover_command(args: &[String]) -> Result<Command, String>
         }),
         _ => Err(usage()),
     }
+}
+
+fn parse_workflow_command(args: &[String]) -> Result<Command, String> {
+    let workspace_id = parse_string_flag(args, "--workspace-id")
+        .or_else(|| std::env::var("TRAVERSE_WORKSPACE_ID").ok())
+        .unwrap_or_else(|| "system".to_string());
+
+    match args {
+        [_, _, _, workflow_path, rest @ ..] if args[2] == "register" => {
+            let override_workspace = parse_string_flag(rest, "--workspace-id");
+            Ok(Command::WorkflowRegister {
+                workflow_path: PathBuf::from(workflow_path),
+                workspace_id: override_workspace.unwrap_or(workspace_id),
+            })
+        }
+        [_, _, ..] if args[2] == "list" => Ok(Command::WorkflowList { workspace_id }),
+        [_, _, _, workflow_id, rest @ ..] if args[2] == "inspect" => {
+            let version = parse_string_flag(rest, "--version");
+            let override_workspace = parse_string_flag(rest, "--workspace-id");
+            Ok(Command::WorkflowInspect {
+                workflow_id: workflow_id.clone(),
+                version,
+                workspace_id: override_workspace.unwrap_or(workspace_id),
+            })
+        }
+        _ => Err(usage()),
+    }
+}
+
+fn parse_string_flag(args: &[String], flag: &str) -> Option<String> {
+    let pos = args.iter().position(|a| a == flag)?;
+    args.get(pos + 1).cloned()
 }
 
 fn inspect_bundle(manifest_path: &Path, json_output: bool) -> Result<String, CliError> {
@@ -963,6 +1050,7 @@ fn inspect_event(contract_path: &Path) -> Result<String, CliError> {
     Ok(render_event_summary(contract_path, &validated.normalized))
 }
 
+#[allow(dead_code)]
 fn inspect_workflow(workflow_path: &Path) -> Result<String, CliError> {
     let contents = read_text_file(workflow_path, "workflow artifact")?;
     let definition = serde_json::from_str::<WorkflowDefinition>(&contents).map_err(|error| {
@@ -973,6 +1061,117 @@ fn inspect_workflow(workflow_path: &Path) -> Result<String, CliError> {
     })?;
 
     Ok(render_workflow_summary(workflow_path, &definition))
+}
+
+fn workflow_register(workflow_path: &Path, workspace_id: &str) -> Result<String, CliError> {
+    let workflow_json = read_text_file(workflow_path, "workflow definition")?;
+    let workflow_value: serde_json::Value =
+        serde_json::from_str(&workflow_json).map_err(|error| {
+            CliError::ValidationFailed(format!(
+                "failed to parse workflow JSON {}: {error}",
+                workflow_path.display()
+            ))
+        })?;
+
+    let registry_scope = if workspace_id == "system" {
+        "public"
+    } else {
+        "private"
+    };
+
+    let body = serde_json::json!({
+        "workspace_id": workspace_id,
+        "scope": "workspace_persisted",
+        "registry_scope": registry_scope,
+        "workflow": workflow_value,
+    })
+    .to_string()
+    .into_bytes();
+
+    let (status, response) = build_in_process_api()?
+        .register_workflow(body, true)
+        .map_err(CliError::IoError)?;
+    if status >= 400 {
+        return Err(CliError::ValidationFailed(format!(
+            "workflow registration failed: {response}"
+        )));
+    }
+
+    Ok(format!(
+        "workflow_id: {}\nversion: {}\ndigest: {}",
+        response["workflow"]["id"].as_str().unwrap_or_default(),
+        response["workflow"]["version"].as_str().unwrap_or_default(),
+        response["workflow"]["digest"].as_str().unwrap_or_default(),
+    ))
+}
+
+fn workflow_list(workspace_id: &str) -> Result<String, CliError> {
+    let (status, response) = build_in_process_api()?
+        .list_workflows(workspace_id, true)
+        .map_err(CliError::IoError)?;
+    if status >= 400 {
+        return Err(CliError::ValidationFailed(format!(
+            "workflow list failed: {response}"
+        )));
+    }
+
+    let mut lines = Vec::new();
+    lines.push(format!("workspace_id: {workspace_id}"));
+    lines.push("workflows:".to_string());
+
+    let Some(items) = response.as_array() else {
+        return Err(CliError::ValidationFailed(
+            "workflow list returned unexpected response shape".to_string(),
+        ));
+    };
+    for item in items {
+        let id = item.get("id").and_then(|v| v.as_str()).unwrap_or_default();
+        let version = item
+            .get("version")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let digest = item
+            .get("digest")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        lines.push(format!("  - {id}@{version} {digest}"));
+    }
+
+    Ok(lines.join("\n"))
+}
+
+fn workflow_inspect(
+    workflow_id: &str,
+    version: Option<&str>,
+    workspace_id: &str,
+) -> Result<String, CliError> {
+    let (status, response) = build_in_process_api()?
+        .get_workflow(workspace_id, workflow_id, version, true)
+        .map_err(CliError::IoError)?;
+    if status >= 400 {
+        return Err(CliError::ValidationFailed(format!(
+            "workflow inspect failed: {response}"
+        )));
+    }
+
+    let workflow = response.get("workflow").cloned().unwrap_or_default();
+    serde_json::to_string_pretty(&workflow).map_err(|e| {
+        CliError::IoError(format!("failed to render workflow inspection output: {e}"))
+    })
+}
+
+fn build_in_process_api() -> Result<http_api::InProcessApi<ExpeditionExampleExecutor>, CliError> {
+    let registered = load_registered_bundle(&canonical_expedition_bundle_path())?;
+    Ok(http_api::InProcessApi::new(http_api::ApiServerConfig {
+        port: 0,
+        allow_unauthenticated: true,
+        capability_registry: registered.capability_registry,
+        workflow_registry: registered.workflow_registry,
+        registry_root: std::env::current_dir()
+            .map_err(|e| CliError::IoError(format!("failed to resolve current directory: {e}")))?
+            .join(".traverse/registry"),
+        executor: ExpeditionExampleExecutor,
+    }))
 }
 
 fn inspect_trace(trace_path: &Path) -> Result<String, CliError> {
@@ -1120,6 +1319,7 @@ fn render_event_summary(path: &Path, contract: &EventContract) -> String {
     lines.join("\n")
 }
 
+#[allow(dead_code)]
 fn render_workflow_summary(path: &Path, definition: &WorkflowDefinition) -> String {
     let mut lines = vec![
         format!("path: {}", path.display()),
@@ -2194,7 +2394,7 @@ mod tests {
         assert!(result.is_err(), "expected Err for --help");
         let text = result.err().unwrap_or_default();
         assert!(text.contains("workflow inspect"));
-        assert!(text.contains("<workflow-path>"));
+        assert!(text.contains("<workflow-id>"));
         assert!(text.contains("Example:"));
     }
 

--- a/crates/traverse-registry/src/workflows.rs
+++ b/crates/traverse-registry/src/workflows.rs
@@ -1850,10 +1850,18 @@ mod tests {
         assert_eq!(types["valid"], "string");
     }
 
+    #[test]
+    fn schema_declares_properties_returns_false_for_non_object_schema() {
+        assert!(!schema_declares_properties(&json!("string-schema")));
+        assert!(!schema_declares_properties(&json!(null)));
+        assert!(!schema_declares_properties(&json!(42)));
+        assert!(!schema_declares_properties(&json!({"type": "array"})));
+        assert!(!schema_declares_properties(&json!({"type": "object"})));
+        assert!(schema_declares_properties(&json!({"type": "object", "properties": {}})));
+    }
+
     // ── validate_schema_compatibility coverage ────────────────────────────────
 
-    /// Creates a capability_registry variant where one capability's contract
-    /// schemas are replaced with the provided `inputs` / `outputs` JSON values.
     fn capability_registry_with_override(
         id: &str,
         inputs: Option<Value>,

--- a/crates/traverse-registry/src/workflows.rs
+++ b/crates/traverse-registry/src/workflows.rs
@@ -153,6 +153,7 @@ pub enum WorkflowErrorCode {
     InvalidSemver,
     DuplicateItem,
     MissingReference,
+    EdgeSchemaMismatch,
     InvalidStartNode,
     InvalidTerminalNode,
     InvalidEdgeReference,
@@ -257,10 +258,10 @@ impl WorkflowRegistry {
                 ));
             };
 
-            if existing == &record
-                && existing_index == &index_entry
-                && existing_definition == &definition
-            {
+            // Idempotent re-registration is driven by content digest and canonical definition,
+            // not by validator metadata. If the definition is identical, return the existing
+            // record without modifying registry state.
+            if existing_definition == &definition {
                 return Ok(WorkflowRegistrationOutcome {
                     record: existing.clone(),
                     index_entry: existing_index.clone(),
@@ -268,18 +269,11 @@ impl WorkflowRegistry {
                 });
             }
 
-            if workflow_digest(existing_definition) != digest {
-                return Err(single_error(
-                    WorkflowErrorCode::ImmutableVersionConflict,
-                    "$.version",
-                    "published workflow versions are immutable within a scope",
-                ));
-            }
 
             return Err(single_error(
                 WorkflowErrorCode::ImmutableVersionConflict,
-                "$.workflow_path",
-                "published workflow versions are immutable and cannot be republished with different metadata",
+                "$.version",
+                "published workflow versions are immutable within a scope",
             ));
         }
 
@@ -657,6 +651,10 @@ fn validate_workflow_references(
         })
         .collect::<BTreeMap<_, _>>();
 
+    // Validate that node input/output field selection is internally consistent and
+    // schema-compatible in deterministic topological order.
+    validate_schema_compatibility(definition, &resolved_by_node, errors);
+
     let mut direct_edges = BTreeMap::<&str, usize>::new();
     let mut event_edges = BTreeMap::<&str, usize>::new();
     for (index, edge) in definition.edges.iter().enumerate() {
@@ -702,6 +700,186 @@ fn validate_workflow_references(
             }
         }
     }
+}
+
+fn validate_schema_compatibility(
+    definition: &WorkflowDefinition,
+    resolved_by_node: &BTreeMap<String, crate::ResolvedCapability>,
+    errors: &mut Vec<WorkflowError>,
+) {
+    // Only validate field-level flow when the workflow declares explicit input properties.
+    // Open-schema workflows ({"type":"object"} with no "properties") opt out of strict checking.
+    if !schema_declares_properties(&definition.inputs.schema) {
+        return;
+    }
+
+    let Some(order) = topological_node_order(definition) else {
+        return;
+    };
+
+    let workflow_input_types = schema_property_types(&definition.inputs.schema);
+    let mut state_types = workflow_input_types.clone();
+
+    for node_index in order {
+        let node = &definition.nodes[node_index];
+        let Some(capability) = resolved_by_node.get(&node.node_id) else {
+            continue;
+        };
+
+        // Skip field-level input checking when the capability input schema is open.
+        let cap_input_schema = &capability.contract.inputs.schema;
+        let input_types = if schema_declares_properties(cap_input_schema) {
+            schema_property_types(cap_input_schema)
+        } else {
+            BTreeMap::new()
+        };
+
+        let cap_input_has_properties = schema_declares_properties(cap_input_schema);
+        for (input_index, key) in node.input.from_workflow_input.iter().enumerate() {
+            let Some(state_type) = state_types.get(key) else {
+                errors.push(workflow_error(
+                    WorkflowErrorCode::EdgeSchemaMismatch,
+                    &format!(
+                        "$.nodes[{node_index}].input.from_workflow_input[{input_index}]"
+                    ),
+                    "workflow input field is not available from prior nodes or workflow inputs",
+                ));
+                continue;
+            };
+
+            // Skip type-checking when the capability input schema is open.
+            if !cap_input_has_properties {
+                continue;
+            }
+
+            let Some(expected_type) = input_types.get(key) else {
+                errors.push(workflow_error(
+                    WorkflowErrorCode::EdgeSchemaMismatch,
+                    &format!(
+                        "$.nodes[{node_index}].input.from_workflow_input[{input_index}]"
+                    ),
+                    "capability input schema is missing referenced field",
+                ));
+                continue;
+            };
+
+            if expected_type != state_type {
+                errors.push(workflow_error(
+                    WorkflowErrorCode::EdgeSchemaMismatch,
+                    &format!(
+                        "$.nodes[{node_index}].input.from_workflow_input[{input_index}]"
+                    ),
+                    &format!(
+                        "field type mismatch: state provides {state_type}, capability expects {expected_type}"
+                    ),
+                ));
+            }
+        }
+
+        // Skip output field checking when the capability output schema is open.
+        let cap_output_schema = &capability.contract.outputs.schema;
+        if schema_declares_properties(cap_output_schema) {
+            let output_types = schema_property_types(cap_output_schema);
+            for (output_index, key) in node.output.to_workflow_state.iter().enumerate() {
+                let Some(value_type) = output_types.get(key) else {
+                    errors.push(workflow_error(
+                        WorkflowErrorCode::EdgeSchemaMismatch,
+                        &format!(
+                            "$.nodes[{node_index}].output.to_workflow_state[{output_index}]"
+                        ),
+                        "capability output schema is missing referenced field",
+                    ));
+                    continue;
+                };
+                state_types.insert(key.clone(), value_type.clone());
+            }
+        } else {
+            // Open output schema: add all declared state keys with an inferred type.
+            for key in &node.output.to_workflow_state {
+                state_types.insert(key.clone(), "object".to_string());
+            }
+        }
+    }
+}
+
+/// Returns true only when the schema is an object schema with an explicit `properties` map.
+/// Schemas that lack an explicit `properties` key are treated as open / schema-less, so
+/// field-level validation is skipped for them.
+fn schema_declares_properties(schema: &Value) -> bool {
+    let Value::Object(root) = schema else { return false };
+    matches!(root.get("type"), Some(Value::String(t)) if t == "object")
+        && root.get("properties").is_some()
+}
+
+fn schema_property_types(schema: &Value) -> BTreeMap<String, String> {
+    let Value::Object(root) = schema else {
+        return BTreeMap::new();
+    };
+    let Some(Value::String(schema_type)) = root.get("type") else {
+        return BTreeMap::new();
+    };
+    if schema_type != "object" {
+        return BTreeMap::new();
+    }
+    let Some(Value::Object(properties)) = root.get("properties") else {
+        return BTreeMap::new();
+    };
+
+    let mut types = BTreeMap::new();
+    for (key, value) in properties {
+        let Value::Object(property) = value else {
+            continue;
+        };
+        let Some(Value::String(property_type)) = property.get("type") else {
+            continue;
+        };
+        types.insert(key.clone(), property_type.clone());
+    }
+    types
+}
+
+fn topological_node_order(definition: &WorkflowDefinition) -> Option<Vec<usize>> {
+    let id_to_index: BTreeMap<&str, usize> = definition
+        .nodes
+        .iter()
+        .enumerate()
+        .map(|(i, n)| (n.node_id.as_str(), i))
+        .collect();
+
+    let n = definition.nodes.len();
+    let mut indegree = vec![0_usize; n];
+    let mut adjacency = vec![Vec::<usize>::new(); n];
+
+    for edge in &definition.edges {
+        if let (Some(&fi), Some(&ti)) =
+            (id_to_index.get(edge.from.as_str()), id_to_index.get(edge.to.as_str()))
+        {
+            adjacency[fi].push(ti);
+            indegree[ti] += 1;
+        }
+    }
+
+    let mut available: Vec<usize> = (0..n).filter(|&i| indegree[i] == 0).collect();
+    available.sort_by_key(|&i| &definition.nodes[i].node_id);
+
+    let mut order = Vec::new();
+    while let Some(next) = available.first().copied() {
+        available.remove(0);
+        order.push(next);
+        for &neighbor in &adjacency[next] {
+            indegree[neighbor] = indegree[neighbor].saturating_sub(1);
+            if indegree[neighbor] == 0 {
+                available.push(neighbor);
+                available.sort_by_key(|&i| &definition.nodes[i].node_id);
+            }
+        }
+    }
+
+    if order.len() != n {
+        return None;
+    }
+
+    Some(order)
 }
 
 fn build_workflow_index(
@@ -1076,6 +1254,68 @@ mod tests {
     }
 
     #[test]
+    fn registers_idempotently_when_definition_digest_matches_even_if_metadata_differs() {
+        let capabilities = capability_registry();
+        let mut registry = WorkflowRegistry::new();
+
+        register_workflow_ok(
+            &mut registry,
+            &capabilities,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition: valid_workflow_definition(),
+                workflow_path: "workflows/original.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "workflow-validator/0.1.0".to_string(),
+            },
+        );
+
+        let outcome = registry
+            .register(
+                &capabilities,
+                WorkflowRegistration {
+                    scope: RegistryScope::Public,
+                    definition: valid_workflow_definition(),
+                    workflow_path: "workflows/changed.json".to_string(),
+                    registered_at: "2026-03-27T01:00:00Z".to_string(),
+                    validator_version: "workflow-validator/9.9.9".to_string(),
+                },
+            )
+            .expect("idempotent registration must succeed");
+
+        assert_eq!(outcome.record.workflow_path, "workflows/original.json");
+    }
+
+    #[test]
+    fn rejects_workflow_with_schema_mismatch_when_required_field_is_unavailable() {
+        let capabilities = capability_registry();
+        let mut registry = WorkflowRegistry::new();
+        let mut definition = valid_workflow_definition();
+        definition.nodes[1]
+            .input
+            .from_workflow_input
+            .push("missing".to_string());
+
+        let failure = registry
+            .register(
+                &capabilities,
+                WorkflowRegistration {
+                    scope: RegistryScope::Public,
+                    definition,
+                    workflow_path: "workflows/bad.json".to_string(),
+                    registered_at: "2026-03-27T00:00:00Z".to_string(),
+                    validator_version: "workflow-validator/0.1.0".to_string(),
+                },
+            )
+            .expect_err("schema mismatch must fail");
+
+        assert!(failure
+            .errors
+            .iter()
+            .any(|error| error.code == WorkflowErrorCode::EdgeSchemaMismatch));
+    }
+
+    #[test]
     fn rejects_invalid_workflow_fields_references_and_cycles() {
         let capabilities = capability_registry();
         let mut registry = WorkflowRegistry::new();
@@ -1329,7 +1569,9 @@ mod tests {
                 validator_version: "validator".to_string(),
             },
         );
-        let failure = register_workflow_err(
+        // Re-registration with the same definition content but different validator metadata is
+        // idempotent: the existing record is returned unchanged (spec 041 behaviour).
+        let outcome = register_workflow_ok(
             &mut registry,
             &capabilities,
             WorkflowRegistration {
@@ -1350,12 +1592,8 @@ mod tests {
                 validator_version: "validator".to_string(),
             },
         );
-        assert!(
-            failure
-                .errors
-                .iter()
-                .any(|error| error.path == "$.workflow_path")
-        );
+        // Idempotent re-registration returns the ORIGINAL record (original path preserved).
+        assert_eq!(outcome.record.workflow_path, "workflows/direct.json");
     }
 
     #[test]
@@ -1584,6 +1822,270 @@ mod tests {
         assert_eq!(
             lookup_order(LookupScope::PreferPrivate),
             &[RegistryScope::Private, RegistryScope::Public]
+        );
+    }
+
+    // ── schema_property_types and helper coverage ─────────────────────────────
+
+    #[test]
+    fn schema_property_types_covers_non_object_and_malformed_schemas() {
+        // Line 828: schema is not a JSON object value at all.
+        assert!(schema_property_types(&json!("not-an-object")).is_empty());
+        // Line 831: schema is an object but has no "type" key.
+        assert!(schema_property_types(&json!({"properties": {}})).is_empty());
+        // Line 834: has "type" key but it is not "object".
+        assert!(schema_property_types(&json!({"type": "array"})).is_empty());
+        // Line 837: type is "object" but no "properties" key.
+        assert!(schema_property_types(&json!({"type": "object"})).is_empty());
+
+        // Lines 843 + 846: properties map has entries that are not JSON objects
+        // (line 843) and entries that are objects without a "type" key (line 846).
+        let types = schema_property_types(&json!({
+            "type": "object",
+            "properties": {
+                "valid":       { "type": "string" },
+                "non_object":  "just-a-string",
+                "no_type_key": { "description": "no type field here" }
+            }
+        }));
+        assert_eq!(types.len(), 1);
+        assert_eq!(types["valid"], "string");
+    }
+
+    // ── validate_schema_compatibility coverage ────────────────────────────────
+
+    /// Creates a capability_registry variant where one capability's contract
+    /// schemas are replaced with the provided `inputs` / `outputs` JSON values.
+    fn capability_registry_with_override(
+        id: &str,
+        inputs: Option<Value>,
+        outputs: Option<Value>,
+    ) -> CapabilityRegistry {
+        let mut registry = CapabilityRegistry::new();
+        for registration in [
+            capability_registration(
+                "content.comments.create-comment-draft",
+                vec![EventReference {
+                    event_id: "content.comments.draft-created".to_string(),
+                    version: "1.0.0".to_string(),
+                }],
+            ),
+            capability_registration(
+                "content.comments.validate-comment",
+                vec![EventReference {
+                    event_id: "content.comments.validated".to_string(),
+                    version: "1.0.0".to_string(),
+                }],
+            ),
+            capability_registration("content.comments.persist-comment", Vec::new()),
+        ] {
+            let mut reg = registration;
+            if reg.contract.id == id {
+                if let Some(s) = inputs.clone() {
+                    reg.contract.inputs.schema = s;
+                }
+                if let Some(s) = outputs.clone() {
+                    reg.contract.outputs.schema = s;
+                }
+            }
+            registry.register(reg).expect("capability registration should succeed");
+        }
+        registry
+    }
+
+    #[test]
+    fn validates_schema_compatibility_with_open_capability_input_schema() {
+        // Covers lines 742 (BTreeMap::new()) and 759-761 (!cap_input_has_properties → continue).
+        // When the capability's input schema is open (no `properties` key), field-level
+        // type-checking is skipped; the workflow must still succeed.
+        let caps = capability_registry_with_override(
+            "content.comments.create-comment-draft",
+            Some(json!({"type": "object"})),
+            None,
+        );
+        let mut registry = WorkflowRegistry::new();
+        register_workflow_ok(
+            &mut registry,
+            &caps,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition: valid_workflow_definition(),
+                workflow_path: "workflows/open-cap-input.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "workflow-validator/0.1.0".to_string(),
+            },
+        );
+    }
+
+    #[test]
+    fn rejects_when_capability_input_schema_missing_referenced_field() {
+        // Covers lines 763-771: state contains a field that the capability's closed
+        // input schema does not declare → EdgeSchemaMismatch.
+        let caps = capability_registry_with_override(
+            "content.comments.create-comment-draft",
+            Some(json!({
+                "type": "object",
+                "properties": {
+                    "comment_text": { "type": "string" }
+                    // intentionally omits "extra_field"
+                }
+            })),
+            None,
+        );
+
+        let mut definition = valid_workflow_definition();
+        // Add extra_field to workflow input schema (so it is in state).
+        definition.inputs.schema = json!({
+            "type": "object",
+            "properties": {
+                "comment_text": { "type": "string" },
+                "extra_field":  { "type": "string" }
+            },
+            "required": ["comment_text"],
+            "additionalProperties": true
+        });
+        // Make the first node also pull extra_field — it is in state but not in cap schema.
+        definition.nodes[0].input.from_workflow_input.push("extra_field".to_string());
+
+        let mut registry = WorkflowRegistry::new();
+        let failure = register_workflow_err(
+            &mut registry,
+            &caps,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition,
+                workflow_path: "workflows/missing-cap-input-field.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "validator".to_string(),
+            },
+        );
+        assert!(failure.errors.iter().any(|e| {
+            e.code == WorkflowErrorCode::EdgeSchemaMismatch
+                && e.message.contains("capability input schema is missing referenced field")
+        }));
+    }
+
+    #[test]
+    fn rejects_field_type_mismatch_between_state_and_capability_input() {
+        // Covers lines 778-789: state supplies a field as `integer` but the capability
+        // input schema declares it as `string` → EdgeSchemaMismatch with type mismatch.
+        let caps = capability_registry(); // default: draft_id: string in cap input
+        let mut definition = valid_workflow_definition();
+        // Override workflow input so draft_id enters state as integer.
+        definition.inputs.schema = json!({
+            "type": "object",
+            "properties": {
+                "comment_text": { "type": "string" },
+                "draft_id":     { "type": "integer" }
+            },
+            "required": ["comment_text"],
+            "additionalProperties": true
+        });
+        // First node takes draft_id directly from workflow input.
+        definition.nodes[0].input.from_workflow_input.push("draft_id".to_string());
+
+        let mut registry = WorkflowRegistry::new();
+        let failure = register_workflow_err(
+            &mut registry,
+            &caps,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition,
+                workflow_path: "workflows/type-mismatch.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "validator".to_string(),
+            },
+        );
+        assert!(failure.errors.iter().any(|e| {
+            e.code == WorkflowErrorCode::EdgeSchemaMismatch
+                && e.message.contains("field type mismatch")
+        }));
+    }
+
+    #[test]
+    fn rejects_when_capability_output_schema_missing_referenced_field() {
+        // Covers lines 796-804: to_workflow_state references a field not present in
+        // the capability's closed output schema → EdgeSchemaMismatch.
+        let caps = capability_registry_with_override(
+            "content.comments.create-comment-draft",
+            None,
+            Some(json!({
+                "type": "object",
+                "properties": {
+                    "draft_id": { "type": "string" }
+                    // intentionally omits "result_token"
+                }
+            })),
+        );
+
+        let mut definition = valid_workflow_definition();
+        // First node asks to write result_token into state, but cap doesn't output it.
+        definition.nodes[0].output.to_workflow_state.push("result_token".to_string());
+
+        let mut registry = WorkflowRegistry::new();
+        let failure = register_workflow_err(
+            &mut registry,
+            &caps,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition,
+                workflow_path: "workflows/missing-cap-output-field.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "validator".to_string(),
+            },
+        );
+        assert!(failure.errors.iter().any(|e| {
+            e.code == WorkflowErrorCode::EdgeSchemaMismatch
+                && e.message.contains("capability output schema is missing referenced field")
+        }));
+    }
+
+    #[test]
+    fn accepts_open_capability_output_schema_and_infers_object_type_for_state() {
+        // Covers lines 808-812: open capability output schema → to_workflow_state keys are
+        // added to state with inferred type "object" rather than rejected.
+        // create-comment-draft has open output; validate-comment has open input so that
+        // the inferred "object" type for draft_id does not cause a type-mismatch on the
+        // next node.  validate-comment's closed output then restores draft_id as "string"
+        // so persist-comment's closed input schema is satisfied.
+        let mut caps = CapabilityRegistry::new();
+
+        let mut create_reg = capability_registration(
+            "content.comments.create-comment-draft",
+            vec![EventReference {
+                event_id: "content.comments.draft-created".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+        );
+        // Open output schema — forces the `else` branch in validate_schema_compatibility.
+        create_reg.contract.outputs.schema = json!({"type": "object"});
+        caps.register(create_reg).expect("capability registration should succeed");
+
+        let mut validate_reg = capability_registration(
+            "content.comments.validate-comment",
+            vec![EventReference {
+                event_id: "content.comments.validated".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+        );
+        // Open input schema — skips type-checking on the "object"-typed draft_id from state.
+        validate_reg.contract.inputs.schema = json!({"type": "object"});
+        caps.register(validate_reg).expect("capability registration should succeed");
+
+        caps.register(capability_registration("content.comments.persist-comment", Vec::new()))
+            .expect("capability registration should succeed");
+
+        let mut registry = WorkflowRegistry::new();
+        register_workflow_ok(
+            &mut registry,
+            &caps,
+            WorkflowRegistration {
+                scope: RegistryScope::Public,
+                definition: valid_workflow_definition(),
+                workflow_path: "workflows/open-cap-output.json".to_string(),
+                registered_at: "2026-03-27T00:00:00Z".to_string(),
+                validator_version: "workflow-validator/0.1.0".to_string(),
+            },
         );
     }
 

--- a/crates/traverse-registry/src/workflows.rs
+++ b/crates/traverse-registry/src/workflows.rs
@@ -269,7 +269,6 @@ impl WorkflowRegistry {
                 });
             }
 
-
             return Err(single_error(
                 WorkflowErrorCode::ImmutableVersionConflict,
                 "$.version",
@@ -739,9 +738,7 @@ fn validate_schema_compatibility(
             let Some(state_type) = state_types.get(key) else {
                 errors.push(workflow_error(
                     WorkflowErrorCode::EdgeSchemaMismatch,
-                    &format!(
-                        "$.nodes[{node_index}].input.from_workflow_input[{input_index}]"
-                    ),
+                    &format!("$.nodes[{node_index}].input.from_workflow_input[{input_index}]"),
                     "workflow input field is not available from prior nodes or workflow inputs",
                 ));
                 continue;
@@ -755,9 +752,7 @@ fn validate_schema_compatibility(
             let Some(expected_type) = input_types.get(key) else {
                 errors.push(workflow_error(
                     WorkflowErrorCode::EdgeSchemaMismatch,
-                    &format!(
-                        "$.nodes[{node_index}].input.from_workflow_input[{input_index}]"
-                    ),
+                    &format!("$.nodes[{node_index}].input.from_workflow_input[{input_index}]"),
                     "capability input schema is missing referenced field",
                 ));
                 continue;
@@ -784,9 +779,7 @@ fn validate_schema_compatibility(
                 let Some(value_type) = output_types.get(key) else {
                     errors.push(workflow_error(
                         WorkflowErrorCode::EdgeSchemaMismatch,
-                        &format!(
-                            "$.nodes[{node_index}].output.to_workflow_state[{output_index}]"
-                        ),
+                        &format!("$.nodes[{node_index}].output.to_workflow_state[{output_index}]"),
                         "capability output schema is missing referenced field",
                     ));
                     continue;
@@ -806,7 +799,9 @@ fn validate_schema_compatibility(
 /// Schemas that lack an explicit `properties` key are treated as open / schema-less, so
 /// field-level validation is skipped for them.
 fn schema_declares_properties(schema: &Value) -> bool {
-    let Value::Object(root) = schema else { return false };
+    let Value::Object(root) = schema else {
+        return false;
+    };
     matches!(root.get("type"), Some(Value::String(t)) if t == "object")
         && root.get("properties").is_some()
 }
@@ -851,9 +846,10 @@ fn topological_node_order(definition: &WorkflowDefinition) -> Option<Vec<usize>>
     let mut adjacency = vec![Vec::<usize>::new(); n];
 
     for edge in &definition.edges {
-        if let (Some(&fi), Some(&ti)) =
-            (id_to_index.get(edge.from.as_str()), id_to_index.get(edge.to.as_str()))
-        {
+        if let (Some(&fi), Some(&ti)) = (
+            id_to_index.get(edge.from.as_str()),
+            id_to_index.get(edge.to.as_str()),
+        ) {
             adjacency[fi].push(ti);
             indegree[ti] += 1;
         }
@@ -1309,10 +1305,12 @@ mod tests {
             )
             .expect_err("schema mismatch must fail");
 
-        assert!(failure
-            .errors
-            .iter()
-            .any(|error| error.code == WorkflowErrorCode::EdgeSchemaMismatch));
+        assert!(
+            failure
+                .errors
+                .iter()
+                .any(|error| error.code == WorkflowErrorCode::EdgeSchemaMismatch)
+        );
     }
 
     #[test]
@@ -1888,7 +1886,9 @@ mod tests {
                     reg.contract.outputs.schema = s;
                 }
             }
-            registry.register(reg).expect("capability registration should succeed");
+            registry
+                .register(reg)
+                .expect("capability registration should succeed");
         }
         registry
     }
@@ -1945,7 +1945,10 @@ mod tests {
             "additionalProperties": true
         });
         // Make the first node also pull extra_field — it is in state but not in cap schema.
-        definition.nodes[0].input.from_workflow_input.push("extra_field".to_string());
+        definition.nodes[0]
+            .input
+            .from_workflow_input
+            .push("extra_field".to_string());
 
         let mut registry = WorkflowRegistry::new();
         let failure = register_workflow_err(
@@ -1961,7 +1964,8 @@ mod tests {
         );
         assert!(failure.errors.iter().any(|e| {
             e.code == WorkflowErrorCode::EdgeSchemaMismatch
-                && e.message.contains("capability input schema is missing referenced field")
+                && e.message
+                    .contains("capability input schema is missing referenced field")
         }));
     }
 
@@ -1982,7 +1986,10 @@ mod tests {
             "additionalProperties": true
         });
         // First node takes draft_id directly from workflow input.
-        definition.nodes[0].input.from_workflow_input.push("draft_id".to_string());
+        definition.nodes[0]
+            .input
+            .from_workflow_input
+            .push("draft_id".to_string());
 
         let mut registry = WorkflowRegistry::new();
         let failure = register_workflow_err(
@@ -2020,7 +2027,10 @@ mod tests {
 
         let mut definition = valid_workflow_definition();
         // First node asks to write result_token into state, but cap doesn't output it.
-        definition.nodes[0].output.to_workflow_state.push("result_token".to_string());
+        definition.nodes[0]
+            .output
+            .to_workflow_state
+            .push("result_token".to_string());
 
         let mut registry = WorkflowRegistry::new();
         let failure = register_workflow_err(
@@ -2036,7 +2046,8 @@ mod tests {
         );
         assert!(failure.errors.iter().any(|e| {
             e.code == WorkflowErrorCode::EdgeSchemaMismatch
-                && e.message.contains("capability output schema is missing referenced field")
+                && e.message
+                    .contains("capability output schema is missing referenced field")
         }));
     }
 
@@ -2059,7 +2070,8 @@ mod tests {
         );
         // Open output schema — forces the `else` branch in validate_schema_compatibility.
         create_reg.contract.outputs.schema = json!({"type": "object"});
-        caps.register(create_reg).expect("capability registration should succeed");
+        caps.register(create_reg)
+            .expect("capability registration should succeed");
 
         let mut validate_reg = capability_registration(
             "content.comments.validate-comment",
@@ -2070,10 +2082,14 @@ mod tests {
         );
         // Open input schema — skips type-checking on the "object"-typed draft_id from state.
         validate_reg.contract.inputs.schema = json!({"type": "object"});
-        caps.register(validate_reg).expect("capability registration should succeed");
-
-        caps.register(capability_registration("content.comments.persist-comment", Vec::new()))
+        caps.register(validate_reg)
             .expect("capability registration should succeed");
+
+        caps.register(capability_registration(
+            "content.comments.persist-comment",
+            Vec::new(),
+        ))
+        .expect("capability registration should succeed");
 
         let mut registry = WorkflowRegistry::new();
         register_workflow_ok(

--- a/crates/traverse-registry/src/workflows.rs
+++ b/crates/traverse-registry/src/workflows.rs
@@ -1857,7 +1857,9 @@ mod tests {
         assert!(!schema_declares_properties(&json!(42)));
         assert!(!schema_declares_properties(&json!({"type": "array"})));
         assert!(!schema_declares_properties(&json!({"type": "object"})));
-        assert!(schema_declares_properties(&json!({"type": "object", "properties": {}})));
+        assert!(schema_declares_properties(
+            &json!({"type": "object", "properties": {}})
+        ));
     }
 
     // ── validate_schema_compatibility coverage ────────────────────────────────

--- a/crates/traverse-registry/src/workflows.rs
+++ b/crates/traverse-registry/src/workflows.rs
@@ -1864,6 +1864,7 @@ mod tests {
 
     // ── validate_schema_compatibility coverage ────────────────────────────────
 
+    #[allow(clippy::needless_pass_by_value)]
     fn capability_registry_with_override(
         id: &str,
         inputs: Option<Value>,

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -16,7 +16,8 @@ use traverse_contracts::{ExecutionTarget, HostApiAccess, Lifecycle, NetworkAcces
 use traverse_registry::{
     CapabilityRegistration, CapabilityRegistry, DiscoveryQuery, ImplementationKind, LookupScope,
     RegistrationOutcome, RegistryFailure, RegistryScope, ResolutionError, ResolvedCapability,
-    WorkflowRegistry, resolve_dependencies, resolve_version_range,
+    WorkflowFailure, WorkflowRegistration, WorkflowRegistrationOutcome, WorkflowRegistry,
+    resolve_dependencies, resolve_version_range,
 };
 
 const RUNTIME_REQUEST_KIND: &str = "runtime_request";
@@ -80,6 +81,31 @@ impl<E> Runtime<E> {
         registration: CapabilityRegistration,
     ) -> Result<RegistrationOutcome, RegistryFailure> {
         self.registry.register(registration)
+    }
+
+    /// Returns a reference to the workflow registry.
+    #[must_use]
+    pub fn workflow_registry(&self) -> &WorkflowRegistry {
+        &self.workflow_registry
+    }
+
+    /// Returns a mutable reference to the workflow registry.
+    #[must_use]
+    pub fn workflow_registry_mut(&mut self) -> &mut WorkflowRegistry {
+        &mut self.workflow_registry
+    }
+
+    /// Registers a workflow into the runtime's workflow registry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkflowFailure`] when the workflow is invalid, references a
+    /// missing capability, contains a cycle, or violates immutability.
+    pub fn register_workflow(
+        &mut self,
+        registration: WorkflowRegistration,
+    ) -> Result<WorkflowRegistrationOutcome, WorkflowFailure> {
+        self.workflow_registry.register(&self.registry, registration)
     }
 }
 

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -105,7 +105,8 @@ impl<E> Runtime<E> {
         &mut self,
         registration: WorkflowRegistration,
     ) -> Result<WorkflowRegistrationOutcome, WorkflowFailure> {
-        self.workflow_registry.register(&self.registry, registration)
+        self.workflow_registry
+            .register(&self.registry, registration)
     }
 }
 

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -815,8 +815,10 @@ fn capability_registry_accessor_returns_registered_capabilities() {
 
 #[test]
 fn workflow_registry_accessors_are_accessible() {
-    use traverse_registry::{RegistryScope, WorkflowDefinition, WorkflowNode, WorkflowNodeInput,
-        WorkflowNodeOutput, WorkflowRegistration};
+    use traverse_registry::{
+        RegistryScope, WorkflowDefinition, WorkflowNode, WorkflowNodeInput, WorkflowNodeOutput,
+        WorkflowRegistration,
+    };
     let reg = registry_with(vec![registration(
         RegistryScope::Public,
         "content.comments.create-comment-draft",

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -814,6 +814,67 @@ fn capability_registry_accessor_returns_registered_capabilities() {
 }
 
 #[test]
+fn workflow_registry_accessors_are_accessible() {
+    use traverse_registry::{RegistryScope, WorkflowDefinition, WorkflowNode, WorkflowNodeInput,
+        WorkflowNodeOutput, WorkflowRegistration};
+    let reg = registry_with(vec![registration(
+        RegistryScope::Public,
+        "content.comments.create-comment-draft",
+        "1.0.0",
+        Lifecycle::Active,
+    )]);
+    let mut runtime = Runtime::new(reg, EchoExecutor);
+
+    let _reg_ref = runtime.workflow_registry();
+    let _reg_mut = runtime.workflow_registry_mut();
+
+    let definition = WorkflowDefinition {
+        kind: "workflow_definition".to_string(),
+        schema_version: "1.0.0".to_string(),
+        id: "test.workflow".to_string(),
+        name: "test".to_string(),
+        version: "1.0.0".to_string(),
+        lifecycle: traverse_contracts::Lifecycle::Active,
+        owner: Owner {
+            team: "traverse-core".to_string(),
+            contact: "test@example.com".to_string(),
+        },
+        summary: "test".to_string(),
+        inputs: SchemaContainer {
+            schema: json!({"type": "object", "properties": {"comment_text": {"type": "string"}}}),
+        },
+        outputs: SchemaContainer {
+            schema: json!({"type": "object", "properties": {"draft_id": {"type": "string"}}}),
+        },
+        nodes: vec![WorkflowNode {
+            node_id: "step".to_string(),
+            capability_id: "content.comments.create-comment-draft".to_string(),
+            capability_version: "1.0.0".to_string(),
+            input: WorkflowNodeInput {
+                from_workflow_input: vec!["comment_text".to_string()],
+            },
+            output: WorkflowNodeOutput {
+                to_workflow_state: vec!["draft_id".to_string()],
+            },
+        }],
+        edges: Vec::new(),
+        start_node: "step".to_string(),
+        terminal_nodes: vec!["step".to_string()],
+        tags: Vec::new(),
+        governing_spec: "007-workflow-registry-traversal".to_string(),
+    };
+
+    let outcome = runtime.register_workflow(WorkflowRegistration {
+        scope: RegistryScope::Public,
+        definition,
+        workflow_path: "workflows/test/workflow.json".to_string(),
+        registered_at: "2026-04-27T00:00:00Z".to_string(),
+        validator_version: "test".to_string(),
+    });
+    assert!(outcome.is_ok(), "workflow registration must succeed");
+}
+
+#[test]
 fn runtime_register_capability_forwards_to_registry_and_is_idempotent() {
     let reg = CapabilityRegistry::new();
     let mut runtime = Runtime::new(reg, EchoExecutor);


### PR DESCRIPTION
## Outcome
Implements spec 041 workflow JSON composition API with registration, listing, inspection, schema compatibility validation, and CLI/HTTP surface.

## Governing Spec
- `041-workflow-composition-api`
- `009-expedition-example-artifacts`

## Project Item
- Closes #367

## Validation
- `cargo test -p traverse-registry -p traverse-contracts -p traverse-runtime`
- `bash scripts/ci/coverage_gate.sh`
- `cargo clippy -p traverse-registry -p traverse-cli`
- `bash scripts/ci/rust_checks.sh`

## Changes
- `WorkflowRegistry`: `register`, `find_exact`, `discover`, `lookup_by_id`
- Field-level schema compatibility validation via index-based topological traversal
- CLI `workflow` subcommands: `register`, `list`, `inspect`
- HTTP API: `POST /workflows`, `GET /workflows`, `GET /workflows/{id}@{version}`
- Cycle detection via DFS; idempotent re-registration on matching digest
- Expedition contracts extended with composite output fields for edge validation
- `topological_node_order` returns `Vec<usize>` for branchless iteration
