### PR TITLE
docs: add approved specs 044 and 045

### DIFF
--- a/.agents/skills/traverse-ops/SKILL.md
+++ b/.agents/skills/traverse-ops/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: "traverse-ops"
+description: "Start or resume the standard Traverse operating model when the user says TRAVERSE OPS, asks to start Traverse ops/dev work, asks for the ready-ticket worker, PR finisher, or backlog gardener, or wants Codex to pick ready Project 1 work and run the Traverse coordination process."
+---
+
+# Traverse Ops
+
+Use this skill when the user wants Codex to start or resume the standard Traverse operating model.
+
+Canonical trigger:
+
+```text
+TRAVERSE OPS
+```
+
+## Workflow
+
+1. Read `.specify/memory/constitution.md` before implementation work.
+2. Read `AGENTS.md` and follow the agent coordination rules.
+3. Inspect current GitHub and Project 1 state.
+4. Prefer finishing existing open PRs before claiming new Ready work.
+5. If no active PR needs attention, pick one Ready Project 1 issue.
+6. Before work on an issue, run the Claude pre-flight checks from `AGENTS.md`:
+   - issue must not have `agent:claude`
+   - no remote `claude/issue-NNN-*` branch may exist
+7. If pre-flight passes, claim the issue:
+   - add `agent:codex`
+   - set Project 1 `Agent` to `Codex`
+   - set Project 1 `Status` to `In Progress`
+8. Use a dedicated `codex/issue-NNN-*` branch.
+9. Keep work scoped to the claimed issue and governing spec.
+10. Open a dedicated PR with validation evidence.
+
+## Operating Lanes
+
+- **Ready-ticket worker**: claim one Ready Project 1 issue and implement it end to end.
+- **PR finisher**: inspect open PRs, fix CI/review issues, update stale branches, and merge when green if allowed.
+- **Backlog gardener**: audit Project 1 statuses, labels, blockers, notes, and missing tickets.
+
+## Guardrails
+
+- Do not mark work `In Progress` unless a real dev thread has started it.
+- Do not use labels as status; Project 1 status is the actionability source of truth.
+- Do not claim work already owned by Claude Code.
+- Do not broaden scope beyond the issue and governing spec.
+- Create future tickets for non-blocking improvements instead of expanding an active slice.
+
+For the full operating model, see `docs/multi-thread-workflow.md`.

--- a/specs/044-application-bundle-manifest/checklists/requirements.md
+++ b/specs/044-application-bundle-manifest/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Application Bundle Manifest
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Approved based on Traverse team review decisions from 2026-06-12.

