### PR TITLE
docs: add youaskm3 v0.3.0 readiness index

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 - [docs/v0.3.0-public-surface-compatibility.md](docs/v0.3.0-public-surface-compatibility.md) — public surface compatibility for the v0.3.0 youaskm3 baseline
 - [docs/v0.3.0-source-build-consumer-packaging.md](docs/v0.3.0-source-build-consumer-packaging.md) — source-build packaging expectations for v0.3.0 consumers
 - [docs/v0.3.0-downstream-validation-path.md](docs/v0.3.0-downstream-validation-path.md) — deterministic downstream validation path for the v0.3.0 youaskm3 baseline
+- [docs/youaskm3-v0.3.0-integration-readiness.md](docs/youaskm3-v0.3.0-integration-readiness.md) — first-release integration readiness index for youaskm3 on Traverse v0.3.0
 - [docs/youaskm3-canonical-app-http-path.md](docs/youaskm3-canonical-app-http-path.md) — release-facing HTTP app path for youaskm3
 - [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) — how to emit and receive governed events from a capability
 - [docs/youaskm3-canonical-mcp-client-path.md](docs/youaskm3-canonical-mcp-client-path.md) — release-facing MCP client path for youaskm3

--- a/docs/v0.3.0-public-surface-compatibility.md
+++ b/docs/v0.3.0-public-surface-compatibility.md
@@ -31,6 +31,7 @@ The following surfaces are public, governed, and release-facing for `v0.3.0`.
 
 The supported packaging expectation for these surfaces is source-build consumption, documented in [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md).
 The deterministic downstream validation path for this baseline is documented in [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md).
+The first-release integration readiness index for `youaskm3` is documented in [docs/youaskm3-v0.3.0-integration-readiness.md](youaskm3-v0.3.0-integration-readiness.md).
 
 These surfaces may receive additive documentation, validation, and optional-field improvements in later `0.x` releases. Downstream consumers should move to a newer release tag when they need newer surfaces.
 
@@ -86,5 +87,6 @@ bash scripts/ci/supply_chain_check.sh
 - [docs/releases/v0.3.0.md](releases/v0.3.0.md)
 - [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md)
 - [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md)
