### PR TITLE
feat: add connector plugin registry

### DIFF
--- a/contracts/connectors/traverse.env/connector_contract.json
+++ b/contracts/connectors/traverse.env/connector_contract.json
@@ -1,0 +1,28 @@
+{
+  "kind": "connector_contract",
+  "schema_version": "1.0.0",
+  "connector_id": "traverse.env",
+  "version": "1.0.0",
+  "capabilities_provided": [
+    "traverse.env.read"
+  ],
+  "required_config_schema": {
+    "type": "object",
+    "required": [
+      "allowed_keys"
+    ],
+    "properties": {
+      "allowed_keys": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "additionalProperties": false
+  },
+  "supported_placement_targets": [
+    "local",
+    "cloud"
+  ]
+}

--- a/contracts/connectors/traverse.fs.read/connector_contract.json
+++ b/contracts/connectors/traverse.fs.read/connector_contract.json
@@ -1,0 +1,25 @@
+{
+  "kind": "connector_contract",
+  "schema_version": "1.0.0",
+  "connector_id": "traverse.fs.read",
+  "version": "1.0.0",
+  "capabilities_provided": [
+    "traverse.fs.read"
+  ],
+  "required_config_schema": {
+    "type": "object",
+    "required": [
+      "root"
+    ],
+    "properties": {
+      "root": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false
+  },
+  "supported_placement_targets": [
+    "local",
+    "cloud"
+  ]
+}

--- a/contracts/connectors/traverse.http/connector_contract.json
+++ b/contracts/connectors/traverse.http/connector_contract.json
@@ -1,0 +1,25 @@
+{
+  "kind": "connector_contract",
+  "schema_version": "1.0.0",
+  "connector_id": "traverse.http",
+  "version": "1.0.0",
+  "capabilities_provided": [
+    "traverse.http.outbound"
+  ],
+  "required_config_schema": {
+    "type": "object",
+    "required": [
+      "base_url"
+    ],
+    "properties": {
+      "base_url": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": false
+  },
+  "supported_placement_targets": [
+    "local",
+    "cloud"
+  ]
+}

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -5401,6 +5401,7 @@ mod tests {
             service_type: ServiceType::Stateless,
             permitted_targets: vec![ExecutionTarget::Local],
             event_trigger: None,
+            connector_requirements: Vec::new(),
         }
     }
 

--- a/crates/traverse-contracts/src/lib.rs
+++ b/crates/traverse-contracts/src/lib.rs
@@ -1,6 +1,6 @@
 //! Capability contract parsing and validation for Traverse.
 
-use semver::Version;
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeSet, HashSet};
@@ -10,6 +10,7 @@ pub use violations::ViolationRecord;
 
 const CAPABILITY_CONTRACT_KIND: &str = "capability_contract";
 const EVENT_CONTRACT_KIND: &str = "event_contract";
+const CONNECTOR_CONTRACT_KIND: &str = "connector_contract";
 const SUPPORTED_SCHEMA_VERSION: &str = "1.0.0";
 const GOVERNED_CONTENT_VERSION: &str = "0.1.0";
 
@@ -47,6 +48,119 @@ pub struct CapabilityContract {
     /// Required for `Subscribable` capabilities: the event type that triggers this capability.
     #[serde(default)]
     pub event_trigger: Option<String>,
+    /// External resource connectors required before this capability can be registered or executed.
+    #[serde(default)]
+    pub connector_requirements: Vec<ConnectorRequirement>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectorContract {
+    pub kind: String,
+    pub schema_version: String,
+    pub connector_id: String,
+    pub version: String,
+    pub capabilities_provided: Vec<String>,
+    pub required_config_schema: Value,
+    #[serde(default = "default_connector_targets")]
+    pub supported_placement_targets: Vec<ExecutionTarget>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectorRequirement {
+    pub connector_id: String,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectorInvocation {
+    pub capability_id: String,
+    pub connector_id: String,
+    pub config: Value,
+    pub input: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectorOutput {
+    pub output: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConnectorError {
+    pub code: String,
+    pub message: String,
+}
+
+pub trait ConnectorPlugin: Send + Sync {
+    fn connector_id(&self) -> &str;
+    fn version(&self) -> &str;
+    fn capabilities_provided(&self) -> &[String];
+    /// Invoke the connector with runtime-injected config and input.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConnectorError`] when the connector cannot satisfy the invocation.
+    fn invoke(&self, invocation: ConnectorInvocation) -> Result<ConnectorOutput, ConnectorError>;
+}
+
+#[must_use]
+pub fn reference_connector_contracts() -> Vec<ConnectorContract> {
+    vec![
+        reference_connector_contract(
+            "traverse.http",
+            vec!["traverse.http.outbound".to_string()],
+            serde_json::json!({
+                "type": "object",
+                "required": ["base_url"],
+                "properties": {
+                    "base_url": {"type": "string"}
+                },
+                "additionalProperties": false
+            }),
+        ),
+        reference_connector_contract(
+            "traverse.fs.read",
+            vec!["traverse.fs.read".to_string()],
+            serde_json::json!({
+                "type": "object",
+                "required": ["root"],
+                "properties": {
+                    "root": {"type": "string"}
+                },
+                "additionalProperties": false
+            }),
+        ),
+        reference_connector_contract(
+            "traverse.env",
+            vec!["traverse.env.read".to_string()],
+            serde_json::json!({
+                "type": "object",
+                "required": ["allowed_keys"],
+                "properties": {
+                    "allowed_keys": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    }
+                },
+                "additionalProperties": false
+            }),
+        ),
+    ]
+}
+
+fn reference_connector_contract(
+    connector_id: &str,
+    capabilities_provided: Vec<String>,
+    required_config_schema: Value,
+) -> ConnectorContract {
+    ConnectorContract {
+        kind: CONNECTOR_CONTRACT_KIND.to_string(),
+        schema_version: SUPPORTED_SCHEMA_VERSION.to_string(),
+        connector_id: connector_id.to_string(),
+        version: "1.0.0".to_string(),
+        capabilities_provided,
+        required_config_schema,
+        supported_placement_targets: default_connector_targets(),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -226,6 +340,10 @@ fn default_permitted_targets() -> Vec<ExecutionTarget> {
         ExecutionTarget::Worker,
         ExecutionTarget::Device,
     ]
+}
+
+fn default_connector_targets() -> Vec<ExecutionTarget> {
+    vec![ExecutionTarget::Local, ExecutionTarget::Cloud]
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -423,6 +541,8 @@ pub enum ValidationErrorCode {
     InvalidPlacementConstraint,
     /// `service_type: subscribable` without a non-empty `event_trigger`.
     MissingEventTrigger,
+    InvalidConnectorContract,
+    InvalidConnectorRequirement,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -464,6 +584,23 @@ pub fn parse_event_contract(json: &str) -> Result<EventContract, ValidationFailu
     })
 }
 
+/// Parses a connector contract from raw JSON text.
+///
+/// # Errors
+///
+/// Returns [`ValidationFailure`] when the JSON payload cannot be deserialized
+/// into the connector contract model.
+pub fn parse_connector_contract(json: &str) -> Result<ConnectorContract, ValidationFailure> {
+    serde_json::from_str::<ConnectorContract>(json).map_err(|error| ValidationFailure {
+        errors: vec![ValidationError {
+            code: ValidationErrorCode::InvalidFormat,
+            message: error.to_string(),
+            path: "$".to_string(),
+            severity: ErrorSeverity::Error,
+        }],
+    })
+}
+
 /// Validates a parsed capability contract against the governed `v0.1` rules.
 ///
 /// # Errors
@@ -493,6 +630,7 @@ pub fn validate_contract(
     validate_execution(&contract.execution, &contract.provenance, &mut errors);
     validate_id_references(&contract.policies, "$.policies", &mut errors);
     validate_dependencies(&contract.dependencies, &mut errors);
+    validate_connector_requirements(&contract.connector_requirements, &mut errors);
     validate_provenance(&contract.provenance, &mut errors);
     validate_evidence(&contract.evidence, &mut errors);
     validate_boundary(&contract, &mut errors);
@@ -515,6 +653,77 @@ pub fn validate_contract(
         },
         normalized: contract,
     })
+}
+
+/// Validates a parsed connector contract.
+///
+/// # Errors
+///
+/// Returns [`ValidationFailure`] when structural or semantic validation fails.
+pub fn validate_connector_contract(
+    contract: ConnectorContract,
+) -> Result<ConnectorContract, ValidationFailure> {
+    let mut errors = Vec::new();
+
+    if contract.kind != CONNECTOR_CONTRACT_KIND {
+        errors.push(error(
+            ValidationErrorCode::InvalidLiteral,
+            "$.kind",
+            "kind must equal connector_contract",
+        ));
+    }
+    if contract.schema_version != SUPPORTED_SCHEMA_VERSION {
+        errors.push(error(
+            ValidationErrorCode::InvalidLiteral,
+            "$.schema_version",
+            "schema_version must equal 1.0.0",
+        ));
+    }
+    validate_non_empty(&contract.connector_id, "$.connector_id", &mut errors);
+    validate_semver(&contract.version, "$.version", &mut errors);
+    validate_unique_strings(
+        &contract.capabilities_provided,
+        "$.capabilities_provided",
+        "capabilities_provided must be unique",
+        &mut errors,
+    );
+    if contract.capabilities_provided.is_empty() {
+        errors.push(error(
+            ValidationErrorCode::MissingRequiredField,
+            "$.capabilities_provided",
+            "capabilities_provided must contain at least one capability id",
+        ));
+    }
+    validate_schema_value(
+        &contract.required_config_schema,
+        "$.required_config_schema",
+        &mut errors,
+    );
+    if contract.supported_placement_targets.is_empty() {
+        errors.push(error(
+            ValidationErrorCode::MissingRequiredField,
+            "$.supported_placement_targets",
+            "supported_placement_targets must contain at least one target",
+        ));
+    }
+    let unique_targets: BTreeSet<_> = contract
+        .supported_placement_targets
+        .iter()
+        .cloned()
+        .collect();
+    if unique_targets.len() != contract.supported_placement_targets.len() {
+        errors.push(error(
+            ValidationErrorCode::DuplicateItem,
+            "$.supported_placement_targets",
+            "supported_placement_targets must be unique",
+        ));
+    }
+
+    if !errors.is_empty() {
+        return Err(ValidationFailure { errors });
+    }
+
+    Ok(contract)
 }
 
 /// Validates a parsed event contract against the governed `v0.1` rules.
@@ -724,7 +933,11 @@ fn validate_schema_container(
     path: &str,
     errors: &mut Vec<ValidationError>,
 ) {
-    if !container.schema.is_object() {
+    validate_schema_value(&container.schema, path, errors);
+}
+
+fn validate_schema_value(schema: &Value, path: &str, errors: &mut Vec<ValidationError>) {
+    if !schema.is_object() {
         errors.push(error(
             ValidationErrorCode::InvalidFormat,
             path,
@@ -974,6 +1187,35 @@ fn validate_dependencies(dependencies: &[DependencyReference], errors: &mut Vec<
                 ValidationErrorCode::DuplicateItem,
                 &id_path,
                 "dependencies must be unique by artifact_type, id, and version",
+            ));
+        }
+    }
+}
+
+fn validate_connector_requirements(
+    requirements: &[ConnectorRequirement],
+    errors: &mut Vec<ValidationError>,
+) {
+    let mut seen = HashSet::new();
+    for (index, requirement) in requirements.iter().enumerate() {
+        let id_path = format!("$.connector_requirements[{index}].connector_id");
+        let version_path = format!("$.connector_requirements[{index}].version");
+        validate_non_empty(&requirement.connector_id, &id_path, errors);
+        if VersionReq::parse(&requirement.version).is_err() {
+            errors.push(error(
+                ValidationErrorCode::InvalidConnectorRequirement,
+                &version_path,
+                "connector requirement version must be a valid semver range",
+            ));
+        }
+        if !seen.insert((
+            requirement.connector_id.clone(),
+            requirement.version.clone(),
+        )) {
+            errors.push(error(
+                ValidationErrorCode::DuplicateItem,
+                &id_path,
+                "connector_requirements must be unique by connector_id and version",
             ));
         }
     }

--- a/crates/traverse-contracts/tests/validation.rs
+++ b/crates/traverse-contracts/tests/validation.rs
@@ -1,16 +1,17 @@
 use std::{fs, path::Path};
 
 use traverse_contracts::{
-    BinaryFormat, CapabilityContract, CapabilityReference, Condition, DependencyArtifactType,
-    DependencyReference, Entrypoint, EntrypointKind, EventClassification, EventContract,
-    EventPayload, EventProvenance, EventProvenanceSource, EventReference, EventType,
+    BinaryFormat, CapabilityContract, CapabilityReference, Condition, ConnectorRequirement,
+    DependencyArtifactType, DependencyReference, Entrypoint, EntrypointKind, EventClassification,
+    EventContract, EventPayload, EventProvenance, EventProvenanceSource, EventReference, EventType,
     EventValidationContext, EventValidationEvidence, EvidenceStatus, EvidenceType, Execution,
     ExecutionConstraints, ExecutionTarget, FilesystemAccess, HostApiAccess, IdReference, Lifecycle,
     NetworkAccess, Owner, PayloadCompatibility, ProducedValidationEvidence, Provenance,
     ProvenanceSource, PublishedContractRecord, PublishedEventRecord, SchemaContainer, ServiceType,
     SideEffect, SideEffectKind, ValidationContext, ValidationErrorCode, ValidationEvidence,
     ValidationFailure, ValidationResult, governed_content_digest, governed_event_content_digest,
-    parse_contract, parse_event_contract, validate_contract, validate_event_contract,
+    parse_connector_contract, parse_contract, parse_event_contract, reference_connector_contracts,
+    validate_connector_contract, validate_contract, validate_event_contract,
 };
 
 const GOVERNING_SPEC: &str = "002-capability-contracts@0.1.0";
@@ -75,6 +76,147 @@ fn rejects_invalid_identity_and_semver() {
             .iter()
             .any(|item| item.code == ValidationErrorCode::InvalidSemver)
     );
+}
+
+#[test]
+fn parses_and_validates_connector_contract() -> Result<(), String> {
+    let contract = reference_connector_contracts()
+        .into_iter()
+        .find(|connector| connector.connector_id == "traverse.http")
+        .ok_or_else(|| "missing traverse.http reference connector".to_string())?;
+    let json = serde_json::to_string(&contract).map_err(|error| error.to_string())?;
+    let parsed = parse_connector_contract(&json).map_err(|error| format!("{error:?}"))?;
+    let validated =
+        validate_connector_contract(parsed.clone()).map_err(|error| format!("{error:?}"))?;
+
+    assert_eq!(validated, parsed);
+    assert_eq!(validated.version, "1.0.0");
+    assert_eq!(
+        validated.capabilities_provided,
+        vec!["traverse.http.outbound".to_string()]
+    );
+    assert!(validated.required_config_schema.is_object());
+    Ok(())
+}
+
+#[test]
+fn rejects_invalid_connector_json() {
+    let errors: Vec<_> = parse_connector_contract("{").err().into_iter().collect();
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].errors[0].code, ValidationErrorCode::InvalidFormat);
+}
+
+#[test]
+fn rejects_invalid_connector_contract_shape() -> Result<(), String> {
+    let mut contract = reference_connector_contracts()
+        .into_iter()
+        .next()
+        .ok_or_else(|| "reference connector should exist".to_string())?;
+    contract.kind = "wrong".to_string();
+    contract.schema_version = "2.0.0".to_string();
+    contract.version = "nope".to_string();
+    contract.capabilities_provided.clear();
+    contract.required_config_schema = serde_json::json!("not-object");
+    contract.supported_placement_targets = vec![ExecutionTarget::Local, ExecutionTarget::Local];
+
+    let errors: Vec<_> = expect_validation_failure(validate_connector_contract(contract))
+        .into_iter()
+        .collect();
+    let failure = &errors[0];
+
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::InvalidLiteral && error.path == "$.kind"
+    }));
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::InvalidLiteral && error.path == "$.schema_version"
+    }));
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::InvalidSemver && error.path == "$.version"
+    }));
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::MissingRequiredField
+            && error.path == "$.capabilities_provided"
+    }));
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::DuplicateItem
+            && error.path == "$.supported_placement_targets"
+    }));
+    Ok(())
+}
+
+#[test]
+fn rejects_connector_contract_without_targets() -> Result<(), String> {
+    let mut contract = reference_connector_contracts()
+        .into_iter()
+        .next()
+        .ok_or_else(|| "reference connector should exist".to_string())?;
+    contract.supported_placement_targets.clear();
+
+    let errors: Vec<_> = expect_validation_failure(validate_connector_contract(contract))
+        .into_iter()
+        .collect();
+
+    assert!(errors[0].errors.iter().any(|error| {
+        error.code == ValidationErrorCode::MissingRequiredField
+            && error.path == "$.supported_placement_targets"
+    }));
+    Ok(())
+}
+
+#[test]
+fn validates_connector_requirements_on_capability_contracts() {
+    let mut contract = valid_contract();
+    contract.connector_requirements.push(ConnectorRequirement {
+        connector_id: "traverse.http".to_string(),
+        version: "^1.0.0".to_string(),
+    });
+
+    let result = validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    );
+
+    assert!(result.is_ok());
+}
+
+#[test]
+fn rejects_invalid_connector_requirements_on_capability_contracts() {
+    let mut contract = valid_contract();
+    contract.connector_requirements = vec![
+        ConnectorRequirement {
+            connector_id: "traverse.http".to_string(),
+            version: "not a range".to_string(),
+        },
+        ConnectorRequirement {
+            connector_id: "traverse.http".to_string(),
+            version: "not a range".to_string(),
+        },
+    ];
+
+    let errors: Vec<_> = expect_validation_failure(validate_contract(
+        contract,
+        &ValidationContext {
+            governing_spec: GOVERNING_SPEC,
+            validator_version: VALIDATOR_VERSION,
+            existing_published: None,
+        },
+    ))
+    .into_iter()
+    .collect();
+    let failure = &errors[0];
+
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::InvalidConnectorRequirement
+            && error.path == "$.connector_requirements[0].version"
+    }));
+    assert!(failure.errors.iter().any(|error| {
+        error.code == ValidationErrorCode::DuplicateItem
+            && error.path == "$.connector_requirements[1].connector_id"
+    }));
 }
 
 #[test]
