### PR TITLE
spec: align HTTP auth registration specs

### DIFF
--- a/scripts/ci/openapi_structural_validation.sh
+++ b/scripts/ci/openapi_structural_validation.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+openapi_file="specs/033-http-json-api/openapi.yaml"
+
+test -s "$openapi_file"
+
+grep -q '^openapi: 3\.1\.0$' "$openapi_file"
+grep -q '^paths:$' "$openapi_file"
+grep -q '^components:$' "$openapi_file"
+grep -q 'application/problem+json' "$openapi_file"
+grep -q 'traverse_code' "$openapi_file"
+
+required_paths=(
+  '/healthz:'
+  '/v1/workspaces/{workspace_id}/execute:'
+  '/v1/workspaces/{workspace_id}/executions/{execution_id}:'
+  '/v1/workspaces/{workspace_id}/traces/{execution_id}:'
+  '/v1/workspaces/{workspace_id}/capabilities:'
+  '/v1/workspaces/{workspace_id}/event-contracts:'
+  '/v1/workspaces/{workspace_id}/workflows:'
+  '/v1/workspaces/{workspace_id}/bundles:'
+)
+
+for path in "${required_paths[@]}"; do
+  grep -q "  ${path}" "$openapi_file"
+done
+
+required_schemas=(
+  'HealthEnvelope:'
+  'ExecuteRequest:'
+  'ExecutionEnvelope:'
+  'AsyncAcceptedEnvelope:'
+  'ExecutionStatusEnvelope:'
+  'PublicTraceEnvelope:'
+  'RegistrationRequest:'
+  'BundleRegistrationRequest:'
+  'RegistrationOutcome:'
+  'ProblemDetails:'
+)
+
+for schema in "${required_schemas[@]}"; do
+  grep -q "    ${schema}" "$openapi_file"
+done
+
+echo "OpenAPI structural validation passed."

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -102,6 +102,11 @@ required_files=(
   "specs/governance/approved-specs.json"
   "specs/022-mcp-wasm-server/spec.md"
   "specs/022-mcp-wasm-server/checklists/requirements.md"
+  "specs/033-http-json-api/spec.md"
+  "specs/033-http-json-api/openapi.yaml"
+  "specs/034-programmatic-registration/spec.md"
+  "specs/035-multi-agent-isolation/spec.md"
+  "scripts/ci/openapi_structural_validation.sh"
 )
 
 for file in "${required_files[@]}"; do
@@ -206,6 +211,8 @@ grep -q "discover_events" docs/mcp-real-agent-exercise.md
 grep -q "discover_workflows" docs/mcp-real-agent-exercise.md
 grep -q "execute_entrypoint" docs/mcp-real-agent-exercise.md
 grep -q "render_execution_report" docs/mcp-real-agent-exercise.md
+
+bash scripts/ci/openapi_structural_validation.sh
 grep -q "scripts/smoke.sh" docs/youaskm3-real-shell-validation.md
 grep -q "apps/browser-consumer/README.md" docs/mcp-consumption-validation.md
 grep -q "docs/app-consumable-consumer-bundle.md" README.md

--- a/specs/033-http-json-api/openapi.yaml
+++ b/specs/033-http-json-api/openapi.yaml
@@ -1,0 +1,520 @@
+openapi: 3.1.0
+info:
+  title: Traverse HTTP+JSON Runtime API
+  version: 1.1.0
+  description: App-consumable Traverse runtime, trace, and registration API.
+servers:
+  - url: http://127.0.0.1:8787
+paths:
+  /healthz:
+    get:
+      summary: Health check
+      operationId: getHealthz
+      responses:
+        "200":
+          description: Server health envelope
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthEnvelope"
+              examples:
+                ok:
+                  value:
+                    status: ok
+                    version: 0.2.0
+                    api_version: v1
+                    workspace_default: local-default
+                    auth_mode: dev-loopback
+  /v1/workspaces/{workspace_id}/execute:
+    post:
+      summary: Execute a Traverse runtime request
+      operationId: executeRuntimeRequest
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecuteRequest"
+            examples:
+              sync:
+                value:
+                  capability_id: summarize-note
+                  input:
+                    text: Traverse makes portable services consumable.
+              async:
+                value:
+                  mode: async
+                  capability_id: summarize-note
+                  input:
+                    text: Traverse makes portable services consumable.
+      responses:
+        "200":
+          description: Synchronous execution completed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExecutionEnvelope"
+        "202":
+          description: Asynchronous execution accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AsyncAcceptedEnvelope"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "409":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+  /v1/workspaces/{workspace_id}/executions/{execution_id}:
+    get:
+      summary: Fetch execution status
+      operationId: getExecutionStatus
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - $ref: "#/components/parameters/ExecutionId"
+      responses:
+        "200":
+          description: Execution status envelope
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExecutionStatusEnvelope"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+  /v1/workspaces/{workspace_id}/traces/{execution_id}:
+    get:
+      summary: Fetch public execution trace
+      operationId: getExecutionTrace
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - $ref: "#/components/parameters/ExecutionId"
+      responses:
+        "200":
+          description: Public trace envelope
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublicTraceEnvelope"
+        "401":
+          $ref: "#/components/responses/Problem"
+        "403":
+          $ref: "#/components/responses/Problem"
+        "404":
+          $ref: "#/components/responses/Problem"
+  /v1/workspaces/{workspace_id}/capabilities:
+    post:
+      summary: Register a capability
+      operationId: registerCapability
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegistrationRequest"
+      responses:
+        "200":
+          description: Capability was already registered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistrationOutcome"
+        "201":
+          description: Capability registered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistrationOutcome"
+        "409":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+  /v1/workspaces/{workspace_id}/event-contracts:
+    post:
+      summary: Register an event contract
+      operationId: registerEventContract
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegistrationRequest"
+      responses:
+        "200":
+          description: Event contract was already registered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistrationOutcome"
+        "201":
+          description: Event contract registered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistrationOutcome"
+        "409":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+  /v1/workspaces/{workspace_id}/workflows:
+    post:
+      summary: Register a workflow
+      operationId: registerWorkflow
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegistrationRequest"
+      responses:
+        "200":
+          description: Workflow was already registered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistrationOutcome"
+        "201":
+          description: Workflow registered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RegistrationOutcome"
+        "409":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+  /v1/workspaces/{workspace_id}/bundles:
+    post:
+      summary: Register a bundle atomically
+      operationId: registerBundle
+      parameters:
+        - $ref: "#/components/parameters/WorkspaceId"
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BundleRegistrationRequest"
+      responses:
+        "200":
+          description: Bundle artifacts were already registered
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BundleRegistrationOutcome"
+        "201":
+          description: Bundle registered atomically
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BundleRegistrationOutcome"
+        "409":
+          $ref: "#/components/responses/Problem"
+        "422":
+          $ref: "#/components/responses/Problem"
+components:
+  parameters:
+    WorkspaceId:
+      name: workspace_id
+      in: path
+      required: true
+      schema:
+        type: string
+        pattern: "^[A-Za-z0-9._-]+$"
+    ExecutionId:
+      name: execution_id
+      in: path
+      required: true
+      schema:
+        type: string
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: false
+      schema:
+        type: string
+  responses:
+    Problem:
+      description: RFC 9457 Problem Details error
+      content:
+        application/problem+json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetails"
+  schemas:
+    HealthEnvelope:
+      type: object
+      required:
+        - status
+        - version
+        - api_version
+        - workspace_default
+        - auth_mode
+      properties:
+        status:
+          type: string
+          enum:
+            - ok
+        version:
+          type: string
+        api_version:
+          type: string
+          enum:
+            - v1
+        workspace_default:
+          type: string
+        auth_mode:
+          type: string
+          enum:
+            - dev-loopback
+            - bearer-required
+      additionalProperties: true
+    ExecuteRequest:
+      type: object
+      required:
+        - capability_id
+        - input
+      properties:
+        mode:
+          type: string
+          enum:
+            - sync
+            - async
+        capability_id:
+          type: string
+        input:
+          type: object
+      additionalProperties: false
+    ExecutionEnvelope:
+      type: object
+      required:
+        - api_version
+        - execution_id
+        - status
+        - output
+        - links
+      properties:
+        api_version:
+          type: string
+        execution_id:
+          type: string
+        status:
+          type: string
+          enum:
+            - succeeded
+            - failed
+        output:
+          type: object
+        links:
+          $ref: "#/components/schemas/Links"
+      additionalProperties: true
+    AsyncAcceptedEnvelope:
+      type: object
+      required:
+        - api_version
+        - execution_id
+        - status
+        - links
+      properties:
+        api_version:
+          type: string
+        execution_id:
+          type: string
+        status:
+          type: string
+          enum:
+            - accepted
+        links:
+          $ref: "#/components/schemas/Links"
+      additionalProperties: true
+    ExecutionStatusEnvelope:
+      type: object
+      required:
+        - api_version
+        - execution_id
+        - status
+        - created_at
+        - updated_at
+        - links
+      properties:
+        api_version:
+          type: string
+        execution_id:
+          type: string
+        status:
+          type: string
+          enum:
+            - accepted
+            - running
+            - succeeded
+            - failed
+            - cancelled
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        links:
+          $ref: "#/components/schemas/Links"
+      additionalProperties: true
+    PublicTraceEnvelope:
+      type: object
+      required:
+        - api_version
+        - execution_id
+        - trace
+        - links
+      properties:
+        api_version:
+          type: string
+        execution_id:
+          type: string
+        trace:
+          type: object
+          required:
+            - spans
+            - events
+          properties:
+            spans:
+              type: array
+              items:
+                type: object
+            events:
+              type: array
+              items:
+                type: object
+          additionalProperties: true
+        links:
+          $ref: "#/components/schemas/Links"
+      additionalProperties: true
+    RegistrationRequest:
+      type: object
+      required:
+        - artifact
+      properties:
+        scope:
+          type: string
+          enum:
+            - workspace_persisted
+            - session_ephemeral
+        artifact:
+          type: object
+      additionalProperties: false
+    BundleRegistrationRequest:
+      type: object
+      required:
+        - bundle
+      properties:
+        scope:
+          type: string
+          enum:
+            - workspace_persisted
+            - session_ephemeral
+        bundle:
+          type: object
+      additionalProperties: false
+    RegistrationOutcome:
+      type: object
+      required:
+        - api_version
+        - registered
+        - already_registered
+        - artifact_type
+        - artifact_id
+        - version
+        - digest
+        - links
+      properties:
+        api_version:
+          type: string
+        registered:
+          type: boolean
+        already_registered:
+          type: boolean
+        artifact_type:
+          type: string
+        artifact_id:
+          type: string
+        version:
+          type: string
+        digest:
+          type: string
+        links:
+          $ref: "#/components/schemas/Links"
+      additionalProperties: true
+    BundleRegistrationOutcome:
+      type: object
+      required:
+        - api_version
+        - registered
+        - already_registered
+        - outcomes
+      properties:
+        api_version:
+          type: string
+        registered:
+          type: boolean
+        already_registered:
+          type: boolean
+        outcomes:
+          type: array
+          items:
+            $ref: "#/components/schemas/RegistrationOutcome"
+      additionalProperties: true
+    Links:
+      type: object
+      additionalProperties:
+        type: string
+    ProblemDetails:
+      type: object
+      required:
+        - type
+        - title
+        - status
+        - detail
+        - traverse_code
+      properties:
+        type:
+          type: string
+          format: uri
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string
+        instance:
+          type: string
+        traverse_code:
+          type: string
+      additionalProperties: true

