### PR TITLE
docs: add spec routing and implementation context

### DIFF
--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -104,9 +104,14 @@ required_files=(
   "specs/022-mcp-wasm-server/checklists/requirements.md"
   "specs/033-http-json-api/spec.md"
   "specs/033-http-json-api/openapi.yaml"
+  "specs/033-http-json-api/context.md"
   "specs/034-programmatic-registration/spec.md"
+  "specs/034-programmatic-registration/context.md"
   "specs/035-multi-agent-isolation/spec.md"
+  "specs/035-multi-agent-isolation/context.md"
+  "specs/README.md"
   "scripts/ci/openapi_structural_validation.sh"
+  "scripts/ci/spec_context_check.sh"
 )
 
 for file in "${required_files[@]}"; do
@@ -213,6 +218,7 @@ grep -q "execute_entrypoint" docs/mcp-real-agent-exercise.md
 grep -q "render_execution_report" docs/mcp-real-agent-exercise.md
 
 bash scripts/ci/openapi_structural_validation.sh
+bash scripts/ci/spec_context_check.sh
 grep -q "scripts/smoke.sh" docs/youaskm3-real-shell-validation.md
 grep -q "apps/browser-consumer/README.md" docs/mcp-consumption-validation.md
 grep -q "docs/app-consumable-consumer-bundle.md" README.md

--- a/scripts/ci/spec_context_check.sh
+++ b/scripts/ci/spec_context_check.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_files=(
+  "specs/README.md"
+  "specs/033-http-json-api/context.md"
+  "specs/034-programmatic-registration/context.md"
+  "specs/035-multi-agent-isolation/context.md"
+)
+
+for file in "${required_files[@]}"; do
+  test -f "$file"
+  test -s "$file"
+done
+
+grep -q "split, focused governing specs" specs/README.md
+grep -q "033-http-json-api" specs/README.md
+grep -q "034-programmatic-registration" specs/README.md
+grep -q "035-multi-agent-isolation" specs/README.md
+grep -q "029-integrated-observability" specs/README.md
+grep -q "043-module-dependency-management" specs/README.md
+
+grep -q "#387" specs/033-http-json-api/context.md
+grep -q "#390" specs/033-http-json-api/context.md
+grep -q "#396" specs/033-http-json-api/context.md
+grep -q "Problem Details" specs/033-http-json-api/context.md
+grep -q "openapi.yaml" specs/033-http-json-api/context.md
+
+grep -q "#397" specs/034-programmatic-registration/context.md
+grep -q "#400" specs/034-programmatic-registration/context.md
+grep -q "All-or-nothing" specs/034-programmatic-registration/context.md
+grep -q "session_ephemeral" specs/034-programmatic-registration/context.md
+
+grep -q "#401" specs/035-multi-agent-isolation/context.md
+grep -q "#403" specs/035-multi-agent-isolation/context.md
+grep -q "workspace_id" specs/035-multi-agent-isolation/context.md
+grep -q "grants:approve" specs/035-multi-agent-isolation/context.md
+
+echo "Spec context check passed."

--- a/specs/033-http-json-api/context.md
+++ b/specs/033-http-json-api/context.md
@@ -1,0 +1,46 @@
+# Implementation Context: HTTP+JSON Runtime API
+
+## Owns
+
+- `traverse-cli serve` app-facing HTTP surface.
+- Local discovery file `.traverse/server.json`.
+- `GET /healthz`.
+- `POST /v1/workspaces/{workspace_id}/execute`.
+- `GET /v1/workspaces/{workspace_id}/executions/{execution_id}`.
+- `GET /v1/workspaces/{workspace_id}/traces/{execution_id}`.
+- JSON envelopes, links, API versioning, CORS, idempotency key behavior, Problem Details shape, and OpenAPI structure.
+
+## Does Not Own
+
+- Registration semantics; use `034-programmatic-registration`.
+- Workspace auth, scopes, runtime grants, and audit rules; use `035-multi-agent-isolation`.
+- Complete telemetry/export semantics; use `029-integrated-observability`.
+- Contract enforcement semantics; use `040-contractual-enforcement-gate`.
+
+## Key Invariants
+
+- `v1` paths must not receive breaking changes after approval.
+- Response envelopes include `api_version`.
+- Mutation requests reject unknown fields.
+- Errors use RFC 9457 Problem Details with `traverse_code`.
+- Local dev may default to `local-default`; production requires explicit workspace.
+- Dev-loopback default bind is `127.0.0.1:8787`.
+- If `.traverse/server.json` contains a token, Unix-like permissions must be `0600`.
+- CORS permits common loopback origins in local dev and exact configured origins in production; wildcard production CORS is not allowed.
+
+## Artifacts
+
+- Governing spec: `specs/033-http-json-api/spec.md`.
+- OpenAPI surface: `specs/033-http-json-api/openapi.yaml`.
+- Structural validation: `scripts/ci/openapi_structural_validation.sh`.
+
+## Implementation Tickets
+
+- `#387` implements `traverse-cli serve` defaults and repo-local discovery.
+- `#390` implements `GET /healthz`.
+- `#391` implements sync and async execute envelopes.
+- `#392` implements execution status fetch.
+- `#393` implements public trace fetch.
+- `#394` implements Problem Details errors.
+- `#395` implements mutation `Idempotency-Key`.
+- `#396` implements CORS policy.