@@ -571,6 +713,7 @@ fn valid_contract() -> CapabilityContract {
             ExecutionTarget::Edge,
         ],
         event_trigger: None,
+        connector_requirements: Vec::new(),
     }
 }
 
@@ -869,6 +1012,24 @@ fn rejects_duplicate_event_references_and_evidence() {
             .iter()
             .any(|item| item.path == "$.evidence[1].kind")
     );
+}
+
+#[test]
+fn validates_checked_in_reference_connector_contracts() -> Result<(), String> {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    for relative_path in [
+        "contracts/connectors/traverse.http/connector_contract.json",
+        "contracts/connectors/traverse.fs.read/connector_contract.json",
+        "contracts/connectors/traverse.env/connector_contract.json",
+    ] {
+        let path = repo_root.join(relative_path);
+        let contents = fs::read_to_string(&path)
+            .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+        let parsed = parse_connector_contract(&contents).map_err(|error| format!("{error:?}"))?;
+        validate_connector_contract(parsed).map_err(|error| format!("{error:?}"))?;
+    }
+
+    Ok(())
 }
 
 #[test]

--- a/crates/traverse-mcp/src/lib.rs
+++ b/crates/traverse-mcp/src/lib.rs
@@ -956,6 +956,7 @@ mod tests {
                 traverse_contracts::ExecutionTarget::Device,
             ],
             event_trigger: None,
