### PR TITLE
docs: add v0.3.0 source-build packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/v0.3.0-public-surface-compatibility.md](docs/v0.3.0-public-surface-compatibility.md) — public surface compatibility for the v0.3.0 youaskm3 baseline
+- [docs/v0.3.0-source-build-consumer-packaging.md](docs/v0.3.0-source-build-consumer-packaging.md) — source-build packaging expectations for v0.3.0 consumers
 - [docs/youaskm3-canonical-app-http-path.md](docs/youaskm3-canonical-app-http-path.md) — release-facing HTTP app path for youaskm3
 - [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) — how to emit and receive governed events from a capability
 - [docs/youaskm3-canonical-mcp-client-path.md](docs/youaskm3-canonical-mcp-client-path.md) — release-facing MCP client path for youaskm3

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -6,6 +6,8 @@ Traverse v0.3.0 is the first GitHub Release after the historical `v0.2.0` tag. T
 
 The downstream public surface compatibility statement is [docs/v0.3.0-public-surface-compatibility.md](../v0.3.0-public-surface-compatibility.md).
 
+Source-build consumer packaging expectations are documented in [docs/v0.3.0-source-build-consumer-packaging.md](../v0.3.0-source-build-consumer-packaging.md).
+
 ## Highlights
 
 - Adds the HTTP/JSON application API surface for downstream apps, including local serve, discovery, registration, and execution paths.

--- a/docs/v0.3.0-public-surface-compatibility.md
+++ b/docs/v0.3.0-public-surface-compatibility.md
@@ -29,6 +29,8 @@ The following surfaces are public, governed, and release-facing for `v0.3.0`.
 | Release source | Git tag `v0.3.0` and GitHub Release source archive | [docs/releases/v0.3.0.md](releases/v0.3.0.md) |
 | Supply-chain evidence | Attached release SBOM, provenance, supply-chain summary, and artifact verification JSON | [docs/releases/v0.3.0.md](releases/v0.3.0.md) |
 
+The supported packaging expectation for these surfaces is source-build consumption, documented in [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md).
+
 These surfaces may receive additive documentation, validation, and optional-field improvements in later `0.x` releases. Downstream consumers should move to a newer release tag when they need newer surfaces.
 
 ## Internal Surfaces
@@ -80,5 +82,6 @@ bash scripts/ci/supply_chain_check.sh
 
 - [docs/compatibility-policy.md](compatibility-policy.md)
 - [docs/releases/v0.3.0.md](releases/v0.3.0.md)