--- a/specs/034-programmatic-registration/context.md
+++ b/specs/034-programmatic-registration/context.md
@@ -1,0 +1,43 @@
+# Implementation Context: Programmatic Registration API
+
+## Owns
+
+- Registration behavior for capabilities, event contracts, workflows, and bundles.
+- Workspace-scoped persistence semantics.
+- `workspace_persisted` and `session_ephemeral` registration scopes.
+- Idempotent same-digest re-registration.
+- Different-digest conflicts.
+- All-or-nothing bundle registration.
+- Pre-storage validation requirement.
+
+## Does Not Own
+
+- HTTP envelope, path versioning, CORS, and Problem Details shape; use `033-http-json-api`.
+- Auth scopes and audit storage mechanics; use `035-multi-agent-isolation`.
+- Dependency resolution; use `043-module-dependency-management`.
+- Contract enforcement policy; use `040-contractual-enforcement-gate`.
+
+## Key Invariants
+
+- Invalid artifacts must never be persisted, cached as active registrations, or made executable.
+- Same id/version/digest is idempotent success.
+- Same id/version with a different digest returns `409 Conflict`.
+- Validation failure returns `422`.
+- Bundle registration validates every artifact before writing any artifact.
+- Partial bundle success is not allowed in v0.
+- Registration mutations should support `Idempotency-Key` as defined by `033-http-json-api`.
+
+## Dependencies
+
+- Capability registry: `005-capability-registry`.
+- Event registry: `011-event-registry`.
+- Workflow registry/traversal: `007-workflow-registry-traversal`.
+- HTTP transport: `033-http-json-api`.
+- Workspace isolation and audit: `035-multi-agent-isolation`.
+
+## Implementation Tickets
+
+- `#397` implements capability registration.
+- `#398` implements event contract registration.
+- `#399` implements workflow registration.
+- `#400` implements atomic bundle registration.