--- a/specs/033-http-json-api/spec.md
+++ b/specs/033-http-json-api/spec.md
@@ -1,159 +1,345 @@
-# Feature Specification: HTTP JSON API
+# Feature Specification: HTTP+JSON Runtime API
 
-**Feature Branch**: `033-http-json-api`
-**Created**: 2026-04-19
-**Status**: Draft
-**Input**: HTTP+JSON external adapter for Traverse, covering `traverse-cli serve`, endpoint definitions, authentication tiers, wire format, versioning, and error envelope for v0 synchronous request/response.
+**Feature Branch**: `033-http-json-api`  
+**Created**: 2026-04-19  
+**Amended**: 2026-05-27  
+**Status**: Approved  
+**Version**: 1.1.0  
+**Input**: Approved product decisions for the app-consumable Traverse HTTP+JSON runtime API.
 
 ## Purpose
 
-This spec defines the HTTP JSON API for Traverse.
+This spec defines the app-consumable HTTP+JSON API for Traverse v0.
 
-It narrows the broad transport-agnostic runtime intent into a concrete, testable model for:
+The API exists so applications such as `youaskm3`, browser clients, local agents, and non-Rust tools can consume Traverse without shelling out to human-readable CLI commands. It is the first stable external runtime surface for app integration.
 
-- embedding an HTTP/1.1 server in `traverse-cli` via a `serve` subcommand
-- exposing a versioned `/v1/` endpoint surface for capability execution, listing, registration, and health
-- enforcing a tiered authentication model that is safe by default for loopback and requires Bearer JWT for non-loopback or production bindings
-- producing structured JSON error envelopes for all failure paths
-- maintaining wire format and versioning discipline suitable for semver governance
+This spec is coordinated with:
 
-This slice does **not** define async or streaming execution, WebSocket transport, or `/v2/` endpoint shapes. It is intentionally limited to synchronous request/response over HTTP/1.1 so the external API surface can be verified before async patterns are introduced.
+- `034-programmatic-registration`
+- `035-multi-agent-isolation`
+- `029-integrated-observability`
+- `030-security-identity-model`
+- `040-contractual-enforcement-gate`
+
+## Scope
+
+In scope:
+
+- `traverse-cli serve`
+- local discovery through `.traverse/server.json`
+- `/healthz`
+- synchronous and asynchronous execution
+- execution status fetch
+- public trace fetch
+- API versioning and response links
+- JSON request/response envelopes
+- RFC 9457 Problem Details errors
+- CORS policy for local and production bindings
+- OpenAPI artifact and CI validation
+
+Out of scope:
+
+- WebSocket transport
+- Server-Sent Events transport
+- federation
+- TLS termination
+- complete observability export shape (governed by `029-integrated-observability`)
+- programmatic registration semantics (governed by `034-programmatic-registration`)
+- workspace authorization semantics (governed by `035-multi-agent-isolation`)
 
 ## User Scenarios and Testing
 
-### User Story 1 - Execute a Capability via HTTP POST from Any Language (Priority: P1)
+### User Story 1 - Execute Through HTTP From Any App (Priority: P1)
 
-As a capability developer, I want to run `traverse-cli serve` and submit a capability execution request via `curl` or any HTTP client so that Traverse is usable from any language without the Rust SDK.
+As an application developer, I want to execute Traverse capabilities through a stable HTTP+JSON API so that my app can consume Traverse without parsing CLI output.
 
-**Why this priority**: Without an HTTP boundary, Traverse is only accessible from Rust callers; the HTTP API is the primary cross-language integration surface.
-
-**Independent Test**: Start `traverse-cli serve`; register one capability; submit `POST /v1/capabilities/execute` with a valid JSON body; verify the response contains a structured trace and result with HTTP 200.
+**Independent Test**: Start `traverse-cli serve`, call `POST /v1/workspaces/local-default/execute`, and verify a stable execution envelope with `execution_id`, `status`, `output`, `api_version`, and `links.trace`.
 
 **Acceptance Scenarios**:
 
-1. **Given** the server is running with a registered capability, **When** a client sends `POST /v1/capabilities/execute` with a valid JSON body, **Then** the server returns HTTP 200 with a JSON body containing a trace and result.
-2. **Given** a request body that fails runtime contract validation, **When** the server processes it, **Then** it returns HTTP 422 with a `{"error": {"code": "...", "message": "..."}}` envelope.
-3. **Given** a request that causes an ambiguous match, **When** the server processes it, **Then** it returns HTTP 409 with an error envelope listing all matching candidates.
+1. **Given** the server is running in dev-loopback mode, **When** a valid synchronous execution request is submitted, **Then** the API returns `200` with an execution envelope.
+2. **Given** the server receives `Prefer: respond-async` or `mode: "async"`, **When** the request is accepted, **Then** the API returns `202` with an `execution_id`, `links.status`, `links.trace`, and optional `links.subscription`.
+3. **Given** a completed async execution, **When** the client fetches `GET /v1/workspaces/{workspace_id}/executions/{execution_id}`, **Then** the API returns the execution status envelope.
 
-### User Story 2 - Call the HTTP API from a Browser Application (Priority: P1)
+### User Story 2 - Integrate From Browser Apps (Priority: P1)
 
-As a browser application developer, I want to call `POST /v1/capabilities/execute` over HTTP from a JavaScript client so that Traverse capabilities are usable from browser-hosted agents.
+As a browser app developer, I want Traverse to expose explicit CORS behavior so that local and production browser clients can call the runtime API safely.
 
-**Why this priority**: Browser integration is a named consumer of this API surface and must be verified before the API is considered stable.
-
-**Independent Test**: Simulate a browser-originated HTTP request (including CORS preflight); verify the server responds correctly to both preflight and the actual POST.
+**Independent Test**: Start the server in local dev mode, send a preflight from a loopback origin, and verify it succeeds. Start the server with a production/non-loopback binding and verify only exact configured origins are accepted.
 
 **Acceptance Scenarios**:
 
-1. **Given** a browser client sends an OPTIONS preflight to `/v1/capabilities/execute`, **When** the server processes it, **Then** it returns the correct CORS headers for the configured allowed origins.
-2. **Given** a browser client sends `POST /v1/capabilities/execute` with content-type `application/json`, **When** the server processes it, **Then** it returns a JSON response with correct content-type and a structured trace.
+1. **Given** dev-loopback mode and no `--allow-origin`, **When** a browser request comes from `http://localhost:*` or `http://127.0.0.1:*`, **Then** the API allows the origin.
+2. **Given** a production or non-loopback binding, **When** CORS is configured, **Then** only exact configured origins are allowed.
+3. **Given** a production or non-loopback binding, **When** no matching origin is configured, **Then** the API rejects the CORS request.
 
-### User Story 3 - Require Bearer JWT for Non-Loopback Bindings (Priority: P2)
+### User Story 3 - Discover Local Server Without Guesswork (Priority: P1)
 
-As an operator, I want the server to require a Bearer JWT for any non-loopback binding so that production deployments are not accidentally exposed without authentication.
+As a local app or agent, I want a repo-local discovery file so that I can find the Traverse server even if the default port is unavailable.
 
-**Why this priority**: The tiered auth model is a safety-critical design decision; unauthenticated production access is a blocking security defect.
-
-**Independent Test**: Start `traverse-cli serve --bind 0.0.0.0:8080`; submit a request without an `Authorization` header; verify the server returns HTTP 401.
-
-**Acceptance Scenarios**:
-
-1. **Given** the server is bound to a non-loopback address, **When** a client sends a request without an `Authorization: Bearer <token>` header, **Then** the server returns HTTP 401 with a structured error envelope.
-2. **Given** the server is bound to a non-loopback address and the client provides a valid JWT, **When** the server processes the request, **Then** it authorizes the request and returns the normal response.
-3. **Given** `--allow-unauthenticated` is set on a non-loopback binding, **When** the server starts, **Then** it logs a clearly visible warning that the binding is unsafe.
-
-### User Story 4 - Health Check Returns 200 Without Credentials (Priority: P2)
-
-As an operator, I want `GET /v1/health` to return 200 without credentials so that load balancers and orchestrators can probe liveness without managing tokens.
-
-**Why this priority**: Health probes are infrastructure-level; requiring auth on a health endpoint breaks standard orchestration patterns.
-
-**Independent Test**: Start the server with auth required; send `GET /v1/health` without any `Authorization` header; verify HTTP 200 with a JSON liveness body.
+**Independent Test**: Start `traverse-cli serve`, read `.traverse/server.json`, call the declared `health_url`, and verify `status: "ok"` before using `base_url`.
 
 **Acceptance Scenarios**:
 
-1. **Given** the server is running with Bearer JWT auth required, **When** a client sends `GET /v1/health` without any `Authorization` header, **Then** the server returns HTTP 200 with a JSON body indicating liveness.
-2. **Given** the server is running, **When** `GET /v1/health` is called, **Then** the response includes at minimum `{"status": "ok"}` and a server version field.
+1. **Given** the server starts successfully, **When** it writes `.traverse/server.json`, **Then** the file includes `base_url`, `health_url`, `workspace_default`, `pid`, `started_at`, and auth metadata.
+2. **Given** `.traverse/server.json` exists, **When** a client wants to use it, **Then** the client MUST verify `GET /healthz` before trusting the file.
+3. **Given** dev-loopback mode mints a local token, **When** the token is written to `.traverse/server.json`, **Then** the file MUST be owner-read/write only (`0600`) on Unix-like systems.
 
-## Edge Cases
+### User Story 4 - Receive Machine-Readable Errors (Priority: P1)
 
