### PR TITLE
docs: add canonical youaskm3 HTTP app path

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 - [docs/workflow-composition-guide.md](docs/workflow-composition-guide.md) — beginner guide to chaining two capabilities into a workflow
 - [docs/tutorial-index.md](docs/tutorial-index.md) — ordered onboarding path for new developers and agents
 - [quickstart.md](quickstart.md) — start here for the first runnable flow
+- [docs/youaskm3-canonical-app-http-path.md](docs/youaskm3-canonical-app-http-path.md) — canonical v0.3.0 HTTP app path for youaskm3
 - [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) — first app-consumable flow
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
@@ -219,6 +220,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
+- [docs/youaskm3-canonical-app-http-path.md](docs/youaskm3-canonical-app-http-path.md) — release-facing HTTP app path for youaskm3
 - [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) — how to emit and receive governed events from a capability
 - [docs/youaskm3-canonical-mcp-client-path.md](docs/youaskm3-canonical-mcp-client-path.md) — release-facing MCP client path for youaskm3
 - [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) — packaged runtime artifact

--- a/docs/app-consumable-acceptance.md
+++ b/docs/app-consumable-acceptance.md
@@ -2,6 +2,8 @@
 
 This is the authoritative end-to-end acceptance path for the first app-consumable Traverse flow.
 
+For the first `youaskm3` release-facing HTTP/JSON path, use [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md).
+
 Use it when you want to prove, in one deterministic run, that:
 
 - the runtime can execute the approved expedition request

--- a/docs/app-consumable-entry-path.md
+++ b/docs/app-consumable-entry-path.md
@@ -8,6 +8,7 @@ This is the canonical documentation path for humans and coding agents working on
 2. Open [quickstart.md](../quickstart.md)
 3. Use the relevant deeper docs only after the quickstart path is clear:
    - [docs/cli-reference.md](cli-reference.md)
