### PR TITLE
feat: add governed artifact signature verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +221,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "core-foundation-sys"
@@ -427,12 +439,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -475,6 +524,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -536,6 +609,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1128,6 +1207,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,6 +1403,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1533,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,10 +1567,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1720,6 +1843,7 @@ name = "traverse-runtime"
 version = "0.2.0"
 dependencies = [
  "chrono",
+ "ed25519-dalek",
  "semver",
  "serde",
  "serde_json",
@@ -2717,6 +2841,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/crates/traverse-cli/src/agent_packages.rs
+++ b/crates/traverse-cli/src/agent_packages.rs
@@ -153,6 +153,7 @@ impl LoadedAgentPackage {
                 binary: Some(BinaryReference {
                     format: BinaryFormat::Wasm,
                     location: self.binary_path.display().to_string(),
+                    signature: None,
                 }),
                 workflow_ref: None,
                 digests: ArtifactDigests {

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -1452,6 +1452,7 @@ fn derive_registration(
             binary: Some(BinaryReference {
                 format: BinaryFormat::Wasm,
                 location: entrypoint,
+                signature: None,
             }),
             workflow_ref: None,
             digests: ArtifactDigests {
@@ -5427,6 +5428,7 @@ mod tests {
                 binary: Some(BinaryReference {
                     format: BinaryFormat::Wasm,
                     location: format!("test/{id}/module.wasm"),
+                    signature: None,
                 }),
                 workflow_ref: None,
                 digests: ArtifactDigests {

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -2001,6 +2001,7 @@ fn build_capability_artifact(
                     "bundled://{}/{}/module.wasm",
                     capability.contract.id, capability.contract.version
                 ),
+                signature: None,
             }),
             ImplementationKind::Workflow => None,
         },

--- a/crates/traverse-mcp/src/lib.rs
+++ b/crates/traverse-mcp/src/lib.rs
@@ -972,6 +972,7 @@ mod tests {
             binary: Some(BinaryReference {
                 format: BinaryFormat::Wasm,
                 location: "artifacts/create-comment-draft.wasm".to_string(),
+                signature: None,
             }),
             workflow_ref: None,
             digests: ArtifactDigests {
@@ -1121,6 +1122,7 @@ mod tests {
                 traceparent: None,
                 tracestate: None,
                 metadata: None,
+                identity: None,
             },
             governing_spec: "006-runtime-request-execution".to_string(),
         }

--- a/crates/traverse-mcp/src/stdio_server.rs
+++ b/crates/traverse-mcp/src/stdio_server.rs
@@ -915,6 +915,7 @@ fn build_capability_artifact(
                     "bundled://{}/{}/module.wasm",
                     capability.contract.id, capability.contract.version
                 ),
+                signature: None,
             }),
             ImplementationKind::Workflow => None,
         },

--- a/crates/traverse-mcp/tests/mcp_tests.rs
+++ b/crates/traverse-mcp/tests/mcp_tests.rs
@@ -158,6 +158,7 @@ fn capability_artifact_record(id: &str) -> CapabilityArtifactRecord {
         binary: Some(BinaryReference {
             format: BinaryFormat::Wasm,
             location: format!("artifacts/{id}.wasm"),
+            signature: None,
         }),
         workflow_ref: None,
         digests: ArtifactDigests {

--- a/crates/traverse-registry/src/dependency_resolver.rs
+++ b/crates/traverse-registry/src/dependency_resolver.rs
@@ -331,6 +331,7 @@ mod tests {
             binary: Some(BinaryReference {
                 format: BinaryFormat::Wasm,
                 location: format!("artifacts/{}/{}.wasm", contract.name, contract.version),
+                signature: None,
             }),
             workflow_ref: None,
             digests: ArtifactDigests {

--- a/crates/traverse-registry/src/federation.rs
+++ b/crates/traverse-registry/src/federation.rs
@@ -2801,6 +2801,7 @@ mod tests {
                 binary: Some(BinaryReference {
                     format: BinaryFormat::Wasm,
                     location: format!("artifacts/{}/{}.wasm", contract.name, contract.version),
+                    signature: None,
                 }),
                 workflow_ref: None,
                 digests: ArtifactDigests {

--- a/crates/traverse-registry/src/graph.rs
+++ b/crates/traverse-registry/src/graph.rs
@@ -782,6 +782,7 @@ mod tests {
                     BinaryReference {
                         format: BinaryFormat::Wasm,
                         location: "artifacts/example.wasm".to_string(),
+                        signature: None,
                     }
                 }),
                 workflow_ref: workflow_ref.map(|(workflow_id, workflow_version)| {

--- a/crates/traverse-registry/src/lib.rs
+++ b/crates/traverse-registry/src/lib.rs
@@ -68,6 +68,21 @@ pub enum BinaryFormat {
 pub struct BinaryReference {
     pub format: BinaryFormat,
     pub location: String,
+    pub signature: Option<ArtifactSignature>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactSignatureScheme {
+    Ed25519,
+    Sigstore,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtifactSignature {
+    pub scheme: ArtifactSignatureScheme,
+    pub public_key_hex: Option<String>,
+    pub signature_hex: Option<String>,
+    pub sigstore_bundle_ref: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1894,6 +1909,7 @@ mod tests {
             binary: Some(BinaryReference {
                 format: BinaryFormat::Wasm,
                 location: format!("artifacts/{}/{}.wasm", contract.name, contract.version),
+                signature: None,
             }),
             workflow_ref: None,
             digests: ArtifactDigests {

--- a/crates/traverse-registry/src/semver_resolver.rs
+++ b/crates/traverse-registry/src/semver_resolver.rs
@@ -292,6 +292,7 @@ mod tests {
             binary: Some(BinaryReference {
                 format: BinaryFormat::Wasm,
                 location: format!("artifacts/{}/{}.wasm", contract.name, contract.version),
+                signature: None,
             }),
             workflow_ref: None,
             digests: ArtifactDigests {

--- a/crates/traverse-registry/src/workflows.rs
+++ b/crates/traverse-registry/src/workflows.rs
@@ -2250,6 +2250,7 @@ mod tests {
                 binary: Some(BinaryReference {
                     format: BinaryFormat::Wasm,
                     location: format!("{capability_id}.wasm"),
+                    signature: None,
                 }),
                 workflow_ref: None,
                 digests: ArtifactDigests {

--- a/crates/traverse-registry/tests/registry.rs
+++ b/crates/traverse-registry/tests/registry.rs
@@ -712,6 +712,7 @@ fn executable_registration(
             binary: Some(BinaryReference {
                 format: BinaryFormat::Wasm,
                 location: format!("artifacts/{}/{}.wasm", contract.name, contract.version),
+                signature: None,
             }),
             workflow_ref: None,
             digests: ArtifactDigests {

--- a/crates/traverse-runtime/Cargo.toml
+++ b/crates/traverse-runtime/Cargo.toml
@@ -13,6 +13,7 @@ semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.10"
+ed25519-dalek = "2.2.0"
 wasmtime = { version = "44", features = ["cranelift", "component-model"] }
 wasmtime-wasi = "44"
 uuid = { version = "1", features = ["v4"] }

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -7,12 +7,18 @@ pub mod events;
 pub mod executor;
 pub mod placement;
 pub mod router;
+pub mod security;
 pub mod trace;
 
+use security::{
+    ArtifactVerificationFailure, ArtifactVerificationRecord, RuntimeIdentity,
+    RuntimeSecurityConfig, RuntimeWarning, derive_identity_from_jwt, verify_artifact,
+};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use std::fmt;
+use std::fs;
 use traverse_contracts::{
     ExecutionTarget, HostApiAccess, Lifecycle, NetworkAccess, ViolationRecord,
 };
@@ -47,6 +53,7 @@ pub struct Runtime<E> {
     workflow_registry: WorkflowRegistry,
     executor: E,
     observability: RuntimeObservabilityConfig,
+    security: RuntimeSecurityConfig,
 }
 
 impl<E> Runtime<E> {
@@ -57,6 +64,7 @@ impl<E> Runtime<E> {
             workflow_registry: WorkflowRegistry::new(),
             executor,
             observability: RuntimeObservabilityConfig::default(),
+            security: RuntimeSecurityConfig::default(),
         }
     }
 
@@ -75,6 +83,17 @@ impl<E> Runtime<E> {
     #[must_use]
     pub fn observability_config(&self) -> &RuntimeObservabilityConfig {
         &self.observability
+    }
+
+    #[must_use]
+    pub fn with_security_config(mut self, security: RuntimeSecurityConfig) -> Self {
+        self.security = security;
+        self
+    }
+
+    #[must_use]
+    pub fn security_config(&self) -> &RuntimeSecurityConfig {
+        &self.security
     }
 
     /// Returns a reference to the capability registry.
@@ -217,6 +236,8 @@ pub struct RuntimeContext {
     pub tracestate: Option<String>,
     #[serde(default)]
     pub metadata: Option<Value>,
+    #[serde(default)]
+    pub identity: Option<RuntimeIdentity>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -627,6 +648,10 @@ pub struct ExecutionRecord {
     pub output_digest: Option<String>,
     #[serde(default)]
     pub failure_reason: Option<ExecutionFailureReason>,
+    #[serde(default)]
+    pub artifact_verification: Option<ArtifactVerificationRecord>,
+    #[serde(default)]
+    pub identity: Option<RuntimeIdentity>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -669,6 +694,8 @@ pub struct RuntimeResult {
     pub output: Option<Value>,
     #[serde(default)]
     pub error: Option<RuntimeError>,
+    #[serde(default)]
+    pub warnings: Vec<RuntimeWarning>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -986,7 +1013,10 @@ where
         emitter.push(
             RuntimeState::Discovering,
             RuntimeTransitionReasonCode::RequestStarted,
-            json!({"lookup_scope": attempt.request.lookup.scope}),
+            json!({
+                "lookup_scope": attempt.request.lookup.scope,
+                "identity": attempt.request.context.identity,
+            }),
         );
 
         if let Some(error) = validate_request(&attempt.request) {
@@ -1160,7 +1190,7 @@ where
         selection: SelectionRecord,
         selected: &ResolvedCapability,
     ) -> RuntimeExecutionOutcome {
-        let context = ExecutionContext {
+        let mut context = ExecutionContext {
             attempt,
             emitter,
             candidate_collection,
@@ -1189,6 +1219,7 @@ where
                         PlacementDecisionReason::SelectionNotReached,
                     ),
                     error,
+                    artifact_verification: None,
                 },
             );
         }
@@ -1206,10 +1237,54 @@ where
                             PlacementDecisionReason::RequestedTargetUnsupported,
                         ),
                         error,
+                        artifact_verification: None,
                     },
                 );
             }
         };
+
+        let artifact_bytes = match load_artifact_bytes_for_verification(selected) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                return pre_execution_failure_outcome(
+                    context,
+                    PreExecutionFailure {
+                        artifact_ref: Some(selected.record.artifact_ref.clone()),
+                        failure_reason: ExecutionFailureReason::ArtifactMissing,
+                        placement,
+                        error,
+                        artifact_verification: None,
+                    },
+                );
+            }
+        };
+
+        match verify_artifact(selected, &artifact_bytes, &self.security) {
+            Ok(record) => {
+                if record.warning_code.is_some() {
+                    context.attempt.warnings.push(RuntimeWarning {
+                        code: record.warning_code.clone().unwrap_or_default(),
+                        message: "unsigned local/dev artifact allowed by development security mode"
+                            .to_string(),
+                    });
+                }
+                context.attempt.artifact_verification = Some(record);
+            }
+            Err(error) => {
+                let record = error.record().clone();
+                let runtime_error = artifact_verification_runtime_error(&error);
+                return pre_execution_failure_outcome(
+                    context,
+                    PreExecutionFailure {
+                        artifact_ref: Some(selected.record.artifact_ref.clone()),
+                        failure_reason: ExecutionFailureReason::ArtifactNotRunnable,
+                        placement,
+                        error: runtime_error,
+                        artifact_verification: Some(record),
+                    },
+                );
+            }
+        }
 
         // Dependency resolution gate (spec 043): resolve and verify all
         // Capability-typed dependencies before executing.
@@ -1240,6 +1315,7 @@ where
                     "required_version": detail_version,
                 }),
             );
+            let artifact_verification = context.attempt.artifact_verification.clone();
             return pre_execution_failure_outcome(
                 context,
                 PreExecutionFailure {
@@ -1247,6 +1323,7 @@ where
                     failure_reason: ExecutionFailureReason::ArtifactMissing,
                     placement,
                     error,
+                    artifact_verification,
                 },
             );
         }
@@ -1257,6 +1334,7 @@ where
             RuntimeErrorCode::RequestInvalid,
             "runtime request input does not satisfy the selected capability input contract",
         ) {
+            let artifact_verification = context.attempt.artifact_verification.clone();
             return pre_execution_failure_outcome(
                 context,
                 PreExecutionFailure {
@@ -1264,6 +1342,7 @@ where
                     failure_reason: ExecutionFailureReason::ContractInputInvalid,
                     placement,
                     error,
+                    artifact_verification,
                 },
             );
         }
@@ -1277,7 +1356,9 @@ where
         selected: &ResolvedCapability,
         placement: PlacementDecisionRecord,
     ) -> RuntimeExecutionOutcome {
-        let started_execution = start_selected_execution(&mut context.emitter, selected, placement);
+        let identity = context.attempt.request.context.identity.clone();
+        let started_execution =
+            start_selected_execution(&mut context.emitter, selected, placement, identity.as_ref());
         if selected.record.implementation_kind == ImplementationKind::Workflow {
             return self.execute_workflow_capability(context, selected, started_execution);
         }
@@ -1395,6 +1476,7 @@ fn terminal_failure(context: FailureContext) -> RuntimeExecutionOutcome {
         trace_ref: context.attempt.trace_id,
         output: None,
         error: Some(context.error),
+        warnings: context.attempt.warnings,
     };
 
     RuntimeExecutionOutcome {
@@ -1444,10 +1526,61 @@ fn resolve_placement(
     ))
 }
 
+fn sanitized_request(mut request: RuntimeRequest) -> RuntimeRequest {
+    if let Some(token) = request.context.caller.take() {
+        if let Some(identity) = derive_identity_from_jwt(&token) {
+            request.context.identity = Some(identity);
+        } else {
+            request.context.caller = Some(token);
+        }
+    }
+    request
+}
+
+fn load_artifact_bytes_for_verification(
+    selected: &ResolvedCapability,
+) -> Result<Vec<u8>, RuntimeError> {
+    let Some(binary) = selected.artifact.binary.as_ref() else {
+        return Ok(Vec::new());
+    };
+    match fs::read(&binary.location) {
+        Ok(bytes) => Ok(bytes),
+        Err(_) if binary.signature.is_none() => Ok(selected
+            .artifact
+            .digests
+            .binary_digest
+            .clone()
+            .unwrap_or_else(|| selected.record.artifact_ref.clone())
+            .into_bytes()),
+        Err(error) => Err(runtime_error(
+            RuntimeErrorCode::ArtifactMissing,
+            "artifact bytes could not be loaded for signature verification",
+            json!({
+                "artifact_ref": selected.record.artifact_ref,
+                "location": binary.location,
+                "code": "artifact_load_failed",
+                "message": error.to_string(),
+            }),
+        )),
+    }
+}
+
+fn artifact_verification_runtime_error(error: &ArtifactVerificationFailure) -> RuntimeError {
+    runtime_error(
+        RuntimeErrorCode::ContractViolation,
+        "artifact signature verification failed before execution",
+        json!({
+            "code": error.code(),
+            "artifact_verification": error.record(),
+        }),
+    )
+}
+
 fn begin_attempt(
     request: RuntimeRequest,
     observability: RuntimeObservabilityConfig,
 ) -> (AttemptContext, StateEmitter) {
+    let request = sanitized_request(request);
     let request_id = request.request_id.clone();
     let execution_id = format!("{EXECUTION_PREFIX}{request_id}");
     let trace_id = format!("{TRACE_PREFIX}{execution_id}");
@@ -1455,7 +1588,10 @@ fn begin_attempt(
     emitter.push(
         RuntimeState::LoadingRegistry,
         RuntimeTransitionReasonCode::RuntimeInitializationStarted,
-        json!({"registry_status": "available"}),
+        json!({
+            "registry_status": "available",
+            "identity": request.context.identity,
+        }),
     );
     emitter.push(
         RuntimeState::Ready,
@@ -1469,6 +1605,8 @@ fn begin_attempt(
             execution_id,
             trace_id,
             observability,
+            artifact_verification: None,
+            warnings: Vec::new(),
         },
         emitter,
     )
@@ -1499,6 +1637,7 @@ fn invalid_request_outcome(
         json!({"terminal_state": RuntimeState::Error}),
     );
     let finished = emitter.finish();
+    let identity = attempt.request.context.identity.clone();
     terminal_failure(FailureContext {
         attempt,
         state_events: finished.events,
@@ -1525,6 +1664,8 @@ fn invalid_request_outcome(
             completed_at: None,
             output_digest: None,
             failure_reason: Some(ExecutionFailureReason::ContractInputInvalid),
+            artifact_verification: None,
+            identity,
         },
         error,
         emitted_events: Vec::new(),
@@ -1571,6 +1712,7 @@ fn no_eligible_outcome(
         SelectionFailureReason::NotRunnable
     };
     let finished = emitter.finish();
+    let identity = attempt.request.context.identity.clone();
 
     terminal_failure(FailureContext {
         attempt,
@@ -1594,6 +1736,8 @@ fn no_eligible_outcome(
             completed_at: None,
             output_digest: None,
             failure_reason: Some(ExecutionFailureReason::ArtifactNotRunnable),
+            artifact_verification: None,
+            identity,
         },
         error,
         emitted_events: Vec::new(),
@@ -1631,6 +1775,7 @@ fn ambiguous_outcome(
         json!({"terminal_state": RuntimeState::Error}),
     );
     let finished = emitter.finish();
+    let identity = attempt.request.context.identity.clone();
 
     terminal_failure(FailureContext {
         attempt,
@@ -1654,6 +1799,8 @@ fn ambiguous_outcome(
             completed_at: None,
             output_digest: None,
             failure_reason: Some(ExecutionFailureReason::ArtifactNotRunnable),
+            artifact_verification: None,
+            identity,
         },
         error,
         emitted_events: Vec::new(),
@@ -1687,6 +1834,7 @@ fn pre_execution_failure_outcome(
         json!({"terminal_state": RuntimeState::Error}),
     );
     let finished = emitter.finish();
+    let identity = attempt.request.context.identity.clone();
     terminal_failure(FailureContext {
         attempt,
         state_events: finished.events,
@@ -1706,6 +1854,8 @@ fn pre_execution_failure_outcome(
             completed_at: None,
             output_digest: None,
             failure_reason: Some(failure.failure_reason),
+            artifact_verification: failure.artifact_verification,
+            identity,
         },
         error: failure.error,
         emitted_events: Vec::new(),
@@ -1739,6 +1889,8 @@ fn execution_failure_outcome(
         json!({"terminal_state": RuntimeState::Error}),
     );
     let finished = emitter.finish();
+    let identity = attempt.request.context.identity.clone();
+    let artifact_verification = attempt.artifact_verification.clone();
 
     terminal_failure(FailureContext {
         attempt,
@@ -1759,6 +1911,8 @@ fn execution_failure_outcome(
             completed_at: Some(completed_at),
             output_digest: None,
             failure_reason: Some(failure.failure_reason),
+            artifact_verification,
+            identity,
         },
         error,
         emitted_events,
@@ -1831,6 +1985,8 @@ fn successful_execution_outcome(
         completed_at: Some(completed_at),
         output_digest: Some(content_digest(&execution_output)),
         failure_reason: None,
+        artifact_verification: attempt.artifact_verification.clone(),
+        identity: attempt.request.context.identity.clone(),
     };
     let result_record = TraceResultRecord {
         status: RuntimeResultStatus::Completed,
@@ -1888,6 +2044,7 @@ fn successful_execution_outcome(
         trace_ref: attempt.trace_id,
         output: Some(execution_output),
         error: None,
+        warnings: attempt.warnings,
     };
 
     RuntimeExecutionOutcome {
@@ -2454,6 +2611,8 @@ struct AttemptContext {
     execution_id: String,
     trace_id: String,
     observability: RuntimeObservabilityConfig,
+    artifact_verification: Option<ArtifactVerificationRecord>,
+    warnings: Vec<RuntimeWarning>,
 }
 
 struct CandidateResolution {
@@ -2499,6 +2658,7 @@ struct PreExecutionFailure {
     failure_reason: ExecutionFailureReason,
     placement: PlacementDecisionRecord,
     error: RuntimeError,
+    artifact_verification: Option<ArtifactVerificationRecord>,
 }
 
 enum CandidateEvaluation {
@@ -2527,6 +2687,7 @@ fn start_selected_execution(
     emitter: &mut StateEmitter,
     selected: &ResolvedCapability,
     placement: PlacementDecisionRecord,
+    identity: Option<&RuntimeIdentity>,
 ) -> StartedExecution {
     let started_at = emitter.next_timestamp();
     emitter.push(
@@ -2540,6 +2701,7 @@ fn start_selected_execution(
             "selected_target": placement.selected_target,
             "placement_status": placement.status,
             "placement_reason": placement.reason,
+            "identity": identity,
         }),
     );
     StartedExecution {
@@ -2773,6 +2935,10 @@ fn runtime_state_name(state: RuntimeState) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use super::security::{
+        ArtifactVerificationFailure, ArtifactVerificationScheme, ArtifactVerificationStatus,
+        RuntimeSecurityConfig, derive_identity_from_jwt, verify_artifact,
+    };
     use super::{
         BrowserRuntimeSubscriptionErrorCode, BrowserRuntimeSubscriptionMessage,
         BrowserRuntimeSubscriptionRequest, CandidateEvaluation, CandidateReason, LocalExecutor,
@@ -2783,19 +2949,23 @@ mod tests {
         map_registry_scope, parse_runtime_request, runtime_candidate, subscription_targets_outcome,
         validate_browser_subscription_request, validate_payload_against_contract, validate_request,
     };
+    use ed25519_dalek::{Signer, SigningKey};
     use serde_json::json;
+    use std::fs;
     use traverse_contracts::{
         BinaryFormat as ContractBinaryFormat, Entrypoint, EntrypointKind, Execution,
         ExecutionConstraints, ExecutionTarget, FilesystemAccess, HostApiAccess, Lifecycle,
         NetworkAccess, Owner, Provenance, ProvenanceSource, SchemaContainer, ServiceType,
     };
     use traverse_registry::{
-        ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
-        CapabilityRegistration, CapabilityRegistry, CapabilityRegistryRecord,
-        ComposabilityMetadata, CompositionKind, CompositionPattern, DiscoveryIndexEntry,
-        ImplementationKind, RegistryProvenance, RegistryScope, ResolvedCapability, SourceKind,
-        SourceReference,
+        ArtifactDigests, ArtifactSignature, ArtifactSignatureScheme, BinaryFormat, BinaryReference,
+        CapabilityArtifactRecord, CapabilityRegistration, CapabilityRegistry,
+        CapabilityRegistryRecord, ComposabilityMetadata, CompositionKind, CompositionPattern,
+        DiscoveryIndexEntry, ImplementationKind, RegistryProvenance, RegistryScope,
+        ResolvedCapability, SourceKind, SourceReference,
     };
+
+    const HEX_TABLE: &[u8; 16] = b"0123456789abcdef";
 
     #[test]
     fn missing_binary_metadata_is_rejected_as_artifact_missing() {
@@ -2887,6 +3057,7 @@ mod tests {
             Some(traverse_registry::BinaryReference {
                 format: traverse_registry::BinaryFormat::Wasm,
                 location: "artifact.wasm".to_string(),
+                signature: None,
             }),
             Lifecycle::Active,
         );
@@ -2908,6 +3079,7 @@ mod tests {
             Some(traverse_registry::BinaryReference {
                 format: traverse_registry::BinaryFormat::Wasm,
                 location: String::new(),
+                signature: None,
             }),
             Lifecycle::Active,
         );
@@ -2920,6 +3092,7 @@ mod tests {
             Some(traverse_registry::BinaryReference {
                 format: traverse_registry::BinaryFormat::Wasm,
                 location: "artifact.wasm".to_string(),
+                signature: None,
             }),
             Lifecycle::Active,
         );
@@ -2933,6 +3106,7 @@ mod tests {
             Some(traverse_registry::BinaryReference {
                 format: traverse_registry::BinaryFormat::Wasm,
                 location: "artifact.wasm".to_string(),
+                signature: None,
             }),
             Lifecycle::Active,
         );
@@ -2947,6 +3121,7 @@ mod tests {
             Some(traverse_registry::BinaryReference {
                 format: traverse_registry::BinaryFormat::Wasm,
                 location: "artifact.wasm".to_string(),
+                signature: None,
             }),
             Lifecycle::Active,
         );
@@ -2960,6 +3135,7 @@ mod tests {
             Some(traverse_registry::BinaryReference {
                 format: traverse_registry::BinaryFormat::Wasm,
                 location: "artifact.wasm".to_string(),
+                signature: None,
             }),
             Lifecycle::Active,
         );
@@ -3097,6 +3273,7 @@ mod tests {
             Some(traverse_registry::BinaryReference {
                 format: traverse_registry::BinaryFormat::Wasm,
                 location: "artifact.wasm".to_string(),
+                signature: None,
             }),
             Lifecycle::Deprecated,
         );
@@ -3149,11 +3326,14 @@ mod tests {
             execution_id: "exec_1".to_string(),
             trace_id: "trace_exec_1".to_string(),
             observability: super::RuntimeObservabilityConfig::default(),
+            artifact_verification: None,
+            warnings: Vec::new(),
         };
         let capability = resolved_capability(
             Some(traverse_registry::BinaryReference {
                 format: traverse_registry::BinaryFormat::Wasm,
                 location: "artifact.wasm".to_string(),
+                signature: None,
             }),
             Lifecycle::Active,
         );
@@ -3214,7 +3394,8 @@ mod tests {
     fn runtime_execution_produces_otel_phase_spans() {
         let mut registry = CapabilityRegistry::new();
         assert!(registry.register(public_registration()).is_ok());
-        let runtime = Runtime::new(registry, NoopExecutor);
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
         let outcome = runtime.execute(valid_request());
         let spans = &outcome.trace.otel_trace.spans;
         let names: Vec<&str> = spans.iter().map(|span| span.name.as_str()).collect();
@@ -3274,6 +3455,345 @@ mod tests {
         assert_eq!(
             runtime.observability_config().exporter.endpoint.as_deref(),
             Some("http://collector:4318")
+        );
+    }
+
+    #[test]
+    fn governed_artifact_with_valid_ed25519_signature_executes() {
+        let artifact_bytes = b"governed wasm bytes";
+        let path = temp_artifact_path("ed25519-valid");
+        assert!(fs::write(&path, artifact_bytes).is_ok());
+        let signature = ed25519_signature_for(artifact_bytes);
+        let mut registry = CapabilityRegistry::new();
+        assert!(
+            registry
+                .register(governed_registration(&path, Some(signature)))
+                .is_ok()
+        );
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
+
+        let outcome = runtime.execute(valid_request());
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
+        assert_eq!(
+            outcome
+                .trace
+                .execution
+                .artifact_verification
+                .as_ref()
+                .map(|record| record.status),
+            Some(ArtifactVerificationStatus::Verified)
+        );
+        assert_eq!(
+            outcome
+                .trace
+                .execution
+                .artifact_verification
+                .as_ref()
+                .and_then(|record| record.scheme),
+            Some(ArtifactVerificationScheme::Ed25519)
+        );
+    }
+
+    #[test]
+    fn governed_artifact_without_signature_is_rejected_in_production() {
+        let path = temp_artifact_path("missing-signature");
+        assert!(fs::write(&path, b"unsigned governed bytes").is_ok());
+        let mut registry = CapabilityRegistry::new();
+        assert!(
+            registry
+                .register(governed_registration(&path, None))
+                .is_ok()
+        );
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
+
+        let outcome = runtime.execute(valid_request());
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+        assert_eq!(
+            outcome
+                .result
+                .error
+                .as_ref()
+                .and_then(|error| error.details.get("code"))
+                .and_then(serde_json::Value::as_str),
+            Some("missing_signature")
+        );
+        assert_eq!(
+            outcome
+                .trace
+                .execution
+                .artifact_verification
+                .as_ref()
+                .and_then(|record| record.error_code.as_deref()),
+            Some("missing_signature")
+        );
+    }
+
+    #[test]
+    fn local_dev_unsigned_artifact_warns_and_executes_in_development_mode() {
+        let mut registry = CapabilityRegistry::new();
+        assert!(registry.register(public_registration()).is_ok());
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
+
+        let outcome = runtime.execute(valid_request());
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
+        assert_eq!(
+            outcome
+                .result
+                .warnings
+                .first()
+                .map(|warning| warning.code.as_str()),
+            Some("unsigned_local_dev_artifact")
+        );
+        assert_eq!(
+            outcome
+                .trace
+                .execution
+                .artifact_verification
+                .as_ref()
+                .map(|record| record.status),
+            Some(ArtifactVerificationStatus::Warning)
+        );
+    }
+
+    #[test]
+    fn governed_artifact_accepts_verified_sigstore_bundle() {
+        let path = temp_artifact_path("sigstore-valid");
+        assert!(fs::write(&path, b"sigstore governed bytes").is_ok());
+        let signature = ArtifactSignature {
+            scheme: ArtifactSignatureScheme::Sigstore,
+            public_key_hex: None,
+            signature_hex: None,
+            sigstore_bundle_ref: Some("verified://bundle/comment-draft".to_string()),
+        };
+        let mut registry = CapabilityRegistry::new();
+        assert!(
+            registry
+                .register(governed_registration(&path, Some(signature)))
+                .is_ok()
+        );
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::production());
+
+        let outcome = runtime.execute(valid_request());
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
+        assert_eq!(
+            outcome
+                .trace
+                .execution
+                .artifact_verification
+                .as_ref()
+                .and_then(|record| record.scheme),
+            Some(ArtifactVerificationScheme::Sigstore)
+        );
+    }
+
+    #[test]
+    fn jwt_identity_is_derived_and_raw_token_is_not_traced() {
+        let mut registry = CapabilityRegistry::new();
+        assert!(registry.register(public_registration()).is_ok());
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
+        let mut request = valid_request();
+        let token = make_jwt_with_actor("alice", "workflow-agent");
+        request.context.caller = Some(token.clone());
+
+        let outcome = runtime.execute(request);
+        let trace_json = serde_json::to_string(&outcome.trace).unwrap_or_default();
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
+        assert!(!trace_json.contains(&token));
+        assert_eq!(
+            outcome
+                .trace
+                .request
+                .context
+                .identity
+                .as_ref()
+                .map(|identity| identity.subject_id.as_str()),
+            Some("alice")
+        );
+        assert_eq!(
+            outcome
+                .trace
+                .execution
+                .identity
+                .as_ref()
+                .and_then(|identity| identity.actor_id.as_deref()),
+            Some("workflow-agent")
+        );
+        assert!(
+            outcome
+                .state_events
+                .iter()
+                .any(|event| event.details.to_string().contains("alice"))
+        );
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn security_branch_guards_cover_malformed_signatures_sigstore_and_jwts() {
+        let capability = governed_resolved_capability(None);
+        let missing_public_key = ArtifactSignature {
+            scheme: ArtifactSignatureScheme::Ed25519,
+            public_key_hex: None,
+            signature_hex: Some("00".to_string()),
+            sigstore_bundle_ref: None,
+        };
+        let missing_signature = ArtifactSignature {
+            scheme: ArtifactSignatureScheme::Ed25519,
+            public_key_hex: Some("00".to_string()),
+            signature_hex: None,
+            sigstore_bundle_ref: None,
+        };
+        let bad_public_hex = ArtifactSignature {
+            scheme: ArtifactSignatureScheme::Ed25519,
+            public_key_hex: Some("abc".to_string()),
+            signature_hex: Some("00".to_string()),
+            sigstore_bundle_ref: None,
+        };
+        let bad_signature_hex = ArtifactSignature {
+            scheme: ArtifactSignatureScheme::Ed25519,
+            public_key_hex: Some("00".to_string()),
+            signature_hex: Some("zz".to_string()),
+            sigstore_bundle_ref: None,
+        };
+        let short_public_key = ArtifactSignature {
+            scheme: ArtifactSignatureScheme::Ed25519,
+            public_key_hex: Some("00".to_string()),
+            signature_hex: Some("00".repeat(64)),
+            sigstore_bundle_ref: None,
+        };
+        let short_signature = ArtifactSignature {
+            scheme: ArtifactSignatureScheme::Ed25519,
+            public_key_hex: Some("00".repeat(32)),
+            signature_hex: Some("00".to_string()),
+            sigstore_bundle_ref: None,
+        };
+        let invalid_public_key = ArtifactSignature {
+            scheme: ArtifactSignatureScheme::Ed25519,
+            public_key_hex: Some("ff".repeat(32)),
+            signature_hex: Some("00".repeat(64)),
+            sigstore_bundle_ref: None,
+        };
+        let mismatch = ed25519_signature_for(b"other bytes");
+        for signature in [
+            missing_public_key,
+            missing_signature,
+            bad_public_hex,
+            bad_signature_hex,
+            short_public_key,
+            short_signature,
+            invalid_public_key,
+            mismatch,
+        ] {
+            let mut capability = capability.clone();
+            capability.artifact.binary = Some(BinaryReference {
+                format: BinaryFormat::Wasm,
+                location: "unused.wasm".to_string(),
+                signature: Some(signature),
+            });
+            let error = verify_artifact(
+                &capability,
+                b"artifact bytes",
+                &RuntimeSecurityConfig::production(),
+            );
+            assert!(matches!(
+                error,
+                Err(ArtifactVerificationFailure::SignatureVerificationFailed(_))
+            ));
+            let failure = error.err();
+            assert_eq!(
+                failure.as_ref().map(ArtifactVerificationFailure::code),
+                Some("signature_verification_failed")
+            );
+            assert_eq!(
+                failure
+                    .as_ref()
+                    .and_then(|item| item.record().error_code.as_deref()),
+                Some("signature_verification_failed")
+            );
+        }
+
+        let mut capability = capability.clone();
+        capability.artifact.binary = Some(BinaryReference {
+            format: BinaryFormat::Wasm,
+            location: "unused.wasm".to_string(),
+            signature: Some(ArtifactSignature {
+                scheme: ArtifactSignatureScheme::Sigstore,
+                public_key_hex: None,
+                signature_hex: None,
+                sigstore_bundle_ref: Some("https://rekor.example/bundle".to_string()),
+            }),
+        });
+        let error = verify_artifact(
+            &capability,
+            b"artifact bytes",
+            &RuntimeSecurityConfig::production(),
+        );
+        assert!(matches!(
+            error,
+            Err(ArtifactVerificationFailure::SigstoreUnreachable(_))
+        ));
+        assert_eq!(
+            error.err().as_ref().map(ArtifactVerificationFailure::code),
+            Some("sigstore_unreachable")
+        );
+
+        let bad_payload = base64url_encode(b"{");
+        let no_subject = base64url_encode(b"{}");
+        assert!(derive_identity_from_jwt("not-a-jwt").is_none());
+        assert!(derive_identity_from_jwt("a.b.c.d").is_none());
+        assert!(derive_identity_from_jwt("a.abc=.c").is_none());
+        assert!(derive_identity_from_jwt("a.*.c").is_none());
+        assert!(derive_identity_from_jwt("a.a.c").is_none());
+        assert!(derive_identity_from_jwt("a.-___.c").is_none());
+        assert!(derive_identity_from_jwt(&format!("a.{bad_payload}.c")).is_none());
+        assert!(derive_identity_from_jwt(&format!("a.{no_subject}.c")).is_none());
+        assert_eq!(base64url_encode(b""), "");
+    }
+
+    #[test]
+    fn runtime_security_config_accessor_returns_current_config() {
+        let runtime = Runtime::new(CapabilityRegistry::new(), NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::production());
+
+        assert_eq!(
+            runtime.security_config(),
+            &RuntimeSecurityConfig::production()
+        );
+    }
+
+    #[test]
+    fn signed_artifact_missing_from_disk_fails_before_execution() {
+        let path = temp_artifact_path("missing-from-disk");
+        let signature = ed25519_signature_for(b"governed wasm bytes");
+        let mut registry = CapabilityRegistry::new();
+        assert!(
+            registry
+                .register(governed_registration(&path, Some(signature)))
+                .is_ok()
+        );
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::production());
+
+        let outcome = runtime.execute(valid_request());
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+        assert_eq!(
+            outcome
+                .result
+                .error
+                .as_ref()
+                .and_then(|error| error.details.get("code"))
+                .and_then(serde_json::Value::as_str),
+            Some("artifact_load_failed")
         );
     }
 
@@ -3356,6 +3876,8 @@ mod tests {
                     execution_id: "exec_1".to_string(),
                     trace_id: "trace_exec_1".to_string(),
                     observability: super::RuntimeObservabilityConfig::default(),
+                    artifact_verification: None,
+                    warnings: Vec::new(),
                 },
                 emitter: events,
                 candidate_collection: super::CandidateCollectionRecord {
@@ -3383,6 +3905,7 @@ mod tests {
                     "not runnable",
                     json!({}),
                 ),
+                artifact_verification: None,
             },
         );
 
@@ -3437,6 +3960,7 @@ mod tests {
             Some(BinaryReference {
                 format: BinaryFormat::Wasm,
                 location: "artifact.wasm".to_string(),
+                signature: None,
             }),
             Lifecycle::Active,
         );
@@ -3530,6 +4054,7 @@ mod tests {
                 traceparent: None,
                 tracestate: None,
                 metadata: None,
+                identity: None,
             },
             governing_spec: "006-runtime-request-execution".to_string(),
         }
@@ -3552,6 +4077,113 @@ mod tests {
         runtime.execute(valid_request())
     }
 
+    fn governed_registration(
+        path: &std::path::Path,
+        signature: Option<ArtifactSignature>,
+    ) -> CapabilityRegistration {
+        let mut registration = public_registration();
+        registration.contract_path = "contracts/approved/comment-draft.json".to_string();
+        registration.artifact.source = SourceReference {
+            kind: SourceKind::Git,
+            location: "https://github.com/enricopiovesan/Traverse".to_string(),
+        };
+        registration.artifact.binary = Some(BinaryReference {
+            format: BinaryFormat::Wasm,
+            location: path.display().to_string(),
+            signature,
+        });
+        registration
+    }
+
+    fn governed_resolved_capability(signature: Option<ArtifactSignature>) -> ResolvedCapability {
+        let mut capability = resolved_capability(
+            Some(BinaryReference {
+                format: BinaryFormat::Wasm,
+                location: "unused.wasm".to_string(),
+                signature,
+            }),
+            Lifecycle::Active,
+        );
+        capability.record.contract_path = "contracts/approved/comment-draft.json".to_string();
+        capability.artifact.source = SourceReference {
+            kind: SourceKind::Git,
+            location: "https://github.com/enricopiovesan/Traverse".to_string(),
+        };
+        capability
+    }
+
+    fn ed25519_signature_for(bytes: &[u8]) -> ArtifactSignature {
+        let signing_key = SigningKey::from_bytes(&[7_u8; 32]);
+        let signature = signing_key.sign(bytes);
+        ArtifactSignature {
+            scheme: ArtifactSignatureScheme::Ed25519,
+            public_key_hex: Some(hex_encode(signing_key.verifying_key().as_bytes())),
+            signature_hex: Some(hex_encode(&signature.to_bytes())),
+            sigstore_bundle_ref: None,
+        }
+    }
+
+    fn temp_artifact_path(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "traverse-runtime-{name}-{}-{}.wasm",
+            std::process::id(),
+            "req_123"
+        ))
+    }
+
+    fn make_jwt_with_actor(subject_id: &str, actor_id: &str) -> String {
+        let header = base64url_encode(br#"{"alg":"none","typ":"JWT"}"#);
+        let payload = serde_json::json!({
+            "sub": subject_id,
+            "act": {"sub": actor_id}
+        });
+        format!(
+            "{}.{}.signature",
+            header,
+            base64url_encode(payload.to_string().as_bytes())
+        )
+    }
+
+    fn hex_encode(bytes: &[u8]) -> String {
+        let mut output = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            output.push(char::from(HEX_TABLE[(byte >> 4) as usize]));
+            output.push(char::from(HEX_TABLE[(byte & 0x0f) as usize]));
+        }
+        output
+    }
+
+    fn base64url_encode(bytes: &[u8]) -> String {
+        const TABLE: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        let mut out = String::new();
+        let mut index = 0;
+        while index + 3 <= bytes.len() {
+            let chunk = &bytes[index..index + 3];
+            let n = (u32::from(chunk[0]) << 16) | (u32::from(chunk[1]) << 8) | u32::from(chunk[2]);
+            out.push(char::from(TABLE[((n >> 18) & 0x3f) as usize]));
+            out.push(char::from(TABLE[((n >> 12) & 0x3f) as usize]));
+            out.push(char::from(TABLE[((n >> 6) & 0x3f) as usize]));
+            out.push(char::from(TABLE[(n & 0x3f) as usize]));
+            index += 3;
+        }
+        match bytes.len() - index {
+            1 => {
+                let n = u32::from(bytes[index]) << 16;
+                out.push(char::from(TABLE[((n >> 18) & 0x3f) as usize]));
+                out.push(char::from(TABLE[((n >> 12) & 0x3f) as usize]));
+            }
+            2 => {
+                let n = (u32::from(bytes[index]) << 16) | (u32::from(bytes[index + 1]) << 8);
+                out.push(char::from(TABLE[((n >> 18) & 0x3f) as usize]));
+                out.push(char::from(TABLE[((n >> 12) & 0x3f) as usize]));
+                out.push(char::from(TABLE[((n >> 6) & 0x3f) as usize]));
+            }
+            _ => {}
+        }
+        out
+    }
+
     fn public_registration() -> CapabilityRegistration {
         CapabilityRegistration {
             scope: RegistryScope::Public,
@@ -3560,6 +4192,7 @@ mod tests {
             artifact: test_artifact(Some(BinaryReference {
                 format: BinaryFormat::Wasm,
                 location: "artifact.wasm".to_string(),
+                signature: None,
             })),
             registered_at: "2026-03-27T00:00:00Z".to_string(),
             tags: vec!["comments".to_string()],
@@ -3769,7 +4402,8 @@ mod tests {
     fn successful_trace() -> super::RuntimeTrace {
         let mut registry = CapabilityRegistry::new();
         assert!(registry.register(public_registration()).is_ok());
-        let runtime = Runtime::new(registry, NoopExecutor);
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
         runtime.execute(valid_request()).trace
     }
 

--- a/crates/traverse-runtime/src/security.rs
+++ b/crates/traverse-runtime/src/security.rs
@@ -1,0 +1,415 @@
+//! Security and identity controls for governed runtime execution.
+
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use traverse_registry::{
+    ArtifactSignature, ArtifactSignatureScheme, ResolvedCapability, SourceKind,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeIdentity {
+    pub subject_id: String,
+    #[serde(default)]
+    pub actor_id: Option<String>,
+    pub token_reference_hash: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeSecurityMode {
+    Production,
+    Development,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeSecurityConfig {
+    pub mode: RuntimeSecurityMode,
+}
+
+impl RuntimeSecurityConfig {
+    #[must_use]
+    pub fn production() -> Self {
+        Self {
+            mode: RuntimeSecurityMode::Production,
+        }
+    }
+
+    #[must_use]
+    pub fn development() -> Self {
+        Self {
+            mode: RuntimeSecurityMode::Development,
+        }
+    }
+}
+
+impl Default for RuntimeSecurityConfig {
+    fn default() -> Self {
+        Self::development()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactVerificationRecord {
+    pub status: ArtifactVerificationStatus,
+    pub trust_level: ArtifactTrustLevel,
+    #[serde(default)]
+    pub scheme: Option<ArtifactVerificationScheme>,
+    #[serde(default)]
+    pub warning_code: Option<String>,
+    #[serde(default)]
+    pub error_code: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactVerificationStatus {
+    Verified,
+    Warning,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactTrustLevel {
+    LocalDev,
+    PublishedGoverned,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactVerificationScheme {
+    Ed25519,
+    Sigstore,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeWarning {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArtifactVerificationFailure {
+    MissingSignature(ArtifactVerificationRecord),
+    SignatureVerificationFailed(ArtifactVerificationRecord),
+    SigstoreUnreachable(ArtifactVerificationRecord),
+}
+
+impl ArtifactVerificationFailure {
+    #[must_use]
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::MissingSignature(_) => "missing_signature",
+            Self::SignatureVerificationFailed(_) => "signature_verification_failed",
+            Self::SigstoreUnreachable(_) => "sigstore_unreachable",
+        }
+    }
+
+    #[must_use]
+    pub fn record(&self) -> &ArtifactVerificationRecord {
+        match self {
+            Self::MissingSignature(record)
+            | Self::SignatureVerificationFailed(record)
+            | Self::SigstoreUnreachable(record) => record,
+        }
+    }
+}
+
+#[must_use]
+pub fn derive_identity_from_jwt(token: &str) -> Option<RuntimeIdentity> {
+    let mut parts = token.split('.');
+    let header = parts.next();
+    let payload = parts.next();
+    let signature = parts.next();
+    if header.is_none() || payload.is_none() || signature.is_none() || parts.next().is_some() {
+        return None;
+    }
+    let payload = payload?;
+    let payload_bytes = base64url_decode(payload).ok()?;
+    let value = serde_json::from_slice::<Value>(&payload_bytes).ok()?;
+    let subject_id = value
+        .get("sub")
+        .and_then(Value::as_str)
+        .filter(|sub| !sub.trim().is_empty())?
+        .to_string();
+    let actor_id = value
+        .get("act")
+        .and_then(|act| act.get("sub"))
+        .and_then(Value::as_str)
+        .filter(|actor| !actor.trim().is_empty())
+        .map(ToString::to_string);
+    Some(RuntimeIdentity {
+        subject_id,
+        actor_id,
+        token_reference_hash: sha256_hex(token.as_bytes()),
+    })
+}
+
+/// Verify artifact trust metadata before execution.
+///
+/// # Errors
+///
+/// Returns [`ArtifactVerificationFailure`] when a governed artifact is missing a
+/// required signature, an Ed25519 signature does not verify, or Sigstore
+/// verification cannot be completed.
+pub fn verify_artifact(
+    capability: &ResolvedCapability,
+    artifact_bytes: &[u8],
+    config: &RuntimeSecurityConfig,
+) -> Result<ArtifactVerificationRecord, ArtifactVerificationFailure> {
+    let trust_level = artifact_trust_level(capability);
+    let Some(binary) = capability.artifact.binary.as_ref() else {
+        return Ok(verified_local_record(trust_level));
+    };
+    let Some(signature) = binary.signature.as_ref() else {
+        if trust_level == ArtifactTrustLevel::LocalDev
+            && config.mode == RuntimeSecurityMode::Development
+        {
+            return Ok(ArtifactVerificationRecord {
+                status: ArtifactVerificationStatus::Warning,
+                trust_level,
+                scheme: None,
+                warning_code: Some("unsigned_local_dev_artifact".to_string()),
+                error_code: None,
+            });
+        }
+        let record = rejected_record(trust_level, None, "missing_signature");
+        return Err(ArtifactVerificationFailure::MissingSignature(record));
+    };
+
+    match signature.scheme {
+        ArtifactSignatureScheme::Ed25519 => verify_ed25519(signature, artifact_bytes, trust_level),
+        ArtifactSignatureScheme::Sigstore => verify_sigstore(signature, trust_level),
+    }
+}
+
+fn artifact_trust_level(capability: &ResolvedCapability) -> ArtifactTrustLevel {
+    if capability.artifact.source.kind == SourceKind::Local {
+        return ArtifactTrustLevel::LocalDev;
+    }
+    let governed_path = capability.record.contract_path.replace('\\', "/");
+    if governed_path.starts_with("contracts/")
+        || governed_path.starts_with("specs/")
+        || governed_path.contains("/contracts/")
+        || governed_path.contains("/specs/")
+        || capability.artifact.source.kind == SourceKind::Git
+            && capability.artifact.source.location.starts_with("https://")
+            && governed_path.contains("approved")
+    {
+        ArtifactTrustLevel::PublishedGoverned
+    } else {
+        ArtifactTrustLevel::LocalDev
+    }
+}
+
+fn verify_ed25519(
+    signature: &ArtifactSignature,
+    artifact_bytes: &[u8],
+    trust_level: ArtifactTrustLevel,
+) -> Result<ArtifactVerificationRecord, ArtifactVerificationFailure> {
+    let Some(public_key_hex) = signature.public_key_hex.as_deref() else {
+        let record = rejected_record(
+            trust_level,
+            Some(ArtifactVerificationScheme::Ed25519),
+            "signature_verification_failed",
+        );
+        return Err(ArtifactVerificationFailure::SignatureVerificationFailed(
+            record,
+        ));
+    };
+    let Some(signature_hex) = signature.signature_hex.as_deref() else {
+        let record = rejected_record(
+            trust_level,
+            Some(ArtifactVerificationScheme::Ed25519),
+            "signature_verification_failed",
+        );
+        return Err(ArtifactVerificationFailure::SignatureVerificationFailed(
+            record,
+        ));
+    };
+    let Ok(public_key_bytes) = hex_decode(public_key_hex) else {
+        let record = rejected_record(
+            trust_level,
+            Some(ArtifactVerificationScheme::Ed25519),
+            "signature_verification_failed",
+        );
+        return Err(ArtifactVerificationFailure::SignatureVerificationFailed(
+            record,
+        ));
+    };
+    let Ok(signature_bytes) = hex_decode(signature_hex) else {
+        let record = rejected_record(
+            trust_level,
+            Some(ArtifactVerificationScheme::Ed25519),
+            "signature_verification_failed",
+        );
+        return Err(ArtifactVerificationFailure::SignatureVerificationFailed(
+            record,
+        ));
+    };
+    let Ok(public_key_array) = <[u8; 32]>::try_from(public_key_bytes.as_slice()) else {
+        let record = rejected_record(
+            trust_level,
+            Some(ArtifactVerificationScheme::Ed25519),
+            "signature_verification_failed",
+        );
+        return Err(ArtifactVerificationFailure::SignatureVerificationFailed(
+            record,
+        ));
+    };
+    let Ok(signature_array) = <[u8; 64]>::try_from(signature_bytes.as_slice()) else {
+        return Err(signature_verification_failed(trust_level));
+    };
+    let key = VerifyingKey::from_bytes(&public_key_array)
+        .map_err(|_| signature_verification_failed(trust_level))?;
+    let signature = Signature::from_bytes(&signature_array);
+    if key.verify(artifact_bytes, &signature).is_err() {
+        return Err(signature_verification_failed(trust_level));
+    }
+    Ok(ArtifactVerificationRecord {
+        status: ArtifactVerificationStatus::Verified,
+        trust_level,
+        scheme: Some(ArtifactVerificationScheme::Ed25519),
+        warning_code: None,
+        error_code: None,
+    })
+}
+
+fn signature_verification_failed(trust_level: ArtifactTrustLevel) -> ArtifactVerificationFailure {
+    ArtifactVerificationFailure::SignatureVerificationFailed(rejected_record(
+        trust_level,
+        Some(ArtifactVerificationScheme::Ed25519),
+        "signature_verification_failed",
+    ))
+}
+
+fn verify_sigstore(
+    signature: &ArtifactSignature,
+    trust_level: ArtifactTrustLevel,
+) -> Result<ArtifactVerificationRecord, ArtifactVerificationFailure> {
+    if signature
+        .sigstore_bundle_ref
+        .as_deref()
+        .is_some_and(|bundle| bundle.starts_with("verified://"))
+    {
+        return Ok(ArtifactVerificationRecord {
+            status: ArtifactVerificationStatus::Verified,
+            trust_level,
+            scheme: Some(ArtifactVerificationScheme::Sigstore),
+            warning_code: None,
+            error_code: None,
+        });
+    }
+
+    let record = rejected_record(
+        trust_level,
+        Some(ArtifactVerificationScheme::Sigstore),
+        "sigstore_unreachable",
+    );
+    Err(ArtifactVerificationFailure::SigstoreUnreachable(record))
+}
+
+fn verified_local_record(trust_level: ArtifactTrustLevel) -> ArtifactVerificationRecord {
+    ArtifactVerificationRecord {
+        status: ArtifactVerificationStatus::Verified,
+        trust_level,
+        scheme: None,
+        warning_code: None,
+        error_code: None,
+    }
+}
+
+fn rejected_record(
+    trust_level: ArtifactTrustLevel,
+    scheme: Option<ArtifactVerificationScheme>,
+    error_code: &str,
+) -> ArtifactVerificationRecord {
+    ArtifactVerificationRecord {
+        status: ArtifactVerificationStatus::Rejected,
+        trust_level,
+        scheme,
+        warning_code: None,
+        error_code: Some(error_code.to_string()),
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        output.push(char::from(HEX_TABLE[(byte >> 4) as usize]));
+        output.push(char::from(HEX_TABLE[(byte & 0x0f) as usize]));
+    }
+    output
+}
+
+const HEX_TABLE: &[u8; 16] = b"0123456789abcdef";
+
+fn hex_decode(input: &str) -> Result<Vec<u8>, ()> {
+    if !input.len().is_multiple_of(2) {
+        return Err(());
+    }
+    let mut output = Vec::with_capacity(input.len() / 2);
+    for pair in input.as_bytes().chunks_exact(2) {
+        let high = hex_nibble(pair[0])?;
+        let low = hex_nibble(pair[1])?;
+        output.push((high << 4) | low);
+    }
+    Ok(output)
+}
+
+fn hex_nibble(byte: u8) -> Result<u8, ()> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'a'..=b'f' => Ok(byte - b'a' + 10),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(()),
+    }
+}
+
+fn base64url_decode(input: &str) -> Result<Vec<u8>, ()> {
+    if input.contains('=') {
+        return Err(());
+    }
+    let mut sextets = Vec::with_capacity(input.len());
+    for ch in input.chars() {
+        let val = match ch {
+            'A'..='Z' => (ch as u8) - b'A',
+            'a'..='z' => (ch as u8) - b'a' + 26,
+            '0'..='9' => (ch as u8) - b'0' + 52,
+            '-' => 62,
+            '_' => 63,
+            _ => return Err(()),
+        };
+        sextets.push(val);
+    }
+    match sextets.len() % 4 {
+        0 | 2 | 3 => {}
+        _ => return Err(()),
+    }
+    let mut out = Vec::with_capacity((sextets.len() * 3) / 4);
+    let mut i = 0;
+    while i + 4 <= sextets.len() {
+        let n = (u32::from(sextets[i]) << 18)
+            | (u32::from(sextets[i + 1]) << 12)
+            | (u32::from(sextets[i + 2]) << 6)
+            | u32::from(sextets[i + 3]);
+        out.push(((n >> 16) & 0xff) as u8);
+        out.push(((n >> 8) & 0xff) as u8);
+        out.push((n & 0xff) as u8);
+        i += 4;
+    }
+    let rem = sextets.len() - i;
+    if rem == 2 {
+        let n = (u32::from(sextets[i]) << 18) | (u32::from(sextets[i + 1]) << 12);
+        out.push(((n >> 16) & 0xff) as u8);
+    } else if rem == 3 {
+        let n = (u32::from(sextets[i]) << 18)
+            | (u32::from(sextets[i + 1]) << 12)
+            | (u32::from(sextets[i + 2]) << 6);
+        out.push(((n >> 16) & 0xff) as u8);
+        out.push(((n >> 8) & 0xff) as u8);
+    }
+    Ok(out)
+}

--- a/crates/traverse-runtime/src/workflows.rs
+++ b/crates/traverse-runtime/src/workflows.rs
@@ -1235,6 +1235,7 @@ mod tests {
                 traceparent: None,
                 tracestate: None,
                 metadata: None,
+                identity: None,
             },
             governing_spec: "006-runtime-request-execution".to_string(),
         });
@@ -1682,6 +1683,7 @@ mod tests {
                     traceparent: None,
                     tracestate: None,
                     metadata: None,
+                    identity: None,
                 },
                 governing_spec: "006-runtime-request-execution".to_string(),
             },
@@ -1707,6 +1709,7 @@ mod tests {
             &selected,
             crate::resolve_placement(crate::PlacementTarget::Local)
                 .unwrap_or_else(|_| unreachable!("local placement should resolve")),
+            None,
         );
         let outcome = runtime.execute_workflow_capability(
             crate::ExecutionContext {
@@ -1765,6 +1768,7 @@ mod tests {
             &selected,
             crate::resolve_placement(crate::PlacementTarget::Local)
                 .unwrap_or_else(|_| unreachable!("local placement should resolve")),
+            None,
         );
         let failing_runtime = Runtime::new(capability_registry_fixture(), FailingWorkflowExecutor)
             .with_workflow_registry(workflow_registry_fixture());
@@ -1893,6 +1897,7 @@ mod tests {
                         binary: Some(BinaryReference {
                             format: BinaryFormat::Wasm,
                             location: format!("{id}.wasm"),
+                            signature: None,
                         }),
                         workflow_ref: None,
                         digests: ArtifactDigests {
@@ -2163,6 +2168,7 @@ mod tests {
                 traceparent: None,
                 tracestate: None,
                 metadata: None,
+                identity: None,
             },
             governing_spec: "006-runtime-request-execution".to_string(),
         }

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -819,6 +819,7 @@ fn base_request_exact() -> RuntimeRequest {
             traceparent: None,
             tracestate: None,
             metadata: None,
+            identity: None,
         },
         governing_spec: "006-runtime-request-execution".to_string(),
     }
@@ -1090,6 +1091,7 @@ fn artifact_record(id: &str, version: &str) -> CapabilityArtifactRecord {
         binary: Some(BinaryReference {
             format: BinaryFormat::Wasm,
             location: format!("artifacts/{id}/{version}/capability.wasm"),
+            signature: None,
         }),
         workflow_ref: None,
         digests: ArtifactDigests {


### PR DESCRIPTION
## Summary
- add governed artifact signature metadata and runtime verification records
- enforce Ed25519 verification before governed/production execution while allowing local dev unsigned artifacts with warnings
- derive sanitized runtime identity from JWT callers and propagate it through traces/events without storing raw tokens
- accept pre-verified Sigstore bundle references for the spec 030 alternate path

Closes #372.

## Governing Spec
- 030-security-identity-model
- 005-capability-registry
- 015-capability-discovery-mcp

## Project Item
- Project 1 item for issue #372 is In Progress and owned by Codex.

## Validation
- cargo check --workspace
- cargo test -p traverse-runtime
- bash scripts/ci/rust_checks.sh
- bash scripts/ci/coverage_gate.sh
- bash scripts/ci/repository_checks.sh
- git diff --check