-- Concurrent requests: the server MUST handle multiple simultaneous requests without corrupting shared registry state.
-- Large request payloads exceeding the configured maximum (default 8MB) MUST be rejected with HTTP 413 before body parsing.
-- Auth token expiry during a long-running synchronous execution: the request is already authorized at intake; mid-execution expiry MUST NOT abort the in-progress execution.
-- Bind failure (port already in use) MUST produce a clear error message to stderr and exit with a non-zero code.
-- Request body that is not valid JSON MUST return HTTP 400 with a structured error envelope, not an unhandled panic.
-- Missing `Content-Type: application/json` header on POST endpoints MUST return HTTP 415.
-- Unknown endpoint paths MUST return HTTP 404 with a structured error envelope.
-- Server started with `--bind` on a non-loopback address without `--allow-unauthenticated` and without a JWT signing key configured MUST fail at startup with a clear configuration error.
+As an agent, I want all API errors to use stable JSON errors so that I can classify failures without regexing strings.
+
+**Independent Test**: Submit malformed JSON, invalid contract input, unauthorized requests, and registry conflicts; verify each response uses `application/problem+json` with `traverse_code`.
+
+## Required Endpoints
+
+### Health
+
+`GET /healthz`
+
+Returns a JSON health envelope:
+
+```json
+{
+  "status": "ok",
+  "version": "0.2.0",
+  "api_version": "v1",
+  "workspace_default": "local-default",
+  "auth_mode": "dev-loopback"
+}
+```
+
+Allowed `auth_mode` values:
+
+- `dev-loopback`
+- `bearer-required`
+
+### Execute
+
+`POST /v1/workspaces/{workspace_id}/execute`
+
+If `workspace_id` is omitted through a local dev convenience route, the server MAY use `local-default` only in dev-loopback mode. Production/non-loopback mode MUST require an explicit `workspace_id`.
+
+Synchronous success response:
+
+```json
+{
+  "api_version": "v1",
+  "execution_id": "exec_01HX...",
+  "status": "succeeded",
+  "output": {},
+  "links": {
+    "self": "/v1/workspaces/local-default/executions/exec_01HX...",
+    "trace": "/v1/workspaces/local-default/traces/exec_01HX..."
+  }
+}
+```
+
+Asynchronous accepted response:
+
+```json
+{
+  "api_version": "v1",
+  "execution_id": "exec_01HX...",
+  "status": "accepted",
+  "links": {
+    "status": "/v1/workspaces/local-default/executions/exec_01HX...",
+    "trace": "/v1/workspaces/local-default/traces/exec_01HX...",
+    "subscription": "/v1/workspaces/local-default/executions/exec_01HX.../events"
+  }
+}
+```
+
+The API MUST support async through either:
+
+- `Prefer: respond-async`
+- request body field `mode: "async"`
+
+### Execution Status
+
+`GET /v1/workspaces/{workspace_id}/executions/{execution_id}`
+
+Response:
+
+```json
+{
+  "api_version": "v1",
+  "execution_id": "exec_01HX...",
+  "status": "running",
+  "created_at": "2026-05-27T12:00:00Z",
+  "updated_at": "2026-05-27T12:00:01Z",
+  "links": {
+    "self": "/v1/workspaces/local-default/executions/exec_01HX...",
+    "trace": "/v1/workspaces/local-default/traces/exec_01HX...",
+    "subscription": "/v1/workspaces/local-default/executions/exec_01HX.../events"
+  }
+}
+```
+
+Allowed status values:
+
+- `accepted`
+- `running`
+- `succeeded`
+- `failed`
+- `cancelled`
+
+### Trace Fetch
+
+`GET /v1/workspaces/{workspace_id}/traces/{execution_id}`
+
+The API returns a stable public trace envelope, not the raw internal trace artifact and not direct OpenTelemetry export:
+
+```json
+{
+  "api_version": "v1",
+  "execution_id": "exec_01HX...",
+  "trace": {
+    "spans": [],
+    "events": []
+  },
+  "links": {
+    "execution": "/v1/workspaces/local-default/executions/exec_01HX..."
+  }
+}
+```
+
+OpenTelemetry export is governed by `029-integrated-observability`.
+
+## Server Startup and Discovery
+
+- `traverse-cli serve` MUST default to `127.0.0.1:8787`.
+- `--bind` MUST allow overriding the bind address.
+- Non-loopback bindings MUST require auth/production mode.
+- If the default port is unavailable, the server MAY fail clearly or select another local port, but if it selects another port it MUST write the selected address to `.traverse/server.json`.
+- Startup MUST print JSON startup information to stdout or stderr in a machine-readable form.
+- `.traverse/server.json` MUST be repo-local for v0 and MUST be ignored by git.
+
+Discovery file required fields:
+
+```json
+{
+  "base_url": "http://127.0.0.1:8787",
+  "health_url": "http://127.0.0.1:8787/healthz",
+  "workspace_default": "local-default",
+  "pid": 12345,
+  "started_at": "2026-05-27T12:00:00Z",
+  "auth_mode": "dev-loopback",
+  "token": "local-dev-token"
+}
+```
+
+When `token` is present, the file MUST be owner-read/write only (`0600`) on Unix-like systems.
+
+## Errors
+
+All API errors MUST use RFC 9457 Problem Details with `Content-Type: application/problem+json`.
+
+Required fields:
+
+```json
+{
+  "type": "https://traverse.dev/problems/validation-failed",
+  "title": "Validation failed",
+  "status": 422,
+  "detail": "The request body violated the runtime request schema.",
+  "instance": "/v1/workspaces/local-default/execute",
+  "traverse_code": "validation_failed"
+}
+```
+
+Status rules:
+
+- Malformed JSON: `400`
+- Unknown fields in core API envelopes or governed payloads: `400` or `422`, depending on whether parsing or domain validation found the error
+- Contract/schema validation failure: `422`
+- Immutable registry conflict: `409`
+- Idempotency key reuse with a different body: `409`
+- Missing/invalid credentials: `401`
+- Valid credentials without permission: `403`
+- Missing resource: `404`
+- Unsupported media type: `415`
+- Payload too large: `413`
+
+## Idempotency
+
+Mutation endpoints SHOULD support optional `Idempotency-Key`.
+
+Rules:
+
+- Reusing the same key with the same request body returns the original result.
+- Reusing the same key with a different request body returns `409 Conflict` with Problem Details.
+- The server MUST store a request hash with the key.
+- The default retention window is 24 hours.
+- Retention MUST be configurable with a documented minimum.
+
+## Versioning and Compatibility
+
+- URL paths MUST use path-based versioning (`/v1/...`).
+- JSON response envelopes MUST include `api_version`.
+- Approved `/v1` APIs MUST NOT introduce breaking changes within `/v1`.
+- Additive response fields are allowed.
+- Clients MUST ignore unknown response fields.
+- Request bodies MUST reject unknown fields in core API envelopes and governed payloads.
+- Response envelopes SHOULD include stable `links` for next actions.
+
+## CORS
+
+- Dev-loopback mode MAY allow common loopback browser origins by default:
+  - `http://localhost:*`
+  - `http://127.0.0.1:*`
+- Production/non-loopback mode MUST require exact configured origins.
+- Wildcard CORS MUST NOT be allowed by default.
+- `--allow-origin <origin>` MUST configure additional allowed origins.
+
+## OpenAPI
+
+- The HTTP API spec MUST include `specs/033-http-json-api/openapi.yaml`.
+- CI MUST validate that the OpenAPI artifact is structurally valid.
+- The OpenAPI document is the machine-readable contract for app consumers.
+- The prose spec wins if prose and OpenAPI conflict until the conflict is corrected.
 
 ## Functional Requirements
 
-- **FR-001**: `traverse-cli` MUST expose a `serve` subcommand that starts a long-running HTTP/1.1 server process.
-- **FR-002**: The server MUST bind to `127.0.0.1:8080` by default; the bind address and port MUST be configurable via `--bind` flag.
-- **FR-003**: All endpoints MUST be versioned under the `/v1/` URL prefix.
-- **FR-004**: The server MUST expose `POST /v1/capabilities/execute` accepting a JSON body and returning a runtime trace and result.
-- **FR-005**: The server MUST expose `GET /v1/capabilities` returning a JSON array of registered capabilities.
-- **FR-006**: The server MUST expose `POST /v1/capabilities/register` accepting a capability contract JSON body and registering the capability.
-- **FR-007**: The server MUST expose `GET /v1/health` returning liveness status and server version without requiring authentication.
-- **FR-008**: All JSON responses MUST use `Content-Type: application/json`.
-- **FR-009**: All error responses MUST use the envelope `{"error": {"code": "<machine_code>", "message": "<human_readable>"}}`.
-- **FR-010**: When the server is bound to loopback (`127.0.0.1` or `::1`) with no explicit `--require-auth` flag, it MUST allow unauthenticated requests (dev mode).
-- **FR-011**: When the server is bound to any non-loopback address, it MUST require `Authorization: Bearer <jwt>` for all endpoints except `GET /v1/health`.
-- **FR-012**: When `--allow-unauthenticated` is passed on a non-loopback binding, the server MUST start but MUST emit a clearly visible startup warning.
-- **FR-013**: The server MUST validate Bearer JWTs against a configured OIDC-compatible signing key; invalid or expired tokens MUST return HTTP 401.
-- **FR-014**: Request bodies exceeding the configured maximum payload size (default 8MB, configurable via `--max-body-bytes`) MUST be rejected with HTTP 413 before full body parsing.
-- **FR-015**: Requests with `Content-Type` other than `application/json` on POST endpoints MUST be rejected with HTTP 415.
-- **FR-016**: Invalid JSON request bodies MUST return HTTP 400 with a structured error envelope.
-- **FR-017**: Bind failures MUST produce a human-readable error on stderr and exit the process with a non-zero code.
-- **FR-018**: The server MUST handle concurrent requests without corrupting registry state; registry access MUST be protected by appropriate synchronization.
-- **FR-019**: CORS headers MUST be configurable; the default MUST allow loopback origins only; non-loopback allowed origins MUST be explicitly configured.
-- **FR-020**: Unknown paths MUST return HTTP 404 with a structured error envelope.
-- **FR-021**: The `POST /v1/capabilities/execute` endpoint MUST delegate to the same runtime execution path used by `traverse-cli run`; it MUST NOT implement a separate execution path.
+- **FR-001**: `traverse-cli serve` MUST start the HTTP+JSON runtime API server.
+- **FR-002**: `traverse-cli serve` MUST default to `127.0.0.1:8787`.
+- **FR-003**: The API MUST expose `GET /healthz`.
+- **FR-004**: The API MUST expose `POST /v1/workspaces/{workspace_id}/execute`.
+- **FR-005**: The API MUST expose `GET /v1/workspaces/{workspace_id}/executions/{execution_id}`.
+- **FR-006**: The API MUST expose `GET /v1/workspaces/{workspace_id}/traces/{execution_id}`.
+- **FR-007**: The API MUST support synchronous and asynchronous execution.
+- **FR-008**: Synchronous success MUST return a stable execution envelope.
+- **FR-009**: Asynchronous acceptance MUST return `202` with `execution_id`, status URL, trace URL, and optional subscription URL.
+- **FR-010**: Trace fetch MUST return a public trace envelope.
+- **FR-011**: All errors MUST use RFC 9457 Problem Details with `traverse_code`.
+- **FR-012**: Validation failures MUST use `422`.
+- **FR-013**: Immutable registry conflicts MUST use `409`.
+- **FR-014**: Unauthenticated access MUST use `401`; unauthorized access MUST use `403`.
+- **FR-015**: Mutation endpoints SHOULD support optional `Idempotency-Key`.
+- **FR-016**: The server MUST write `.traverse/server.json` in dev-loopback mode.
+- **FR-017**: Discovery files containing a token MUST be owner-read/write only (`0600`) on Unix-like systems.
+- **FR-018**: The server MUST expose coarse `auth_mode` in health output.
+- **FR-019**: Local dev MAY use `local-default` when `workspace_id` is omitted; production MUST require explicit workspace.
+- **FR-020**: The API MUST reject unknown request fields in core API envelopes and governed payloads.
+- **FR-021**: The API MUST include `api_version` in response envelopes.
+- **FR-022**: The API MUST include stable links for next actions.
+- **FR-023**: CORS MUST follow the dev-loopback and production rules above.
+- **FR-024**: CI MUST validate `specs/033-http-json-api/openapi.yaml`.
 