+            connector_requirements: Vec::new(),
         }
     }
 

--- a/crates/traverse-mcp/tests/mcp_tests.rs
+++ b/crates/traverse-mcp/tests/mcp_tests.rs
@@ -126,6 +126,7 @@ fn capability_contract() -> traverse_contracts::CapabilityContract {
             ExecutionTarget::Edge,
         ],
         event_trigger: None,
+        connector_requirements: Vec::new(),
     }
 }
 

--- a/crates/traverse-registry/src/dependency_resolver.rs
+++ b/crates/traverse-registry/src/dependency_resolver.rs
@@ -302,6 +302,7 @@ mod tests {
             service_type: ServiceType::Stateless,
             permitted_targets: vec![ExecutionTarget::Local],
             event_trigger: None,
+            connector_requirements: Vec::new(),
         }
     }
 

--- a/crates/traverse-registry/src/federation.rs
+++ b/crates/traverse-registry/src/federation.rs
@@ -2683,6 +2683,7 @@ mod tests {
                 traverse_contracts::ExecutionTarget::Device,
             ],
             event_trigger: None,
+            connector_requirements: Vec::new(),
         }
     }
 

--- a/crates/traverse-registry/src/graph.rs
+++ b/crates/traverse-registry/src/graph.rs
@@ -883,6 +883,7 @@ mod tests {
                 ExecutionTarget::Device,
             ],
             event_trigger: None,
