### PR TITLE
feat: add serve discovery file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.agents/skills/
 !.agents/skills/**
 target/
+.traverse/
 .DS_Store
 *.profraw
 *.profdata

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::{IpAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 use traverse_contracts::{CapabilityContract, parse_contract};
 use traverse_registry::{
     ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
@@ -23,6 +24,8 @@ const SYSTEM_WORKSPACE_ID: &str = "system";
 const SYSTEM_ADMIN_SUBJECT: &str = "system_admin";
 const PERSISTED_REGISTRY_SCHEMA_VERSION: &str = "1.0.0";
 const WORKSPACE_METADATA_SCHEMA_VERSION: &str = "1.0.0";
+const DEFAULT_WORKSPACE_ID: &str = "local-default";
+const SERVER_DISCOVERY_SCHEMA_VERSION: &str = "1.0.0";
 
 /// Errors that can occur while serving the HTTP/JSON API.
 #[derive(Debug)]
@@ -44,7 +47,7 @@ impl std::fmt::Display for ServeError {
 
 /// Configuration for the HTTP/JSON API server.
 pub struct ApiServerConfig<E> {
-    pub port: u16,
+    pub bind_address: String,
     pub allow_unauthenticated: bool,
     pub capability_registry: CapabilityRegistry,
     pub workflow_registry: WorkflowRegistry,
@@ -90,6 +93,19 @@ struct PersistedWorkflowRegistrationV1 {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+struct ServerDiscoveryV1 {
+    schema_version: String,
+    base_url: String,
+    health_url: String,
+    workspace_default: String,
+    pid: u32,
+    started_at: String,
+    auth_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    local_dev_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct WorkspaceMetadataV1 {
     schema_version: String,
     workspace_id: String,
@@ -128,13 +144,22 @@ pub fn serve_http_api<E>(config: ApiServerConfig<E>) -> Result<(), ServeError>
 where
     E: LocalExecutor + Clone,
 {
-    let bind_addr = format!("0.0.0.0:{}", config.port);
-    let listener = TcpListener::bind(&bind_addr)
-        .map_err(|e| ServeError::BindFailed(format!("{bind_addr}: {e}")))?;
+    let listener = TcpListener::bind(&config.bind_address)
+        .map_err(|e| ServeError::BindFailed(format!("{}: {e}", config.bind_address)))?;
 
     let local_addr = listener
         .local_addr()
         .map_err(|e| ServeError::BindFailed(format!("could not read local address: {e}")))?;
+    let auth_mode = if local_addr.ip().is_loopback() {
+        "dev-loopback"
+    } else {
+        "bearer-required"
+    };
+    let local_dev_token = if local_addr.ip().is_loopback() {
+        Some(mint_local_dev_token(&local_addr.to_string()))
+    } else {
+        None
+    };
 
     if config.allow_unauthenticated {
         eprintln!(
@@ -147,6 +172,14 @@ where
         "traverse-cli serve: HTTP/JSON API listening on http://{local_addr} (spec 033-http-json-api)"
     );
     let _ = std::io::stderr().flush();
+
+    write_server_discovery(
+        Path::new("."),
+        &format!("http://{local_addr}"),
+        auth_mode,
+        local_dev_token.as_deref(),
+    )
+    .map_err(ServeError::BindFailed)?;
 
     let mut workspaces = HashMap::new();
     workspaces.insert(
@@ -181,6 +214,69 @@ where
         }
     }
 
+    Ok(())
+}
+
+fn mint_local_dev_token(local_addr: &str) -> String {
+    let now = unix_timestamp();
+    format!(
+        "trv_local_{}_{}",
+        std::process::id(),
+        crate::agent_packages::fnv1a64(format!("{local_addr}:{now}").as_bytes())
+    )
+}
+
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn write_server_discovery(
+    repo_root: &Path,
+    base_url: &str,
+    auth_mode: &str,
+    local_dev_token: Option<&str>,
+) -> Result<PathBuf, String> {
+    let traverse_dir = repo_root.join(".traverse");
+    std::fs::create_dir_all(&traverse_dir)
+        .map_err(|e| format!("failed to create .traverse directory: {e}"))?;
+    let discovery_path = traverse_dir.join("server.json");
+    let discovery = ServerDiscoveryV1 {
+        schema_version: SERVER_DISCOVERY_SCHEMA_VERSION.to_string(),
+        base_url: base_url.to_string(),
+        health_url: format!("{base_url}/healthz"),
+        workspace_default: DEFAULT_WORKSPACE_ID.to_string(),
+        pid: std::process::id(),
+        started_at: generated_registered_at().map_err(|e| e.message)?,
+        auth_mode: auth_mode.to_string(),
+        local_dev_token: local_dev_token.map(str::to_string),
+    };
+    let body = serde_json::to_vec_pretty(&discovery)
+        .map_err(|e| format!("failed to serialize server discovery file: {e}"))?;
+    std::fs::write(&discovery_path, body)
+        .map_err(|e| format!("failed to write {}: {e}", discovery_path.display()))?;
+    if local_dev_token.is_some() {
+        set_owner_read_write(&discovery_path)?;
+    }
+    Ok(discovery_path)
+}
+
+#[cfg(unix)]
+fn set_owner_read_write(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|e| {
+        format!(
+            "failed to set owner-only permissions on {}: {e}",
+            path.display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn set_owner_read_write(_path: &Path) -> Result<(), String> {
     Ok(())
 }
 
@@ -2627,6 +2723,56 @@ mod tests {
         assert_eq!(body["api_version"], "v1");
         assert_eq!(body["workspace_default"], "local-default");
         assert_eq!(body["auth_mode"], "bearer-required");
+    }
+
+    #[test]
+    fn server_discovery_file_contains_health_url_and_local_token_metadata() {
+        let repo_root = test_registry_root();
+        let discovery_path = write_server_discovery(
+            &repo_root,
+            "http://127.0.0.1:8787",
+            "dev-loopback",
+            Some("local-token"),
+        )
+        .expect("discovery file must be written");
+
+        assert_eq!(discovery_path, repo_root.join(".traverse/server.json"));
+        let body = std::fs::read_to_string(&discovery_path).expect("discovery file must be read");
+        let json: Value = serde_json::from_str(&body).expect("discovery must be valid json");
+        assert_eq!(json["schema_version"], SERVER_DISCOVERY_SCHEMA_VERSION);
+        assert_eq!(json["base_url"], "http://127.0.0.1:8787");
+        assert_eq!(json["health_url"], "http://127.0.0.1:8787/healthz");
+        assert_eq!(json["workspace_default"], DEFAULT_WORKSPACE_ID);
+        assert_eq!(json["auth_mode"], "dev-loopback");
+        assert_eq!(json["local_dev_token"], "local-token");
+        assert!(json["pid"].as_u64().is_some());
+        assert!(
+            json["started_at"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn token_bearing_discovery_file_is_owner_read_write_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let repo_root = test_registry_root();
+        let discovery_path = write_server_discovery(
+            &repo_root,
+            "http://127.0.0.1:8787",
+            "dev-loopback",
+            Some("local-token"),
+        )
+        .expect("discovery file must be written");
+
+        let mode = std::fs::metadata(&discovery_path)
+            .expect("metadata must be readable")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
     }
 
     // ------------------------------------------------------------------

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -90,7 +90,7 @@ enum Command {
         workspace_id: String,
     },
     Serve {
-        port: u16,
+        bind_address: String,
         allow_unauthenticated: bool,
     },
 }
@@ -134,10 +134,10 @@ fn main() -> ExitCode {
             }
         }
         Ok(Command::Serve {
-            port,
+            bind_address,
             allow_unauthenticated,
         }) => {
-            if let Err(error) = run_serve(port, allow_unauthenticated) {
+            if let Err(error) = run_serve(bind_address, allow_unauthenticated) {
                 eprintln!("{error}");
                 ExitCode::FAILURE
             } else {
@@ -643,11 +643,11 @@ fn parse_browser_adapter_command(args: &[String]) -> Result<Command, String> {
 }
 
 fn help_serve() -> String {
-    "traverse-cli serve [--port <port>] [--allow-unauthenticated]
+    "traverse-cli serve [--bind <address>] [--port <port>] [--allow-unauthenticated]
 
   Purpose:
-    Start a long-running HTTP/JSON API server on 0.0.0.0:<port>. Exposes three
-    endpoints under /v1/:
+    Start a long-running HTTP/JSON API server on 127.0.0.1:8787 by default.
+    Writes .traverse/server.json for local app discovery and exposes:
       GET  /healthz                    Returns the spec 033 health envelope.
       GET  /v1/capabilities            Returns JSON array of registered capabilities.
       POST /v1/capabilities/execute    Accepts RuntimeRequest JSON, returns trace + result.
@@ -657,7 +657,8 @@ fn help_serve() -> String {
     --allow-unauthenticated is set.
 
   Optional flags:
-    --port <N>                 Port to listen on (default: 8080).
+    --bind <address>           Address and port to listen on (default: 127.0.0.1:8787).
+    --port <N>                 Compatibility shortcut for --bind 127.0.0.1:<N>.
     --allow-unauthenticated    Accept unauthenticated requests from non-loopback
                                addresses. Prints a warning to stderr. Unsafe in
                                production.
@@ -665,36 +666,47 @@ fn help_serve() -> String {
 
   Example:
     traverse-cli serve
-    traverse-cli serve --port 9090
+    traverse-cli serve --bind 127.0.0.1:9090
     traverse-cli serve --port 9090 --allow-unauthenticated"
         .to_string()
 }
 
 fn parse_serve_command(args: &[String]) -> Result<Command, String> {
     let allow_unauthenticated = args.iter().any(|a| a == "--allow-unauthenticated");
-
+    let bind_flag_pos = args.iter().position(|a| a == "--bind");
     let port_flag_pos = args.iter().position(|a| a == "--port");
-    let port: u16 = if let Some(pos) = port_flag_pos {
+
+    if bind_flag_pos.is_some() && port_flag_pos.is_some() {
+        return Err("--bind and --port cannot be used together".to_string());
+    }
+
+    let bind_address = if let Some(pos) = bind_flag_pos {
         args.get(pos + 1)
+            .ok_or_else(|| "--bind requires a value".to_string())?
+            .clone()
+    } else if let Some(pos) = port_flag_pos {
+        let port = args
+            .get(pos + 1)
             .ok_or_else(|| "--port requires a value".to_string())?
             .parse::<u16>()
-            .map_err(|_| "--port value must be a valid port number (0-65535)".to_string())?
+            .map_err(|_| "--port value must be a valid port number (0-65535)".to_string())?;
+        format!("127.0.0.1:{port}")
     } else {
-        8080
+        "127.0.0.1:8787".to_string()
     };
 
     Ok(Command::Serve {
-        port,
+        bind_address,
         allow_unauthenticated,
     })
 }
 
-fn run_serve(port: u16, allow_unauthenticated: bool) -> Result<(), String> {
+fn run_serve(bind_address: String, allow_unauthenticated: bool) -> Result<(), String> {
     let registered =
         load_registered_bundle(&canonical_expedition_bundle_path()).map_err(|e| e.to_string())?;
 
     let config = http_api::ApiServerConfig {
-        port,
+        bind_address,
         allow_unauthenticated,
         capability_registry: registered.capability_registry,
         workflow_registry: registered.workflow_registry,
@@ -1163,7 +1175,7 @@ fn workflow_inspect(
 fn build_in_process_api() -> Result<http_api::InProcessApi<ExpeditionExampleExecutor>, CliError> {
     let registered = load_registered_bundle(&canonical_expedition_bundle_path())?;
     Ok(http_api::InProcessApi::new(http_api::ApiServerConfig {
-        port: 0,
+        bind_address: "127.0.0.1:0".to_string(),
         allow_unauthenticated: true,
         capability_registry: registered.capability_registry,
         workflow_registry: registered.workflow_registry,
@@ -1515,7 +1527,7 @@ fn render_trace_summary(trace_path: &Path, trace: &RuntimeTrace) -> String {
 }
 
 fn usage() -> String {
-    "usage: traverse-cli <bundle|agent|event|trace|workflow|expedition|federation> <inspect|register|execute|peers|sync|status> <artifact-path> [request-path] [--trace-out <trace-path>] | traverse-cli browser-adapter serve [--bind <address>] | traverse-cli serve [--port <N>] [--allow-unauthenticated]".to_string()
+    "usage: traverse-cli <bundle|agent|event|trace|workflow|expedition|federation> <inspect|register|execute|peers|sync|status> <artifact-path> [request-path] [--trace-out <trace-path>] | traverse-cli browser-adapter serve [--bind <address>] | traverse-cli serve [--bind <address>] [--port <N>] [--allow-unauthenticated]".to_string()
 }
 
 fn write_trace_artifact(path: &Path, trace: &RuntimeTrace) -> Result<(), CliError> {
@@ -2271,7 +2283,7 @@ mod tests {
     #![allow(clippy::expect_used)]
 
     use super::{
-        execute_agent, execute_expedition, inspect_agent, inspect_bundle, inspect_event,
+        Command, execute_agent, execute_expedition, inspect_agent, inspect_bundle, inspect_event,
         inspect_trace, inspect_workflow, parse_command, register_bundle,
     };
     use crate::agent_packages::fnv1a64;
@@ -2349,6 +2361,82 @@ mod tests {
         assert!(parse_command(&event).is_ok());
         assert!(parse_command(&trace).is_ok());
         assert!(parse_command(&workflow).is_ok());
+    }
+
+    #[test]
+    fn parse_serve_defaults_to_loopback_8787() {
+        let args = vec!["traverse-cli".to_string(), "serve".to_string()];
+
+        let command = parse_command(&args).expect("serve command should parse");
+
+        match command {
+            Command::Serve {
+                bind_address,
+                allow_unauthenticated,
+            } => {
+                assert_eq!(bind_address, "127.0.0.1:8787");
+                assert!(!allow_unauthenticated);
+            }
+            other => assert!(matches!(other, Command::Serve { .. })),
+        }
+    }
+
+    #[test]
+    fn parse_serve_accepts_bind_override() {
+        let args = vec![
+            "traverse-cli".to_string(),
+            "serve".to_string(),
+            "--bind".to_string(),
+            "127.0.0.1:9090".to_string(),
+        ];
+
+        let command = parse_command(&args).expect("serve command should parse");
+
+        match command {
+            Command::Serve { bind_address, .. } => {
+                assert_eq!(bind_address, "127.0.0.1:9090");
+            }
+            other => assert!(matches!(other, Command::Serve { .. })),
+        }
+    }
+
+    #[test]
+    fn parse_serve_keeps_port_as_loopback_shortcut() {
+        let args = vec![
+            "traverse-cli".to_string(),
+            "serve".to_string(),
+            "--port".to_string(),
+            "9090".to_string(),
+            "--allow-unauthenticated".to_string(),
+        ];
+
+        let command = parse_command(&args).expect("serve command should parse");
+
+        match command {
+            Command::Serve {
+                bind_address,
+                allow_unauthenticated,
+            } => {
+                assert_eq!(bind_address, "127.0.0.1:9090");
+                assert!(allow_unauthenticated);
+            }
+            other => assert!(matches!(other, Command::Serve { .. })),
+        }
+    }
+
+    #[test]
+    fn parse_serve_rejects_bind_and_port_together() {
+        let args = vec![
+            "traverse-cli".to_string(),
+            "serve".to_string(),
+            "--bind".to_string(),
+            "127.0.0.1:9090".to_string(),
+            "--port".to_string(),
+            "9091".to_string(),
+        ];
+
+        let error = parse_command(&args).expect_err("bind plus port should be rejected");
+        assert!(error.contains("--bind and --port cannot be used together"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implement the spec 033 `traverse-cli serve` startup defaults and repo-local discovery file.

## Governing Spec

- `033-http-json-api`

## Project Item

- Closes #387
- GitHub Project 1 item is marked In Progress and assigned to Codex.

## What Changed

- Contracts changed: none.
- Runtime behavior changed: `traverse-cli serve` now defaults to `127.0.0.1:8787`, supports `--bind`, keeps `--port` as a loopback compatibility shortcut, writes `.traverse/server.json`, and marks `.traverse/` ignored.
- Compatibility impact: aligns server startup and discovery behavior with approved spec 033 v1.1.0.
- ADR needed or linked: none.

## Validation

- [x] Spec alignment checked: `bash scripts/ci/repository_checks.sh`
- [x] Contract alignment checked: no contract changes.
- [x] Tests updated and passing: `cargo test -p traverse-cli parse_serve`, `cargo test -p traverse-cli server_discovery`, `cargo test -p traverse-cli token_bearing_discovery_file_is_owner_read_write_only`
- [x] Core coverage preserved: `bash scripts/ci/rust_checks.sh`
- [x] Required validation gates passing locally: `cargo fmt --check`, `bash scripts/ci/repository_checks.sh`, `bash scripts/ci/rust_checks.sh`

## Notes

Live smoke passed with `cargo run -p traverse-cli -- serve --bind 127.0.0.1:18787`, `GET /healthz`, and `.traverse/server.json` validation.
