### PR TITLE
docs: add v0.3.0 downstream validation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/v0.3.0-public-surface-compatibility.md](docs/v0.3.0-public-surface-compatibility.md) — public surface compatibility for the v0.3.0 youaskm3 baseline
 - [docs/v0.3.0-source-build-consumer-packaging.md](docs/v0.3.0-source-build-consumer-packaging.md) — source-build packaging expectations for v0.3.0 consumers
+- [docs/v0.3.0-downstream-validation-path.md](docs/v0.3.0-downstream-validation-path.md) — deterministic downstream validation path for the v0.3.0 youaskm3 baseline
 - [docs/youaskm3-canonical-app-http-path.md](docs/youaskm3-canonical-app-http-path.md) — release-facing HTTP app path for youaskm3
 - [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) — how to emit and receive governed events from a capability
 - [docs/youaskm3-canonical-mcp-client-path.md](docs/youaskm3-canonical-mcp-client-path.md) — release-facing MCP client path for youaskm3

--- a/docs/v0.3.0-downstream-validation-path.md
+++ b/docs/v0.3.0-downstream-validation-path.md
@@ -1,0 +1,97 @@
+# Traverse v0.3.0 Downstream Validation Path
+
+This page defines the deterministic Traverse-side validation path that `youaskm3` can cite for its first release against Traverse `v0.3.0`.
+
+It exists to answer one release question:
+
+> Can a downstream app pin Traverse `v0.3.0` and validate the documented MCP and HTTP/JSON app surfaces without relying on private Traverse internals?
+
+## Supported Baseline
+
+- Traverse release: `v0.3.0`
+- Consumer: `youaskm3`
+- Packaging model: source-build consumption
+- MCP surface: `cargo run -p traverse-mcp -- stdio`
+- HTTP/JSON app surface: `cargo run -p traverse-cli -- serve`
+
+This validation path complements [docs/v0.3.0-public-surface-compatibility.md](v0.3.0-public-surface-compatibility.md) and [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md).
+
+## Clean Checkout Commands
+
+Run this sequence from a clean Traverse checkout pinned to the released tag:
+
+```bash
+git clone https://github.com/enricopiovesan/Traverse.git
+cd Traverse
+git checkout v0.3.0
+cargo build
+bash scripts/ci/mcp_consumption_validation.sh
+bash scripts/ci/app_consumable_acceptance.sh
+bash scripts/ci/youaskm3_compatibility_conformance.sh
+bash scripts/ci/repository_checks.sh
+```
+
+The sequence intentionally includes both release-facing surfaces:
+
+- MCP-facing validation through `scripts/ci/mcp_consumption_validation.sh`
+- app-facing HTTP/JSON validation through `scripts/ci/app_consumable_acceptance.sh`
+- compatibility aggregation through `scripts/ci/youaskm3_compatibility_conformance.sh`
+- discoverability and documentation guardrails through `scripts/ci/repository_checks.sh`
+
+## Expected Success Evidence
+
+The successful validation run should prove:
+
+- the Traverse workspace builds from the pinned `v0.3.0` source checkout
+- the downstream MCP path exposes the public Traverse MCP consumption surface
+- the MCP evidence includes `consumer_name: youaskm3`
+- the MCP evidence includes `validated_flow_id: youaskm3_mcp_validation`
+- the app-consumable path can exercise the public HTTP/JSON browser adapter and app acceptance flow
+- the compatibility wrapper can run the downstream Traverse-side conformance checks together
+- repository checks confirm that the validation path remains documented and discoverable
+
+The validation output is command-line evidence. No private `youaskm3` repository checkout is required for this Traverse-side proof.
+
+## Expected Failure Evidence
+
+The path should fail deterministically when:
+
+- Rust or Cargo is unavailable
+- the checkout is not pinned to a compatible Traverse release
+- the public MCP server path cannot be discovered or exercised
+- the app-consumable acceptance path cannot start or validate the local HTTP/JSON surface
+- a local port needed by an app smoke check is already occupied
+- required validation docs or scripts are missing from the repository
+
+When a failure occurs, keep the failing command output with the release evidence. The failing command name is part of the triage signal.
+
+## Claims This Supports
+
+This validation supports these first-release claims:
+
+- `youaskm3` can pin Traverse `v0.3.0`.
+- `youaskm3` can cite a source-build Traverse consumer path.
+- `youaskm3` can rely on the documented MCP stdio path for first-release integration work.
+- `youaskm3` can rely on the documented HTTP/JSON app path for first-release integration work.
+- The Traverse-side evidence uses public docs and scripts, not private internals.
+
+## Claims Still Owned By youaskm3
+
+This validation does not prove:
+
+- the `youaskm3` product UI is complete
+- every `youaskm3` application feature works
+- every possible external MCP client is compatible
+- production hosting, native installers, or package-manager distribution
+- private downstream release gates inside the `youaskm3` repository
+
+`youaskm3` still owns its product release validation. Traverse owns this public runtime and integration-surface validation path.
+
+## Related Docs
+
+- [docs/v0.3.0-public-surface-compatibility.md](v0.3.0-public-surface-compatibility.md)
+- [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md)
+- [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
+- [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md)
+- [docs/youaskm3-integration-validation.md](youaskm3-integration-validation.md)
+- [docs/youaskm3-compatibility-conformance-suite.md](youaskm3-compatibility-conformance-suite.md)

--- a/docs/v0.3.0-public-surface-compatibility.md
+++ b/docs/v0.3.0-public-surface-compatibility.md
@@ -30,6 +30,7 @@ The following surfaces are public, governed, and release-facing for `v0.3.0`.
 | Supply-chain evidence | Attached release SBOM, provenance, supply-chain summary, and artifact verification JSON | [docs/releases/v0.3.0.md](releases/v0.3.0.md) |
 
 The supported packaging expectation for these surfaces is source-build consumption, documented in [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md).
+The deterministic downstream validation path for this baseline is documented in [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md).
 
 These surfaces may receive additive documentation, validation, and optional-field improvements in later `0.x` releases. Downstream consumers should move to a newer release tag when they need newer surfaces.
 
@@ -69,6 +70,7 @@ Use these validation entrypoints as the evidence path for the public surfaces:
 ```bash
 bash scripts/ci/app_consumable_acceptance.sh
 bash scripts/ci/mcp_consumption_validation.sh
+bash scripts/ci/youaskm3_compatibility_conformance.sh
 bash scripts/ci/repository_checks.sh
 ```
 
@@ -83,5 +85,6 @@ bash scripts/ci/supply_chain_check.sh
 - [docs/compatibility-policy.md](compatibility-policy.md)
 - [docs/releases/v0.3.0.md](releases/v0.3.0.md)
 - [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md)
+- [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md)
 - [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
 - [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md)

--- a/docs/v0.3.0-source-build-consumer-packaging.md
+++ b/docs/v0.3.0-source-build-consumer-packaging.md
@@ -60,6 +60,8 @@ cargo run -p traverse-mcp -- stdio
 
 Use [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md) for the full MCP-facing flow.
 
+Use [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md) for the combined MCP and HTTP/JSON downstream evidence path that `youaskm3` can cite.
+
 ## Release Artifacts
 
 The GitHub Release for `v0.3.0` publishes source plus supply-chain evidence artifacts.
@@ -107,5 +109,6 @@ Expected result:
 
 - [docs/releases/v0.3.0.md](releases/v0.3.0.md)
 - [docs/v0.3.0-public-surface-compatibility.md](v0.3.0-public-surface-compatibility.md)
+- [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md)
 - [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
 - [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md)

--- a/docs/youaskm3-canonical-app-http-path.md
+++ b/docs/youaskm3-canonical-app-http-path.md
@@ -61,6 +61,7 @@ Requirements:
 - `jq` for the copy/pasteable shell examples below
 
 For packaging and source-build expectations, see [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md).
+For the combined release evidence path that includes this app surface, see [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md).
 
 ## Discover The Server
 
@@ -185,4 +186,5 @@ These checks prove that the released app-consumable path remains documented, the
 - [docs/app-consumable-entry-path.md](app-consumable-entry-path.md)
 - [docs/app-consumable-acceptance.md](app-consumable-acceptance.md)
 - [docs/browser-adapter.md](browser-adapter.md)
+- [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md)
 - [docs/youaskm3-integration-validation.md](youaskm3-integration-validation.md)

--- a/docs/youaskm3-canonical-mcp-client-path.md
+++ b/docs/youaskm3-canonical-mcp-client-path.md
@@ -34,6 +34,7 @@ Requirements:
 - an MCP client that supports stdio server commands
 
 For packaging and source-build expectations, see [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md).
+For the combined release evidence path that includes this MCP surface, see [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md).
 
 ## Example Client Configuration
 
@@ -108,4 +109,5 @@ These checks prove that the released public MCP path can start, expose the expec
 - [docs/mcp-stdio-server.md](mcp-stdio-server.md)
 - [docs/mcp-consumption-validation.md](mcp-consumption-validation.md)
 - [docs/mcp-real-agent-exercise.md](mcp-real-agent-exercise.md)
+- [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md)
 - [docs/youaskm3-integration-validation.md](youaskm3-integration-validation.md)

--- a/docs/youaskm3-integration-validation.md
+++ b/docs/youaskm3-integration-validation.md
@@ -22,6 +22,8 @@ For the shortest Traverse-side start path, begin with [quickstart.md](../quickst
 
 For the first release-facing HTTP/JSON app path, use [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md).
 
+For the single Traverse `v0.3.0` downstream validation path that `youaskm3` can cite for release evidence, use [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md).
+
 ## Governing Spec
 
 - `specs/019-downstream-consumer-contract/spec.md`
@@ -59,6 +61,8 @@ For the broader release-aligned compatibility check, also run:
 ```bash
 bash scripts/ci/youaskm3_compatibility_conformance.sh
 ```
+
+For the pinned Traverse `v0.3.0` release evidence sequence, follow [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md).
 
 For the published-artifact validation against the released Traverse runtime and MCP artifacts, also run:
 

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -16,6 +16,7 @@ required_files=(
   "docs/compatibility-policy.md"
   "docs/v0.3.0-public-surface-compatibility.md"
   "docs/v0.3.0-source-build-consumer-packaging.md"
+  "docs/v0.3.0-downstream-validation-path.md"
   "docs/troubleshooting.md"
   "docs/adapter-boundaries.md"
   "docs/contract-publication-policy.md"
@@ -333,11 +334,25 @@ grep -q "docs/youaskm3-canonical-app-http-path.md" docs/v0.3.0-public-surface-co
 grep -q "docs/youaskm3-canonical-mcp-client-path.md" docs/v0.3.0-public-surface-compatibility.md
 grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-source-build-consumer-packaging.md" README.md
+grep -q "docs/v0.3.0-downstream-validation-path.md" README.md
 grep -q "cargo build" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-cli -- serve" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-mcp -- stdio" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "traverse-sbom.cdx.json" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "No package-manager distribution" docs/v0.3.0-source-build-consumer-packaging.md
+grep -q "Traverse v0.3.0 Downstream Validation Path" docs/v0.3.0-downstream-validation-path.md
+grep -q "git checkout v0.3.0" docs/v0.3.0-downstream-validation-path.md
+grep -q "bash scripts/ci/mcp_consumption_validation.sh" docs/v0.3.0-downstream-validation-path.md
+grep -q "bash scripts/ci/app_consumable_acceptance.sh" docs/v0.3.0-downstream-validation-path.md
+grep -q "bash scripts/ci/youaskm3_compatibility_conformance.sh" docs/v0.3.0-downstream-validation-path.md
+grep -q "bash scripts/ci/repository_checks.sh" docs/v0.3.0-downstream-validation-path.md
+grep -q "consumer_name: youaskm3" docs/v0.3.0-downstream-validation-path.md
+grep -q "validated_flow_id: youaskm3_mcp_validation" docs/v0.3.0-downstream-validation-path.md
+grep -q "docs/v0.3.0-downstream-validation-path.md" docs/v0.3.0-public-surface-compatibility.md
+grep -q "docs/v0.3.0-downstream-validation-path.md" docs/v0.3.0-source-build-consumer-packaging.md
+grep -q "docs/v0.3.0-downstream-validation-path.md" docs/youaskm3-canonical-app-http-path.md
+grep -q "docs/v0.3.0-downstream-validation-path.md" docs/youaskm3-canonical-mcp-client-path.md
+grep -q "docs/v0.3.0-downstream-validation-path.md" docs/youaskm3-integration-validation.md
 grep -q "docs/v0.3.0-public-surface-compatibility.md" README.md
 grep -q "docs/v0.3.0-public-surface-compatibility.md" docs/compatibility-policy.md
 grep -q "docs/youaskm3-canonical-app-http-path.md" README.md


### PR DESCRIPTION
## Summary
- Add a deterministic Traverse v0.3.0 downstream validation path for youaskm3.
- Link the path from the public compatibility, packaging, canonical app, canonical MCP, and integration docs.
- Guard discoverability through repository checks.

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate
- 019-downstream-consumer-contract
- 023-browser-hosted-mcp-consumer-model
- 028-schema-alignment-gate-v02
- 031-supply-chain-hardening
- 040-contractual-enforcement-gate

## Project Item
- Closes #438
- Project 1 item: PVTI_lAHOAEZXvs4BS6Nszgu7BbQ

## Validation
- bash scripts/ci/mcp_consumption_validation.sh
- bash scripts/ci/app_consumable_acceptance.sh
- bash scripts/ci/youaskm3_compatibility_conformance.sh
- bash scripts/ci/repository_checks.sh

Note: app_consumable_acceptance was rerun by itself after an initial transient local port 4174 collision from parallel validation.