+            connector_requirements: Vec::new(),
             provenance: Provenance {
                 source: ProvenanceSource::Greenfield,
                 author: "graph".to_string(),

--- a/crates/traverse-registry/src/lib.rs
+++ b/crates/traverse-registry/src/lib.rs
@@ -20,13 +20,13 @@ pub use semver_resolver::{
 };
 pub use workflows::*;
 
-use semver::Version;
+use semver::{Version, VersionReq};
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use traverse_contracts::{
-    CapabilityContract, ErrorSeverity, EventReference, IdReference, Lifecycle, Owner,
-    PublishedContractRecord, ValidationContext, ValidationFailure, governed_content_digest,
-    validate_contract,
+    CapabilityContract, ConnectorContract, ConnectorRequirement, ErrorSeverity, EventReference,
+    ExecutionTarget, IdReference, Lifecycle, Owner, PublishedContractRecord, ValidationContext,
+    ValidationFailure, governed_content_digest, validate_connector_contract, validate_contract,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -133,6 +133,29 @@ pub struct CapabilityRegistration {
     pub registered_at: String,
     pub tags: Vec<String>,
     pub composability: ComposabilityMetadata,
+    pub governing_spec: String,
+    pub validator_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectorRegistration {
+    pub scope: RegistryScope,
+    pub contract: ConnectorContract,
+    pub contract_path: String,
+    pub registered_at: String,
+    pub governing_spec: String,
+    pub validator_version: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnectorRegistryRecord {
+    pub scope: RegistryScope,
+    pub connector_id: String,
+    pub version: String,
+    pub capabilities_provided: Vec<String>,
+    pub supported_placement_targets: Vec<ExecutionTarget>,
+    pub contract_path: String,
+    pub registered_at: String,
     pub governing_spec: String,
     pub validator_version: String,
 }
@@ -263,6 +286,9 @@ pub enum RegistryErrorCode {
     InvalidSemverProgression,
     SemverTooSmall,
     UnknownCompatibility,
+    InvalidConnectorContract,
+    MissingRequiredConnector,
+    ConnectorVersionIncompatible,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -281,6 +307,7 @@ pub struct RegistryFailure {
 #[derive(Debug, Clone, Default)]
 pub struct CapabilityRegistry {
     contracts: BTreeMap<RegistryKey, CapabilityContract>,
+    connectors: BTreeMap<RegistryKey, ConnectorRegistryRecord>,
     records: BTreeMap<RegistryKey, CapabilityRegistryRecord>,
     artifacts: BTreeMap<String, CapabilityArtifactRecord>,
     index: BTreeMap<RegistryKey, DiscoveryIndexEntry>,
@@ -293,6 +320,61 @@ impl CapabilityRegistry {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Registers a connector contract as a first-class registry entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryFailure`] when the connector contract is invalid or
+    /// the same connector version has already been registered with different metadata.
+    pub fn register_connector(
+        &mut self,
+        request: ConnectorRegistration,
+    ) -> Result<ConnectorRegistryRecord, RegistryFailure> {
+        let connector =
+            validate_connector_contract(request.contract).map_err(|failure| RegistryFailure {
+                errors: failure
+                    .errors
+                    .into_iter()
+                    .map(|error| RegistryError {
+                        code: RegistryErrorCode::InvalidConnectorContract,
+                        target: error.path,
+                        message: error.message,
+                        severity: error.severity,
+                    })
+                    .collect(),
+            })?;
+        let key = (
+            request.scope,
+            connector.connector_id.clone(),
+            connector.version.clone(),
+        );
+        let record = ConnectorRegistryRecord {
+            scope: request.scope,
+            connector_id: connector.connector_id,
+            version: connector.version,
+            capabilities_provided: connector.capabilities_provided,
+            supported_placement_targets: connector.supported_placement_targets,
+            contract_path: request.contract_path,
+            registered_at: request.registered_at,
+            governing_spec: request.governing_spec,
+            validator_version: request.validator_version,
+        };
+
+        if let Some(existing) = self.connectors.get(&key) {
+            if existing == &record {
+                return Ok(existing.clone());
+            }
+            return Err(single_error(
+                RegistryErrorCode::ImmutableVersionConflict,
+                "$.connector",
+                "connector version is immutable once registered",
+            ));
+        }
+
+        self.connectors.insert(key, record.clone());
+        Ok(record)
     }
 
     /// Registers a capability publication into the registry.
@@ -360,6 +442,11 @@ impl CapabilityRegistry {
         .map_err(map_contract_failure)?;
 
         let contract = validated.normalized;
+        validate_connector_requirements_for_registration(
+            &contract.connector_requirements,
+            &self.connectors,
+            scope,
+        )?;
         let contract_digest = governed_content_digest(&contract);
         let artifact_ref = artifact.artifact_ref.clone();
         let record = build_registry_record(&RegistryRecordInput {
@@ -474,6 +561,38 @@ impl CapabilityRegistry {
         }
 
         results.sort_by(compare_index_entries);
+        results
+    }
+
+    #[must_use]
+    pub fn discover_connectors(
+        &self,
+        lookup_scope: LookupScope,
+        connector_id: &str,
+        version_range: &str,
+    ) -> Vec<ConnectorRegistryRecord> {
+        let Ok(requirement) = VersionReq::parse(version_range) else {
+            return Vec::new();
+        };
+        let mut results = Vec::new();
+        let mut shadowed = BTreeSet::new();
+        for &scope in lookup_order(lookup_scope) {
+            for ((entry_scope, id, version), record) in &self.connectors {
+                if *entry_scope != scope || id != connector_id {
+                    continue;
+                }
+                if !shadowed.insert((id.clone(), version.clone())) {
+                    continue;
+                }
+                let Ok(parsed) = Version::parse(version) else {
+                    continue;
+                };
+                if requirement.matches(&parsed) {
+                    results.push(record.clone());
+                }
+            }
+        }
+        results.sort_by(|a, b| a.version.cmp(&b.version));
         results
     }
 
@@ -767,6 +886,58 @@ fn validate_registration_fields(
     validate_unique_strings(&composability.requires, "$.composability.requires", errors);
     validate_patterns(&composability.patterns, errors);
     validate_artifact(artifact, composability, errors);
+}
+
+fn validate_connector_requirements_for_registration(
+    requirements: &[ConnectorRequirement],
+    connectors: &BTreeMap<RegistryKey, ConnectorRegistryRecord>,
+    scope: RegistryScope,
+) -> Result<(), RegistryFailure> {
+    for requirement in requirements {
+        let matching_id = connectors
+            .iter()
+            .filter(|((entry_scope, connector_id, _), _)| {
+                (*entry_scope == scope || *entry_scope == RegistryScope::Public)
+                    && connector_id == &requirement.connector_id
+            })
+            .collect::<Vec<_>>();
+        if matching_id.is_empty() {
+            return Err(single_error(
+                RegistryErrorCode::MissingRequiredConnector,
+                "$.connector_requirements",
+                &format!(
+                    "missing_required_connector: {} {}",
+                    requirement.connector_id, requirement.version
+                ),
+            ));
+        }
+        let parsed_range = VersionReq::parse(&requirement.version).map_err(|_| {
+            single_error(
+                RegistryErrorCode::ConnectorVersionIncompatible,
+                "$.connector_requirements",
+                &format!(
+                    "connector_version_incompatible: {} {}",
+                    requirement.connector_id, requirement.version
+                ),
+            )
+        })?;
+        let has_satisfying_version = matching_id.iter().any(|((_, _, version), _)| {
+            Version::parse(version)
+                .map(|parsed| parsed_range.matches(&parsed))
+                .unwrap_or(false)
+        });
+        if !has_satisfying_version {
+            return Err(single_error(
+                RegistryErrorCode::ConnectorVersionIncompatible,
+                "$.connector_requirements",
+                &format!(
+                    "connector_version_incompatible: {} {}",
+                    requirement.connector_id, requirement.version
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn validate_artifact(
@@ -1189,6 +1360,53 @@ mod tests {
         let discovered = registry.discover(LookupScope::PreferPrivate, &DiscoveryQuery::default());
         assert_eq!(discovered.len(), 1);
         assert_eq!(discovered[0].scope, RegistryScope::Private);
+    }
+
+    #[test]
+    fn connector_helpers_cover_invalid_range_and_invalid_stored_version_paths() {
+        let mut registry = CapabilityRegistry::new();
+        let key = (
+            RegistryScope::Public,
+            "traverse.env".to_string(),
+            "not-semver".to_string(),
+        );
+        registry.connectors.insert(
+            key,
+            ConnectorRegistryRecord {
+                scope: RegistryScope::Public,
+                connector_id: "traverse.env".to_string(),
+                version: "not-semver".to_string(),
+                capabilities_provided: vec!["traverse.env.read".to_string()],
+                supported_placement_targets: vec![ExecutionTarget::Local],
+                contract_path: "contracts/connectors/traverse.env/connector_contract.json"
+                    .to_string(),
+                registered_at: "2026-04-19T00:00:00Z".to_string(),
+                governing_spec: "039-connector-plugin-architecture".to_string(),
+                validator_version: "registry-test".to_string(),
+            },
+        );
+
+        assert!(
+            registry
+                .discover_connectors(LookupScope::PublicOnly, "traverse.env", "^1.0.0")
+                .is_empty()
+        );
+
+        let requirements = vec![traverse_contracts::ConnectorRequirement {
+            connector_id: "traverse.env".to_string(),
+            version: "not a range".to_string(),
+        }];
+        let failure = validate_connector_requirements_for_registration(
+            &requirements,
+            &registry.connectors,
+            RegistryScope::Public,
+        )
+        .expect_err("invalid range should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            RegistryErrorCode::ConnectorVersionIncompatible
+        );
     }
 
     #[test]
@@ -1783,6 +2001,7 @@ mod tests {
                 ExecutionTarget::Device,
             ],
             event_trigger: None,
+            connector_requirements: Vec::new(),
         }
     }
 

--- a/crates/traverse-registry/src/semver_resolver.rs
+++ b/crates/traverse-registry/src/semver_resolver.rs
@@ -270,6 +270,7 @@ mod tests {
             service_type: ServiceType::Stateless,
             permitted_targets: vec![ExecutionTarget::Local],
             event_trigger: None,
+            connector_requirements: Vec::new(),
         }
     }
 

--- a/crates/traverse-registry/src/workflows.rs
+++ b/crates/traverse-registry/src/workflows.rs
@@ -2236,6 +2236,7 @@ mod tests {
                     ExecutionTarget::Device,
                 ],
                 event_trigger: None,
+                connector_requirements: Vec::new(),
             },
             contract_path: format!("contracts/{capability_id}.json"),
             artifact: CapabilityArtifactRecord {

--- a/crates/traverse-registry/tests/registry.rs
+++ b/crates/traverse-registry/tests/registry.rs
@@ -5,20 +5,21 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use traverse_contracts::{
-    BinaryFormat as ContractBinaryFormat, CapabilityContract, Condition, DependencyArtifactType,
-    DependencyReference, Entrypoint, EntrypointKind, EventClassification, EventContract,
-    EventPayload, EventProvenance, EventProvenanceSource, EventReference, EventType,
+    BinaryFormat as ContractBinaryFormat, CapabilityContract, Condition, ConnectorRequirement,
+    DependencyArtifactType, DependencyReference, Entrypoint, EntrypointKind, EventClassification,
+    EventContract, EventPayload, EventProvenance, EventProvenanceSource, EventReference, EventType,
     EvidenceStatus, EvidenceType, Execution, ExecutionConstraints, ExecutionTarget,
     FilesystemAccess, HostApiAccess, IdReference, Lifecycle, NetworkAccess, Owner,
     PayloadCompatibility, Provenance, ProvenanceSource, SchemaContainer, ServiceType, SideEffect,
-    SideEffectKind, ValidationEvidence,
+    SideEffectKind, ValidationEvidence, reference_connector_contracts,
 };
 use traverse_registry::{
     ArtifactDigests, BinaryFormat, BinaryReference, BundleLoadErrorCode, CapabilityArtifactRecord,
     CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
-    CompositionPattern, DiscoveryQuery, EventRegistration, EventRegistry, EventRegistryErrorCode,
-    ImplementationKind, LookupScope, RegistryErrorCode, RegistryProvenance, RegistryScope,
-    SourceKind, SourceReference, WorkflowReference, load_registry_bundle, resolve_version_range,
+    CompositionPattern, ConnectorRegistration, DiscoveryQuery, EventRegistration, EventRegistry,
+    EventRegistryErrorCode, ImplementationKind, LookupScope, RegistryErrorCode, RegistryProvenance,
+    RegistryScope, SourceKind, SourceReference, WorkflowReference, load_registry_bundle,
+    resolve_version_range,
 };
 
 #[test]
@@ -63,6 +64,174 @@ fn duplicate_identical_registration_is_idempotent() {
 
     assert_eq!(first.record, second.record);
     assert_eq!(first.index_entry, second.index_entry);
+}
+
+#[test]
+fn registers_and_discovers_reference_connector() {
+    let mut registry = CapabilityRegistry::new();
+    let connector = reference_connector_contracts()
+        .into_iter()
+        .find(|contract| contract.connector_id == "traverse.http")
+        .expect("traverse.http reference connector should exist");
+
+    let record = registry
+        .register_connector(connector_registration(RegistryScope::Public, connector))
+        .expect("connector registration should pass");
+    let discovered =
+        registry.discover_connectors(LookupScope::PublicOnly, "traverse.http", "^1.0.0");
+
+    assert_eq!(discovered, vec![record]);
+}
+
+#[test]
+fn connector_registration_rejects_invalid_contract() {
+    let mut registry = CapabilityRegistry::new();
+    let mut connector = reference_connector_contracts()
+        .into_iter()
+        .next()
+        .expect("reference connector should exist");
+    connector.connector_id.clear();
+
+    let failure = registry
+        .register_connector(connector_registration(RegistryScope::Public, connector))
+        .expect_err("invalid connector contract should fail");
+
+    assert!(failure.errors.iter().any(|error| {
+        error.code == RegistryErrorCode::InvalidConnectorContract
+            && error.target == "$.connector_id"
+    }));
+}
+
+#[test]
+fn connector_registration_is_idempotent_and_rejects_conflicts() {
+    let mut registry = CapabilityRegistry::new();
+    let connector = reference_connector_contracts()
+        .into_iter()
+        .find(|contract| contract.connector_id == "traverse.env")
+        .expect("traverse.env reference connector should exist");
+    let request = connector_registration(RegistryScope::Public, connector.clone());
+
+    let first = registry
+        .register_connector(request.clone())
+        .expect("connector registration should pass");
+    let second = registry
+        .register_connector(request)
+        .expect("identical connector registration should be idempotent");
+    assert_eq!(first, second);
+
+    let mut conflicting_request = connector_registration(RegistryScope::Public, connector);
+    conflicting_request.registered_at = "2026-04-20T00:00:00Z".to_string();
+    let failure = registry
+        .register_connector(conflicting_request)
+        .expect_err("different connector metadata should conflict");
+    assert_eq!(
+        failure.errors[0].code,
+        RegistryErrorCode::ImmutableVersionConflict
+    );
+}
+
+#[test]
+fn connector_discovery_handles_invalid_ranges_and_private_shadowing() {
+    let mut registry = CapabilityRegistry::new();
+    let connector = reference_connector_contracts()
+        .into_iter()
+        .find(|contract| contract.connector_id == "traverse.env")
+        .expect("traverse.env reference connector should exist");
+    registry
+        .register_connector(connector_registration(
+            RegistryScope::Public,
+            connector.clone(),
+        ))
+        .expect("public connector registration should pass");
+    registry
+        .register_connector(connector_registration(RegistryScope::Private, connector))
+        .expect("private connector registration should pass");
+
+    assert!(
+        registry
+            .discover_connectors(LookupScope::PreferPrivate, "traverse.env", "not a range")
+            .is_empty()
+    );
+    assert!(
+        registry
+            .discover_connectors(LookupScope::PreferPrivate, "traverse.http", "^1.0.0")
+            .is_empty()
+    );
+
+    let discovered =
+        registry.discover_connectors(LookupScope::PreferPrivate, "traverse.env", "^1.0.0");
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].scope, RegistryScope::Private);
+}
+
+#[test]
+fn capability_registration_rejects_missing_required_connector() {
+    let mut registry = CapabilityRegistry::new();
+    let mut contract = base_contract("content.comments.create-comment-draft", "1.0.0");
+    contract.connector_requirements.push(ConnectorRequirement {
+        connector_id: "traverse.http".to_string(),
+        version: "^1.0.0".to_string(),
+    });
+
+    let failure = registry
+        .register(executable_registration(RegistryScope::Public, contract))
+        .expect_err("missing connector should reject registration");
+
+    assert!(failure.errors.iter().any(|error| {
+        error.code == RegistryErrorCode::MissingRequiredConnector
+            && error.message.contains("missing_required_connector")
+    }));
+}
+
+#[test]
+fn capability_registration_rejects_incompatible_connector_version() {
+    let mut registry = CapabilityRegistry::new();
+    let connector = reference_connector_contracts()
+        .into_iter()
+        .find(|contract| contract.connector_id == "traverse.http")
+        .expect("traverse.http reference connector should exist");
+    registry
+        .register_connector(connector_registration(RegistryScope::Public, connector))
+        .expect("connector registration should pass");
+
+    let mut contract = base_contract("content.comments.create-comment-draft", "1.0.0");
+    contract.connector_requirements.push(ConnectorRequirement {
+        connector_id: "traverse.http".to_string(),
+        version: "^2.0.0".to_string(),
+    });
+
+    let failure = registry
+        .register(executable_registration(RegistryScope::Public, contract))
+        .expect_err("incompatible connector should reject registration");
+
+    assert!(failure.errors.iter().any(|error| {
+        error.code == RegistryErrorCode::ConnectorVersionIncompatible
+            && error.message.contains("connector_version_incompatible")
+    }));
+}
+
+#[test]
+fn capability_registration_accepts_satisfied_connector_requirement() {
+    let mut registry = CapabilityRegistry::new();
+    let connector = reference_connector_contracts()
+        .into_iter()
+        .find(|contract| contract.connector_id == "traverse.http")
+        .expect("traverse.http reference connector should exist");
+    registry
+        .register_connector(connector_registration(RegistryScope::Public, connector))
+        .expect("connector registration should pass");
+
+    let mut contract = base_contract("content.comments.create-comment-draft", "1.0.0");
+    contract.connector_requirements.push(ConnectorRequirement {
+        connector_id: "traverse.http".to_string(),
+        version: "^1.0.0".to_string(),
+    });
+
+    let outcome = registry
+        .register(executable_registration(RegistryScope::Public, contract))
+        .expect("satisfied connector requirement should allow registration");
+
+    assert_eq!(outcome.record.id, "content.comments.create-comment-draft");
 }
 
 #[test]
@@ -585,6 +754,25 @@ fn event_registration(scope: RegistryScope, contract: EventContract) -> EventReg
     }
 }
 
+fn connector_registration(
+    scope: RegistryScope,
+    contract: traverse_contracts::ConnectorContract,
+) -> ConnectorRegistration {
+    ConnectorRegistration {
+        scope,
+        contract_path: format!(
+            "registry/{}/connectors/{}/{}.json",
+            scope_name(scope),
+            contract.connector_id,
+            contract.version
+        ),
+        registered_at: "2026-04-19T00:00:00Z".to_string(),
+        governing_spec: "039-connector-plugin-architecture".to_string(),
+        validator_version: "registry-test".to_string(),
+        contract,
+    }
+}
+
 fn workflow_registration(
     scope: RegistryScope,
     contract: CapabilityContract,
@@ -710,6 +898,7 @@ fn base_contract(id: &str, version: &str) -> CapabilityContract {
             ExecutionTarget::Device,
         ],
         event_trigger: None,
+        connector_requirements: Vec::new(),
     }
 }
 

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -3648,6 +3648,7 @@ mod tests {
                 ExecutionTarget::Device,
             ],
             event_trigger: None,
+            connector_requirements: Vec::new(),
         }
     }
 

--- a/crates/traverse-runtime/src/workflows.rs
+++ b/crates/traverse-runtime/src/workflows.rs
@@ -2122,6 +2122,7 @@ mod tests {
                 ExecutionTarget::Device,
             ],
             event_trigger: None,
+            connector_requirements: Vec::new(),
         }
     }
 

--- a/crates/traverse-runtime/tests/expedition_wasm_tests.rs
+++ b/crates/traverse-runtime/tests/expedition_wasm_tests.rs
@@ -147,6 +147,7 @@ fn expedition_contract() -> CapabilityContract {
             ExecutionTarget::Device,
         ],
         event_trigger: None,
+        connector_requirements: Vec::new(),
     }
 }
 

--- a/crates/traverse-runtime/tests/placement_tests.rs
+++ b/crates/traverse-runtime/tests/placement_tests.rs
@@ -86,6 +86,7 @@ fn base_contract() -> CapabilityContract {
             ExecutionTarget::Edge,
         ],
         event_trigger: None,
+        connector_requirements: Vec::new(),
     }
 }
 

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -99,6 +99,7 @@ fn base_contract(service_type: ServiceType) -> CapabilityContract {
         service_type,
         permitted_targets: vec![ExecutionTarget::Local, ExecutionTarget::Cloud],
         event_trigger: None,
+        connector_requirements: Vec::new(),
     }
 }
 

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -1074,6 +1074,7 @@ fn capability_contract(
             traverse_contracts::ExecutionTarget::Device,
         ],
         event_trigger: None,
+        connector_requirements: Vec::new(),
     }
 }
 
@@ -1393,6 +1394,7 @@ fn simple_registration(scope: RegistryScope, id: &str, version: &str) -> Capabil
         service_type: traverse_contracts::ServiceType::Stateless,
         permitted_targets: vec![ExecutionTarget::Local],
         event_trigger: None,
+        connector_requirements: Vec::new(),
     };
     CapabilityRegistration {
         scope,


### PR DESCRIPTION
## Summary
- Adds the governed connector contract surface for spec 039, including `ConnectorContract`, `ConnectorRequirement`, invocation/output/error types, and the `ConnectorPlugin` trait in `traverse-contracts`.
- Adds v0 reference connector contracts for `traverse.http`, `traverse.fs.read`, and `traverse.env`.
- Extends the capability registry with connector registration/discovery and enforces capability connector requirements during registration with deterministic `missing_required_connector` and `connector_version_incompatible` failures.
- Keeps existing runtime/CLI/MCP fixtures backward-compatible by populating empty connector requirements where Rust struct literals need the new field.

## Governing Spec
- `039-connector-plugin-architecture`
- `014-service-type-taxonomy`
- `006-runtime-request-execution`
- `001-foundation-v0-1`
- `015-capability-discovery-mcp`

## Project Item
- Issue: #370
- Project: https://github.com/users/enricopiovesan/projects/1
- Status: In Progress

## Validation
- `cargo fmt --check`
- `cargo test -p traverse-contracts connector -- --test-threads=1`
- `cargo test -p traverse-registry connector -- --test-threads=1`
- `bash scripts/ci/coverage_gate.sh`
- `bash scripts/ci/rust_checks.sh`
- `bash scripts/ci/repository_checks.sh`
- `git diff --check`

Closes #370
