### PR TITLE
feat: add application manifest validation schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "traverse-contracts",
 ]
 

--- a/crates/traverse-registry/Cargo.toml
+++ b/crates/traverse-registry/Cargo.toml
@@ -11,6 +11,7 @@ traverse-contracts = { path = "../traverse-contracts" }
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+sha2 = "0.10"
 
 [dev-dependencies]
 [lints]

--- a/crates/traverse-registry/src/application_manifest.rs
+++ b/crates/traverse-registry/src/application_manifest.rs
@@ -1,0 +1,519 @@
+use serde::Deserialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+use std::fmt::Write;
+use std::fs;
+use std::path::{Path, PathBuf};
+use traverse_contracts::{
+    CapabilityContract, ConnectorRequirement, ExecutionTarget, parse_contract,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationBundleManifest {
+    pub app_id: String,
+    pub version: String,
+    pub schema_version: String,
+    pub workspace_defaults: Value,
+    pub components: Vec<ApplicationComponent>,
+    pub workflows: Vec<ApplicationWorkflowRef>,
+    pub model_dependencies: Vec<ApplicationModelDependency>,
+    pub config_schema: Value,
+    pub default_config: Value,
+    pub placement_policy: Value,
+    pub public_surfaces: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationComponent {
+    pub reference: ApplicationComponentRef,
+    pub manifest_path: PathBuf,
+    pub manifest: WasmComponentManifest,
+    pub contract_path: PathBuf,
+    pub contract: CapabilityContract,
+    pub wasm_binary_path: PathBuf,
+    pub verified_wasm_digest: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ApplicationComponentRef {
+    pub component_id: String,
+    pub version: String,
+    pub digest: String,
+    pub manifest_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ApplicationWorkflowRef {
+    pub workflow_id: String,
+    pub workflow_version: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ApplicationModelDependency {
+    pub dependency_id: String,
+    pub requirement_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WasmComponentManifest {
+    pub component_id: String,
+    pub version: String,
+    pub schema_version: String,
+    pub capability_id: String,
+    pub capability_version: String,
+    pub contract_path: String,
+    pub wasm_binary_path: String,
+    pub wasm_digest: String,
+    pub runtime_constraints: Value,
+    pub permitted_targets: Vec<ExecutionTarget>,
+    pub dependencies: Vec<WasmComponentDependency>,
+    pub connector_requirements: Vec<ConnectorRequirement>,
+    pub validation_evidence: Vec<Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct WasmComponentDependency {
+    pub component_id: String,
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub digest: Option<String>,
+    #[serde(default)]
+    pub version_range: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplicationManifestErrorCode {
+    ManifestParentMissing,
+    ManifestReadFailed,
+    ManifestParseFailed,
+    DuplicateComponentReference,
+    AppComponentManifestMissing,
+    ComponentManifestReadFailed,
+    ComponentManifestParseFailed,
+    ComponentReferenceMismatch,
+    ComponentContractMissing,
+    ComponentContractParseFailed,
+    ComponentContractMismatch,
+    ComponentWasmMissing,
+    InvalidDigestMetadata,
+    ComponentDigestMismatch,
+    ComponentDependencyMustBeConcrete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationManifestError {
+    pub code: ApplicationManifestErrorCode,
+    pub path: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationManifestFailure {
+    pub errors: Vec<ApplicationManifestError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplicationManifestSerde {
+    app_id: String,
+    version: String,
+    schema_version: String,
+    workspace_defaults: Value,
+    components: Vec<ApplicationComponentRef>,
+    workflows: Vec<ApplicationWorkflowRef>,
+    model_dependencies: Vec<ApplicationModelDependency>,
+    config_schema: Value,
+    default_config: Value,
+    placement_policy: Value,
+    public_surfaces: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WasmComponentManifestSerde {
+    component_id: String,
+    version: String,
+    schema_version: String,
+    capability_id: String,
+    capability_version: String,
+    contract_path: String,
+    wasm_binary_path: String,
+    wasm_digest: String,
+    runtime_constraints: Value,
+    permitted_targets: Vec<ExecutionTarget>,
+    dependencies: Vec<WasmComponentDependency>,
+    connector_requirements: Vec<ConnectorRequirement>,
+    validation_evidence: Vec<Value>,
+}
+
+/// Loads and validates a Traverse application manifest plus its referenced
+/// concrete WASM component manifests.
+///
+/// # Errors
+///
+/// Returns [`ApplicationManifestFailure`] when the app manifest, component
+/// manifests, contracts, concrete component dependencies, or WASM digests are
+/// invalid for spec `044-application-bundle-manifest`.
+pub fn load_application_bundle_manifest(
+    manifest_path: &Path,
+) -> Result<ApplicationBundleManifest, ApplicationManifestFailure> {
+    let manifest_dir = manifest_path.parent().ok_or_else(|| {
+        single_error(
+            ApplicationManifestErrorCode::ManifestParentMissing,
+            manifest_path.display().to_string(),
+            format!(
+                "application manifest {} has no parent directory",
+                manifest_path.display()
+            ),
+        )
+    })?;
+
+    let manifest_contents = fs::read_to_string(manifest_path).map_err(|error| {
+        single_error(
+            ApplicationManifestErrorCode::ManifestReadFailed,
+            manifest_path.display().to_string(),
+            format!(
+                "failed to read application manifest {}: {error}",
+                manifest_path.display()
+            ),
+        )
+    })?;
+
+    let manifest: ApplicationManifestSerde =
+        serde_json::from_str(&manifest_contents).map_err(|error| {
+            single_error(
+                ApplicationManifestErrorCode::ManifestParseFailed,
+                manifest_path.display().to_string(),
+                format!(
+                    "failed to parse application manifest {}: {error}",
+                    manifest_path.display()
+                ),
+            )
+        })?;
+
+    ensure_unique_component_refs(&manifest.components)?;
+
+    let components = manifest
+        .components
+        .iter()
+        .map(|component| load_component(manifest_dir, component))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(ApplicationBundleManifest {
+        app_id: manifest.app_id,
+        version: manifest.version,
+        schema_version: manifest.schema_version,
+        workspace_defaults: manifest.workspace_defaults,
+        components,
+        workflows: manifest.workflows,
+        model_dependencies: manifest.model_dependencies,
+        config_schema: manifest.config_schema,
+        default_config: manifest.default_config,
+        placement_policy: manifest.placement_policy,
+        public_surfaces: manifest.public_surfaces,
+    })
+}
+
+fn ensure_unique_component_refs(
+    components: &[ApplicationComponentRef],
+) -> Result<(), ApplicationManifestFailure> {
+    let mut seen = BTreeSet::new();
+    for component in components {
+        let key = format!("{}@{}", component.component_id, component.version);
+        if !seen.insert(key.clone()) {
+            return Err(single_error(
+                ApplicationManifestErrorCode::DuplicateComponentReference,
+                key.clone(),
+                format!("duplicate component reference in application manifest: {key}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn load_component(
+    manifest_dir: &Path,
+    reference: &ApplicationComponentRef,
+) -> Result<ApplicationComponent, ApplicationManifestFailure> {
+    let manifest_path = manifest_dir.join(&reference.manifest_path);
+    if !manifest_path.is_file() {
+        return Err(single_error(
+            ApplicationManifestErrorCode::AppComponentManifestMissing,
+            manifest_path.display().to_string(),
+            format!(
+                "missing component manifest for {} at {}",
+                reference.component_id,
+                manifest_path.display()
+            ),
+        ));
+    }
+
+    let manifest_contents = fs::read_to_string(&manifest_path).map_err(|error| {
+        single_error(
+            ApplicationManifestErrorCode::ComponentManifestReadFailed,
+            manifest_path.display().to_string(),
+            format!(
+                "failed to read component manifest {}: {error}",
+                manifest_path.display()
+            ),
+        )
+    })?;
+
+    let component: WasmComponentManifestSerde =
+        serde_json::from_str(&manifest_contents).map_err(|error| {
+            single_error(
+                ApplicationManifestErrorCode::ComponentManifestParseFailed,
+                manifest_path.display().to_string(),
+                format!(
+                    "failed to parse component manifest {}: {error}",
+                    manifest_path.display()
+                ),
+            )
+        })?;
+
+    let expected_wasm_digest =
+        ensure_component_reference_matches(reference, &component, &manifest_path)?;
+    ensure_concrete_component_dependencies(&component.dependencies, &manifest_path)?;
+
+    let component_dir = manifest_path.parent().unwrap_or(manifest_dir);
+    let contract_path = component_dir.join(&component.contract_path);
+    let contract = load_component_contract(&contract_path, &component)?;
+    let wasm_binary_path = component_dir.join(&component.wasm_binary_path);
+    let verified_wasm_digest = verify_wasm_digest(&wasm_binary_path, &expected_wasm_digest)?;
+
+    Ok(ApplicationComponent {
+        reference: reference.clone(),
+        manifest_path,
+        manifest: to_component_manifest(component),
+        contract_path,
+        contract,
+        wasm_binary_path,
+        verified_wasm_digest,
+    })
+}
+
+fn ensure_component_reference_matches(
+    reference: &ApplicationComponentRef,
+    component: &WasmComponentManifestSerde,
+    manifest_path: &Path,
+) -> Result<String, ApplicationManifestFailure> {
+    if reference.component_id != component.component_id || reference.version != component.version {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ComponentReferenceMismatch,
+            manifest_path.display().to_string(),
+            format!(
+                "component reference mismatch for {}: app declared {}@{}, component manifest contains {}@{}",
+                manifest_path.display(),
+                reference.component_id,
+                reference.version,
+                component.component_id,
+                component.version
+            ),
+        ));
+    }
+    let expected_digest = normalize_sha256_digest(&reference.digest).ok_or_else(|| {
+        single_error(
+            ApplicationManifestErrorCode::InvalidDigestMetadata,
+            "$.components[].digest".to_string(),
+            format!(
+                "component reference {}@{} declares invalid digest metadata",
+                reference.component_id, reference.version
+            ),
+        )
+    })?;
+    let component_digest = normalize_sha256_digest(&component.wasm_digest).ok_or_else(|| {
+        single_error(
+            ApplicationManifestErrorCode::InvalidDigestMetadata,
+            "$.wasm_digest".to_string(),
+            format!(
+                "component manifest {}@{} declares invalid wasm_digest metadata",
+                component.component_id, component.version
+            ),
+        )
+    })?;
+    if expected_digest != component_digest {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ComponentDigestMismatch,
+            manifest_path.display().to_string(),
+            format!(
+                "component digest mismatch for {}@{}: app declared {}, component manifest declared {}",
+                component.component_id, component.version, reference.digest, component.wasm_digest
+            ),
+        ));
+    }
+    Ok(expected_digest)
+}
+
+fn ensure_concrete_component_dependencies(
+    dependencies: &[WasmComponentDependency],
+    manifest_path: &Path,
+) -> Result<(), ApplicationManifestFailure> {
+    for dependency in dependencies {
+        let concrete = dependency.version.as_deref().is_some_and(has_text)
+            && dependency.digest.as_deref().is_some_and(has_text)
+            && dependency.version_range.is_none();
+        if !concrete {
+            return Err(single_error(
+                ApplicationManifestErrorCode::ComponentDependencyMustBeConcrete,
+                manifest_path.display().to_string(),
+                format!(
+                    "component dependency {} must declare concrete version and digest without version_range",
+                    dependency.component_id
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn load_component_contract(
+    contract_path: &Path,
+    component: &WasmComponentManifestSerde,
+) -> Result<CapabilityContract, ApplicationManifestFailure> {
+    if !contract_path.is_file() {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ComponentContractMissing,
+            contract_path.display().to_string(),
+            format!(
+                "missing capability contract for {} at {}",
+                component.component_id,
+                contract_path.display()
+            ),
+        ));
+    }
+
+    let contract_contents = fs::read_to_string(contract_path).map_err(|error| {
+        single_error(
+            ApplicationManifestErrorCode::ComponentContractMissing,
+            contract_path.display().to_string(),
+            format!(
+                "failed to read capability contract {}: {error}",
+                contract_path.display()
+            ),
+        )
+    })?;
+
+    let contract = parse_contract(&contract_contents).map_err(|failure| {
+        let detail = failure
+            .errors
+            .into_iter()
+            .map(|error| format!("{} at {}", error.message, error.path))
+            .collect::<Vec<_>>()
+            .join("; ");
+        single_error(
+            ApplicationManifestErrorCode::ComponentContractParseFailed,
+            contract_path.display().to_string(),
+            format!(
+                "failed to parse capability contract for {}: {}",
+                component.component_id, detail
+            ),
+        )
+    })?;
+
+    if contract.id != component.capability_id || contract.version != component.capability_version {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ComponentContractMismatch,
+            contract_path.display().to_string(),
+            format!(
+                "component contract mismatch for {}: manifest declared {}@{}, contract contains {}@{}",
+                component.component_id,
+                component.capability_id,
+                component.capability_version,
+                contract.id,
+                contract.version
+            ),
+        ));
+    }
+
+    Ok(contract)
+}
+
+fn verify_wasm_digest(
+    wasm_binary_path: &Path,
+    expected: &str,
+) -> Result<String, ApplicationManifestFailure> {
+    if !wasm_binary_path.is_file() {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ComponentWasmMissing,
+            wasm_binary_path.display().to_string(),
+            format!("missing WASM binary at {}", wasm_binary_path.display()),
+        ));
+    }
+    let bytes = fs::read(wasm_binary_path).map_err(|error| {
+        single_error(
+            ApplicationManifestErrorCode::ComponentWasmMissing,
+            wasm_binary_path.display().to_string(),
+            format!(
+                "failed to read WASM binary {}: {error}",
+                wasm_binary_path.display()
+            ),
+        )
+    })?;
+    let actual = sha256_hex(&bytes);
+    if expected != actual {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ComponentDigestMismatch,
+            wasm_binary_path.display().to_string(),
+            format!(
+                "WASM digest mismatch for {}: expected sha256:{expected}, got sha256:{actual}",
+                wasm_binary_path.display()
+            ),
+        ));
+    }
+    Ok(format!("sha256:{actual}"))
+}
+
+fn to_component_manifest(component: WasmComponentManifestSerde) -> WasmComponentManifest {
+    WasmComponentManifest {
+        component_id: component.component_id,
+        version: component.version,
+        schema_version: component.schema_version,
+        capability_id: component.capability_id,
+        capability_version: component.capability_version,
+        contract_path: component.contract_path,
+        wasm_binary_path: component.wasm_binary_path,
+        wasm_digest: component.wasm_digest,
+        runtime_constraints: component.runtime_constraints,
+        permitted_targets: component.permitted_targets,
+        dependencies: component.dependencies,
+        connector_requirements: component.connector_requirements,
+        validation_evidence: component.validation_evidence,
+    }
+}
+
+fn normalize_sha256_digest(value: &str) -> Option<String> {
+    let digest = value.strip_prefix("sha256:").unwrap_or(value);
+    if digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        Some(digest.to_ascii_lowercase())
+    } else {
+        None
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(output, "{byte:02x}");
+    }
+    output
+}
+
+fn has_text(value: &str) -> bool {
+    !value.trim().is_empty()
+}
+
+fn single_error(
+    code: ApplicationManifestErrorCode,
+    path: String,
+    message: String,
+) -> ApplicationManifestFailure {
+    ApplicationManifestFailure {
+        errors: vec![ApplicationManifestError {
+            code,
+            path,
+            message,
+        }],
+    }
+}

--- a/crates/traverse-registry/src/lib.rs
+++ b/crates/traverse-registry/src/lib.rs
@@ -1,5 +1,6 @@
 //! Registry support for Traverse.
 
+mod application_manifest;
 mod bundle;
 pub mod dependency_resolver;
 mod events;
@@ -7,6 +8,7 @@ mod federation;
 mod graph;
 pub mod semver_resolver;
 mod workflows;
+pub use application_manifest::*;
 pub use bundle::*;
 pub use dependency_resolver::{
     DigestMismatch, MAX_TRANSITIVE_DEPTH, ResolutionError, ResolvedDependencyLock,
@@ -937,9 +939,7 @@ fn validate_connector_requirements_for_registration(
             )
         })?;
         let has_satisfying_version = matching_id.iter().any(|((_, _, version), _)| {
-            Version::parse(version)
-                .map(|parsed| parsed_range.matches(&parsed))
-                .unwrap_or(false)
+            Version::parse(version).is_ok_and(|parsed| parsed_range.matches(&parsed))
         });
         if !has_satisfying_version {
             return Err(single_error(

--- a/crates/traverse-registry/tests/application_manifest.rs
+++ b/crates/traverse-registry/tests/application_manifest.rs
@@ -1,0 +1,672 @@
+#![allow(clippy::expect_used)]
+
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::fmt::Write;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+use traverse_registry::{ApplicationManifestErrorCode, load_application_bundle_manifest};
+
+#[test]
+fn loads_checked_in_application_manifest_with_real_wasm_component() {
+    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/applications/expedition-readiness/app.manifest.json");
+
+    let bundle = load_application_bundle_manifest(&manifest_path)
+        .expect("checked-in application bundle should validate");
+
+    assert_eq!(bundle.app_id, "expedition.readiness");
+    assert_eq!(bundle.version, "1.0.0");
+    assert_eq!(bundle.components.len(), 1);
+    assert_eq!(
+        bundle.components[0].manifest.component_id,
+        "expedition.readiness.validate-team-readiness-component"
+    );
+    assert_eq!(
+        bundle.components[0].contract.id,
+        "expedition.planning.validate-team-readiness"
+    );
+    assert_eq!(
+        bundle.components[0].verified_wasm_digest,
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99"
+    );
+}
+
+#[test]
+fn rejects_manifest_path_without_parent_directory() {
+    let failure = load_application_bundle_manifest(PathBuf::new().as_path())
+        .expect_err("empty manifest path should fail before reading");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ManifestParentMissing
+    );
+}
+
+#[test]
+fn rejects_missing_application_manifest_file() {
+    let fixture = AppFixture::new("missing-app-manifest");
+
+    let failure = load_application_bundle_manifest(&fixture.root.join("missing.manifest.json"))
+        .expect_err("missing app manifest should fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ManifestReadFailed
+    );
+}
+
+#[test]
+fn rejects_invalid_application_manifest_json() {
+    let fixture = AppFixture::new("invalid-app-manifest");
+    fs::write(fixture.app_manifest_path(), "{ not valid json ")
+        .expect("invalid app manifest fixture should write");
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("invalid app manifest json should fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ManifestParseFailed
+    );
+}
+
+#[test]
+fn rejects_missing_component_manifest() {
+    let fixture = AppFixture::new("missing-component");
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/missing/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("missing component manifest must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::AppComponentManifestMissing
+    );
+}
+
+#[test]
+fn rejects_duplicate_component_references() {
+    let fixture = AppFixture::new("duplicate-components");
+    let refs = json!([
+        component_ref(
+            "expedition.readiness.validate-team-readiness-component",
+            "1.0.0",
+            "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+            "components/a/component.manifest.json",
+        ),
+        component_ref(
+            "expedition.readiness.validate-team-readiness-component",
+            "1.0.0",
+            "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+            "components/b/component.manifest.json",
+        )
+    ]);
+    fixture.write_app_manifest(&refs);
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("duplicate component references must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::DuplicateComponentReference
+    );
+}
+
+#[test]
+fn rejects_unreadable_component_manifest() {
+    let fixture = AppFixture::new("unreadable-component-manifest");
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+    fs::write(fixture.component_manifest_path(), "{}")
+        .expect("component manifest fixture should write");
+    make_unreadable(&fixture.component_manifest_path());
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("unreadable component manifest must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentManifestReadFailed
+    );
+}
+
+#[test]
+fn rejects_invalid_component_manifest_json() {
+    let fixture = AppFixture::new("invalid-component-manifest");
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+    fs::write(fixture.component_manifest_path(), "{ not valid json ")
+        .expect("invalid component manifest fixture should write");
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("invalid component manifest json must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentManifestParseFailed
+    );
+}
+
+#[test]
+fn rejects_component_reference_identity_mismatch() {
+    let fixture = AppFixture::new("component-reference-mismatch");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "component_id": "expedition.readiness.other-component",
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("component reference mismatch must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentReferenceMismatch
+    );
+}
+
+#[test]
+fn rejects_component_contract_identity_mismatch() {
+    let fixture = AppFixture::new("contract-mismatch");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "capability_id": "expedition.planning.not-the-contract",
+        "capability_version": "1.0.0",
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("contract mismatch must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentContractMismatch
+    );
+}
+
+#[test]
+fn rejects_component_manifest_digest_mismatch() {
+    let fixture = AppFixture::new("component-manifest-digest-mismatch");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("app/component digest mismatch must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentDigestMismatch
+    );
+}
+
+#[test]
+fn rejects_invalid_component_manifest_digest_metadata() {
+    let fixture = AppFixture::new("invalid-component-digest");
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": "fnv1a64:dffc31d6401c84d6",
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("invalid component digest metadata must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::InvalidDigestMetadata
+    );
+}
+
+#[test]
+fn rejects_invalid_digest_metadata() {
+    let fixture = AppFixture::new("invalid-digest");
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "fnv1a64:dffc31d6401c84d6",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": "fnv1a64:dffc31d6401c84d6",
+        "dependencies": []
+    }));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("invalid digest metadata must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::InvalidDigestMetadata
+    );
+}
+
+#[test]
+fn rejects_missing_component_contract() {
+    let fixture = AppFixture::new("missing-contract");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "contract_path": "missing-contract.json",
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("missing component contract must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentContractMissing
+    );
+}
+
+#[test]
+fn rejects_unreadable_component_contract() {
+    let fixture = AppFixture::new("unreadable-contract");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    let contract_path = fixture
+        .root
+        .join("components/validate-team-readiness/unreadable-contract.json");
+    fs::write(&contract_path, "{}").expect("contract fixture should write");
+    make_unreadable(&contract_path);
+    fixture.write_component_manifest(&json!({
+        "contract_path": "unreadable-contract.json",
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("unreadable component contract must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentContractMissing
+    );
+}
+
+#[test]
+fn rejects_invalid_component_contract_json() {
+    let fixture = AppFixture::new("invalid-contract");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    let contract_path = fixture
+        .root
+        .join("components/validate-team-readiness/invalid-contract.json");
+    fs::write(&contract_path, "{}").expect("contract fixture should write");
+    fixture.write_component_manifest(&json!({
+        "contract_path": "invalid-contract.json",
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("invalid component contract must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentContractParseFailed
+    );
+}
+
+#[test]
+fn rejects_missing_wasm_binary() {
+    let fixture = AppFixture::new("missing-wasm");
+    let digest = "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99";
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": digest,
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        digest,
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("missing WASM binary must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentWasmMissing
+    );
+}
+
+#[test]
+fn rejects_unreadable_wasm_binary() {
+    let fixture = AppFixture::new("unreadable-wasm");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    make_unreadable(&fixture.wasm_path());
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("unreadable WASM binary must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentWasmMissing
+    );
+}
+
+#[test]
+fn rejects_wasm_digest_mismatch() {
+    let fixture = AppFixture::new("digest-mismatch");
+    let _digest = fixture.write_wasm("different bytes");
+    let wrong_digest = "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99";
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": wrong_digest,
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        wrong_digest,
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("digest mismatch must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentDigestMismatch
+    );
+}
+
+#[test]
+fn rejects_version_range_component_dependencies() {
+    let fixture = AppFixture::new("range-dependency");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": [
+            {
+                "component_id": "expedition.readiness.other-component",
+                "version_range": "^1.0.0"
+            }
+        ]
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("version range dependency must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentDependencyMustBeConcrete
+    );
+}
+
+#[test]
+fn accepts_concrete_component_dependencies() {
+    let fixture = AppFixture::new("concrete-dependency");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": [
+            {
+                "component_id": "expedition.readiness.other-component",
+                "version": "1.0.0",
+                "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+        ]
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let bundle = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect("concrete component dependencies should validate");
+
+    assert_eq!(bundle.components[0].manifest.dependencies.len(), 1);
+}
+
+#[test]
+fn rejects_component_dependencies_without_concrete_version_and_digest() {
+    let fixture = AppFixture::new("missing-concrete-dependency");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": [
+            {
+                "component_id": "expedition.readiness.other-component",
+                "version": " "
+            }
+        ]
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("non-concrete dependency must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentDependencyMustBeConcrete
+    );
+}
+
+struct AppFixture {
+    root: PathBuf,
+}
+
+impl AppFixture {
+    fn new(name: &str) -> Self {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("traverse-app-manifest-{name}-{nanos}"));
+        fs::create_dir_all(root.join("components/validate-team-readiness"))
+            .expect("fixture directories should be created");
+        Self { root }
+    }
+
+    fn app_manifest_path(&self) -> PathBuf {
+        self.root.join("app.manifest.json")
+    }
+
+    fn component_manifest_path(&self) -> PathBuf {
+        self.root
+            .join("components/validate-team-readiness/component.manifest.json")
+    }
+
+    fn wasm_path(&self) -> PathBuf {
+        self.root
+            .join("components/validate-team-readiness/component.wasm")
+    }
+
+    fn write_app_manifest(&self, components: &serde_json::Value) {
+        let app = json!({
+            "app_id": "expedition.readiness",
+            "version": "1.0.0",
+            "schema_version": "1.0.0",
+            "workspace_defaults": {
+                "workspace_id": "test"
+            },
+            "components": components,
+            "workflows": [],
+            "model_dependencies": [],
+            "config_schema": {
+                "type": "object"
+            },
+            "default_config": {},
+            "placement_policy": {
+                "preferred_targets": ["local"]
+            },
+            "public_surfaces": ["cli"]
+        });
+        fs::write(self.app_manifest_path(), app.to_string()).expect("app manifest should write");
+    }
+
+    fn write_component_manifest(&self, overrides: &serde_json::Value) {
+        let component_id = overrides
+            .get("component_id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("expedition.readiness.validate-team-readiness-component");
+        let version = overrides
+            .get("version")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("1.0.0");
+        let wasm_digest = overrides
+            .get("wasm_digest")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99");
+        let capability_id = overrides
+            .get("capability_id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("expedition.planning.validate-team-readiness");
+        let capability_version = overrides
+            .get("capability_version")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("1.0.0");
+        let dependencies = overrides
+            .get("dependencies")
+            .cloned()
+            .unwrap_or_else(|| json!([]));
+        let default_contract_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+            "../../contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+        );
+        let contract_path = overrides
+            .get("contract_path")
+            .cloned()
+            .unwrap_or_else(|| json!(default_contract_path));
+        let wasm_binary_path = overrides
+            .get("wasm_binary_path")
+            .cloned()
+            .unwrap_or_else(|| json!("component.wasm"));
+        let component = json!({
+            "component_id": component_id,
+            "version": version,
+            "schema_version": "1.0.0",
+            "capability_id": capability_id,
+            "capability_version": capability_version,
+            "contract_path": contract_path,
+            "wasm_binary_path": wasm_binary_path,
+            "wasm_digest": wasm_digest,
+            "runtime_constraints": {
+                "host_api_access": "none",
+                "network_access": "forbidden",
+                "filesystem_access": "none"
+            },
+            "permitted_targets": ["local"],
+            "dependencies": dependencies,
+            "connector_requirements": [],
+            "validation_evidence": []
+        });
+        fs::write(self.component_manifest_path(), component.to_string())
+            .expect("component manifest should write");
+    }
+
+    fn write_wasm(&self, contents: &str) -> String {
+        fs::write(self.wasm_path(), contents.as_bytes()).expect("wasm fixture should write");
+        sha256_hex(contents.as_bytes())
+    }
+}
+
+fn make_unreadable(path: &PathBuf) {
+    let mut permissions = fs::metadata(path)
+        .expect("fixture metadata should be available")
+        .permissions();
+    permissions.set_mode(0o000);
+    fs::set_permissions(path, permissions).expect("fixture should become unreadable");
+}
+
+fn component_ref(id: &str, version: &str, digest: &str, manifest_path: &str) -> serde_json::Value {
+    json!({
+        "component_id": id,
+        "version": version,
+        "digest": digest,
+        "manifest_path": manifest_path
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(output, "{byte:02x}");
+    }
+    output
+}

--- a/crates/traverse-registry/tests/registry.rs
+++ b/crates/traverse-registry/tests/registry.rs
@@ -3,6 +3,7 @@
 use serde_json::json;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 use traverse_contracts::{
     BinaryFormat as ContractBinaryFormat, CapabilityContract, Condition, ConnectorRequirement,
@@ -1658,11 +1659,16 @@ fn load_example_json(relative_path: &str) -> serde_json::Value {
 }
 
 fn unique_temp_dir() -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    let path = std::env::temp_dir().join(format!("traverse-registry-bundle-test-{nanos}"));
+    let sequence = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let process_id = std::process::id();
+    let path = std::env::temp_dir().join(format!(
+        "traverse-registry-bundle-test-{process_id}-{nanos}-{sequence}"
+    ));
     fs::create_dir_all(&path).expect("temporary directory should create");
     path
 }

--- a/examples/applications/expedition-readiness/app.manifest.json
+++ b/examples/applications/expedition-readiness/app.manifest.json
@@ -1,0 +1,63 @@
+{
+  "app_id": "expedition.readiness",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "workspace_defaults": {
+    "workspace_id": "expedition-local",
+    "registry_scope": "private"
+  },
+  "components": [
+    {
+      "component_id": "expedition.readiness.validate-team-readiness-component",
+      "version": "1.0.0",
+      "digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+      "manifest_path": "components/validate-team-readiness/component.manifest.json"
+    }
+  ],
+  "workflows": [
+    {
+      "workflow_id": "expedition.planning.plan-expedition",
+      "workflow_version": "1.0.0",
+      "path": "../../../workflows/examples/expedition/plan-expedition/workflow.json"
+    }
+  ],
+  "model_dependencies": [
+    {
+      "dependency_id": "expedition-readiness-validation-v1",
+      "requirement_ref": "045-governed-model-dependency-resolution"
+    }
+  ],
+  "config_schema": {
+    "type": "object",
+    "required": [
+      "workspace_id"
+    ],
+    "properties": {
+      "workspace_id": {
+        "type": "string"
+      },
+      "readiness_mode": {
+        "type": "string",
+        "enum": [
+          "deterministic"
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "default_config": {
+    "workspace_id": "expedition-local",
+    "readiness_mode": "deterministic"
+  },
+  "placement_policy": {
+    "preferred_targets": [
+      "local"
+    ],
+    "allow_fallback": false
+  },
+  "public_surfaces": [
+    "cli",
+    "http_json",
+    "mcp"
+  ]
+}

--- a/examples/applications/expedition-readiness/components/validate-team-readiness/component.manifest.json
+++ b/examples/applications/expedition-readiness/components/validate-team-readiness/component.manifest.json
@@ -1,0 +1,28 @@
+{
+  "component_id": "expedition.readiness.validate-team-readiness-component",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "capability_id": "expedition.planning.validate-team-readiness",
+  "capability_version": "1.0.0",
+  "contract_path": "../../../../../contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+  "wasm_binary_path": "../../../../agents/team-readiness-agent/artifacts/validate-team-readiness-agent.wasm",
+  "wasm_digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "device"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "checked_in_fixture",
+      "status": "passed",
+      "produced_by": "repository_checks"
+    }
+  ]
+}

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -479,6 +479,7 @@
         "crates/traverse-contracts/",
         "crates/traverse-registry/",
         "crates/traverse-runtime/",
+        "examples/applications/",
         "specs/044-application-bundle-manifest/",
         "specs/governance/"
       ]


### PR DESCRIPTION
## Summary

- Add versioned Rust schema models and validation for Traverse application manifests and concrete WASM component manifests.
- Validate component manifest references, duplicate component refs, capability contract identity/version alignment, concrete component dependencies, digest metadata, and SHA-256 WASM binary digests.
- Add a checked-in real application manifest example backed by the existing team-readiness WASM artifact.
- Extend spec routing so `examples/applications/` is governed by spec 044.

## Governing Spec

- `044-application-bundle-manifest`

## Project Item

- Issue: #446
- Project: Traverse Project 1
- Agent: Codex
- Status: In Progress until PR merge

## Validation

- `cargo fmt`
- `cargo test -p traverse-registry`
- `cargo clippy -p traverse-registry -- -D warnings`
- `PATH="$HOME/.cargo/bin:$PATH" LLVM_COV=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-cov LLVM_PROFDATA=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata bash scripts/ci/coverage_gate.sh`
- `bash scripts/ci/spec_context_check.sh`
- `jq empty specs/governance/approved-specs.json`
- `git diff --check`
- `bash scripts/ci/repository_checks.sh`

Closes #446