-## Non-Functional Requirements
+## Quality Gates
 
-- **NFR-001 Safety**: Non-loopback bindings MUST require explicit auth configuration; the server MUST NOT silently default to unauthenticated on non-loopback bindings.
-- **NFR-002 Determinism**: The HTTP layer MUST not alter the determinism of the runtime execution path; same request body MUST produce the same trace and result.
-- **NFR-003 Portability**: The HTTP server implementation MUST be decoupled from the runtime core; `traverse-runtime` MUST remain a library crate with no HTTP dependency.
-- **NFR-004 Testability**: Endpoint handler logic MUST be testable without a live TCP listener; integration tests MUST test via in-process HTTP client.
-- **NFR-005 Compatibility**: The `/v1/` wire format MUST be stable and semver-versioned; breaking changes MUST be introduced under `/v2/` and MUST NOT modify `/v1/` response shapes.
-- **NFR-006 Observability**: The server MUST log each inbound request with method, path, response status, and latency in a structured format.
-- **NFR-007 Startup Correctness**: The server MUST validate its own configuration at startup and fail fast with a clear error if any required configuration is missing or invalid.
-
-## Non-Negotiable Quality Standards
-
-- **QG-001**: Auth bypass on non-loopback bindings MUST be impossible without the explicit `--allow-unauthenticated` flag; any code path that allows unauthenticated non-loopback access without this flag is a spec violation.
-- **QG-002**: All error responses MUST use the structured envelope; free-form error strings or unhandled panics surfacing as HTTP 500 are blocking defects.
-- **QG-003**: The HTTP endpoint handlers MUST delegate to `traverse-runtime` without duplicating execution logic; code duplication between `traverse-cli run` and `traverse-cli serve` execution paths is a spec violation.
-- **QG-004**: Core handler logic MUST reach 100% automated line coverage.
-- **QG-005**: The server MUST pass all endpoint contract tests before merge; deviations from the declared wire format are blocking CI failures.
-
-## Key Entities
-
-- **HTTP Server**: The embedded HTTP/1.1 server process started by `traverse-cli serve`.
-- **Endpoint**: A versioned HTTP route under `/v1/` that accepts JSON requests and returns JSON responses.
-- **Auth Tier**: The authentication policy applied based on bind address — dev mode (loopback, no auth) or production mode (non-loopback, Bearer JWT required).
-- **Error Envelope**: The canonical JSON error response shape `{"error": {"code": "...", "message": "..."}}` used by all error responses.
-- **Bearer JWT**: A JSON Web Token presented in the `Authorization` header for production-mode authentication, validated against a configured OIDC-compatible signing key.
-- **Max Payload**: The configurable upper bound on request body size; requests exceeding this limit are rejected with HTTP 413.
-- **CORS Configuration**: The set of allowed origins for cross-origin requests; defaults to loopback only.
-- **Wire Format**: The stable JSON request and response shapes versioned under `/v1/`.
+- **QG-001**: Every endpoint in this spec MUST appear in `openapi.yaml`.
+- **QG-002**: Every endpoint MUST include at least one example request or response in the spec or OpenAPI artifact.
+- **QG-003**: All endpoint tests MUST assert required fields rather than exact full JSON equality, because additive response fields are allowed.
+- **QG-004**: No implementation PR may merge against proposed specs before spec approval.
+- **QG-005**: Draft implementation branches may exist while specs are proposed, but implementation may not merge until the governing spec is approved.
 
 ## Success Criteria
 
-- **SC-001**: A developer runs `traverse-cli serve`, registers a capability, and executes it via `curl` or any HTTP client without using the Rust SDK.
-- **SC-002**: A non-loopback binding without `--allow-unauthenticated` rejects all non-health requests without a valid Bearer JWT.
-- **SC-003**: `GET /v1/health` returns HTTP 200 with a liveness payload regardless of auth configuration.
-- **SC-004**: A request with a payload exceeding the configured maximum is rejected with HTTP 413 before body parsing completes.
-- **SC-005**: Core endpoint handler logic reaches 100% automated line coverage.
-
-## Out of Scope
-
-- Asynchronous or streaming execution (request/response is synchronous in v0)
-- WebSocket or Server-Sent Events transport
-- `/v2/` endpoint shapes
-- Fine-grained role-based access control beyond the dev/production auth tier
-- TLS termination (assumed to be handled by a reverse proxy)
-- API rate limiting
-- OpenAPI/Swagger schema generation
-- Multi-tenant isolation at the HTTP layer
+- **SC-001**: A local app can discover the Traverse server through `.traverse/server.json` and verify `/healthz`.
+- **SC-002**: A browser app can call the local API from a loopback origin without wildcard CORS.
+- **SC-003**: A non-loopback binding requires Bearer auth and exact CORS origin configuration.
+- **SC-004**: A client can execute synchronously and receive an execution envelope.
+- **SC-005**: A client can request async execution, poll execution status, and fetch a public trace envelope.
+- **SC-006**: Invalid requests produce RFC 9457 Problem Details with stable `traverse_code`.
+- **SC-007**: The OpenAPI YAML validates in CI.

--- a/specs/034-programmatic-registration/spec.md
+++ b/specs/034-programmatic-registration/spec.md
@@ -1,157 +1,227 @@
-# Feature Specification: Programmatic Capability Registration
+# Feature Specification: Programmatic Registration API
 
-**Feature Branch**: `034-programmatic-registration`
-**Created**: 2026-04-19
-**Status**: Draft
-**Input**: Runtime capability registration via the HTTP API, covering workspace-scoped persistence, idempotency by contract digest, full contract validation at registration time, and session-ephemeral scope for one-off capabilities.
+**Feature Branch**: `034-programmatic-registration`  
+**Created**: 2026-04-19  
+**Amended**: 2026-05-27  
+**Status**: Approved  
+**Version**: 1.1.0  
+**Input**: Approved product decisions for programmatic registration of capabilities, event contracts, workflows, and bundles.
 
 ## Purpose
 
-This spec defines programmatic capability registration for Traverse.
+This spec defines the programmatic registration API for Traverse v0.
 
-It narrows the broad registry extensibility intent into a concrete, testable model for:
+Apps and agents need to register governed artifacts without shelling out to CLI commands. Registration must be reliable, idempotent, workspace-scoped, and strict enough that invalid artifacts never enter the runtime registry.
 
-- accepting capability contract submissions via `POST /v1/capabilities/register`
-- validating contracts fully at registration time before any persistence
-- keying the registry by (workspace_id, capability_id, version) for workspace-scoped isolation
-- making registration idempotent for the same contract digest within a workspace
-- supporting two registration scopes: `workspace_persisted` (default) and `session_ephemeral`
-- rejecting conflicting re-registrations with a deterministic `ImmutableVersionConflict` error
+This spec is coordinated with:
 
-This slice does **not** define capability artifact distribution, remote artifact fetching, or multi-workspace federation. It is intentionally limited to the registration lifecycle so the registry control plane can be built and verified before artifact management is added.
+- `033-http-json-api`
+- `035-multi-agent-isolation`
+- `005-capability-registry`
+- `011-event-registry`
+- `007-workflow-registry-traversal`
+- `040-contractual-enforcement-gate`
+
+## Scope
+
+In scope:
+
+- capability registration
+- event contract registration
+- workflow registration
+- bundle registration
+- workspace-scoped persistence
+- session-ephemeral registration scope
+- registration outcome envelopes
+- idempotent duplicate handling
+- all-or-nothing bundle transactions
+- pre-storage validation
+- audit logging requirements
+
+Out of scope:
+
+- artifact deletion/deregistration
+- remote artifact fetching
+- dependency resolution (governed by `043-module-dependency-management`)
+- federation
+- registry UI
+
+## Required Endpoints
+
+The HTTP surface is governed by `033-http-json-api`; this spec governs registration behavior for these endpoints:
+
+- `POST /v1/workspaces/{workspace_id}/capabilities`
+- `POST /v1/workspaces/{workspace_id}/event-contracts`
+- `POST /v1/workspaces/{workspace_id}/workflows`
+- `POST /v1/workspaces/{workspace_id}/bundles`
+
+Separate endpoints are required for the three artifact types so validation and authorization stay clear. Bundle upload is also required so package/install flows can remain ergonomic.
 
 ## User Scenarios and Testing
 
-### User Story 1 - Register a Capability at Runtime Without a CLI Command (Priority: P1)
+### User Story 1 - Register Artifacts Programmatically (Priority: P1)
 
-As an agent or automation system, I want to register a capability via `POST /v1/capabilities/register` so that capabilities can be provisioned dynamically without requiring a manual CLI step.
+As an agent or application, I want to register capabilities, event contracts, and workflows through stable HTTP endpoints so that runtime setup can be automated.
 
-**Why this priority**: Programmatic registration is the primary mechanism for agent-driven capability provisioning; without it, Traverse cannot be used in headless or automated contexts.
-
-**Independent Test**: Send `POST /v1/capabilities/register` with a valid capability contract JSON body including a `workspace_id`; verify the capability is immediately executable via `POST /v1/capabilities/execute` without a CLI command.
+**Independent Test**: Submit valid capability, event contract, and workflow registration requests in one workspace; verify each returns a registration outcome envelope and is available to runtime/discovery logic without CLI registration.
 
 **Acceptance Scenarios**:
 