+   - [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
    - [docs/app-consumable-acceptance.md](app-consumable-acceptance.md)
    - [docs/app-consumable-release-checklist.md](app-consumable-release-checklist.md)
    - [docs/app-consumable-consumer-bundle.md](app-consumable-consumer-bundle.md)
@@ -27,6 +28,7 @@ If a new human or agent asks where to begin, point them to the README first and 
 
 - The README is the front door.
 - The quickstart is the first executable consumer path.
+- The canonical `youaskm3` HTTP path explains how downstream apps consume `traverse-cli serve`, `.traverse/server.json`, registration, execution, and trace fetch on the released `v0.3.0` baseline.
 - The CLI reference explains the supported command surface and separates public commands from internal/test-only paths.
 - The versioned consumer bundle explains what a downstream app installs and which released surfaces it may rely on.
 - The package release pointer explains how the governed app-consumable package release is identified downstream.

--- a/docs/browser-adapter.md
+++ b/docs/browser-adapter.md
@@ -17,6 +17,7 @@ The current approved path is the local adapter used by the app-consumable quicks
 Relevant docs:
 
 - [quickstart.md](../quickstart.md)
+- [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
 - [docs/app-consumable-entry-path.md](app-consumable-entry-path.md)
 - [apps/browser-consumer/README.md](../apps/browser-consumer/README.md)
 - [docs/adapter-boundaries.md](adapter-boundaries.md)
@@ -80,6 +81,7 @@ Primary docs:
 
 - [quickstart.md](../quickstart.md)
 - [docs/app-consumable-entry-path.md](app-consumable-entry-path.md)
+- [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
 
 ### MCP Stdio Server
 

--- a/docs/youaskm3-canonical-app-http-path.md
+++ b/docs/youaskm3-canonical-app-http-path.md
@@ -1,0 +1,186 @@
+# Canonical Traverse HTTP App Path for youaskm3
+
+This page is the release-facing HTTP/JSON integration path that `youaskm3` can cite for its first real release.
+
+Supported Traverse baseline: `v0.3.0`
+
+## What Is Supported
+
+For the first `youaskm3` release, the canonical Traverse app-facing path is a local source-build HTTP/JSON server:
+
+```bash
+cargo run -p traverse-cli -- serve
+```
+
+This starts the governed app-consumable API on `127.0.0.1:8787` by default and writes a local discovery file at:
+
+```text
+.traverse/server.json
+```
+
+The supported downstream app category is a local app, development shell, or browser-hosted consumer that can read the discovery file or receive the discovered `base_url`, then call the documented HTTP/JSON API.
+
+## Public App Surface
+
+The first-release public HTTP/JSON path is governed by:
+
+- [specs/033-http-json-api/openapi.yaml](../specs/033-http-json-api/openapi.yaml)
+- [specs/033-http-json-api/spec.md](../specs/033-http-json-api/spec.md)
+- [specs/034-programmatic-registration/spec.md](../specs/034-programmatic-registration/spec.md)
+- [specs/035-multi-agent-isolation/spec.md](../specs/035-multi-agent-isolation/spec.md)
+
+The app-facing surfaces `youaskm3` can depend on at `v0.3.0` are:
+
+- `traverse-cli serve`
+- `.traverse/server.json`
+- `GET /healthz`
+- `POST /v1/workspaces/{workspace_id}/capabilities`
+- `POST /v1/workspaces/{workspace_id}/execute`
+- `GET /v1/workspaces/{workspace_id}/executions/{execution_id}`
+- `GET /v1/workspaces/{workspace_id}/traces/{execution_id}`
+- RFC 9457 Problem Details error envelopes
+
+Implementation details inside `crates/traverse-cli/src/http_api.rs`, in-memory stores, test helpers, and private registry internals are not downstream app API.
+
+## Start From The Released Tag
+
+Downstream consumers should pin the released Traverse tag instead of following repository head:
+
+```bash
+git clone https://github.com/enricopiovesan/Traverse.git
+cd Traverse
+git checkout v0.3.0
+cargo run -p traverse-cli -- serve
+```
+
+Requirements:
+
+- Rust 1.94+
+- local source checkout of Traverse `v0.3.0`
+- an HTTP client such as `curl`
+- `jq` for the copy/pasteable shell examples below
+
+## Discover The Server
+
+In another terminal, read the local discovery file:
+
+```bash
+BASE_URL="$(jq -r '.base_url' .traverse/server.json)"
+HEALTH_URL="$(jq -r '.health_url' .traverse/server.json)"
+WORKSPACE_ID="$(jq -r '.workspace_default' .traverse/server.json)"
+AUTH_MODE="$(jq -r '.auth_mode' .traverse/server.json)"
+
+printf 'base_url=%s\nhealth_url=%s\nworkspace=%s\nauth_mode=%s\n' \
+  "$BASE_URL" "$HEALTH_URL" "$WORKSPACE_ID" "$AUTH_MODE"
+```
+
+Expected local development values:
+
+- `base_url`: `http://127.0.0.1:8787`
+- `health_url`: `http://127.0.0.1:8787/healthz`
+- `workspace_default`: `local-default`
+- `auth_mode`: `dev-loopback`
+
+If `.traverse/server.json` contains a local token, the file is host-local discovery material and must not be committed. The repository already ignores `.traverse/`.
+
+## Check Health
+
+```bash
+curl -sS "$HEALTH_URL"
+```
+
+Expected result:
+
+- HTTP 200
+- `status: ok`
+- `api_version: v1`
+- the same `workspace_default` reported by `.traverse/server.json`
+
+## Register One Capability
+
+This example registers the checked-in hello-world capability into the default workspace. It uses only source checkout artifacts and the public HTTP registration endpoint.
+
+```bash
+ARTIFACT_PATH="$PWD/examples/hello-world/say-hello-agent/artifacts/say-hello-agent.wasm"
+
+jq --arg artifact_path "$ARTIFACT_PATH" '
+  .execution.entrypoint.command = $artifact_path
+  | {
+      scope: "workspace_persisted",
+      registry_scope: "public",
+      tags: ["youaskm3-http-path"],
+      contract: .
+    }
+' contracts/examples/hello-world/capabilities/say-hello/contract.json \
+  > /tmp/traverse-register-say-hello.json
+
+curl -sS \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  --data @/tmp/traverse-register-say-hello.json \
+  "$BASE_URL/v1/workspaces/$WORKSPACE_ID/capabilities"
+```
+
+Expected result:
+
+- HTTP 201 for the first registration, or HTTP 200 if the same artifact is already registered
+- `artifact_type: capability`
+- `artifact_id: hello.world.say-hello`
+- `links.execute: /v1/workspaces/{workspace_id}/execute`
+
+## Execute The Capability
+
+```bash
+curl -sS \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  --data @examples/hello-world/runtime-requests/say-hello.json \
+  "$BASE_URL/v1/workspaces/$WORKSPACE_ID/execute" \
+  > /tmp/traverse-say-hello-execution.json
+
+cat /tmp/traverse-say-hello-execution.json
+```
+
+Expected result:
+
+- HTTP 200
+- `api_version: v1`
+- `status: succeeded`
+- an `execution_id`
+- `links.trace`
+
+## Fetch The Public Trace
+
+```bash
+EXECUTION_ID="$(jq -r '.execution_id' /tmp/traverse-say-hello-execution.json)"
+
+curl -sS \
+  "$BASE_URL/v1/workspaces/$WORKSPACE_ID/traces/$EXECUTION_ID"
+```
+
+Expected result:
+
+- HTTP 200
+- public trace envelope
+- no raw private runtime internals
+- OpenTelemetry-compatible trace identifiers when present
+
+## Validation
+
+Run the deterministic app-consumable validation commands from the Traverse repository root:
+
+```bash
+bash scripts/ci/app_consumable_acceptance.sh
+bash scripts/ci/browser_consumer_package_smoke.sh
+bash scripts/ci/repository_checks.sh
+```
+
+These checks prove that the released app-consumable path remains documented, the browser-consumer package remains discoverable, and the repository-level documentation assertions still include the canonical HTTP path.
+
+## Related Docs
+
+- [quickstart.md](../quickstart.md)
+- [docs/app-consumable-entry-path.md](app-consumable-entry-path.md)
+- [docs/app-consumable-acceptance.md](app-consumable-acceptance.md)
+- [docs/browser-adapter.md](browser-adapter.md)
+- [docs/youaskm3-integration-validation.md](youaskm3-integration-validation.md)

--- a/docs/youaskm3-integration-validation.md
+++ b/docs/youaskm3-integration-validation.md
@@ -11,6 +11,7 @@ It stays on governed public Traverse surfaces only:
 - the versioned Traverse consumer bundle
 - the real-agent MCP exercise guide
 - the published-artifact validation path for the released Traverse runtime and MCP artifacts
+- the canonical HTTP/JSON app path at [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
 - [docs/youaskm3-published-artifact-validation.md](youaskm3-published-artifact-validation.md)
 - [docs/youaskm3-compatibility-conformance-suite.md](youaskm3-compatibility-conformance-suite.md)
 - the `youaskm3` compatibility conformance suite
@@ -18,6 +19,8 @@ It stays on governed public Traverse surfaces only:
 - the `youaskm3` real shell validation
 
 For the shortest Traverse-side start path, begin with [quickstart.md](../quickstart.md).
+
+For the first release-facing HTTP/JSON app path, use [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md).
 
 ## Governing Spec
 

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -24,6 +24,7 @@ required_files=(
   "docs/youaskm3-canonical-mcp-client-path.md"
   "docs/mcp-real-agent-exercise.md"
   "docs/app-consumable-release-checklist.md"
+  "docs/youaskm3-canonical-app-http-path.md"
   "docs/app-consumable-consumer-bundle.md"
   "docs/app-consumable-release-artifact.md"
   "docs/app-consumable-package-release-pointer.md"
@@ -325,6 +326,15 @@ grep -q "## Prerequisites" quickstart.md
 grep -q "browser-adapter serve --bind 127.0.0.1:4174" quickstart.md
 grep -q "node apps/react-demo/server.mjs --adapter http://127.0.0.1:4174 --port 4173" quickstart.md
 grep -q "apps/browser-consumer/README.md" docs/app-consumable-entry-path.md
+grep -q "docs/youaskm3-canonical-app-http-path.md" README.md
+grep -q "docs/youaskm3-canonical-app-http-path.md" docs/app-consumable-entry-path.md
+grep -q "Supported Traverse baseline: \`v0.3.0\`" docs/youaskm3-canonical-app-http-path.md
+grep -q "cargo run -p traverse-cli -- serve" docs/youaskm3-canonical-app-http-path.md
+grep -q ".traverse/server.json" docs/youaskm3-canonical-app-http-path.md
+grep -q "POST /v1/workspaces/{workspace_id}/capabilities" docs/youaskm3-canonical-app-http-path.md
+grep -q "POST /v1/workspaces/{workspace_id}/execute" docs/youaskm3-canonical-app-http-path.md
+grep -q "GET /v1/workspaces/{workspace_id}/traces/{execution_id}" docs/youaskm3-canonical-app-http-path.md
+grep -q "bash scripts/ci/app_consumable_acceptance.sh" docs/youaskm3-canonical-app-http-path.md
 grep -q "browser-targeted consumer package" apps/browser-consumer/README.md
 grep -q "browser_consumer_package_smoke.sh" apps/browser-consumer/README.md
 grep -q "browser-hosted app" apps/browser-consumer/README.md


### PR DESCRIPTION
## Summary
- add the canonical v0.3.0 HTTP/JSON app path that youaskm3 can cite
- document serve, discovery, health, registration, execution, and trace fetch steps
- link the path from README, app-consumable docs, browser adapter docs, and youaskm3 validation docs
- add repository checks so the app path stays discoverable

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate
- 023-browser-hosted-mcp-consumer-model
- 028-schema-alignment-gate-v02
- 031-supply-chain-hardening
- 033-http-json-api
- 034-programmatic-registration
- 035-multi-agent-isolation
- 040-contractual-enforcement-gate

## Project Item
- Closes #435

## Validation
- `git diff --check`
- `bash scripts/ci/app_consumable_acceptance.sh`
- `bash scripts/ci/browser_consumer_package_smoke.sh`
- `bash scripts/ci/repository_checks.sh`