### PR TITLE
docs: add v0.3.0 public surface compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
+- [docs/v0.3.0-public-surface-compatibility.md](docs/v0.3.0-public-surface-compatibility.md) — public surface compatibility for the v0.3.0 youaskm3 baseline
 - [docs/youaskm3-canonical-app-http-path.md](docs/youaskm3-canonical-app-http-path.md) — release-facing HTTP app path for youaskm3
 - [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) — how to emit and receive governed events from a capability
 - [docs/youaskm3-canonical-mcp-client-path.md](docs/youaskm3-canonical-mcp-client-path.md) — release-facing MCP client path for youaskm3

--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -64,6 +64,10 @@ The boundary between governed core runtime responsibilities and optional adapter
 
 - `docs/adapter-boundaries.md`
 
+The release-facing downstream compatibility statement for the current `youaskm3` baseline is:
+
+- `docs/v0.3.0-public-surface-compatibility.md`
+
 ## Specs
 
 Approved specs are immutable once they govern implementation.

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -4,6 +4,8 @@ Release date: 2026-06-06
 
 Traverse v0.3.0 is the first GitHub Release after the historical `v0.2.0` tag. The `v0.2.0` tag remains part of the repository history, but it was not published as a GitHub Release. Consumers should pin `v0.3.0` for the current app-consumable, supply-chain-hardened baseline.
 
+The downstream public surface compatibility statement is [docs/v0.3.0-public-surface-compatibility.md](../v0.3.0-public-surface-compatibility.md).
+
 ## Highlights
 
 - Adds the HTTP/JSON application API surface for downstream apps, including local serve, discovery, registration, and execution paths.

--- a/docs/v0.3.0-public-surface-compatibility.md
+++ b/docs/v0.3.0-public-surface-compatibility.md
@@ -1,0 +1,84 @@
+# Traverse v0.3.0 Public Surface Compatibility
+
+This statement defines what downstream consumers, including `youaskm3`, can safely cite and pin from Traverse `v0.3.0`.
+
+It narrows the general [compatibility policy](compatibility-policy.md) to the released `v0.3.0` app-consumable baseline. It does not create a `1.0` stability promise.
+
+## Pinning Rule
+
+Downstream consumers SHOULD pin Traverse `v0.3.0` for the first `youaskm3` release.
+
+Do not depend on `main`, unpublished branches, private repo knowledge, or internal crate paths when making a release claim.
+
+Recommended checkout:
+
+```bash
+git clone https://github.com/enricopiovesan/Traverse.git
+cd Traverse
+git checkout v0.3.0
+```
+
+## Public Consumer Surfaces
+
+The following surfaces are public, governed, and release-facing for `v0.3.0`.
+
+| Surface | Public dependency point | Primary docs |
+|---|---|---|
+| HTTP/JSON app API | `traverse-cli serve`, `.traverse/server.json`, `/healthz`, workspace registration, workspace execution, public trace fetch | [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md) |
+| MCP stdio path | `cargo run -p traverse-mcp -- stdio` from a `v0.3.0` checkout | [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md) |
+| Release source | Git tag `v0.3.0` and GitHub Release source archive | [docs/releases/v0.3.0.md](releases/v0.3.0.md) |
+| Supply-chain evidence | Attached release SBOM, provenance, supply-chain summary, and artifact verification JSON | [docs/releases/v0.3.0.md](releases/v0.3.0.md) |
+
+These surfaces may receive additive documentation, validation, and optional-field improvements in later `0.x` releases. Downstream consumers should move to a newer release tag when they need newer surfaces.
+
+## Internal Surfaces
+
+The following are not public downstream dependency points in `v0.3.0` unless another release-facing document explicitly promotes them:
+
+- private Rust functions, structs, and test helpers
+- in-memory HTTP server implementation details
+- files under `target/`
+- local `.traverse/` runtime state
+- private registry storage layout
+- CI helper internals beyond the documented validation command entrypoints
+- unreleased branches and open pull requests
+
+These internals can change without a downstream compatibility promise.
+
+## Pre-1.0 Compatibility Meaning
+
+Traverse remains a `0.x` project at `v0.3.0`.
+
+That means:
+
+- governed public surfaces are documented and validated
+- breaking changes should happen through explicit release notes and version movement
+- downstream consumers should pin exact release tags
+- no downstream project should assume a final `1.0` compatibility contract yet
+
+For `youaskm3`, the honest first-release claim is:
+
+> `youaskm3` can pin Traverse `v0.3.0` and consume the documented HTTP/JSON app path and MCP stdio path without relying on private Traverse internals.
+
+## Validation
+
+Use these validation entrypoints as the evidence path for the public surfaces:
+
+```bash
+bash scripts/ci/app_consumable_acceptance.sh
+bash scripts/ci/mcp_consumption_validation.sh
+bash scripts/ci/repository_checks.sh
+```
+
+For broader release evidence, also use:
+
+```bash
+bash scripts/ci/supply_chain_check.sh
+```
+
+## Related Docs
+
+- [docs/compatibility-policy.md](compatibility-policy.md)
+- [docs/releases/v0.3.0.md](releases/v0.3.0.md)
+- [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
+- [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md)

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -14,6 +14,7 @@ required_files=(
   ".specify/memory/constitution.md"
   "docs/quality-standards.md"
   "docs/compatibility-policy.md"
+  "docs/v0.3.0-public-surface-compatibility.md"
   "docs/troubleshooting.md"
   "docs/adapter-boundaries.md"
   "docs/contract-publication-policy.md"
@@ -326,6 +327,12 @@ grep -q "## Prerequisites" quickstart.md
 grep -q "browser-adapter serve --bind 127.0.0.1:4174" quickstart.md
 grep -q "node apps/react-demo/server.mjs --adapter http://127.0.0.1:4174 --port 4173" quickstart.md
 grep -q "apps/browser-consumer/README.md" docs/app-consumable-entry-path.md
+grep -q "git checkout v0.3.0" docs/v0.3.0-public-surface-compatibility.md
+grep -q "docs/youaskm3-canonical-app-http-path.md" docs/v0.3.0-public-surface-compatibility.md
+grep -q "docs/youaskm3-canonical-mcp-client-path.md" docs/v0.3.0-public-surface-compatibility.md
+grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
+grep -q "docs/v0.3.0-public-surface-compatibility.md" README.md
+grep -q "docs/v0.3.0-public-surface-compatibility.md" docs/compatibility-policy.md
 grep -q "docs/youaskm3-canonical-app-http-path.md" README.md
 grep -q "docs/youaskm3-canonical-app-http-path.md" docs/app-consumable-entry-path.md
 grep -q "Supported Traverse baseline: \`v0.3.0\`" docs/youaskm3-canonical-app-http-path.md


### PR DESCRIPTION
## Summary
- add a v0.3.0 public surface compatibility statement for downstream consumers
- clarify public MCP, HTTP/JSON app API, release source, and supply-chain evidence surfaces
- link the statement from README, compatibility policy, release notes, and repository checks

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate
- 028-schema-alignment-gate-v02
- 031-supply-chain-hardening
- 040-contractual-enforcement-gate

## Project Item
- Closes #436

## Validation
- `git diff --check`
- `bash scripts/ci/repository_checks.sh`