--- a/specs/044-application-bundle-manifest/spec.md
+++ b/specs/044-application-bundle-manifest/spec.md
@@ -1,0 +1,177 @@
+# Feature Specification: Application Bundle Manifest
+
+**Feature Branch**: `044-application-bundle-manifest`
+**Created**: 2026-06-12
+**Status**: Approved
+**Input**: Downstream knowledge-app MVP requirements and approval decisions from Traverse team review on 2026-06-12. The downstream app provides an app manifest, concrete WASM component manifests, app configuration, and dependency declarations. Traverse validates, registers, executes, and exposes the app through public runtime, HTTP/JSON, and MCP surfaces.
+
+## Purpose
+
+This spec defines the first Traverse application bundle manifest model for downstream apps that ship real WASM business components and depend on Traverse as the governed runtime boundary.
+
+The manifest model has two layers:
+
+1. **Application manifest**: Declares the downstream app identity, workspace defaults, required workflows, concrete WASM component dependencies, selectable model dependency references, governed configuration schema, safe defaults, public surface needs, and placement policy.
+2. **WASM component manifest**: Declares one executable component package, including capability identity, contract identity, WASM binary path and digest, runtime constraints, permitted targets, required dependencies, connectors, and validation evidence.
+
+Pure business capabilities are concrete. If an app declares a WASM microservice component, Traverse MUST validate and execute that concrete component; Traverse MUST NOT substitute another implementation unless the app manifest is changed and revalidated.
+
+AI/model dependencies are not owned by this spec. Application manifests MAY reference model dependency requirements, but selectable model candidate semantics, availability checks, and inference selection are governed by `045-governed-model-dependency-resolution`.
+
+## User Scenarios and Testing
+
+### User Story 1 - Validate a Complete App Bundle (Priority: P1)
+
+As a downstream app developer, I want Traverse to validate one app manifest and its referenced WASM component manifests before registration so that invalid app bundles never enter a workspace.
+
+**Why this priority**: Manifest validation is the entry point for all downstream app integration. Without it, Traverse cannot safely distinguish app-owned behavior from runtime-owned governance.
+
+**Independent Test**: Submit an app manifest that references two valid WASM component manifests, capability contracts, and workflow definitions. Verify validation succeeds and returns a machine-readable readiness record.
+
+**Acceptance Scenarios**:
+
+1. **Given** an app manifest references valid component manifests and all referenced files exist, **When** Traverse validates the app bundle, **Then** validation succeeds and returns app id, app version, component ids, workflow ids, digests, and readiness status.
+2. **Given** an app manifest references a missing component manifest, **When** Traverse validates the app bundle, **Then** validation fails with `app_component_manifest_missing` and identifies the missing reference.
+3. **Given** a component manifest declares a WASM digest that does not match the referenced binary, **When** Traverse validates the app bundle, **Then** validation fails with `component_digest_mismatch` before registration.
+
+### User Story 2 - Register an App Bundle Atomically (Priority: P1)
+
+As a downstream app CLI, I want to register a complete app bundle through public Traverse APIs so that all capabilities, events, workflows, component manifests, and app metadata enter the workspace together or not at all.
+
+**Why this priority**: Downstream apps need one reliable setup operation. Partial app registration would produce confusing runtime failures and break repeatable setup.
+
+**Independent Test**: Register a complete app bundle through the public bundle registration path. Verify the response includes all artifact ids, versions, digests, execution links, and registration evidence. Re-register the same bundle and verify idempotency.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid app bundle, **When** the bundle is registered into a workspace, **Then** Traverse stores all app, component, capability, event, and workflow artifacts atomically and returns `201`.
+2. **Given** the same app bundle is registered again unchanged, **When** registration is repeated, **Then** Traverse returns `200` with the same artifact ids and digests.
+3. **Given** any artifact in the bundle is invalid, **When** registration is attempted, **Then** Traverse rejects the entire bundle and writes no partial registry state.
+
+### User Story 3 - Generate App and Component Manifests With CLI (Priority: P1)
+
+As an app author, I want `traverse-cli app new` and `traverse-cli component new` flows so that new Traverse apps and components start with governed manifest structure instead of ad hoc files.
+
+**Why this priority**: Manifest authoring must be repeatable and discoverable. A first-class CLI flow prevents downstream apps from inventing incompatible structures.
+
+**Independent Test**: Run `traverse-cli app new youaskm3` and `traverse-cli component new knowledge.retrieve`. Verify the generated files are schema-valid, contain no fake product behavior, and make registration fail until real executable component metadata is provided.
+
+**Acceptance Scenarios**:
+
+1. **Given** no app bundle exists, **When** a developer runs `traverse-cli app new youaskm3`, **Then** Traverse creates a repo-local app bundle directory with an app manifest, workspace config template, workflow directory, component reference directory, and bundle README.
+2. **Given** a component id, **When** a developer runs `traverse-cli component new knowledge.retrieve`, **Then** Traverse creates a buildable component package structure with a component manifest and capability contract template but no fake product logic.
+3. **Given** `--register` is passed to `app new`, **When** the generated bundle has no complete executable components, **Then** Traverse does not register the bundle and returns a clear validation result explaining which required executable artifacts are missing.
+
+### User Story 4 - Merge Manifest Defaults With Workspace Config (Priority: P2)
+
+As a local-first app operator, I want app manifests to declare governed defaults while workspace-local config supplies machine-specific values so that one app bundle can run in different local environments without committing private paths or secrets.
+
+**Why this priority**: Downstream apps need portability and repeatable validation, but local paths, provider endpoints, user preferences, and browser origins differ by workspace.
+
+**Independent Test**: Validate an app manifest with a workspace-local config file. Verify Traverse validates both schemas, applies the defined precedence rules, and returns an effective non-sensitive config summary.
+
+**Acceptance Scenarios**:
+
+1. **Given** an app manifest declares config schema and safe defaults, **When** workspace-local config provides allowed overrides, **Then** Traverse validates the merged config and records the effective non-sensitive values in readiness evidence.
+2. **Given** workspace-local config tries to override an immutable manifest field, **When** validation runs, **Then** Traverse rejects the config with `app_config_immutable_override`.
+3. **Given** workspace-local config contains a value that fails the manifest-declared schema, **When** validation runs, **Then** Traverse rejects the config with `app_config_invalid`.
+
+## Edge Cases
+
+- App manifest references a component id that is declared twice - fail validation with `duplicate_component_reference`.
+- Component manifest references a capability contract whose id or version does not match the component declaration - fail with `component_contract_mismatch`.
+- App manifest declares a pure WASM component dependency using a version range - fail with `component_dependency_must_be_concrete`.
+- App manifest declares a model dependency without any candidates - defer to `045-governed-model-dependency-resolution` for candidate validation and report the delegated failure in app readiness evidence.
+- Workspace-local config is absent - apply manifest defaults and fail only for required config values without defaults.
+- Workspace-local config includes secrets - accept only in the local runtime config boundary and never include secret values in public traces or readiness summaries.
+- App bundle registration is interrupted - either all artifacts are registered or none are registered; retry must be safe.
+- App manifest references a workflow that references a missing component capability - fail at bundle validation before registration.
+- App scaffold target directory already exists - fail unless an explicit force/update mode is provided by a later spec.
+- Component scaffold creates build files but no product logic - generated component is not treated as executable until real implementation metadata and digest are supplied.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Traverse MUST define an application manifest schema with at minimum: `app_id`, `version`, `schema_version`, `workspace_defaults`, `components`, `workflows`, `model_dependencies`, `config_schema`, `default_config`, `placement_policy`, and `public_surfaces`.
+- **FR-002**: Traverse MUST define a WASM component manifest schema with at minimum: `component_id`, `version`, `capability_id`, `capability_version`, `contract_path`, `wasm_binary_path`, `wasm_digest`, `runtime_constraints`, `permitted_targets`, `dependencies`, `connector_requirements`, and `validation_evidence`.
+- **FR-003**: Application manifest component dependencies for pure WASM microservices MUST be concrete references to component id, version, and digest; version ranges are not permitted for pure component substitution in this slice.
+- **FR-004**: Traverse MUST validate that every component manifest referenced by an app manifest exists, is schema-valid, and references an existing capability contract.
+- **FR-005**: Traverse MUST validate that each component manifest's capability id and version match the referenced capability contract.
+- **FR-006**: Traverse MUST verify each referenced WASM binary digest before app bundle registration succeeds.
+- **FR-007**: Traverse MUST validate workflow definitions referenced by the app bundle and ensure every workflow node references a concrete component-backed capability present in the bundle or already registered in the workspace.
+- **FR-008**: Traverse MUST register app bundles atomically; any validation or registration failure MUST prevent all bundle artifacts from being written.
+- **FR-009**: App bundle registration MUST be idempotent when the same app id, app version, component digests, workflow digests, and config schema are resubmitted unchanged.
+- **FR-010**: App bundle registration responses MUST include machine-readable artifact ids, versions, digests, workspace id, registration status, readiness status, and execution/inspection links.
+- **FR-011**: Traverse MUST support app manifest defaults plus workspace-local config overrides with explicit precedence rules: immutable manifest identity and component references cannot be overridden; environment-specific fields may be overridden only when declared overrideable.
+- **FR-012**: Traverse MUST reject workspace-local config that attempts to override immutable manifest fields with `app_config_immutable_override`.
+- **FR-013**: Traverse MUST never include secret workspace-local config values in public readiness evidence, public traces, or registration responses.
+- **FR-014**: `traverse-cli app new <app-id>` MUST generate a repo-local app bundle structure with schema-valid manifest/config files and no fake product behavior.
+- **FR-015**: `traverse-cli component new <component-id>` MUST generate a component package structure with manifest and contract files suitable for real WASM implementation, but the generated component MUST NOT be considered executable until real implementation metadata and digest are supplied.
+- **FR-016**: `traverse-cli app new <app-id> --register --workspace <workspace-id>` MUST attempt registration only after validation; incomplete generated bundles MUST fail registration with a clear machine-readable validation result.
+- **FR-017**: Application manifests MAY reference model dependencies, but candidate selection, availability checks, inference provider validation, and model placement heuristics MUST be governed by `045-governed-model-dependency-resolution`.
+- **FR-018**: App bundle validation MUST produce readiness evidence that separates app manifest validity, component validity, workflow validity, config validity, and delegated model dependency readiness.
+- **FR-019**: App bundle validation and registration MUST be exposed through public Traverse surfaces and MUST NOT require downstream apps to call private crate internals.
+- **FR-020**: App bundle manifest and component manifest schemas MUST be versioned and governed by the spec-alignment gate.
+
+### Non-Functional Requirements
+
+- **NFR-001 Determinism**: Given the same app bundle files, workspace state, and workspace-local config, validation MUST produce the same result and ordering of validation messages.
+- **NFR-002 Atomicity**: Bundle registration MUST never leave partial app, component, capability, event, or workflow state in the workspace.
+- **NFR-003 Portability**: App manifests MUST remain portable across local environments by keeping machine-specific paths, provider endpoints, and secrets in workspace-local config.
+- **NFR-004 Traceability**: Registration and validation evidence MUST identify the app manifest, component manifests, workflow definitions, digests, and effective non-sensitive config used.
+- **NFR-005 Testability**: Manifest schema validation, component digest verification, config merge rules, idempotent registration, and CLI scaffold behavior MUST be independently testable.
+- **NFR-006 Security**: Secret workspace-local config values MUST be excluded from public evidence and public traces by default.
+- **NFR-007 Compatibility**: Manifest schema changes MUST follow semver-compatible evolution; breaking schema changes require a new major schema version and a governing spec update.
+
+### Non-Negotiable Quality Standards
+
+- **QG-001**: Pure WASM business component dependencies MUST be concrete and must not be silently substituted by Traverse.
+- **QG-002**: App bundle registration MUST be atomic; partial registration is a blocking defect.
+- **QG-003**: Component digest verification MUST run before registration; unchecked WASM binaries are not executable.
+- **QG-004**: CLI scaffolding MUST NOT generate fake product behavior that can pass as a working downstream app capability.
+- **QG-005**: Public readiness and trace evidence MUST NOT leak secret workspace-local configuration.
+
+### Key Entities
+
+- **Application Manifest**: The app-owned governed artifact declaring app identity, components, workflows, model dependencies, config schema, defaults, and public surface needs.
+- **WASM Component Manifest**: The component-owned governed artifact declaring one concrete executable WASM package and its contract, digest, constraints, dependencies, and validation evidence.
+- **Application Bundle**: The complete set of app manifest, component manifests, capability contracts, event contracts, workflow definitions, WASM binaries, and config schema submitted for validation or registration.
+- **Workspace-Local Config**: Runtime-local configuration values for one workspace, including paths, local provider endpoints, browser origins, preferences, and secrets.
+- **Effective App Config**: The validated merge of manifest defaults and workspace-local overrides, excluding secret values from public evidence.
+- **App Readiness Evidence**: Machine-readable validation output describing whether the app bundle, components, workflows, config, and delegated model dependencies are ready.
+- **Concrete Component Dependency**: A manifest reference to a specific component id, version, and digest that Traverse must execute without substitution.
+
+## Success Criteria
+
+- **SC-001**: A complete downstream app bundle can be validated from a clean checkout and produces machine-readable readiness evidence for app, component, workflow, config, and model dependency sections.
+- **SC-002**: A valid app bundle can be registered atomically through public Traverse APIs; repeating the same registration is idempotent.
+- **SC-003**: A bundle with any missing component manifest, invalid contract reference, digest mismatch, or invalid workflow fails before any partial registry state is written.
+- **SC-004**: `traverse-cli app new` and `traverse-cli component new` generate schema-valid manifest structures without fake executable product behavior.
+- **SC-005**: Workspace-local config can override declared environment-specific fields while immutable app/component identity fields remain protected.
+- **SC-006**: Public registration/readiness output excludes secret values and includes all non-sensitive artifact ids, versions, digests, and validation outcomes needed by downstream apps.
+
+## Assumptions
+
+- Downstream apps own their product UI, source ingestion tooling, source content, and product release notes.
+- Traverse owns validation, registration, execution, dependency governance, runtime traces, app-facing HTTP/JSON surfaces, and MCP-facing surfaces.
+- Pure app business behavior is shipped as real WASM components with real manifests and digests; generated placeholders are not acceptable executable artifacts.
+- Workspace-local config is runtime-owned generated or operator-authored state and is not a governed source artifact unless explicitly promoted.
+- The first model dependency selection behavior is governed separately by `045-governed-model-dependency-resolution`.
+
+## Issue Mapping
+
+- [#446](https://github.com/enricopiovesan/Traverse/issues/446) - Define application and WASM component manifest schemas.
+- [#447](https://github.com/enricopiovesan/Traverse/issues/447) - Implement atomic application bundle registration.
+- [#448](https://github.com/enricopiovesan/Traverse/issues/448) - Add `app new` and `component new` CLI flows.
+- [#449](https://github.com/enricopiovesan/Traverse/issues/449) - Validate workspace config merge and secret redaction.
+- [#454](https://github.com/enricopiovesan/Traverse/issues/454) - Add downstream app MVP conformance suite across specs 044 and 045.
+
+## Out of Scope
+
+- Model candidate selection, model availability checks, and inference provider execution rules, except for references delegated to spec `045`.
+- File conversion from PDF, DOCX, PPTX, or other user files into raw artifacts.
+- Product UI layout, chat UX, graph visualization, source cards, or downstream release notes.
+- Remote/cloud app bundle distribution and native installers.
+- Automatic migration of existing ad hoc downstream app manifests into this schema.
+- Dynamic substitution of pure WASM business components at runtime.

--- a/specs/045-governed-model-dependency-resolution/checklists/requirements.md
+++ b/specs/045-governed-model-dependency-resolution/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Governed Model Dependency Resolution
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Approved based on Traverse team review decisions from 2026-06-12.

--- a/specs/045-governed-model-dependency-resolution/spec.md
+++ b/specs/045-governed-model-dependency-resolution/spec.md
@@ -1,0 +1,173 @@
+# Feature Specification: Governed Model Dependency Resolution
+
+**Feature Branch**: `045-governed-model-dependency-resolution`
+**Created**: 2026-06-12
+**Status**: Approved
+**Input**: Downstream knowledge-app MVP requirements and Traverse team approval decisions from 2026-06-12. Model inference must be real, not placeholder behavior. Model dependencies are selectable candidates declared by the app manifest, resolved by Traverse using availability, basic model fit, and app priority.
+
+## Purpose
+
+This spec promotes model dependencies from documentation-only declarations into governed runtime dependencies for real local inference.
+
+Pure business capabilities remain concrete WASM components governed by `044-application-bundle-manifest`. Model dependencies are different: the app manifest may provide multiple concrete model/provider candidates for one abstract inference interface, and Traverse decides which candidate to use using governed, traceable heuristics.
+
+The first real provider path is local inference through an Ollama-backed capability implementation unless a later approved spec replaces that provider. The downstream app must not hardcode Ollama, llama.cpp, WebLLM, a cloud API, or any provider-specific path in product logic. Provider-specific behavior belongs behind Traverse-governed inference capability implementations and connectors.
+
+No deterministic fake, placeholder, or stub inference implementation satisfies this spec.
+
+## User Scenarios and Testing
+
+### User Story 1 - Resolve a Real Local Model Candidate (Priority: P1)
+
+As a downstream app, I want to declare multiple concrete model candidates for an inference interface so that Traverse can select a real available local model without the app owning provider-specific logic.
+
+**Why this priority**: Real model selection is the central MVP gap. Without it, the app cannot honestly say Traverse owns inference execution.
+
+**Independent Test**: Provide an app manifest with an inference dependency containing multiple Ollama-backed candidates. With one candidate installed and available locally, validate that Traverse selects that candidate and records the decision.
+
+**Acceptance Scenarios**:
+
+1. **Given** an app manifest declares `traverse.inference.generate` with multiple concrete candidates, **When** Traverse validates model readiness, **Then** it checks candidate availability and model fit and selects the highest-priority passing candidate.
+2. **Given** the highest-priority candidate is unavailable but a lower-priority candidate is available and fits, **When** Traverse resolves the model dependency, **Then** it selects the lower-priority passing candidate and records why the first candidate was rejected.
+3. **Given** no candidate is available or fit, **When** Traverse resolves the dependency, **Then** it fails with `model_dependency_unsatisfied` before user-facing execution begins.
+
+### User Story 2 - Validate Model Readiness During App Setup (Priority: P1)
+
+As a local-first app operator, I want app bundle registration/setup validation to report model provider and model readiness so that users discover missing local model setup before asking a question.
+
+**Why this priority**: Readiness evidence is necessary for a practical local MVP. Setup must reveal provider/model gaps early.
+
+**Independent Test**: Validate an app bundle when the local provider is not running, when the provider is running but the model is missing, and when the model is installed. Verify distinct readiness outcomes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the local provider is not reachable, **When** setup validation runs, **Then** readiness evidence reports `model_provider_unavailable`.
+2. **Given** the provider is reachable but a declared model is not installed, **When** setup validation runs, **Then** readiness evidence reports `model_candidate_unavailable`.
+3. **Given** a declared model is reachable and satisfies basic fit requirements, **When** setup validation runs, **Then** readiness evidence reports the candidate as ready.
+
+### User Story 3 - Revalidate Model Availability at Execution Time (Priority: P1)
+
+As a runtime user, I want Traverse to re-check model availability immediately before inference so that a model removed or stopped after registration cannot cause ambiguous failures.
+
+**Why this priority**: Registration-time readiness is not enough. Local model availability can change between setup and execution.
+
+**Independent Test**: Validate an app bundle successfully, then make the selected model unavailable before execution. Verify execution fails with a stable model dependency error and a trace-ready failure classification.
+
+**Acceptance Scenarios**:
+
+1. **Given** app setup validation previously succeeded, **When** the selected provider is stopped before execution, **Then** Traverse revalidates and fails with `model_provider_unavailable`.
+2. **Given** the selected model is removed before execution but another candidate is available and fits, **When** execution begins, **Then** Traverse may select the available passing candidate according to policy and records the switch in trace evidence.
+3. **Given** no candidate passes execution-time revalidation, **When** inference would begin, **Then** Traverse fails with `model_dependency_unsatisfied` before invoking downstream product logic that depends on inference.
+
+### User Story 4 - Record Public Trace Evidence for Model Selection (Priority: P2)
+
+As a UI or auditor, I want public trace evidence to show which model/provider was selected and why so that answer production remains explainable without exposing private prompts or secret config.
+
+**Why this priority**: Model selection is a runtime decision. It must be visible enough for downstream UI and audit views without leaking sensitive content.
+
+**Independent Test**: Execute a workflow that resolves an inference dependency. Fetch the public trace and verify it includes interface requested, candidates evaluated, selected candidate, placement, and non-sensitive rejection reasons.
+
+**Acceptance Scenarios**:
+
+1. **Given** model resolution succeeds, **When** the public trace is fetched, **Then** it includes requested inference interface, evaluated candidates, selected provider, selected model, selected placement, and selection reason.
+2. **Given** model resolution fails, **When** the public trace or failure envelope is inspected, **Then** it includes stable failure code and non-sensitive candidate rejection reasons.
+3. **Given** workspace-local provider config contains sensitive values, **When** trace evidence is produced, **Then** secret values are omitted from public trace output.
+
+## Edge Cases
+
+- Provider endpoint is configured but unreachable - setup readiness reports `model_provider_unavailable`; execution revalidation fails with the same code if no alternate candidate passes.
+- Provider is reachable but model is not installed - report `model_candidate_unavailable`.
+- Model is available but does not satisfy required context window - reject candidate with `model_context_window_insufficient`.
+- Model is available but does not support the requested interface - reject candidate with `model_interface_unsupported`.
+- App manifest lists duplicate candidate ids for the same interface and model - fail readiness validation with `duplicate_model_candidate`.
+- Candidate has invalid provider-specific configuration - fail with `model_candidate_config_invalid`.
+- Candidate priority ties after filtering - resolve deterministically by manifest order and record the tie in trace evidence.
+- Setup validation succeeds but execution-time model availability changes - re-run resolution and record whether selection changed.
+- Workspace-local provider config includes secrets - use them only in runtime-local execution and never emit them in public trace/readiness evidence.
+- A fake or placeholder inference capability is registered - it cannot satisfy this spec unless it invokes a real model provider and produces real inference output.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Traverse MUST define a governed model dependency declaration for app manifests containing at minimum: `interface_id`, `version_range`, `selection_policy`, `required_capabilities`, `minimum_context_window`, and `candidates`.
+- **FR-002**: Each model candidate MUST declare at minimum: candidate id, provider capability id, provider implementation id, model identifier, placement target, priority, required provider config keys, and non-sensitive model metadata.
+- **FR-003**: Model dependencies MUST be satisfied by real governed inference capability implementations; fake, placeholder, or documentation-only implementations MUST NOT satisfy readiness or execution.
+- **FR-004**: The first approved provider path MUST support a real local Ollama-backed inference implementation behind a Traverse-governed inference capability interface.
+- **FR-005**: Downstream apps MUST depend on the abstract inference interface and candidate set; downstream app product code MUST NOT hardcode provider-specific inference calls.
+- **FR-006**: Traverse MUST evaluate model candidates using this MVP heuristic order: provider/model availability, requested inference interface support, placement policy, minimum context window, then app-declared priority.
+- **FR-007**: If all filtered candidates fail, Traverse MUST return `model_dependency_unsatisfied` with non-sensitive rejection reasons for each candidate.
+- **FR-008**: Traverse MUST perform model readiness checks during app setup or bundle validation and include readiness results in app readiness evidence.
+- **FR-009**: Traverse MUST revalidate model availability and basic fit at execution time before invoking inference.
+- **FR-010**: Execution-time revalidation MAY select a different passing candidate than setup validation when the original candidate is unavailable and policy permits fallback; the trace MUST record the change.
+- **FR-011**: Candidate selection MUST be deterministic for the same app manifest, workspace-local config, provider state, and model metadata.
+- **FR-012**: Public trace evidence MUST include requested interface, evaluated candidates, rejected candidate reasons, selected provider, selected model, selected placement, and selection reason.
+- **FR-013**: Public trace evidence MUST NOT include private prompts, private source text, secret provider configuration, or raw model credentials.
+- **FR-014**: Missing provider, missing model, unsupported interface, insufficient context window, invalid candidate config, and unsatisfied model dependency failures MUST each have stable machine-readable error codes.
+- **FR-015**: Model readiness evidence MUST distinguish setup validation failures from execution-time availability failures.
+- **FR-016**: Model candidate metadata MUST be versioned and validated as part of the app manifest and workspace-local config merge governed by `044-application-bundle-manifest`.
+- **FR-017**: The selected inference implementation and placement MUST be visible through both HTTP/JSON execution trace retrieval and MCP execution report surfaces when the workflow is exposed through both.
+- **FR-018**: Model dependency resolution MUST not require downstream app code changes when a new compatible provider implementation is added to the candidate set and app policy permits it.
+
+### Non-Functional Requirements
+
+- **NFR-001 Determinism**: Candidate filtering and priority selection MUST produce the same result for the same manifest, config, provider state, and model metadata.
+- **NFR-002 Explainability**: Every selected or rejected candidate MUST have a non-sensitive reason suitable for UI readiness and public trace views.
+- **NFR-003 Local-First Operation**: The first approved model provider path MUST work without paid external services.
+- **NFR-004 Privacy**: Public traces and readiness evidence MUST not reveal private prompts, private source text, secrets, or credentials.
+- **NFR-005 Portability**: Provider-specific implementation details MUST remain behind Traverse-governed inference capability implementations and not leak into downstream app product logic.
+- **NFR-006 Testability**: Availability checks, candidate filtering, context-window filtering, priority selection, fallback behavior, and trace evidence generation MUST be independently testable.
+- **NFR-007 Compatibility**: Inference interface and candidate schema changes MUST follow semver-compatible evolution.
+
+### Non-Negotiable Quality Standards
+
+- **QG-001**: No fake, placeholder, or documentation-only inference implementation may satisfy this spec.
+- **QG-002**: The downstream app MUST NOT own provider-specific model invocation logic.
+- **QG-003**: Model availability MUST be checked during setup/readiness validation and rechecked at execution time.
+- **QG-004**: Selection trace evidence MUST identify selected provider/model/placement and rejected candidate reasons without leaking private data.
+- **QG-005**: Missing or unsuitable model dependencies MUST fail before user-facing answer execution begins.
+
+### Key Entities
+
+- **Model Dependency Declaration**: App manifest requirement for an abstract inference interface plus candidate set and selection policy.
+- **Inference Interface**: A stable governed capability contract such as `traverse.inference.generate` that downstream workflows depend on.
+- **Model Candidate**: One concrete provider/model option that can satisfy an inference interface if available and fit.
+- **Provider Implementation**: A governed inference capability implementation, such as an Ollama-backed local provider.
+- **Model Readiness Evidence**: Setup-time validation output showing provider availability, model availability, interface support, context fit, and candidate selection readiness.
+- **Model Resolution Trace**: Execution-time trace evidence showing evaluated candidates, selected candidate, placement, and reasons.
+- **Basic Model Fit**: MVP candidate filters for requested interface, placement policy, and minimum context window.
+
+## Success Criteria
+
+- **SC-001**: A downstream app manifest can declare multiple real local model candidates for an inference interface, and Traverse selects the highest-priority available candidate that satisfies basic fit.
+- **SC-002**: Setup validation distinguishes provider unavailable, model unavailable, unsupported interface, insufficient context, and ready candidates with stable machine-readable codes.
+- **SC-003**: Execution revalidates model availability and either selects a passing candidate or fails before inference-dependent product behavior begins.
+- **SC-004**: Public traces and MCP execution reports identify selected model/provider/placement and non-sensitive rejection reasons.
+- **SC-005**: Downstream app product logic remains provider-neutral while Traverse invokes a real local inference implementation.
+- **SC-006**: No fake or placeholder inference implementation can pass readiness or execution validation for this spec.
+
+## Assumptions
+
+- Application bundle manifest structure, workspace-local config merge, and concrete WASM component dependencies are governed by `044-application-bundle-manifest`.
+- The first real local provider path is Ollama-backed because it provides the shortest source-build developer path to real local inference.
+- Later providers such as llama.cpp, WebLLM, or cloud APIs may be added as compatible implementations of the same inference interface under future approved specs.
+- Model quality ranking and benchmark-based routing are not required for the first MVP heuristic.
+- Downstream source ingestion, artifact construction, retrieval indexes, and UI rendering remain owned by the downstream app unless wrapped as governed Traverse components.
+
+## Issue Mapping
+
+- [#450](https://github.com/enricopiovesan/Traverse/issues/450) - Define governed inference interface and model candidate schema.
+- [#451](https://github.com/enricopiovesan/Traverse/issues/451) - Implement real local Ollama inference provider capability.
+- [#452](https://github.com/enricopiovesan/Traverse/issues/452) - Resolve model dependencies at setup and execution time.
+- [#453](https://github.com/enricopiovesan/Traverse/issues/453) - Expose model selection evidence in traces and MCP reports.
+- [#454](https://github.com/enricopiovesan/Traverse/issues/454) - Add downstream app MVP conformance suite across specs 044 and 045.
+
+## Out of Scope
+
+- Fake, placeholder, stub, or documentation-only inference behavior.
+- Full benchmark-based model routing and historical performance learning.
+- Cloud/server model execution as a first provider path.
+- Browser-native WebLLM provider execution.
+- Model weight distribution, native installers, or package-manager installation.
+- Embedding-specific interfaces unless added by a later approved spec.
+- Product-level answer quality scoring beyond model selection and traceability.

--- a/specs/README.md
+++ b/specs/README.md
@@ -34,6 +34,8 @@ Traverse uses split, focused governing specs instead of one giant spec file. Thi
 | Programmatic workflow building and composition | `041-workflow-composition-api` |
 | MCP library surface and embeddable agent APIs | `042-mcp-library-surface` |
 | Module dependency registry and resolution strategy | `043-module-dependency-management` |
+| Downstream app manifests, component manifests, app config, and app/component CLI scaffolding | `044-application-bundle-manifest` |
+| Real model dependency candidates, local inference readiness, selection heuristics, and model selection trace evidence | `045-governed-model-dependency-resolution` |
 
 ## Context Hygiene
 

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -467,6 +467,37 @@
         "specs/043-module-dependency-management/",
         "specs/governance/"
       ]
+    },
+    {
+      "id": "044-application-bundle-manifest",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/044-application-bundle-manifest/spec.md",
+      "governs": [
+        "crates/traverse-cli/",
+        "crates/traverse-contracts/",
+        "crates/traverse-registry/",
+        "crates/traverse-runtime/",
+        "specs/044-application-bundle-manifest/",
+        "specs/governance/"
+      ]
+    },
+    {
+      "id": "045-governed-model-dependency-resolution",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/045-governed-model-dependency-resolution/spec.md",
+      "governs": [
+        "crates/traverse-cli/",
+        "crates/traverse-contracts/",
+        "crates/traverse-registry/",
+        "crates/traverse-runtime/",
+        "crates/traverse-mcp/",
+        "specs/045-governed-model-dependency-resolution/",
+        "specs/governance/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add approved spec 044 for application bundle manifests, component manifests, dependency declarations, and Traverse app/component creation flows.
- Add approved spec 045 for governed model dependency resolution with concrete provider/model choices and runtime decision evidence.
- Add the local Traverse ops skill so `TRAVERSE OPS` resolves to the documented coordination workflow.
- Register specs 044 and 045 in the spec README and approved-specs governance manifest.

## Governing Spec

- `044-application-bundle-manifest`
- `045-governed-model-dependency-resolution`

## Project Item

- Issue: #455
- Project: Traverse Project 1
- Agent: Codex
- Status: In Progress until PR merge

## Validation

- `jq empty specs/governance/approved-specs.json`
- `bash scripts/ci/spec_context_check.sh`
- `bash scripts/ci/openapi_structural_validation.sh`
- `bash scripts/ci/repository_checks.sh`
- `git diff --check`

Closes #455
