### PR TITLE
feat: enforce WASI host ABI imports

### DIFF
--- a/crates/traverse-cli/src/agent_packages.rs
+++ b/crates/traverse-cli/src/agent_packages.rs
@@ -10,6 +10,7 @@ use traverse_registry::{
     CapabilityRegistration, ComposabilityMetadata, CompositionKind, CompositionPattern,
     ImplementationKind, RegistryProvenance, RegistryScope, SourceKind, SourceReference,
 };
+use traverse_runtime::executor::SUPPORTED_HOST_ABI_VERSION;
 
 const AGENT_PACKAGE_KIND: &str = "agent_package";
 const AGENT_PACKAGE_SCHEMA_VERSION: &str = "1.0.0";
@@ -67,6 +68,7 @@ pub struct AgentBinaryReference {
     pub path: String,
     pub format: String,
     pub expected_digest: String,
+    pub abi_version: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -308,6 +310,11 @@ fn validate_manifest_shape(
         return Err(
             "agent package binary.path and binary.expected_digest must be non-empty".to_string(),
         );
+    }
+    if manifest.binary.abi_version != SUPPORTED_HOST_ABI_VERSION {
+        return Err(format!(
+            "agent package binary.abi_version must equal {SUPPORTED_HOST_ABI_VERSION}"
+        ));
     }
     if manifest.binary.format != "wasm" {
         return Err("agent package binary.format must equal wasm".to_string());

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -26,6 +26,7 @@ use traverse_registry::{
     WorkflowDefinition, WorkflowReference, WorkflowRegistration, WorkflowRegistry,
     load_registry_bundle,
 };
+use traverse_runtime::executor::{SUPPORTED_HOST_ABI_VERSION, verify_wasm_host_abi_bytes};
 use traverse_runtime::{
     LocalExecutionFailure, LocalExecutionFailureCode, LocalExecutor, Runtime,
     RuntimeExecutionOutcome, RuntimeRequest, RuntimeResultStatus, RuntimeTrace,
@@ -51,6 +52,9 @@ enum Command {
     AgentExecute {
         manifest_path: PathBuf,
         request_path: PathBuf,
+    },
+    WasmAbiVerify {
+        wasm_paths: Vec<PathBuf>,
     },
     FederationPeers {
         manifest_path: PathBuf,
@@ -197,6 +201,7 @@ fn run_command(command: Command) -> Result<String, CliError> {
             manifest_path,
             request_path,
         } => execute_agent(&manifest_path, &request_path),
+        Command::WasmAbiVerify { wasm_paths } => verify_wasm_abi_imports(&wasm_paths),
         Command::FederationPeers { manifest_path } => {
             render_federation_peers(&manifest_path).map_err(CliError::IoError)
         }
@@ -258,6 +263,7 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
         (Some("serve"), _) => parse_serve_command(args),
         (Some("federation"), Some(_)) => parse_federation_command(args),
         (Some("agent"), Some("execute")) => parse_agent_execute_command(args),
+        (Some("wasm"), Some("abi")) => parse_wasm_abi_command(args),
         (Some("expedition"), Some("execute")) => parse_expedition_execute_command(args),
         (Some("capability"), Some("discover")) => parse_capability_discover_command(args),
         (Some("workflow"), Some(_)) => parse_workflow_command(args),
@@ -273,6 +279,8 @@ fn subcommand_help(family: Option<&str>, subcommand: Option<&str>) -> String {
         (Some("agent"), Some("inspect")) => help_agent_inspect(),
         (Some("agent"), Some("execute")) => help_agent_execute(),
         (Some("agent"), _) => help_agent(),
+        (Some("wasm"), Some("abi")) => help_wasm_abi(),
+        (Some("wasm"), _) => help_wasm(),
         (Some("workflow"), Some("register")) => help_workflow_register(),
         (Some("workflow"), Some("list")) => help_workflow_list(),
         (Some("workflow"), Some("inspect")) => help_workflow_inspect(),
@@ -391,6 +399,35 @@ fn help_agent() -> String {
     execute <manifest-path> <request-path>       Execute an agent against a runtime request.
 
   Run `traverse-cli agent <subcommand> --help` for subcommand-specific help."
+        .to_string()
+}
+
+fn help_wasm_abi() -> String {
+    "traverse-cli wasm abi verify <wasm-path>...
+
+  Purpose:
+    Validate one or more compiled WASM artifacts against the Traverse Host ABI
+    v1 import whitelist before publication. Fails if any artifact imports a
+    host function outside the governed ABI surface.
+
+  Required arguments:
+    <wasm-path>...   One or more .wasm files to validate.
+
+  Optional flags:
+    --help           Print this help text.
+
+  Example:
+    traverse-cli wasm abi verify examples/hello-world/say-hello-agent/artifacts/say-hello-agent.wasm"
+        .to_string()
+}
+
+fn help_wasm() -> String {
+    "traverse-cli wasm <subcommand> [options]
+
+  Subcommands:
+    abi verify <wasm-path>...   Validate WASM host imports against Traverse Host ABI v1.
+
+  Run `traverse-cli wasm abi --help` for subcommand-specific help."
         .to_string()
 }
 
@@ -797,6 +834,20 @@ fn parse_agent_execute_command(args: &[String]) -> Result<Command, String> {
     }
 }
 
+fn parse_wasm_abi_command(args: &[String]) -> Result<Command, String> {
+    match args {
+        [_, _, abi, verify, wasm_paths @ ..] if abi == "abi" && verify == "verify" => {
+            if wasm_paths.is_empty() {
+                return Err(usage());
+            }
+            Ok(Command::WasmAbiVerify {
+                wasm_paths: wasm_paths.iter().map(PathBuf::from).collect(),
+            })
+        }
+        _ => Err(usage()),
+    }
+}
+
 fn parse_federation_command(args: &[String]) -> Result<Command, String> {
     match args {
         [_, _, _, manifest_path] if args[2] == "peers" => Ok(Command::FederationPeers {
@@ -987,6 +1038,30 @@ fn execute_agent(manifest_path: &Path, request_path: &Path) -> Result<String, Cl
         &package.manifest.capability_ref.id,
         &outcome,
     ))
+}
+
+fn verify_wasm_abi_imports(wasm_paths: &[PathBuf]) -> Result<String, CliError> {
+    let mut lines = Vec::new();
+    for wasm_path in wasm_paths {
+        let wasm_bytes = fs::read(wasm_path).map_err(|error| {
+            CliError::IoError(format!(
+                "failed to read WASM artifact {}: {error}",
+                wasm_path.display()
+            ))
+        })?;
+        let validation = verify_wasm_host_abi_bytes(&wasm_bytes, SUPPORTED_HOST_ABI_VERSION)
+            .map_err(|error| {
+                CliError::ValidationFailed(format!("{}: {error}", wasm_path.display()))
+            })?;
+        lines.push(format!(
+            "{}: ABI {} import whitelist passed ({} imports)",
+            wasm_path.display(),
+            validation.abi_version,
+            validation.imports.len()
+        ));
+    }
+
+    Ok(lines.join("\n"))
 }
 
 fn execute_expedition(
@@ -2345,6 +2420,13 @@ mod tests {
             "examples/agents/expedition-intent-agent/manifest.json".to_string(),
             "examples/agents/runtime-requests/interpret-expedition-intent.json".to_string(),
         ];
+        let wasm_abi_verify = vec![
+            "traverse-cli".to_string(),
+            "wasm".to_string(),
+            "abi".to_string(),
+            "verify".to_string(),
+            "examples/hello-world/say-hello-agent/artifacts/say-hello-agent.wasm".to_string(),
+        ];
         let expedition_execute = vec![
             "traverse-cli".to_string(),
             "expedition".to_string(),
@@ -2383,6 +2465,7 @@ mod tests {
         assert!(parse_command(&bundle_register).is_ok());
         assert!(parse_command(&agent_inspect).is_ok());
         assert!(parse_command(&agent_execute).is_ok());
+        assert!(parse_command(&wasm_abi_verify).is_ok());
         assert!(parse_command(&expedition_execute).is_ok());
         assert!(parse_command(&expedition_execute_with_trace).is_ok());
         assert!(parse_command(&event).is_ok());
@@ -3176,7 +3259,8 @@ mod tests {
   "binary": {{
     "path": "./artifacts/{}",
     "format": "wasm",
-    "expected_digest": "{}"
+    "expected_digest": "{}",
+    "abi_version": "1.0.0"
   }},
   "constraints": {{
     "host_api_access": "none",

--- a/crates/traverse-runtime/src/executor/host_abi_v1.json
+++ b/crates/traverse-runtime/src/executor/host_abi_v1.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "1.0.0",
+  "abi_version": "1.0.0",
+  "target": "wasm32-wasip1",
+  "imports": [
+    {
+      "module": "wasi_snapshot_preview1",
+      "name": "fd_read",
+      "category": "stdio"
+    },
+    {
+      "module": "wasi_snapshot_preview1",
+      "name": "fd_write",
+      "category": "stdio"
+    },
+    {
+      "module": "wasi_snapshot_preview1",
+      "name": "proc_exit",
+      "category": "stdio"
+    },
+    {
+      "module": "traverse_host",
+      "name": "capability_id",
+      "category": "environment_query"
+    },
+    {
+      "module": "traverse_host",
+      "name": "capability_version",
+      "category": "environment_query"
+    },
+    {
+      "module": "traverse_host",
+      "name": "runtime_config",
+      "category": "environment_query"
+    },
+    {
+      "module": "traverse_host",
+      "name": "trace_context",
+      "category": "execution_metadata"
+    },
+    {
+      "module": "traverse_host",
+      "name": "execution_id",
+      "category": "execution_metadata"
+    }
+  ]
+}

--- a/crates/traverse-runtime/src/executor/mod.rs
+++ b/crates/traverse-runtime/src/executor/mod.rs
@@ -10,7 +10,10 @@ pub mod native;
 pub mod wasm;
 
 pub use native::NativeExecutor;
-pub use wasm::WasmExecutor;
+pub use wasm::{
+    HostAbiImport, HostAbiValidation, SUPPORTED_HOST_ABI_VERSION, WasmExecutor,
+    supported_host_abi_versions, verify_wasm_host_abi_bytes,
+};
 
 use serde_json::Value;
 
@@ -34,6 +37,8 @@ pub struct ExecutorCapability {
     pub wasm_binary_path: Option<String>,
     /// Expected SHA-256 hex digest of the WASM binary (only relevant for `ArtifactType::Wasm`).
     pub wasm_checksum: Option<String>,
+    /// Traverse Host ABI version declared by the module manifest.
+    pub host_abi_version: Option<String>,
 }
 
 /// Error returned by a [`CapabilityExecutor`].
@@ -45,6 +50,21 @@ pub enum ExecutorError {
     ChecksumMismatch { expected: String, actual: String },
     /// The Wasmtime engine or linker could not be configured.
     RuntimeSetupFailed(String),
+    /// The WASM artifact is malformed and cannot be parsed as a module.
+    MalformedWasmArtifact { error_code: String, detail: String },
+    /// The WASM artifact declares an unsupported Traverse Host ABI version.
+    UnsupportedAbiVersion {
+        error_code: String,
+        requested: String,
+        supported: String,
+    },
+    /// The WASM artifact imports a host function outside the declared ABI whitelist.
+    UnauthorizedHostImport {
+        error_code: String,
+        abi_version: String,
+        module: String,
+        name: String,
+    },
     /// The WASM module trapped or returned a non-zero exit code.
     ExecutionFailed(String),
     /// The executor produced output that could not be parsed as JSON.
@@ -61,6 +81,26 @@ impl std::fmt::Display for ExecutorError {
                 write!(f, "checksum mismatch: expected {expected}, got {actual}")
             }
             Self::RuntimeSetupFailed(msg) => write!(f, "runtime setup failed: {msg}"),
+            Self::MalformedWasmArtifact { error_code, detail } => {
+                write!(f, "{error_code}: {detail}")
+            }
+            Self::UnsupportedAbiVersion {
+                error_code,
+                requested,
+                supported,
+            } => write!(
+                f,
+                "{error_code}: requested Traverse Host ABI {requested}, supported {supported}"
+            ),
+            Self::UnauthorizedHostImport {
+                error_code,
+                abi_version,
+                module,
+                name,
+            } => write!(
+                f,
+                "{error_code}: ABI {abi_version} does not allow import {module}::{name}"
+            ),
             Self::ExecutionFailed(msg) => write!(f, "execution failed: {msg}"),
             Self::OutputDeserializationFailed(msg) => {
                 write!(f, "output deserialization failed: {msg}")

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -4,6 +4,7 @@
 //! Input is fed via WASI stdin; output is captured from WASI stdout.
 //! No ambient WASI authority is granted — all capabilities are deny-by-default.
 
+use serde::Deserialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -13,6 +14,67 @@ use wasmtime_wasi::p1::WasiP1Ctx;
 use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
 
 use super::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError};
+
+/// Traverse Host ABI v1 is independently versioned from the runtime crate.
+pub const SUPPORTED_HOST_ABI_VERSION: &str = "1.0.0";
+
+const HOST_ABI_V1_WHITELIST: &str = include_str!("host_abi_v1.json");
+
+/// A host import observed in a WASM module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostAbiImport {
+    /// Imported module namespace.
+    pub module: String,
+    /// Imported function or item name.
+    pub name: String,
+}
+
+/// Successful load-time ABI validation evidence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostAbiValidation {
+    /// ABI version used for whitelist validation.
+    pub abi_version: String,
+    /// All imports observed in deterministic module/name order.
+    pub imports: Vec<HostAbiImport>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HostAbiWhitelist {
+    abi_version: String,
+    imports: Vec<HostAbiWhitelistImport>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HostAbiWhitelistImport {
+    module: String,
+    name: String,
+}
+
+/// Return the Traverse Host ABI versions supported by this runtime.
+#[must_use]
+pub fn supported_host_abi_versions() -> &'static [&'static str] {
+    &[SUPPORTED_HOST_ABI_VERSION]
+}
+
+/// Validate a WASM binary against the declared Traverse Host ABI import whitelist.
+///
+/// # Errors
+///
+/// Returns [`ExecutorError`] when the binary is malformed, the ABI version is unsupported,
+/// or a module imports a host function outside the whitelist.
+pub fn verify_wasm_host_abi_bytes(
+    wasm_bytes: &[u8],
+    abi_version: &str,
+) -> Result<HostAbiValidation, ExecutorError> {
+    let engine = Engine::default();
+    let module = Module::from_binary(&engine, wasm_bytes).map_err(|e| {
+        ExecutorError::MalformedWasmArtifact {
+            error_code: "malformed_wasm_artifact".to_string(),
+            detail: format!("module compile: {e}"),
+        }
+    })?;
+    validate_module_imports(&module, abi_version)
+}
 
 /// Executes `.wasm32-wasi` capability binaries via Wasmtime.
 ///
@@ -64,7 +126,12 @@ impl CapabilityExecutor for WasmExecutor {
             }
         }
 
-        self.run_wasm(&binary, input)
+        let abi_version = capability
+            .host_abi_version
+            .as_deref()
+            .unwrap_or(SUPPORTED_HOST_ABI_VERSION);
+
+        self.run_wasm(&binary, input, abi_version)
     }
 }
 
@@ -78,12 +145,39 @@ impl WasmExecutor {
     /// Returns [`ExecutorError`] if input serialization fails, the WASM module cannot be
     /// compiled or linked, execution fails, or stdout is not valid JSON.
     pub fn run_bytes(&self, wasm_bytes: &[u8], input: &Value) -> Result<Value, ExecutorError> {
-        self.run_wasm(wasm_bytes, input)
+        self.run_bytes_with_host_abi(wasm_bytes, input, SUPPORTED_HOST_ABI_VERSION)
     }
 
-    fn run_wasm(&self, wasm_bytes: &[u8], input: &Value) -> Result<Value, ExecutorError> {
+    /// Execute pre-loaded WASM bytes with an explicit Traverse Host ABI version.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutorError`] if ABI validation fails or execution cannot complete.
+    pub fn run_bytes_with_host_abi(
+        &self,
+        wasm_bytes: &[u8],
+        input: &Value,
+        abi_version: &str,
+    ) -> Result<Value, ExecutorError> {
+        self.run_wasm(wasm_bytes, input, abi_version)
+    }
+
+    fn run_wasm(
+        &self,
+        wasm_bytes: &[u8],
+        input: &Value,
+        abi_version: &str,
+    ) -> Result<Value, ExecutorError> {
         let input_json = serde_json::to_string(input)
             .map_err(|e| ExecutorError::ExecutionFailed(format!("input serialization: {e}")))?;
+
+        let module = Module::from_binary(&self.engine, wasm_bytes).map_err(|e| {
+            ExecutorError::MalformedWasmArtifact {
+                error_code: "malformed_wasm_artifact".to_string(),
+                detail: format!("module compile: {e}"),
+            }
+        })?;
+        validate_module_imports(&module, abi_version)?;
 
         // Clone pipe reference before passing to builder — needed to read output after execution
         let stdout_pipe = MemoryOutputPipe::new(65536);
@@ -101,9 +195,6 @@ impl WasmExecutor {
             .map_err(|e| ExecutorError::RuntimeSetupFailed(e.to_string()))?;
 
         let mut store: Store<WasiP1Ctx> = Store::new(&self.engine, wasi_ctx);
-
-        let module = Module::from_binary(&self.engine, wasm_bytes)
-            .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("module compile: {e}")))?;
 
         linker
             .module(&mut store, "", &module)
@@ -133,4 +224,52 @@ fn sha256_hex(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
     format!("{:x}", hasher.finalize())
+}
+
+fn validate_module_imports(
+    module: &Module,
+    abi_version: &str,
+) -> Result<HostAbiValidation, ExecutorError> {
+    let whitelist = host_abi_whitelist(abi_version)?;
+    let mut imports = module
+        .imports()
+        .map(|import| HostAbiImport {
+            module: import.module().to_string(),
+            name: import.name().to_string(),
+        })
+        .collect::<Vec<_>>();
+    imports.sort_by(|a, b| a.module.cmp(&b.module).then_with(|| a.name.cmp(&b.name)));
+
+    for import in &imports {
+        if !whitelist
+            .imports
+            .iter()
+            .any(|allowed| allowed.module == import.module && allowed.name == import.name)
+        {
+            return Err(ExecutorError::UnauthorizedHostImport {
+                error_code: "unauthorized_host_import".to_string(),
+                abi_version: abi_version.to_string(),
+                module: import.module.clone(),
+                name: import.name.clone(),
+            });
+        }
+    }
+
+    Ok(HostAbiValidation {
+        abi_version: whitelist.abi_version,
+        imports,
+    })
+}
+
+fn host_abi_whitelist(abi_version: &str) -> Result<HostAbiWhitelist, ExecutorError> {
+    if abi_version != SUPPORTED_HOST_ABI_VERSION {
+        return Err(ExecutorError::UnsupportedAbiVersion {
+            error_code: "unsupported_abi_version".to_string(),
+            requested: abi_version.to_string(),
+            supported: supported_host_abi_versions().join(", "),
+        });
+    }
+
+    serde_json::from_str::<HostAbiWhitelist>(HOST_ABI_V1_WHITELIST)
+        .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("invalid ABI whitelist: {e}")))
 }

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -2,7 +2,8 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use traverse_runtime::executor::{
     ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, NativeExecutor,
-    WasmExecutor,
+    SUPPORTED_HOST_ABI_VERSION, WasmExecutor, supported_host_abi_versions,
+    verify_wasm_host_abi_bytes,
 };
 
 // --- NativeExecutor tests ---
@@ -46,6 +47,7 @@ fn native_executor_rejects_wasm_artifact_type() -> Result<(), String> {
         artifact_type: ArtifactType::Wasm,
         wasm_binary_path: None,
         wasm_checksum: None,
+        host_abi_version: None,
     };
     let err = expect_err(executor.execute(&cap, &json!({})), "expected type error")?;
 
@@ -89,6 +91,7 @@ fn wasm_executor_errors_when_no_path_set() -> Result<(), String> {
         artifact_type: ArtifactType::Wasm,
         wasm_binary_path: None,
         wasm_checksum: None,
+        host_abi_version: None,
     };
     let err = expect_err(
         executor.execute(&cap, &json!({})),
@@ -111,6 +114,7 @@ fn wasm_executor_errors_on_missing_file() -> Result<(), String> {
         artifact_type: ArtifactType::Wasm,
         wasm_binary_path: Some("/nonexistent/path/module.wasm".to_string()),
         wasm_checksum: None,
+        host_abi_version: None,
     };
     let err = expect_err(
         executor.execute(&cap, &json!({})),
@@ -147,6 +151,7 @@ fn wasm_executor_detects_checksum_mismatch() -> Result<(), String> {
         wasm_checksum: Some(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
         ),
+        host_abi_version: None,
     };
 
     let err = expect_err(
@@ -235,6 +240,95 @@ fn wasm_executor_rejects_invalid_json_output() -> Result<(), String> {
     Ok(())
 }
 
+#[test]
+fn wasm_host_abi_verifier_accepts_sanctioned_stdio_imports() -> Result<(), String> {
+    let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;
+
+    let validation = verify_wasm_host_abi_bytes(&wasm_bytes, SUPPORTED_HOST_ABI_VERSION)
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert_eq!(validation.abi_version, SUPPORTED_HOST_ABI_VERSION);
+    assert_eq!(supported_host_abi_versions(), &[SUPPORTED_HOST_ABI_VERSION]);
+    assert!(
+        validation.imports.iter().any(|import| {
+            import.module == "wasi_snapshot_preview1" && import.name == "fd_read"
+        })
+    );
+    assert!(
+        validation.imports.iter().any(|import| {
+            import.module == "wasi_snapshot_preview1" && import.name == "fd_write"
+        })
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_host_abi_verifier_rejects_unauthorized_import_before_execution() -> Result<(), String> {
+    let wat_src = r#"
+        (module
+            (import "wasi_snapshot_preview1" "random_get"
+                (func $random_get (param i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (func $_start (export "_start")
+                unreachable
+            )
+        )
+    "#;
+    let wasm_bytes = wat::parse_str(wat_src).map_err(|e| format!("WAT parse: {e}"))?;
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+
+    let err = expect_err(
+        executor.run_bytes(&wasm_bytes, &json!({})),
+        "expected unauthorized host import",
+    )?;
+
+    assert_eq!(
+        err,
+        ExecutorError::UnauthorizedHostImport {
+            error_code: "unauthorized_host_import".to_string(),
+            abi_version: SUPPORTED_HOST_ABI_VERSION.to_string(),
+            module: "wasi_snapshot_preview1".to_string(),
+            name: "random_get".to_string(),
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_host_abi_verifier_rejects_unsupported_abi_version() -> Result<(), String> {
+    let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+
+    let err = expect_err(
+        executor.run_bytes_with_host_abi(&wasm_bytes, &json!({}), "2.0.0"),
+        "expected unsupported ABI version",
+    )?;
+
+    assert_eq!(
+        err,
+        ExecutorError::UnsupportedAbiVersion {
+            error_code: "unsupported_abi_version".to_string(),
+            requested: "2.0.0".to_string(),
+            supported: SUPPORTED_HOST_ABI_VERSION.to_string(),
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_host_abi_verifier_reports_malformed_binary() -> Result<(), String> {
+    let err = expect_err(
+        verify_wasm_host_abi_bytes(b"not-a-wasm-binary", SUPPORTED_HOST_ABI_VERSION),
+        "expected malformed WASM artifact",
+    )?;
+
+    assert!(
+        matches!(err, ExecutorError::MalformedWasmArtifact { .. }),
+        "expected MalformedWasmArtifact, got {err:?}"
+    );
+    Ok(())
+}
+
 // --- Debug impl coverage ---
 
 #[test]
@@ -263,6 +357,30 @@ fn executor_error_display_covers_all_variants() {
         (
             ExecutorError::RuntimeSetupFailed("bad linker".to_string()),
             "runtime setup failed: bad linker",
+        ),
+        (
+            ExecutorError::MalformedWasmArtifact {
+                error_code: "malformed_wasm_artifact".to_string(),
+                detail: "bad magic".to_string(),
+            },
+            "malformed_wasm_artifact: bad magic",
+        ),
+        (
+            ExecutorError::UnsupportedAbiVersion {
+                error_code: "unsupported_abi_version".to_string(),
+                requested: "2.0.0".to_string(),
+                supported: "1.0.0".to_string(),
+            },
+            "unsupported_abi_version: requested Traverse Host ABI 2.0.0, supported 1.0.0",
+        ),
+        (
+            ExecutorError::UnauthorizedHostImport {
+                error_code: "unauthorized_host_import".to_string(),
+                abi_version: "1.0.0".to_string(),
+                module: "wasi_snapshot_preview1".to_string(),
+                name: "random_get".to_string(),
+            },
+            "unauthorized_host_import: ABI 1.0.0 does not allow import wasi_snapshot_preview1::random_get",
         ),
         (
             ExecutorError::ExecutionFailed("trapped".to_string()),
@@ -319,6 +437,7 @@ fn wasm_executor_full_execute_path_via_disk() -> Result<(), String> {
         artifact_type: ArtifactType::Wasm,
         wasm_binary_path: Some(tmp.clone()),
         wasm_checksum: None, // no checksum — exercises the skip-checksum branch
+        host_abi_version: None,
     };
 
     let input = json!({ "disk": true });
@@ -362,6 +481,7 @@ fn wasm_executor_execute_with_matching_checksum_succeeds() -> Result<(), String>
         artifact_type: ArtifactType::Wasm,
         wasm_binary_path: Some(tmp.clone()),
         wasm_checksum: Some(checksum),
+        host_abi_version: Some("1.0.0".to_string()),
     };
 
     let result = executor
@@ -386,14 +506,15 @@ fn wasm_executor_invalid_binary_triggers_runtime_setup_failed() -> Result<(), St
         artifact_type: ArtifactType::Wasm,
         wasm_binary_path: Some(tmp.clone()),
         wasm_checksum: None,
+        host_abi_version: None,
     };
 
     let err = expect_err(executor.execute(&cap, &json!({})), "expected error")?;
     std::fs::remove_file(&tmp).ok();
 
     assert!(
-        matches!(err, ExecutorError::RuntimeSetupFailed(_)),
-        "expected RuntimeSetupFailed, got {err:?}"
+        matches!(err, ExecutorError::MalformedWasmArtifact { .. }),
+        "expected MalformedWasmArtifact, got {err:?}"
     );
     Ok(())
 }
@@ -406,6 +527,7 @@ fn native_capability(id: &str) -> ExecutorCapability {
         artifact_type: ArtifactType::Native,
         wasm_binary_path: None,
         wasm_checksum: None,
+        host_abi_version: None,
     }
 }
 
@@ -417,6 +539,28 @@ fn tempfile_path() -> String {
             .map(|d| d.as_nanos())
             .unwrap_or(0)
     )
+}
+
+fn echo_wat() -> &'static str {
+    r#"
+        (module
+            (import "wasi_snapshot_preview1" "fd_read"
+                (func $fd_read (param i32 i32 i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "proc_exit"
+                (func $proc_exit (param i32)))
+            (memory (export "memory") 1)
+            (func $_start (export "_start")
+                (i32.store (i32.const 0) (i32.const 8))
+                (i32.store (i32.const 4) (i32.const 4096))
+                (drop (call $fd_read (i32.const 0) (i32.const 0) (i32.const 1) (i32.const 4100)))
+                (i32.store (i32.const 0) (i32.const 8))
+                (i32.store (i32.const 4) (i32.load (i32.const 4100)))
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 4104)))
+            )
+        )
+    "#
 }
 
 /// Assert that `result` is `Err`, returning the error value or a descriptive `String` failure.

--- a/crates/traverse-runtime/tests/expedition_wasm_tests.rs
+++ b/crates/traverse-runtime/tests/expedition_wasm_tests.rs
@@ -275,6 +275,7 @@ fn expedition_wasm_execution_writes_trace() -> Result<(), String> {
             artifact_type: ArtifactType::Wasm,
             wasm_binary_path: Some(tmp_path.clone()),
             wasm_checksum: None,
+            host_abi_version: None,
         },
         emitted_events: Vec::new(),
     };
@@ -393,6 +394,7 @@ fn run_expedition_via_router(wasm_bytes: &[u8], tmp_path: &str) -> Result<Router
             artifact_type: ArtifactType::Wasm,
             wasm_binary_path: Some(tmp_path.to_string()),
             wasm_checksum: None,
+            host_abi_version: None,
         },
         emitted_events: Vec::new(),
     };

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -114,6 +114,7 @@ fn native_executor_capability(capability_id: &str) -> ExecutorCapability {
         artifact_type: ArtifactType::Native,
         wasm_binary_path: None,
         wasm_checksum: None,
+        host_abi_version: None,
     }
 }
 

--- a/examples/agents/expedition-intent-agent/manifest.json
+++ b/examples/agents/expedition-intent-agent/manifest.json
@@ -23,7 +23,8 @@
   "binary": {
     "path": "./artifacts/interpret-expedition-intent-agent.wasm",
     "format": "wasm",
-    "expected_digest": "fnv1a64:dffc31d6401c84d6"
+    "expected_digest": "fnv1a64:dffc31d6401c84d6",
+    "abi_version": "1.0.0"
   },
   "constraints": {
     "host_api_access": "none",

--- a/examples/agents/team-readiness-agent/manifest.json
+++ b/examples/agents/team-readiness-agent/manifest.json
@@ -23,7 +23,8 @@
   "binary": {
     "path": "./artifacts/validate-team-readiness-agent.wasm",
     "format": "wasm",
-    "expected_digest": "fnv1a64:dffc31d6401c84d6"
+    "expected_digest": "fnv1a64:dffc31d6401c84d6",
+    "abi_version": "1.0.0"
   },
   "constraints": {
     "host_api_access": "none",

--- a/examples/hello-world/say-hello-agent/manifest.json
+++ b/examples/hello-world/say-hello-agent/manifest.json
@@ -23,7 +23,8 @@
   "binary": {
     "path": "./artifacts/say-hello-agent.wasm",
     "format": "wasm",
-    "expected_digest": "fnv1a64:dffc31d6401c84d6"
+    "expected_digest": "fnv1a64:dffc31d6401c84d6",
+    "abi_version": "1.0.0"
   },
   "constraints": {
     "host_api_access": "none",

--- a/examples/templates/executable-capability-package/manifest.template.json
+++ b/examples/templates/executable-capability-package/manifest.template.json
@@ -23,7 +23,8 @@
   "binary": {
     "path": "./artifacts/package.wasm",
     "format": "wasm",
-    "expected_digest": "fnv1a64:dffc31d6401c84d6"
+    "expected_digest": "fnv1a64:dffc31d6401c84d6",
+    "abi_version": "1.0.0"
   },
   "constraints": {
     "host_api_access": "none",

--- a/scripts/ci/executable_package_template_smoke.sh
+++ b/scripts/ci/executable_package_template_smoke.sh
@@ -22,6 +22,7 @@ grep -q '"capability_ref"' "$manifest_path"
 grep -q '"workflow_refs"' "$manifest_path"
 grep -q '"model_dependencies"' "$manifest_path"
 grep -q '"expected_digest": "fnv1a64:dffc31d6401c84d6"' "$manifest_path"
+grep -q '"abi_version": "1.0.0"' "$manifest_path"
 grep -q 'printf' "$build_script"
 
 printf 'Executable package template smoke passed.\n'

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -79,6 +79,7 @@ required_files=(
   "scripts/ci/app_consumable_package_release_pointer.sh"
   "scripts/ci/wasm_agent_authoring_guide_smoke.sh"
   "scripts/ci/hello_world_example_smoke.sh"
+  "scripts/ci/wasi_host_abi_imports.sh"
   "scripts/ci/zero_to_hero_acceptance.sh"
   "scripts/ci/wasm_microservice_authoring_guide_smoke.sh"
   "scripts/ci/downstream_publication_strategy_smoke.sh"
@@ -351,5 +352,8 @@ grep -q "## Governing Spec" .github/pull_request_template.md
 
 echo "Running new-capability scaffold smoke..."
 TRAVERSE_REPO_ROOT="$(pwd)" bash "$(pwd)/scripts/ci/new_capability_scaffold_smoke.sh"
+
+echo "Running WASI host ABI import whitelist verification..."
+TRAVERSE_REPO_ROOT="$(pwd)" bash "$(pwd)/scripts/ci/wasi_host_abi_imports.sh"
 
 echo "Repository checks passed."

--- a/scripts/ci/wasi_host_abi_imports.sh
+++ b/scripts/ci/wasi_host_abi_imports.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${TRAVERSE_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "${repo_root}"
+
+wasm_artifacts=()
+while IFS= read -r artifact; do
+  wasm_artifacts+=("${artifact}")
+done < <(find examples -type f -name '*.wasm' | sort)
+
+if [[ "${#wasm_artifacts[@]}" -eq 0 ]]; then
+  echo "No checked-in WASM artifacts found for Traverse Host ABI verification." >&2
+  exit 1
+fi
+
+cargo run -q -p traverse-cli -- wasm abi verify "${wasm_artifacts[@]}"


### PR DESCRIPTION
## Summary
- Add Traverse Host ABI v1 whitelist artifact and runtime load-time import validation before WASM execution.
- Add stable structured ABI errors for malformed modules, unsupported ABI versions, and unauthorized host imports.
- Require agent package manifests to declare binary ABI version 1.0.0 and update checked-in manifests/templates.
- Add `traverse-cli wasm abi verify` plus CI coverage for all checked-in WASM artifacts.

## Validation
- cargo fmt --check
- cargo test -p traverse-runtime --test executor_tests -- --test-threads=1
- cargo test -p traverse-cli agent -- --test-threads=1
- bash scripts/ci/wasi_host_abi_imports.sh
- bash scripts/ci/repository_checks.sh
- bash scripts/ci/rust_checks.sh
- bash scripts/ci/coverage_gate.sh

## Governing Spec
- 038-wasi-host-insulation
- 017-ai-agent-packaging
- 040-contractual-enforcement-gate
- 008-expedition-example-domain

## Project Item
- GitHub Project 1 item for #369 is In Progress and assigned to Codex.

## Issue
- Closes #369