-1. **Given** a valid capability contract JSON body with a `workspace_id`, **When** the client sends `POST /v1/capabilities/register`, **Then** the server validates the contract, persists it under `workspace_persisted` scope, and returns HTTP 201 with the registered capability record.
-2. **Given** a successful registration, **When** the client sends `POST /v1/capabilities/execute` with a matching request, **Then** the runtime discovers and executes the newly registered capability.
-3. **Given** a capability registered under `workspace_persisted` scope, **When** the server restarts, **Then** the capability is still present in the registry and executable.
+1. **Given** a valid capability contract, **When** it is submitted to `/capabilities`, **Then** the registry stores it and returns a registration outcome envelope.
+2. **Given** a valid event contract, **When** it is submitted to `/event-contracts`, **Then** the event registry stores it and returns a registration outcome envelope.
+3. **Given** a valid workflow definition, **When** it is submitted to `/workflows`, **Then** the workflow registry stores it and returns a registration outcome envelope.
 
-### User Story 2 - Idempotent Re-registration With the Same Digest (Priority: P1)
+### User Story 2 - Retry Safely (Priority: P1)
 
-As an agent, I want re-registering the same capability with the same contract digest to succeed silently so that registration logic does not need to track whether a capability was previously registered.
+As an agent, I want registration to be idempotent so retries after crashes or network failures do not create conflicts when the artifact is unchanged.
 
-**Why this priority**: Idempotency is required for safe automation; without it, agents must implement their own deduplication, which leaks registry concerns into capability authors.
+**Independent Test**: Submit the same artifact twice. Verify the second response has `already_registered: true`; submit the same id/version with a different digest and verify `409 Conflict`.
 
-**Independent Test**: Register a capability; register the same capability a second time with an identical contract digest; verify the server returns HTTP 200 with `already_registered: true` and does not write to persistent storage again.
+### User Story 3 - Install Bundles Atomically (Priority: P1)
 
-**Acceptance Scenarios**:
+As an app maintainer, I want bundle registration to be all-or-nothing so that partially installed capability sets cannot leave the workspace in an inconsistent state.
 
-1. **Given** a capability already registered under a given workspace, **When** the same contract digest is submitted for the same capability id and version, **Then** the server returns HTTP 200 with `{"already_registered": true}` and does not modify the existing registry entry.
-2. **Given** two concurrent registration requests for the same capability from two agents, **When** both requests complete, **Then** exactly one write occurs and both agents receive a success response (`already_registered: true` or HTTP 201).
+**Independent Test**: Submit a bundle containing one valid artifact and one invalid artifact; verify the API returns an error and no artifacts from the bundle are stored.
 
-### User Story 3 - Session-Ephemeral Registration for One-Off Tasks (Priority: P2)
+### User Story 4 - Support Ephemeral Local Automation (Priority: P2)
 
-As an agent, I want to register a capability with `scope: session_ephemeral` so that the capability is cleaned up automatically on server restart without requiring an explicit deregistration call.
+As an automation agent, I want `session_ephemeral` registration for one-off capabilities that should disappear when the server session ends.
 
-**Why this priority**: Ephemeral registrations are important for short-lived automation tasks; persistent storage of one-off capabilities wastes registry space and leaks between sessions.
+**Independent Test**: Register an artifact with `scope: "session_ephemeral"`; verify it is available in the current process and absent after restart.
 
-**Independent Test**: Register a capability with `scope: session_ephemeral`; verify it is executable in the current session; simulate server restart; verify the capability is no longer present in the registry.
+## Registration Request Model
 
-**Acceptance Scenarios**:
+Every registration request is scoped by URL path `workspace_id`.
 
-1. **Given** a capability registered with `scope: session_ephemeral`, **When** the server restarts, **Then** the capability is absent from the registry and cannot be executed.
-2. **Given** a session-ephemeral capability registered in the current session, **When** the client executes it, **Then** it runs successfully within the same session.
+Request bodies MUST reject unknown fields.
 
-### User Story 4 - Reject Invalid Contracts Before Touching the Registry (Priority: P2)
+Supported registration scopes:
 
-As a platform developer, I want invalid capability contracts to be rejected at registration time so that malformed contracts never reach the registry or persistent storage.
+- `workspace_persisted` (default)
+- `session_ephemeral`
 
-**Why this priority**: Pre-persistence validation is a non-negotiable correctness guarantee; a registry containing invalid contracts can cause silent runtime failures.
+`workspace_persisted` entries survive restart. `session_ephemeral` entries are process/session-scoped and MUST NOT be written to persistent registry storage.
 
-**Independent Test**: Submit `POST /v1/capabilities/register` with a contract body missing a required field (e.g., `service_type`); verify the server returns HTTP 422 with a structured validation error and no registry write occurs.
+## Registration Outcome Envelope
 
-**Acceptance Scenarios**:
+Successful registration MUST return a registration outcome envelope:
 
-1. **Given** a contract body missing required fields, **When** the client sends `POST /v1/capabilities/register`, **Then** the server returns HTTP 422 with a structured error listing each violated requirement and does not write to the registry.
-2. **Given** a contract with an invalid `artifact_type` value, **When** the client sends the registration, **Then** the server returns HTTP 422 with a machine-readable error code and the offending field path.
-3. **Given** a contract where the declared state schema is malformed JSON Schema, **When** the client sends the registration, **Then** the server returns HTTP 422 with a `malformed_state_schema` error before any persistence.
+```json
+{
+  "api_version": "v1",
+  "registered": true,
+  "already_registered": false,
+  "artifact_type": "capability",
+  "artifact_id": "summarize-note",
+  "version": "1.2.3",
+  "digest": "sha256:abc123",
+  "scope": "workspace_persisted",
+  "links": {
+    "self": "/v1/workspaces/local-default/capabilities/summarize-note/1.2.3",
+    "execute": "/v1/workspaces/local-default/execute"
+  }
+}
+```
 
-## Edge Cases
+Re-registration with the same digest MUST return success with:
 
-- Concurrent registration of the same capability from two agents simultaneously: idempotency MUST hold regardless of request interleaving; no duplicate writes and no conflicting error responses.
-- `workspace_id` missing from the request body MUST be rejected with HTTP 400 and a clear `missing_workspace_id` error before any validation proceeds.
-- Registration of a capability whose artifact is not yet present locally MUST return a structured `artifact_not_found` error; partial registration MUST NOT be persisted.
-- Version conflict: same `capability_id`, same `workspace_id`, different `version`, different digest — this is a valid new registration; same `capability_id`, same `workspace_id`, same `version`, different digest MUST return `ImmutableVersionConflict`.
-- Registration with a `workspace_id` that contains invalid characters (e.g., path separators) MUST be rejected before any file system or storage operation.
-- Re-registration attempt for a `session_ephemeral` capability after server restart MUST succeed as a fresh registration (the old entry no longer exists).
-- Contract body exceeding the HTTP max payload limit (governed by spec 033) MUST be rejected by the HTTP layer before the registry is consulted.
+```json
+{
+  "api_version": "v1",
+  "registered": false,
+  "already_registered": true,
+  "artifact_type": "capability",
+  "artifact_id": "summarize-note",
+  "version": "1.2.3",
+  "digest": "sha256:abc123",
+  "links": {
+    "self": "/v1/workspaces/local-default/capabilities/summarize-note/1.2.3"
+  }
+}
+```
+
+## Validation and Conflicts
+
+- Traverse MUST validate before storing.
+- Invalid artifacts MUST be rejected.
+- Invalid artifacts MUST NOT be persisted, cached as active registrations, or made executable.
+- Same id/version/digest is idempotent success.
+- Same id/version with different digest is `409 Conflict`.
+- Contract/schema validation failure is `422`.
+- Bundle registration is all-or-nothing.
+- Failed bundle registration MUST leave the registry in its pre-request state.
+
+## Bundle Registration
+
+`POST /v1/workspaces/{workspace_id}/bundles`
+
+Bundle registration MUST:
+
+- validate every artifact first
+- compute every digest deterministically
+- detect internal duplicate/conflicting ids before writing
+- stage writes before commit
+- commit all artifacts atomically
+- roll back all staged writes if any validation or conflict fails
+
+Partial success is not allowed in v0.
+
+## Idempotency-Key
+
+Registration endpoints are mutation endpoints and SHOULD support `Idempotency-Key` as specified by `033-http-json-api`.
+
+If the same `Idempotency-Key` is reused with a different request body, the API MUST return `409 Conflict` with Problem Details.
+
+## Audit Log
+
+Every successful or failed registry mutation attempt MUST emit a workspace-local append-only JSONL audit log entry as governed by `035-multi-agent-isolation`.
+
+At minimum, audit entries MUST include:
+
+- timestamp
+- workspace_id
+- actor_id or subject_id (non-secret)
+- artifact_type
+- artifact_id when parseable
+- version when parseable
+- digest when computed
+- outcome (`registered`, `already_registered`, `conflict`, `validation_failed`)
+- traverse_code for failures
 
 ## Functional Requirements
 
