### PR TITLE
chore: prepare Traverse v0.3.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "semver",
  "serde",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "semver",
  "serde",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "semver",
  "serde",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/enricopiovesan/Traverse"
 rust-version = "1.94"
-version = "0.2.0"
+version = "0.3.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Spec Governed](https://img.shields.io/badge/spec-governed-blueviolet)](specs/governance/approved-specs.json)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
-[![Version](https://img.shields.io/badge/version-v0.1--rc-lightgrey)](https://github.com/enricopiovesan/Traverse/releases)
+[![Version](https://img.shields.io/badge/version-v0.3.0-blue)](https://github.com/enricopiovesan/Traverse/releases)
 
 
 

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,45 @@
+# Traverse v0.3.0
+
+Release date: 2026-06-06
+
+Traverse v0.3.0 is the first GitHub Release after the historical `v0.2.0` tag. The `v0.2.0` tag remains part of the repository history, but it was not published as a GitHub Release. Consumers should pin `v0.3.0` for the current app-consumable, supply-chain-hardened baseline.
+
+## Highlights
+
+- Adds the HTTP/JSON application API surface for downstream apps, including local serve, discovery, registration, and execution paths.
+- Adds workspace identity, auth, runtime grants, isolation policy, and audit evidence for app-facing execution.
+- Adds OpenTelemetry-compatible runtime trace export so runtime decisions can be inspected outside Traverse-specific tooling.
+- Adds WASI Host ABI v1 insulation so host imports are validated through a governed compatibility boundary.
+- Adds connector plugin registry and resolution primitives for external integration growth.
+- Adds the portable DataStore runtime model for the AP-leaning state path used by browser/offline-first consumers.
+- Adds governed artifact signature verification, including Ed25519 and Sigstore trust paths.
+- Adds supply-chain hardening evidence, including SBOM generation, provenance evidence, reproducibility checks, and artifact verification.
+
+## Compatibility Notes
+
+- Traverse remains a `0.x` project. Public surfaces are governed and validated, but compatibility is still allowed to evolve before a `1.0` stability commitment.
+- The `v0.2.0` tag exists as a historical workspace version bump and should not be treated as the current published release baseline.
+- No cross-platform binary package is attached to this release. The release publishes source, release notes, and supply-chain evidence artifacts.
+
+## Validation
+
+Release preparation must pass these local gates before tagging:
+
+```bash
+bash scripts/ci/repository_checks.sh
+bash scripts/ci/rust_checks.sh
+bash scripts/ci/coverage_gate.sh
+bash scripts/ci/supply_chain_check.sh
+```
+
+The GitHub Release should attach the generated supply-chain evidence from `target/supply-chain/`:
+
+- `traverse-sbom.cdx.json`
+- `supply-chain-summary.json`
+- `artifact-verify-report.json`
+- `traverse-cli.provenance.json`
+
+## Traceability
+
+- Release issue: https://github.com/enricopiovesan/Traverse/issues/432
+- Governing specs: `001-foundation-v0-1`, `031-supply-chain-hardening`


### PR DESCRIPTION
## Summary
- bump the Traverse workspace release metadata from `0.2.0` to `0.3.0`
- update the README release badge to `v0.3.0`
- add `docs/releases/v0.3.0.md` with release highlights, compatibility notes, validation steps, and supply-chain evidence expectations

## Governing Spec
- 001-foundation-v0-1
- 025-wasm-executor-adapter
- 031-supply-chain-hardening
- 038-wasi-host-insulation

## Project Item
- Closes #432

## Validation
- `git diff --check`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/rust_checks.sh`
- `bash scripts/ci/coverage_gate.sh`
- `bash scripts/ci/supply_chain_check.sh`