### PR TITLE
docs: add canonical youaskm3 MCP path

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/adapter-boundaries.md](docs/adapter-boundaries.md) — adapter and portability boundaries
+- [docs/youaskm3-canonical-mcp-client-path.md](docs/youaskm3-canonical-mcp-client-path.md) — canonical v0.3.0 MCP client path for youaskm3
 - [docs/mcp-stdio-server.md](docs/mcp-stdio-server.md) — supported MCP server bootstrap path and command surface
 - [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md) — how to create new WASM agents
 - [docs/wasm-agent-team-readiness-example.md](docs/wasm-agent-team-readiness-example.md) — second governed WASM AI agent example
@@ -219,6 +220,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) — how to emit and receive governed events from a capability
+- [docs/youaskm3-canonical-mcp-client-path.md](docs/youaskm3-canonical-mcp-client-path.md) — release-facing MCP client path for youaskm3
 - [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) — packaged runtime artifact
 - [docs/packaged-traverse-mcp-server-artifact.md](docs/packaged-traverse-mcp-server-artifact.md) — packaged MCP server artifact
 - [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md) — youaskm3 integration validation

--- a/docs/mcp-consumption-validation.md
+++ b/docs/mcp-consumption-validation.md
@@ -6,6 +6,8 @@ For the shortest local start path before you run this downstream validation, beg
 
 For the dedicated Traverse MCP server package foundation, begin with [docs/mcp-stdio-server.md](mcp-stdio-server.md).
 
+For the release-facing `youaskm3` MCP client path that downstream documentation should cite, begin with [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md).
+
 For the packaged MCP server artifact, see [docs/packaged-traverse-mcp-server-artifact.md](packaged-traverse-mcp-server-artifact.md).
 
 This validation path is governed by:

--- a/docs/mcp-stdio-server.md
+++ b/docs/mcp-stdio-server.md
@@ -4,6 +4,8 @@ The dedicated Traverse MCP WASM server package is the thin, governed host-facing
 
 The packaged MCP server artifact is defined in [docs/packaged-traverse-mcp-server-artifact.md](packaged-traverse-mcp-server-artifact.md).
 
+For the first `youaskm3` release-facing client path, use [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md).
+
 It is intentionally narrow:
 
 - it stays a façade over Traverse runtime authority
@@ -80,4 +82,11 @@ Run repository checks:
 
 ```bash
 bash scripts/ci/repository_checks.sh
+```
+
+For downstream `youaskm3` release evidence, also run:
+
+```bash
+bash scripts/ci/mcp_consumption_validation.sh
+bash scripts/ci/mcp_real_agent_exercise_smoke.sh
 ```