-- **FR-001**: The server MUST expose `POST /v1/capabilities/register` accepting a capability contract JSON body and a required `workspace_id` field.
-- **FR-002**: Every registration request MUST include a `workspace_id`; requests without `workspace_id` MUST be rejected with HTTP 400 and a `missing_workspace_id` error before any further processing.
-- **FR-003**: The registry MUST key each entry by the compound key `(workspace_id, capability_id, version)`; registrations in different workspaces MUST be isolated from each other.
-- **FR-004**: The server MUST fully validate the submitted contract before any write to the registry, including schema validation, required field presence, `service_type` validity, and `artifact_type` validity.
-- **FR-005**: Contracts that fail validation MUST be rejected with HTTP 422 and a structured error body listing each violated requirement; no partial registry write MUST occur.
-- **FR-006**: A malformed `state_schema` field in the contract MUST cause rejection with a `malformed_state_schema` error code before any registry write.
-- **FR-007**: When the submitted contract digest matches an existing entry for the same `(workspace_id, capability_id, version)`, the server MUST return HTTP 200 with `{"already_registered": true}` and MUST NOT perform a new write.
-- **FR-008**: When a different contract digest is submitted for an existing `(workspace_id, capability_id, version)`, the server MUST return HTTP 409 with an `ImmutableVersionConflict` error and MUST NOT overwrite the existing entry.
-- **FR-009**: Concurrent registration requests for the same key MUST be handled with correct mutual exclusion; exactly one write MUST occur and both callers MUST receive a non-error response.
-- **FR-010**: The registration request MUST include a `scope` field with valid values `workspace_persisted` (default) or `session_ephemeral`; unknown scope values MUST be rejected with HTTP 422.
-- **FR-011**: `workspace_persisted` registrations MUST be written to persistent storage and MUST survive server restarts.
-- **FR-012**: `session_ephemeral` registrations MUST be held in-memory only and MUST NOT be written to persistent storage; they MUST be absent from the registry after a server restart.
-- **FR-013**: A capability registered via this endpoint MUST be immediately discoverable and executable via `POST /v1/capabilities/execute` without requiring a separate activation step.
-- **FR-014**: `GET /v1/capabilities?workspace_id=<id>` MUST return only capabilities registered in the specified workspace; capabilities from other workspaces MUST NOT appear in the response.
-- **FR-015**: A `workspace_id` containing path separators, null bytes, or other invalid characters MUST be rejected with HTTP 400 before any storage or file system operation.
-- **FR-016**: The registration response for a new HTTP 201 registration MUST include the full registered capability record with its computed digest, scope, and workspace_id.
-- **FR-017**: Registration of a capability whose referenced artifact is not present locally MUST return HTTP 422 with an `artifact_not_found` error and MUST NOT persist a registry entry.
-- **FR-018**: The contract digest MUST be computed deterministically by the server; callers MUST NOT provide the digest as an input field.
-- **FR-019**: The registry MUST support listing capabilities filtered by `workspace_id`; the listing MUST include both `workspace_persisted` and `session_ephemeral` entries for the current session.
-- **FR-020**: All registry mutations MUST be atomic from the caller's perspective; a failed registration MUST leave the registry in its pre-request state.
+- **FR-001**: The API MUST expose separate endpoints for capabilities, event contracts, workflows, and bundles.
+- **FR-002**: The API MUST validate every artifact before storing.
+- **FR-003**: Invalid artifacts MUST be rejected and MUST NOT be stored.
+- **FR-004**: Registration MUST be workspace-scoped by URL path.
+- **FR-005**: `workspace_persisted` MUST be the default scope.
+- **FR-006**: `session_ephemeral` MUST be supported for current-session registrations.
+- **FR-007**: Same id/version/digest MUST return idempotent success.
+- **FR-008**: Same id/version with different digest MUST return `409 Conflict`.
+- **FR-009**: Contract/schema validation failures MUST return `422`.
+- **FR-010**: Successful registration MUST return a registration outcome envelope.
+- **FR-011**: Registration outcomes MUST include digest evidence.
+- **FR-012**: Registration outcomes MUST include stable links for next actions.
+- **FR-013**: Bundle registration MUST be all-or-nothing.
+- **FR-014**: Bundle registration MUST detect conflicting entries before storage.
+- **FR-015**: Registration endpoints SHOULD honor `Idempotency-Key`.
+- **FR-016**: Registration endpoints MUST reject unknown request fields.
+- **FR-017**: Registry mutations MUST emit audit log entries.
+- **FR-018**: Registered artifacts MUST be immediately visible to the runtime within the same workspace.
 
-## Non-Functional Requirements
+## Quality Gates
 
-- **NFR-001 Idempotency**: Registration MUST be idempotent for the same `(workspace_id, capability_id, version, digest)` tuple regardless of how many times or how concurrently the request is issued.
-- **NFR-002 Atomicity**: Registry writes MUST be atomic; partial writes that leave the registry in an inconsistent state are blocking defects.
-- **NFR-003 Isolation**: Registrations in one workspace MUST NOT be visible to registry lookups in another workspace.
-- **NFR-004 Testability**: Contract validation, idempotency logic, and scope handling MUST be testable independently of the HTTP transport layer.
-- **NFR-005 Determinism**: Contract digest computation MUST be deterministic; the same contract bytes MUST always produce the same digest.
-- **NFR-006 Compatibility**: The registration request and response wire format MUST be semver-versioned and stable; breaking changes require a new governing spec version.
-- **NFR-007 Fail-Fast Validation**: Contract validation MUST occur fully before any storage operation is initiated; the validation and persistence phases MUST be clearly separated.
-
-## Non-Negotiable Quality Standards
-
-- **QG-001**: An invalid contract MUST NEVER reach the persistent registry; any code path that writes an unvalidated contract is a spec violation.
-- **QG-002**: Idempotency MUST hold under concurrent load; a race condition that produces duplicate registry entries or conflicting error responses is a blocking defect.
-- **QG-003**: `workspace_id` MUST be validated for illegal characters before any file system or storage operation; an injection via `workspace_id` is a blocking security defect.
-- **QG-004**: Core registration logic (validation, idempotency, scope handling, digest computation) MUST reach 100% automated line coverage.
-- **QG-005**: The registration wire format MUST be verified against the governing spec before merge; drift from the declared interface is a blocking CI failure.
-
-## Key Entities
-
-- **Registration Request**: The HTTP request body submitted to `POST /v1/capabilities/register`, containing the capability contract, `workspace_id`, and optional `scope`.
-- **Contract Digest**: A deterministic hash of the submitted capability contract, computed by the server and used as the idempotency key.
-- **Registration Key**: The compound key `(workspace_id, capability_id, version)` used to look up and store registry entries.
-- **Registration Scope**: The lifecycle policy for a registry entry — `workspace_persisted` survives restarts; `session_ephemeral` does not.
-- **ImmutableVersionConflict**: The structured error returned when a different contract digest is submitted for an already-registered `(workspace_id, capability_id, version)`.
-- **Workspace**: A named isolation boundary for capability registrations; each registration belongs to exactly one workspace.
-- **Validation Phase**: The pre-persistence step that checks schema, required fields, `service_type`, `artifact_type`, and state schema correctness before any write.
-- **Persistent Registry Storage**: The durable backend (filesystem or embedded DB) used for `workspace_persisted` entries.
+- **QG-001**: Invalid artifacts reaching persistent registry storage are a blocking defect.
+- **QG-002**: Partial bundle installation is a blocking defect.
+- **QG-003**: Idempotent retry behavior MUST be tested for each endpoint.
+- **QG-004**: Conflict behavior MUST be tested for each artifact type.
+- **QG-005**: Registration endpoint examples MUST appear in `specs/033-http-json-api/openapi.yaml`.
 
 ## Success Criteria
 
-- **SC-001**: An agent registers a capability via `POST /v1/capabilities/register` and immediately executes it via `POST /v1/capabilities/execute` without any CLI command.
-- **SC-002**: Re-registering the same capability with the same contract digest returns HTTP 200 with `already_registered: true` regardless of how many times the request is issued.
-- **SC-003**: A `session_ephemeral` registration is absent from the registry after a server restart.
-- **SC-004**: A registration request with an invalid contract is rejected with HTTP 422 before any registry write occurs.
-- **SC-005**: Core registration logic reaches 100% automated line coverage under the protected coverage gate.
-
-## Out of Scope
-
-- Capability deregistration or explicit deletion from the registry
-- Remote artifact fetching or distribution at registration time
-- Cross-workspace capability sharing or federation
-- Capability versioning migration tooling
-- Bulk registration from a manifest file
-- Webhook or event notification on registration
-- Registration of capabilities without a `workspace_id` (anonymous workspace)
+- **SC-001**: An app can register a capability, event contract, workflow, and bundle over HTTP.
+- **SC-002**: Duplicate registration with the same digest returns idempotent success.
+- **SC-003**: Duplicate registration with a different digest returns `409 Conflict`.
+- **SC-004**: Invalid registration returns `422` before storage.
+- **SC-005**: Bundle registration is atomic.
+- **SC-006**: Registration writes append audit log entries.

--- a/specs/035-multi-agent-isolation/spec.md
+++ b/specs/035-multi-agent-isolation/spec.md
@@ -1,161 +1,224 @@
-# Feature Specification: Multi-Agent Workspace Isolation
+# Feature Specification: Workspace Auth and Multi-Agent Isolation
 
-**Feature Branch**: `035-multi-agent-isolation`
-**Created**: 2026-04-19
-**Status**: Draft
-**Input**: Isolation model for multi-agent environments in Traverse, covering workspace-keyed registry scoping, subject-based authorization, shared workspace opt-in, and admin operations. Unblocks GitHub issue #303.
+**Feature Branch**: `035-multi-agent-isolation`  
+**Created**: 2026-04-19  
+**Amended**: 2026-05-27  
+**Status**: Approved  
+**Version**: 1.1.0  
+**Input**: Approved product decisions for workspace-scoped authentication, authorization, runtime grants, and audit logging.
 
 ## Purpose
 
-This spec defines the workspace isolation model for Traverse runtime and registry operations.
+This spec defines the workspace authentication and multi-agent isolation model for Traverse v0.
 
-Without isolation, any agent registering capabilities or events into the global registry can observe and interfere with the registrations of every other agent. This is unacceptable when Traverse hosts concurrent agents for distinct principals (CI pipelines, separate teams, different environments).
+Traverse must support multiple agents, apps, users, CI jobs, and local browser sessions without allowing one caller to read, mutate, or execute another workspace's registry objects. The isolation boundary is `workspace_id`.
 
-The isolation model introduced here:
+This spec is coordinated with:
 
-- scopes every registry operation to a `workspace_id`
-- enforces that `subject_id` (derived from the JWT per spec 030) may only access workspaces it owns or has been explicitly granted access to
-- allows teams to opt in to a shared workspace where multiple subjects collaborate
-- reserves a `system` workspace for privileged admin operations
-- preserves the existing registry and runtime API shapes while adding workspace scope as a required dimension
+- `033-http-json-api`
+- `034-programmatic-registration`
+- `030-security-identity-model`
+- `031-supply-chain-hardening`
+- `040-contractual-enforcement-gate`
 