--- a/specs/035-multi-agent-isolation/context.md
+++ b/specs/035-multi-agent-isolation/context.md
@@ -1,0 +1,46 @@
+# Implementation Context: Workspace Auth and Multi-Agent Isolation
+
+## Owns
+
+- Workspace identity and isolation.
+- `dev-loopback` and `bearer-required` auth modes.
+- OIDC-style bearer JWT identity interpretation.
+- Scope-based authorization.
+- Runtime grants.
+- Local dev token discovery requirements.
+- Workspace-local append-only JSONL audit log requirements.
+
+## Does Not Own
+
+- HTTP endpoint envelope and CORS mechanics; use `033-http-json-api`.
+- Registration mutation semantics; use `034-programmatic-registration`.
+- Artifact provenance and signing; use `031-supply-chain-hardening`.
+- Broader trust model direction; use `030-security-identity-model`.
+
+## Key Invariants
+
+- `workspace_id` is the isolation boundary for runtime, registry, trace, event subscription, and audit operations.
+- Non-dev bindings require `Authorization: Bearer <token>`.
+- Missing or invalid credentials return `401`.
+- Valid credentials without required scope return `403`.
+- Tokens must not appear in telemetry, trace output, or audit logs.
+- Callers must not provide trusted `subject_id` or `actor_id` in request bodies.
+- v0 enforcement is scope-based, not role-based.
+- Runtime grants are temporary only in v0: `execution` or `session`.
+- Runtime grants require approval by a caller with `grants:approve`.
+
+## Minimum Scopes
+
+- `workspace:read`.
+- `runtime:execute`.
+- `runtime:trace:read`.
+- `registry:read`.
+- `registry:write`.
+- `events:subscribe`.
+- `grants:approve`.
+
+## Implementation Tickets
+
+- `#401` implements workspace scopes and bearer authorization.
+- `#402` implements runtime grants.
+- `#403` implements workspace audit JSONL logs.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,48 @@
+# Traverse Spec Routing Guide
+
+Traverse uses split, focused governing specs instead of one giant spec file. This keeps the context load small for agents and reviewers: start here, open only the owning spec, then follow the listed dependencies when the change crosses a boundary.
+
+## Routing Rules
+
+- Start with the row that owns the behavior you are changing.
+- Read the owning `spec.md` before implementation.
+- Read `context.md` when it exists; it summarizes invariants, non-ownership, and issue mappings for low-context agent work.
+- Do not duplicate rules across specs. Cross-reference the owning spec instead.
+- If two specs appear to own the same rule, update this guide or create a clarification ticket before implementation.
+
+## App-Consumable Runtime Cluster
+
+| Question | Owning spec | Context file |
+| --- | --- | --- |
+| HTTP endpoints, response envelopes, errors, CORS, OpenAPI, local server discovery | `033-http-json-api` | `specs/033-http-json-api/context.md` |
+| Capability, event contract, workflow, and bundle registration semantics | `034-programmatic-registration` | `specs/034-programmatic-registration/context.md` |
+| Workspace identity, bearer auth, scopes, runtime grants, and audit log rules | `035-multi-agent-isolation` | `specs/035-multi-agent-isolation/context.md` |
+
+## Strategic Spec Ownership
+
+| Question | Owning spec |
+| --- | --- |
+| Integrated telemetry, traces, metrics, log semantics | `029-integrated-observability` |
+| Security model, trust boundaries, identity direction | `030-security-identity-model` |
+| Supply chain hardening, provenance, artifact trust | `031-supply-chain-hardening` |
+| Portable state and data access constraints | `032-universal-data-access` |
+| Event delivery, replay, and missed-event recovery | `036-event-subscription-replay` |
+| Semver range matching and compatible version selection | `037-semver-range-resolution` |
+| WASI and host ABI insulation from standards churn | `038-wasi-host-insulation` |
+| Connector/plugin model and third-party integrations | `039-connector-plugin-architecture` |
+| Contractual enforcement gates and fail-fast validation | `040-contractual-enforcement-gate` |
+| Programmatic workflow building and composition | `041-workflow-composition-api` |
+| MCP library surface and embeddable agent APIs | `042-mcp-library-surface` |
+| Module dependency registry and resolution strategy | `043-module-dependency-management` |
+
+## Context Hygiene
+
+Implementation agents should prefer this read order:
+
+1. `specs/README.md`
+2. owning `context.md`, when present
+3. owning `spec.md`
+4. directly referenced specs only
+5. related implementation ticket and PR
+
+This pattern is intentionally boring. Boring here means fewer accidental cross-spec rewrites, smaller LLM prompts, and less archaeology before code can move.


### PR DESCRIPTION
## Summary

Add a low-context spec routing layer so agents can find the owning Traverse spec without reading every approved document.

## Governing Spec

- `004-spec-alignment-gate`
- `033-http-json-api`
- `034-programmatic-registration`
- `035-multi-agent-isolation`

## Project Item

- Closes #405
- GitHub Project 1 item is marked In Progress and assigned to Codex.

## What Changed

- Contracts changed: none.
- Runtime behavior changed: none.
- Compatibility impact: additive documentation and CI guard only.
- ADR needed or linked: none; this is spec-discoverability documentation under approved specs.

## Validation

- [x] Spec alignment checked: `bash scripts/ci/repository_checks.sh`
- [x] Contract alignment checked: no contract changes.
- [x] Tests updated and passing: `bash scripts/ci/spec_context_check.sh`
- [x] Core coverage preserved: no runtime/core code changes.
- [x] Required validation gates passing locally: `bash scripts/ci/repository_checks.sh`

## Notes

This keeps Traverse on split specs rather than one giant spec file, while giving implementation agents a first-stop routing guide and short context files for specs `033`, `034`, and `035`.