+- [docs/youaskm3-v0.3.0-integration-readiness.md](youaskm3-v0.3.0-integration-readiness.md)
 - [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
 - [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md)

--- a/docs/youaskm3-integration-validation.md
+++ b/docs/youaskm3-integration-validation.md
@@ -24,6 +24,8 @@ For the first release-facing HTTP/JSON app path, use [docs/youaskm3-canonical-ap
 
 For the single Traverse `v0.3.0` downstream validation path that `youaskm3` can cite for release evidence, use [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md).
 
+For the first-release readiness index that ties the canonical paths, compatibility statement, packaging expectations, and validation evidence together, use [docs/youaskm3-v0.3.0-integration-readiness.md](youaskm3-v0.3.0-integration-readiness.md).
+
 ## Governing Spec
 
 - `specs/019-downstream-consumer-contract/spec.md`

--- a/docs/youaskm3-v0.3.0-integration-readiness.md
+++ b/docs/youaskm3-v0.3.0-integration-readiness.md
@@ -1,0 +1,85 @@
+# youaskm3 Traverse v0.3.0 Integration Readiness
+
+This page is the release-facing index for the first `youaskm3` release that depends on Traverse.
+
+## Readiness Answer
+
+Yes, `youaskm3` can honestly claim it is built on Traverse for runtime and MCP when it pins Traverse `v0.3.0` and follows the documented public surfaces below.
+
+The honest claim is narrow:
+
+> `youaskm3` uses Traverse `v0.3.0` for the source-build runtime surface, HTTP/JSON app integration path, and MCP stdio integration path. Product UI, ingestion behavior, and downstream release validation remain owned by `youaskm3`.
+
+## Required Traverse Artifacts
+
+| Readiness Area | Required Artifact |
+|---|---|
+| MCP client path | [docs/youaskm3-canonical-mcp-client-path.md](youaskm3-canonical-mcp-client-path.md) |
+| HTTP/JSON app path | [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md) |
+| Public compatibility statement | [docs/v0.3.0-public-surface-compatibility.md](v0.3.0-public-surface-compatibility.md) |
+| Source-build packaging expectations | [docs/v0.3.0-source-build-consumer-packaging.md](v0.3.0-source-build-consumer-packaging.md) |
+| Downstream validation evidence path | [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md) |
+
+## Traverse Owns
+
+Traverse owns these first-release responsibilities:
+
+- the `v0.3.0` release tag and source-build baseline
+- the documented `traverse-cli serve` HTTP/JSON app path
+- the documented `cargo run -p traverse-mcp -- stdio` MCP path
+- repository-local validation scripts for Traverse-side app and MCP evidence
+- compatibility, packaging, and validation docs that downstream release notes can cite
+- repository checks that keep the release-facing docs discoverable
+
+## youaskm3 Owns
+
+`youaskm3` owns these first-release responsibilities:
+
+- product UI and user workflows
+- ingestion, source presentation, and knowledge-app behavior
+- app-specific MCP client wiring and runtime launch decisions
+- downstream repo release gates and smoke tests
+- any product claim beyond the documented Traverse `v0.3.0` runtime and MCP surfaces
+
+## First-Release Readiness Checklist
+
+Use this checklist before `youaskm3` cites Traverse in a release note or app-facing spec.
+
+- [ ] `youaskm3` pins Traverse `v0.3.0` rather than `main` or an unpublished branch.
+- [ ] The release notes cite the canonical MCP path.
+- [ ] The release notes cite the canonical HTTP/JSON app path.
+- [ ] The release notes cite the public surface compatibility statement.
+- [ ] The release notes cite the source-build packaging expectations.
+- [ ] The release notes cite the downstream validation path.
+- [ ] The Traverse-side validation sequence passes from a clean `v0.3.0` checkout.
+- [ ] Any `youaskm3` product claims are validated in the `youaskm3` repository, not inferred from Traverse checks.
+
+## Traverse-Side Validation
+
+From a clean Traverse checkout pinned to `v0.3.0`, use:
+
+```bash
+git clone https://github.com/enricopiovesan/Traverse.git
+cd Traverse
+git checkout v0.3.0
+cargo build
+bash scripts/ci/mcp_consumption_validation.sh
+bash scripts/ci/app_consumable_acceptance.sh
+bash scripts/ci/youaskm3_compatibility_conformance.sh
+bash scripts/ci/repository_checks.sh
+```
+
+This is the same evidence path documented in [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md).
+
+## Not Ready Claims
+
+Do not claim that Traverse `v0.3.0` provides:
+
+- a hosted production runtime
+- native installers or package-manager distribution
+- every possible MCP client integration
+- `youaskm3` product completeness
+- ingestion support such as `markitdown`
+- a final `1.0` compatibility guarantee
+
+Those claims require separate specs, tickets, implementation, and release evidence.

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -17,6 +17,7 @@ required_files=(
   "docs/v0.3.0-public-surface-compatibility.md"
   "docs/v0.3.0-source-build-consumer-packaging.md"
   "docs/v0.3.0-downstream-validation-path.md"
+  "docs/youaskm3-v0.3.0-integration-readiness.md"
   "docs/troubleshooting.md"
   "docs/adapter-boundaries.md"
   "docs/contract-publication-policy.md"
@@ -335,6 +336,7 @@ grep -q "docs/youaskm3-canonical-mcp-client-path.md" docs/v0.3.0-public-surface-
 grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-source-build-consumer-packaging.md" README.md
 grep -q "docs/v0.3.0-downstream-validation-path.md" README.md
+grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" README.md
 grep -q "cargo build" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-cli -- serve" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-mcp -- stdio" docs/v0.3.0-source-build-consumer-packaging.md
@@ -353,6 +355,19 @@ grep -q "docs/v0.3.0-downstream-validation-path.md" docs/v0.3.0-source-build-con
 grep -q "docs/v0.3.0-downstream-validation-path.md" docs/youaskm3-canonical-app-http-path.md
 grep -q "docs/v0.3.0-downstream-validation-path.md" docs/youaskm3-canonical-mcp-client-path.md
 grep -q "docs/v0.3.0-downstream-validation-path.md" docs/youaskm3-integration-validation.md
+grep -q "youaskm3 Traverse v0.3.0 Integration Readiness" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "Traverse \`v0.3.0\`" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "docs/youaskm3-canonical-mcp-client-path.md" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "docs/youaskm3-canonical-app-http-path.md" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "docs/v0.3.0-public-surface-compatibility.md" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "docs/v0.3.0-source-build-consumer-packaging.md" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "docs/v0.3.0-downstream-validation-path.md" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "Traverse Owns" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "youaskm3 Owns" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "First-Release Readiness Checklist" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "bash scripts/ci/youaskm3_compatibility_conformance.sh" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" docs/youaskm3-integration-validation.md
+grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-public-surface-compatibility.md" README.md
 grep -q "docs/v0.3.0-public-surface-compatibility.md" docs/compatibility-policy.md
 grep -q "docs/youaskm3-canonical-app-http-path.md" README.md


### PR DESCRIPTION
## Summary
- Add the first-release integration readiness index for youaskm3 on Traverse v0.3.0.
- Link the readiness index from README, public compatibility, and integration validation docs.
- Guard the readiness artifact and required links through repository checks.

## Governing Spec
- 001-foundation-v0-1
- 004-spec-alignment-gate
- 019-downstream-consumer-contract
- 023-browser-hosted-mcp-consumer-model
- 028-schema-alignment-gate-v02
- 031-supply-chain-hardening
- 040-contractual-enforcement-gate

## Project Item
- Closes #439
- Project 1 item: PVTI_lAHOAEZXvs4BS6Nszgu7Bco

## Validation
- bash scripts/ci/repository_checks.sh
- bash scripts/ci/youaskm3_compatibility_conformance.sh