-This spec does **not** address distributed cross-process isolation, federated workspace directories, or quota enforcement. Those are future concerns.
+## Scope
+
+In scope:
+
+- workspace identity and isolation
+- dev-loopback auth mode
+- bearer-required production mode
+- OIDC-style bearer JWT identity
+- scope-based authorization
+- runtime grants
+- local dev token discovery
+- audit logging for registration, runtime grants, and auth failures
+
+Out of scope:
+
+- JWT issuance service
+- external IdP configuration details
+- billing/quotas
+- federation
+- full admin UI
+- persisted workspace grants in v0
+
+## Identity Model
+
+Traverse uses an OIDC-style bearer JWT as the canonical caller identity format for non-dev modes.
+
+Rules:
+
+- Tokens are secrets and MUST NOT be exported to telemetry, trace output, or audit logs.
+- The runtime MUST derive `subject_id` and `actor_id` from validated identity claims.
+- Callers MUST NOT provide trusted `subject_id` or `actor_id` fields directly in request bodies.
+- Telemetry and audit logs MAY include stable non-secret subject/actor identifiers and token hashes/references where useful.
+
+## Workspace Model
+
+- Every runtime, registry, trace, event subscription, and audit operation is scoped to a `workspace_id`.
+- `workspace_id` is explicit in production URLs.
+- Local dev may use `local-default` when omitted, as governed by `033-http-json-api`.
+- The registry key space includes `workspace_id`.
+- A module compromise is assumed to affect only the workspace plus explicitly delegated resources available to that execution/session.
+
+## Auth Modes
+
+### `dev-loopback`
+
+Used only for loopback local development.
+
+Rules:
+
+- May allow local requests without a user-provided token.
+- SHOULD mint a local ephemeral bearer token.
+- MUST write local discovery metadata to `.traverse/server.json`.
+- If the discovery file contains a token, it MUST be owner-read/write only (`0600`) on Unix-like systems.
+- Scopes are optional in dev-loopback mode.
+- Responses SHOULD expose effective scopes so clients can test scoped flows locally.
+
+### `bearer-required`
+
+Used for production or non-loopback bindings.
+
+Rules:
+
+- Requires `Authorization: Bearer <token>`.
+- Missing/invalid credentials return `401`.
+- Valid credentials without required scope return `403`.
+- Production/non-loopback CORS must use exact configured origins.
+
+## Scope-Based Authorization
+
+v0 uses operation-specific scopes.
+
+Minimum scopes:
+
+- `workspace:read`
+- `runtime:execute`
+- `runtime:trace:read`
+- `registry:read`
+- `registry:write`
+- `events:subscribe`
+- `grants:approve`
+
+Roles MAY be introduced later as a convenience layer over scopes, but v0 enforcement is scope-based.
+
+## Runtime Grants
+
+Modules declare static manifest permissions. Runtime grants may add temporary delegated access.
+
+Supported v0 grant lifetimes:
+
+- `execution`
+- `session`
+
+Persisted workspace grants are out of scope for v0.
+
+Runtime grant rules:
+
+- Static manifest permissions define the maximum ordinary permission envelope.
+- Runtime grants require explicit approval by a caller with `grants:approve`.
+- Runtime grants MUST be auditable.
+- Runtime grants MUST include lifetime, granted scope/resource, approver identity, and expiration.
+- Runtime grants MUST NOT silently persist beyond their declared lifetime.
 
 ## User Scenarios and Testing
 
-### User Story 1 — Two Agents Cannot Access Each Other's Capabilities (Priority: P1)
+### User Story 1 - Isolate Workspaces (Priority: P1)
 
-As a platform operator, I want two agents running under different subject identities to have completely separate views of the registry so that one agent cannot discover, read, or execute the other's registered capabilities.
+As a platform operator, I want one agent's workspace to be invisible to another unauthorized agent so that concurrent agents cannot interfere with each other.
 
-**Why this priority**: Workspace isolation is the foundational safety property of multi-agent Traverse. All other isolation features depend on it being correct.
+**Independent Test**: Register the same capability id in two workspaces; verify each workspace resolves only its own registration and unauthorized reads return `403` without leaking metadata.
 
-**Independent Test**: Register two agents under distinct subjects. Each registers a capability with the same capability id. Verify that a runtime request from agent A resolves only agent A's registration and that agent B's registration is invisible to agent A's resolution path.
+### User Story 2 - Support Local Browser Development (Priority: P1)
 
-**Acceptance Scenarios**:
+As a local app developer, I want dev-loopback mode to be easy while still letting my app test bearer-token behavior.
 
-1. **Given** two agents registered under distinct `subject_id` values, each with their own workspace, **When** agent A submits a runtime request for a capability id that both have registered, **Then** the runtime resolves only the registration in agent A's workspace and never evaluates agent B's registration.
-2. **Given** agent A attempts to list, read, or execute capabilities in a workspace owned by agent B, **When** the authorization check runs, **Then** the runtime rejects the operation with an `unauthorized_workspace` error before any registry lookup occurs.
-3. **Given** agent B's workspace is deleted, **When** agent A submits a request, **Then** agent A's runtime behavior is entirely unaffected.
+**Independent Test**: Start `traverse-cli serve` in dev-loopback mode; verify `.traverse/server.json` contains a local token, has owner-only permissions, and `/healthz` reports `auth_mode: "dev-loopback"`.
 
-### User Story 2 — CI Pipeline Isolation (Priority: P1)
+### User Story 3 - Require Production Authorization (Priority: P1)
 
-As a CI engineer, I want pipeline runs to register capabilities under ephemeral workspace identifiers so that test registrations cannot pollute production workspaces or interfere with each other across builds.
+As an operator, I want non-loopback bindings to require bearer auth and scopes so that exposed servers do not run with unsafe defaults.
 
-**Why this priority**: CI is the primary driver of ephemeral, high-volume capability registration. Without workspace isolation, CI registrations are a correctness hazard for production agents.
+**Independent Test**: Start the server with a non-loopback binding; verify missing credentials return `401` and missing scopes return `403`.
 
-**Independent Test**: Register capabilities under workspace `ci.build-001` and workspace `production`. Verify that a runtime request scoped to `production` never resolves anything registered under `ci.build-001`.
+### User Story 4 - Delegate Temporary Access Safely (Priority: P2)
 
-**Acceptance Scenarios**:
+As an app user, I want to approve a runtime grant for a specific execution or session so a module can access a delegated resource without broad workspace permissions.
 
-1. **Given** a CI pipeline that registers capabilities under workspace `ci.build-NNN`, **When** a runtime request is scoped to workspace `production`, **Then** the registry returns no results from `ci.build-NNN` registrations.
-2. **Given** two concurrent CI builds using `ci.build-001` and `ci.build-002`, **When** both register a capability with the same id, **Then** each build's runtime resolves its own registration without conflict.
-3. **Given** the CI workspace `ci.build-001` expires or is deleted, **When** the production workspace is queried, **Then** no references to `ci.build-001` registrations are visible.
+**Independent Test**: Approve an execution-scoped grant, verify the module can use it during the execution, and verify it is unavailable after the execution ends.
 
-### User Story 3 — Shared Workspace for Team Collaboration (Priority: P2)
+## Audit Log
 
-As a team lead, I want to declare a workspace as shared so that multiple authenticated agents within my team can register and execute capabilities in the same namespace.
+v0 audit logs are workspace-local append-only JSONL files.
 
-**Why this priority**: Some legitimate multi-agent workflows require collaboration within one registry namespace. Shared workspaces must be an explicit opt-in, not a default.
+Required audited operations:
 
-**Independent Test**: Create a shared workspace. Register two different subjects as members. Verify each subject can register and execute capabilities in the workspace and that a third non-member subject is rejected.
+- registration attempts and outcomes
+- runtime grant creation/use/revocation/expiry
+- auth failures
 
-**Acceptance Scenarios**:
+Audit entries MUST NOT contain bearer tokens or raw secrets.
 
-1. **Given** a workspace declared `shared: true` with two member subjects, **When** either subject registers a capability in that workspace, **Then** both subjects can discover and execute it via runtime requests scoped to that workspace.
-2. **Given** a shared workspace with two members, **When** a third subject not in the member list submits a request scoped to the shared workspace, **Then** the runtime rejects the operation with `unauthorized_workspace`.
-3. **Given** a shared workspace, **When** one member deregisters a capability, **Then** the other member immediately loses the ability to resolve that capability from the workspace.
+At minimum, audit entries MUST include:
 
-### User Story 4 — Admin Workspace for System Operations (Priority: P2)
+- timestamp
+- workspace_id
+- event_type
+- subject_id or actor_id when available
+- effective scopes when relevant
+- target resource when relevant
+- outcome
+- traverse_code for failures
 
-As a platform administrator, I want to use a privileged token to list all workspaces and inspect their metadata via the reserved `system` workspace so that I can audit multi-agent usage without needing individual workspace access.
+## Errors
 
-**Why this priority**: Administrative visibility is required for operations, debugging, and compliance without compromising per-workspace isolation.
+Error response shape is governed by `033-http-json-api`.
 
-**Independent Test**: Issue a request scoped to `system` with a JWT carrying a privileged role claim. Verify the response lists all active workspaces. Issue the same request with a non-privileged token and verify rejection.
+Required mappings:
 
-**Acceptance Scenarios**:
-
-1. **Given** a JWT with a privileged role claim, **When** the caller submits a request scoped to workspace `system`, **Then** the runtime returns a list of all active workspaces with their metadata.
-2. **Given** a JWT without a privileged role claim, **When** the caller attempts any operation scoped to workspace `system`, **Then** the runtime rejects the request with `insufficient_privileges`.
-3. **Given** a new workspace is created by an agent, **When** an admin lists workspaces via the `system` scope, **Then** the new workspace appears in the listing with accurate metadata.
-
-## Edge Cases
-
-- `subject_id` derived from an expired JWT — the runtime MUST reject the request without consulting cached identity state; no stale identity may be used for authorization.
-- `workspace_id` that is an empty string or contains only whitespace — reject at the validation boundary with a `workspace_id_invalid` error before any registry operation.
-- Concurrent creation of the same workspace by two agents — idempotent; workspace creation is keyed on `workspace_id` and the second creation attempt returns the existing workspace without error.
-- A legacy-style request that omits `workspace_id` entirely — reject with a `workspace_id_required` migration error containing a pointer to the migration guide; do not silently default to a global scope.
-- A subject attempting to create a workspace it already owns — idempotent; return the existing workspace.
-- A shared workspace with zero members — treat as inaccessible; no subject can access it until at least one member is added.
-- The `system` workspace cannot be deleted, renamed, or declared `shared: true` — any such attempt MUST be rejected with `reserved_workspace`.
-- A request that references a workspace id that does not exist — reject with `workspace_not_found` before any registry lookup.
+- Missing/invalid credentials: `401`, `traverse_code: "unauthenticated"`
+- Valid credentials without scope: `403`, `traverse_code: "unauthorized"`
+- Unauthorized workspace access: `403`, `traverse_code: "unauthorized_workspace"`
+- Invalid workspace id: `422`, `traverse_code: "workspace_id_invalid"`
+- Missing workspace id in production: `400`, `traverse_code: "workspace_id_required"`
 
 ## Functional Requirements
 