+- [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md)
 - [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
 - [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md)

--- a/docs/v0.3.0-source-build-consumer-packaging.md
+++ b/docs/v0.3.0-source-build-consumer-packaging.md
@@ -1,0 +1,111 @@
+# Traverse v0.3.0 Source-Build Consumer Packaging
+
+This page documents how downstream consumers, including `youaskm3`, should consume Traverse `v0.3.0` for the first release when no polished cross-platform binary package is attached.
+
+## Packaging Decision
+
+Traverse `v0.3.0` is source-build supported.
+
+That means the supported consumer path is:
+
+1. pin the released `v0.3.0` tag
+2. build from source with the documented Rust toolchain
+3. start the HTTP/JSON app server or MCP stdio server from that checkout
+4. validate the path with the documented commands
+
+No package-manager distribution, native installer, or polished cross-platform binary package is required for the first `youaskm3` release.
+
+## Requirements
+
+- Rust 1.94+
+- Git
+- a local shell capable of running Cargo commands
+- `jq` for the HTTP walkthroughs and release evidence inspection
+- optional: `curl` for HTTP/JSON app API checks
+
+## Checkout And Build
+
+```bash
+git clone https://github.com/enricopiovesan/Traverse.git
+cd Traverse
+git checkout v0.3.0
+cargo build
+```
+
+The source checkout is the package boundary for `v0.3.0`. Downstream consumers should not copy private build artifacts out of `target/` and treat them as a stable distribution format.
+
+## Start The HTTP/JSON App Surface
+
+For downstream app integration:
+
+```bash
+cargo run -p traverse-cli -- serve
+```
+
+This starts the app-consumable HTTP/JSON API and writes local discovery information to:
+
+```text
+.traverse/server.json
+```
+
+Use [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md) for the full app-facing flow.
+
+## Start The MCP Surface
+
+For MCP client integration:
+
+```bash
+cargo run -p traverse-mcp -- stdio
+```
+
+Use [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md) for the full MCP-facing flow.
+
+## Release Artifacts
+
+The GitHub Release for `v0.3.0` publishes source plus supply-chain evidence artifacts.
+
+The attached evidence files are:
+
+- `traverse-sbom.cdx.json`: CycloneDX SBOM for dependency visibility.
+- `supply-chain-summary.json`: summary of the release supply-chain checks.
+- `artifact-verify-report.json`: artifact verification report produced by the Traverse verification path.
+- `traverse-cli.provenance.json`: provenance evidence for the built CLI artifact used during supply-chain validation.
+
+These files prove release evidence and build integrity checks. They are not a replacement for a platform-specific binary package.
+
+## What Is Not Packaged Yet
+
+Traverse `v0.3.0` does not promise:
+
+- Homebrew, npm, pip, apt, or container distribution
+- native installers
+- signed platform-specific CLI binaries
+- hosted Traverse services
+- a final `1.0` compatibility contract
+
+Those can be added in later releases without changing the first `youaskm3` release requirement.
+
+## Validation
+
+From the pinned checkout:
+
+```bash
+cargo build
+cargo run -p traverse-cli -- --help
+cargo run -p traverse-mcp -- stdio --simulate-startup-failure
+bash scripts/ci/repository_checks.sh
+```
+
+Expected result:
+
+- the workspace builds successfully
+- the CLI help prints the supported command surface
+- the MCP failure simulation exits through the documented deterministic error path
+- repository checks pass
+
+## Related Docs
+
+- [docs/releases/v0.3.0.md](releases/v0.3.0.md)
+- [docs/v0.3.0-public-surface-compatibility.md](v0.3.0-public-surface-compatibility.md)
+- [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
+- [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md)

--- a/docs/youaskm3-canonical-app-http-path.md
+++ b/docs/youaskm3-canonical-app-http-path.md
@@ -60,6 +60,8 @@ Requirements:
 - an HTTP client such as `curl`
 - `jq` for the copy/pasteable shell examples below
 
+For packaging and source-build expectations, see [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md).
+
 ## Discover The Server
 
 In another terminal, read the local discovery file:

--- a/docs/youaskm3-canonical-mcp-client-path.md
+++ b/docs/youaskm3-canonical-mcp-client-path.md
@@ -33,6 +33,8 @@ Requirements:
 - local source checkout of Traverse `v0.3.0`
 - an MCP client that supports stdio server commands
 
+For packaging and source-build expectations, see [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md).
+
 ## Example Client Configuration
 
 For a stdio MCP client that accepts JSON server configuration, use this shape and replace `/absolute/path/to/Traverse` with the local Traverse checkout:

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -15,6 +15,7 @@ required_files=(
   "docs/quality-standards.md"
   "docs/compatibility-policy.md"
   "docs/v0.3.0-public-surface-compatibility.md"
+  "docs/v0.3.0-source-build-consumer-packaging.md"
   "docs/troubleshooting.md"
   "docs/adapter-boundaries.md"
   "docs/contract-publication-policy.md"
@@ -331,6 +332,12 @@ grep -q "git checkout v0.3.0" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/youaskm3-canonical-app-http-path.md" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/youaskm3-canonical-mcp-client-path.md" docs/v0.3.0-public-surface-compatibility.md
 grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
+grep -q "docs/v0.3.0-source-build-consumer-packaging.md" README.md
+grep -q "cargo build" docs/v0.3.0-source-build-consumer-packaging.md
+grep -q "cargo run -p traverse-cli -- serve" docs/v0.3.0-source-build-consumer-packaging.md
+grep -q "cargo run -p traverse-mcp -- stdio" docs/v0.3.0-source-build-consumer-packaging.md
+grep -q "traverse-sbom.cdx.json" docs/v0.3.0-source-build-consumer-packaging.md
+grep -q "No package-manager distribution" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "docs/v0.3.0-public-surface-compatibility.md" README.md
 grep -q "docs/v0.3.0-public-surface-compatibility.md" docs/compatibility-policy.md
 grep -q "docs/youaskm3-canonical-app-http-path.md" README.md


### PR DESCRIPTION
## Summary
- add v0.3.0 source-build consumer packaging expectations for youaskm3 and downstream consumers
- document clone/tag checkout, cargo build, CLI/MCP startup commands, release evidence artifacts, and honest packaging limits
- link the packaging statement from README, release notes, compatibility, and canonical app/MCP path docs

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate
- 023-browser-hosted-mcp-consumer-model
- 028-schema-alignment-gate-v02
- 031-supply-chain-hardening
- 040-contractual-enforcement-gate

## Project Item
- Closes #437

## Validation
- `cargo build`
- `cargo run -p traverse-cli -- --help` output-shape check; command exits non-zero after usage by current CLI behavior
- `cargo run -p traverse-mcp -- stdio --simulate-startup-failure` deterministic failure-envelope check
- `git diff --check`
- `bash scripts/ci/repository_checks.sh`