--- a/docs/youaskm3-canonical-mcp-client-path.md
+++ b/docs/youaskm3-canonical-mcp-client-path.md
@@ -1,0 +1,109 @@
+# Canonical Traverse MCP Client Path for youaskm3
+
+This page is the release-facing MCP integration path that `youaskm3` can cite for its first real release.
+
+Supported Traverse baseline: `v0.3.0`
+
+## What Is Supported
+
+For the first `youaskm3` release, the canonical Traverse MCP path is:
+
+```bash
+cargo run -p traverse-mcp -- stdio
+```
+
+This starts the governed Traverse MCP stdio server from a source checkout pinned to `v0.3.0`.
+
+The supported client category is any MCP client that can launch a local stdio server command and route tool calls over that process. A real client such as Claude Desktop fits this category when configured to run the local `traverse-mcp` command.
+
+## Recommended Source Checkout
+
+Downstream consumers should pin the released Traverse tag instead of following repository head:
+
+```bash
+git clone https://github.com/enricopiovesan/Traverse.git
+cd Traverse
+git checkout v0.3.0
+cargo run -p traverse-mcp -- stdio
+```
+
+Requirements:
+
+- Rust 1.94+
+- local source checkout of Traverse `v0.3.0`
+- an MCP client that supports stdio server commands
+
+## Example Client Configuration
+
+For a stdio MCP client that accepts JSON server configuration, use this shape and replace `/absolute/path/to/Traverse` with the local Traverse checkout:
+
+```json
+{
+  "mcpServers": {
+    "traverse": {
+      "command": "cargo",
+      "args": [
+        "run",
+        "-p",
+        "traverse-mcp",
+        "--",
+        "stdio"
+      ],
+      "cwd": "/absolute/path/to/Traverse"
+    }
+  }
+}
+```
+
+Expected startup behavior:
+
+- the client launches `cargo run -p traverse-mcp -- stdio`
+- Traverse emits deterministic MCP stdio envelopes
+- the client can discover the governed MCP server description, content groups, entrypoints, validation path, execution path, and execution report path
+
+## Public MCP Surfaces
+
+The first-release public MCP path exposes the governed surfaces documented by [docs/mcp-stdio-server.md](mcp-stdio-server.md):
+
+- `describe_server`
+- `list_content_groups`
+- `describe_content_group`
+- `list_entrypoints`
+- `describe_entrypoint`
+- `validate_entrypoint`
+- `execute_entrypoint`
+- `render_execution_report`
+- `shutdown`
+
+The lower-level Rust library helpers in `crates/traverse-mcp` remain implementation details unless a release-facing document explicitly names them as public consumer API.
+
+## What This Does Not Promise
+
+This path does not promise:
+
+- every possible MCP client walkthrough
+- hosted MCP server operation
+- cross-platform binary distribution
+- a final `1.0` compatibility guarantee
+- access to private Traverse internals
+
+For `v0.3.0`, the honest claim is narrower: `youaskm3` can use Traverse through a released, source-build, stdio MCP path.
+
+## Validation
+
+Run the deterministic validation commands from the Traverse repository root:
+
+```bash
+bash scripts/ci/mcp_stdio_server_smoke.sh
+bash scripts/ci/mcp_consumption_validation.sh
+bash scripts/ci/mcp_real_agent_exercise_smoke.sh
+```
+
+These checks prove that the released public MCP path can start, expose the expected server surface, validate the downstream `youaskm3` consumption path, and exercise a real-agent MCP flow without private repository knowledge.
+
+## Related Docs
+
+- [docs/mcp-stdio-server.md](mcp-stdio-server.md)
+- [docs/mcp-consumption-validation.md](mcp-consumption-validation.md)
+- [docs/mcp-real-agent-exercise.md](mcp-real-agent-exercise.md)
+- [docs/youaskm3-integration-validation.md](youaskm3-integration-validation.md)

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -21,6 +21,7 @@ required_files=(
   "docs/expedition-example-smoke.md"
   "docs/mcp-consumption-validation.md"
   "docs/mcp-stdio-server.md"
+  "docs/youaskm3-canonical-mcp-client-path.md"
   "docs/mcp-real-agent-exercise.md"
   "docs/app-consumable-release-checklist.md"
   "docs/app-consumable-consumer-bundle.md"
@@ -340,6 +341,12 @@ grep -q "bash scripts/ci/mcp_stdio_server_discovery_smoke.sh" docs/mcp-stdio-ser
 grep -q "render_execution_report" docs/mcp-stdio-server.md
 grep -q "list_entrypoints" docs/mcp-stdio-server.md
 grep -q "describe_entrypoint" docs/mcp-stdio-server.md
+grep -q "Supported Traverse baseline: \`v0.3.0\`" docs/youaskm3-canonical-mcp-client-path.md
+grep -q "cargo run -p traverse-mcp -- stdio" docs/youaskm3-canonical-mcp-client-path.md
+grep -q "stdio MCP client" docs/youaskm3-canonical-mcp-client-path.md
+grep -q "bash scripts/ci/mcp_consumption_validation.sh" docs/youaskm3-canonical-mcp-client-path.md
+grep -q "docs/youaskm3-canonical-mcp-client-path.md" README.md
+grep -q "docs/youaskm3-canonical-mcp-client-path.md" docs/mcp-consumption-validation.md
 grep -q "consumer_name: youaskm3" docs/youaskm3-integration-validation.md
 grep -q "validated_flow_id: youaskm3_mcp_validation" docs/youaskm3-integration-validation.md
 grep -q "bash scripts/ci/project_board_audit.sh" docs/project-management.md


### PR DESCRIPTION
## Summary
- add a release-facing canonical Traverse MCP client path for youaskm3 on v0.3.0
- link the path from README and existing MCP validation/bootstrap docs
- add repository checks so the path and validation links remain discoverable

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate
- 023-browser-hosted-mcp-consumer-model
- 028-schema-alignment-gate-v02
- 031-supply-chain-hardening
- 040-contractual-enforcement-gate

## Project Item
- Closes #434

## Validation
- `git diff --check`
- `bash scripts/ci/mcp_stdio_server_smoke.sh`
- `bash scripts/ci/mcp_consumption_validation.sh`
- `bash scripts/ci/mcp_real_agent_exercise_smoke.sh`
- `bash scripts/ci/repository_checks.sh`