-- **FR-001**: Every registry API operation (capability registration, deregistration, lookup, event registration, workflow registration) MUST accept `workspace_id` as a required field.
-- **FR-002**: The runtime MUST enforce that `workspace_id` is present and non-empty on every incoming request before executing any business logic; absence MUST produce a `workspace_id_required` error.
-- **FR-003**: The runtime MUST validate `workspace_id` is a non-empty, non-whitespace string of at most 128 characters consisting of alphanumeric characters, hyphens, dots, and underscores only.
-- **FR-004**: Every registry lookup MUST be scoped to the provided `workspace_id` and MUST NOT return results from any other workspace unless the requesting subject has explicit shared-workspace access.
-- **FR-005**: The runtime MUST derive `subject_id` from the validated JWT on every request and MUST NOT accept a caller-supplied `subject_id`.
-- **FR-006**: The runtime MUST verify that the `subject_id` derived from the JWT is the owner of the referenced `workspace_id` or is a declared member of a shared workspace before executing any registry operation.
-- **FR-007**: Authorization failure MUST produce an `unauthorized_workspace` error and MUST NOT leak any workspace metadata, capability names, or event names from the rejected workspace.
-- **FR-008**: Workspace creation MUST be idempotent — submitting a create request for an existing `workspace_id` owned by the same subject MUST return the existing workspace without modifying it.
-- **FR-009**: A workspace MUST support a `shared` boolean flag; default value is `false`; a workspace owner MAY set `shared: true` to enable multi-subject access.
-- **FR-010**: When `shared: true`, the workspace owner MUST provide an explicit member list of `subject_id` values; the runtime MUST enforce that only listed subjects can access the workspace.
-- **FR-011**: Two workspaces MAY register capabilities with the same capability id without conflict; the registry MUST distinguish registrations by `(workspace_id, capability_id)` composite key.
-- **FR-012**: The `system` workspace_id MUST be reserved; the runtime MUST reject any attempt to create, delete, rename, or modify the `system` workspace by a non-privileged caller.
-- **FR-013**: Operations scoped to the `system` workspace MUST require a JWT carrying a privileged role claim; requests without the privileged claim MUST be rejected with `insufficient_privileges`.
-- **FR-014**: The `system` workspace MUST support a `list_workspaces` operation that returns all active workspace metadata (ids, owners, shared flag, member count, creation timestamp).
-- **FR-015**: JWT expiry MUST be re-validated on every request; the runtime MUST NOT use a cached `subject_id` from a previous request once the JWT has expired.
-- **FR-016**: Registry state mutations (registration, deregistration, membership changes) within one workspace MUST be immediately visible to all subjects with access to that workspace on subsequent requests.
-- **FR-017**: Concurrent creation of the same workspace by two agents MUST be handled atomically; exactly one creation wins and the other receives the existing workspace; neither request MUST see an error.
-- **FR-018**: The runtime MUST emit a structured workspace audit event for each workspace creation, deletion, membership change, and authorization failure.
-- **FR-019**: Workspace deletion MUST atomically deregister all capabilities, events, and workflows associated with that workspace.
-- **FR-020**: The runtime MUST propagate `workspace_id` through all internal execution contexts so that trace artifacts and state events are labelled with the workspace scope.
+- **FR-001**: Every registry, runtime, trace, event subscription, and audit operation MUST be workspace-scoped.
+- **FR-002**: Production/non-loopback requests MUST require bearer auth.
+- **FR-003**: Dev-loopback mode MAY mint a local ephemeral bearer token.
+- **FR-004**: Dev-loopback discovery files containing tokens MUST use owner-read/write permissions on Unix-like systems.
+- **FR-005**: v0 authorization MUST be scope-based.
+- **FR-006**: v0 MUST define the minimum scopes listed in this spec.
+- **FR-007**: Dev-loopback mode MAY make scopes optional but SHOULD expose effective scopes in responses.
+- **FR-008**: The runtime MUST derive identity from validated credentials and MUST NOT trust caller-supplied identity fields.
+- **FR-009**: Workspace access requires the required scope for the operation.
+- **FR-010**: Unauthorized workspace access MUST return `403` without leaking workspace metadata.
+- **FR-011**: Module blast radius MUST be limited to the workspace plus explicitly delegated resources.
+- **FR-012**: Modules MUST declare static manifest permissions.
+- **FR-013**: Runtime grants MUST support `execution` and `session` lifetimes.
+- **FR-014**: Runtime grants MUST require approval by a caller with `grants:approve`.
+- **FR-015**: Runtime grants MUST be audited.
+- **FR-016**: Registration attempts, runtime grants, and auth failures MUST write audit log entries.
+- **FR-017**: Audit logs MUST be workspace-local append-only JSONL files.
+- **FR-018**: Audit logs MUST NOT contain bearer tokens or raw secrets.
 
-## Non-Functional Requirements
+## Quality Gates
 
-- **NFR-001 Correctness**: Cross-workspace data leakage MUST be treated as a critical defect; no registry query path may return results from a workspace not matching the resolved scope.
-- **NFR-002 Determinism**: Authorization decisions and workspace lookup results MUST be deterministic for the same JWT, workspace state, and request input.
-- **NFR-003 Performance**: Workspace authorization and registry scoping MUST add no more than one additional indexed lookup per request compared to the pre-isolation baseline.
-- **NFR-004 Testability**: Workspace isolation, authorization enforcement, shared workspace access, and system workspace privilege checks MUST each be independently testable without requiring a running JWT issuer.
-- **NFR-005 Auditability**: Every authorization failure and workspace mutation MUST produce a structured, machine-readable audit event suitable for compliance review.
-- **NFR-006 Compatibility**: The addition of `workspace_id` MUST be a versioned, semver-disciplined breaking change; legacy clients without `workspace_id` MUST receive a `workspace_id_required` error rather than silent degradation.
-- **NFR-007 Maintainability**: Workspace resolution, authorization enforcement, and scoped registry lookup MUST be implemented as clearly separated concerns within `traverse-runtime` and `traverse-registry`.
-
-## Non-Negotiable Quality Standards
-
-- **QG-001**: No registry read or write operation MAY return or modify data from a workspace that the caller does not own or have explicit shared access to; any such cross-workspace access is a blocker defect.
-- **QG-002**: JWT expiry MUST be checked on every inbound request; stale identity MUST never be used to authorize a workspace operation.
-- **QG-003**: Authorization failures MUST NOT leak workspace metadata, capability names, or event names from the rejected workspace in any error response or audit trail visible to the unauthorized caller.
-- **QG-004**: 100% automated line coverage is required for workspace authorization, scoped registry lookup, shared workspace access enforcement, and system workspace privilege checks.
-- **QG-005**: Workspace isolation behavior MUST align with this governing spec and fail the spec-alignment CI gate when drift occurs.
-
-## Key Entities
-
-- **Workspace**: A named, subject-owned scope within the Traverse registry. All registry objects (capabilities, events, workflows) belong to exactly one workspace.
-- **workspace_id**: The stable string identifier for a workspace. Required on all API calls. Validated for format at the request boundary.
-- **subject_id**: The identity of the caller, derived from the validated JWT. The runtime MUST derive this value; callers MUST NOT supply it directly.
-- **Workspace Member**: A `subject_id` explicitly granted access to a shared workspace by the workspace owner.
-- **Shared Workspace**: A workspace declared `shared: true` with an explicit member list. Multiple subjects may register and execute capabilities within a shared workspace.
-- **System Workspace**: The reserved `system` workspace_id. Supports privileged administrative operations. Cannot be created, deleted, or modified by unprivileged callers.
-- **Workspace Audit Event**: A structured event emitted on workspace creation, deletion, membership change, or authorization failure.
+- **QG-001**: Cross-workspace registry leakage is a blocking defect.
+- **QG-002**: Non-loopback unauthenticated access is a blocking defect.
+- **QG-003**: Missing audit entries for registration, runtime grants, or auth failures are blocking defects.
+- **QG-004**: Bearer tokens appearing in traces, telemetry, or audit logs are blocking security defects.
+- **QG-005**: Runtime grants that outlive their declared lifetime are blocking defects.
 
 ## Success Criteria
 
-- **SC-001**: Two agents under distinct subject identities cannot observe each other's registry registrations when each operates within its own workspace.
-- **SC-002**: A runtime request that omits `workspace_id` is rejected with `workspace_id_required` before any registry lookup occurs.
-- **SC-003**: A shared workspace correctly grants access to all declared members and rejects all non-members.
-- **SC-004**: The `system` workspace rejects unprivileged callers and returns a correct workspace listing to privileged callers.
-- **SC-005**: Concurrent workspace creation with the same `workspace_id` is idempotent and produces no error for either caller.
-- **SC-006**: 100% automated line coverage is achieved for all workspace isolation and authorization paths.
-
-## Out of Scope
-
-- Distributed cross-process workspace federation
-- Workspace quota enforcement (capability count limits, event volume limits)
-- Workspace billing or usage metering
-- JWT issuance or key management (handled by the identity layer per spec 030)
-- Workspace templates or cloning
-- Role-based access control within a workspace (fine-grained per-capability permissions)
-- Cross-workspace capability sharing without shared workspace declaration
+- **SC-001**: Two workspaces can register the same artifact id/version without visibility or mutation conflicts.
+- **SC-002**: Non-loopback requests without valid bearer auth return `401`.
+- **SC-003**: Valid credentials without required scopes return `403`.
+- **SC-004**: Dev-loopback mode produces usable local discovery metadata with safe token permissions.
+- **SC-005**: Execution-scoped grants expire when execution ends.
+- **SC-006**: Session-scoped grants expire when the session ends.
+- **SC-007**: Registration, runtime grant, and auth failure audit entries are written as JSONL.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -344,18 +344,19 @@
     },
     {
       "id": "033-http-json-api",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "approved",
       "immutable": true,
       "path": "specs/033-http-json-api/spec.md",
       "governs": [
         "crates/traverse-cli/",
-        "crates/traverse-runtime/"
+        "crates/traverse-runtime/",
+        "specs/033-http-json-api/openapi.yaml"
       ]
     },
     {
       "id": "034-programmatic-registration",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "approved",
       "immutable": true,
       "path": "specs/034-programmatic-registration/spec.md",
@@ -366,7 +367,7 @@
     },
     {
       "id": "035-multi-agent-isolation",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "approved",
       "immutable": true,
       "path": "specs/035-multi-agent-isolation/spec.md",


### PR DESCRIPTION
Fixes #300.
Fixes #302.
Fixes #303.

## Summary
- Amends specs 033/034/035 to v1.1.0 with the approved app-consumable HTTP/Auth/Registration decisions.
- Adds the required OpenAPI YAML artifact for the HTTP+JSON API.
- Adds lightweight OpenAPI structural validation and wires it into repository checks.

## Governing Spec
- 004-spec-alignment-gate
- 033-http-json-api
- 034-programmatic-registration
- 035-multi-agent-isolation

## Project Item
- #300
- #302
- #303

## Implementation Ticket Plan
- Create one blocked implementation ticket per endpoint/feature after GitHub project auth is refreshed.
- Implementation branches may start while the spec PR is open, but implementation PRs must not merge until this spec PR is merged.

## Validation
- bash scripts/ci/openapi_structural_validation.sh
- bash scripts/ci/repository_checks.sh
