### PR TITLE
feat: add atomic application bundle registration

### DIFF
--- a/crates/traverse-registry/src/application_manifest.rs
+++ b/crates/traverse-registry/src/application_manifest.rs
@@ -1,12 +1,21 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::fs;
 use std::path::{Path, PathBuf};
 use traverse_contracts::{
-    CapabilityContract, ConnectorRequirement, ExecutionTarget, parse_contract,
+    CapabilityContract, ConnectorRequirement, ErrorSeverity, ExecutionTarget,
+    governed_content_digest, parse_contract,
+};
+
+use crate::{
+    ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
+    CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
+    CompositionPattern, EventRegistry, ImplementationKind, LookupScope, RegistryProvenance,
+    RegistryScope, SourceKind, SourceReference, WorkflowDefinition, WorkflowRegistration,
+    WorkflowRegistry,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -25,6 +34,234 @@ pub struct ApplicationBundleManifest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationRegistryRecord {
+    pub scope: RegistryScope,
+    pub workspace_id: String,
+    pub app_id: String,
+    pub version: String,
+    pub manifest_path: String,
+    pub manifest_digest: String,
+    pub bundle_digest: String,
+    pub registered_at: String,
+    pub readiness_status: ApplicationReadinessStatus,
+    pub components: Vec<ApplicationRegisteredComponent>,
+    pub workflows: Vec<ApplicationRegisteredWorkflow>,
+    pub inspection_link: String,
+    pub execution_links: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplicationReadinessStatus {
+    Ready,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ApplicationRegisteredComponent {
+    pub component_id: String,
+    pub component_version: String,
+    pub capability_id: String,
+    pub capability_version: String,
+    pub wasm_digest: String,
+    pub artifact_ref: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ApplicationRegisteredWorkflow {
+    pub workflow_id: String,
+    pub workflow_version: String,
+    pub workflow_digest: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplicationRegistrationStatus {
+    Created,
+    AlreadyRegistered,
+}
+
+impl ApplicationRegistrationStatus {
+    #[must_use]
+    pub fn http_status(self) -> u16 {
+        match self {
+            Self::Created => 201,
+            Self::AlreadyRegistered => 200,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationRegistrationOutcome {
+    pub status: ApplicationRegistrationStatus,
+    pub record: ApplicationRegistryRecord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationRegistrationRequest {
+    pub scope: RegistryScope,
+    pub workspace_id: String,
+    pub manifest_path: PathBuf,
+    pub registered_at: String,
+    pub validator_version: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApplicationRegistrationErrorCode {
+    ManifestValidationFailed,
+    MissingRequiredEvent,
+    WorkflowReadFailed,
+    WorkflowParseFailed,
+    WorkflowReferenceMismatch,
+    CapabilityRegistrationFailed,
+    WorkflowRegistrationFailed,
+    ImmutableApplicationVersionConflict,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationRegistrationError {
+    pub code: ApplicationRegistrationErrorCode,
+    pub path: String,
+    pub message: String,
+    pub severity: ErrorSeverity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationRegistrationFailure {
+    pub errors: Vec<ApplicationRegistrationError>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ApplicationRegistry {
+    records: BTreeMap<(RegistryScope, String, String), ApplicationRegistryRecord>,
+}
+
+impl ApplicationRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a complete application bundle atomically.
+    ///
+    /// The method validates the app manifest, component manifests, component
+    /// contracts, referenced WASM digests, required event references, and
+    /// workflow references before any caller-visible registry state is
+    /// replaced. Failed registration attempts leave the application,
+    /// capability, and workflow registries unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApplicationRegistrationFailure`] when manifest validation,
+    /// dependency validation, capability registration, workflow registration,
+    /// or immutable application id/version checks fail.
+    pub fn register_bundle(
+        &mut self,
+        capabilities: &mut CapabilityRegistry,
+        events: &EventRegistry,
+        workflows: &mut WorkflowRegistry,
+        request: &ApplicationRegistrationRequest,
+    ) -> Result<ApplicationRegistrationOutcome, ApplicationRegistrationFailure> {
+        let manifest = load_application_bundle_manifest(&request.manifest_path)
+            .map_err(map_manifest_failure)?;
+        let workflow_artifacts = load_application_workflows(&request.manifest_path, &manifest)?;
+        validate_component_event_references(events, request.scope, &manifest.components)?;
+
+        let mut staged_apps = self.clone();
+        let mut staged_capabilities = capabilities.clone();
+        let mut staged_workflows = workflows.clone();
+        let mut registered_components = Vec::new();
+        let mut registered_workflows = Vec::new();
+
+        for component in &manifest.components {
+            let registration =
+                build_application_capability_registration(&manifest, component, request);
+            let outcome = staged_capabilities
+                .register(registration)
+                .map_err(|failure| map_capability_registration_failure(component, failure))?;
+            registered_components.push(ApplicationRegisteredComponent {
+                component_id: component.manifest.component_id.clone(),
+                component_version: component.manifest.version.clone(),
+                capability_id: outcome.record.id,
+                capability_version: outcome.record.version,
+                wasm_digest: component.verified_wasm_digest.clone(),
+                artifact_ref: outcome.artifact.artifact_ref,
+            });
+        }
+
+        for workflow in workflow_artifacts {
+            let outcome = staged_workflows
+                .register(
+                    &staged_capabilities,
+                    WorkflowRegistration {
+                        scope: request.scope,
+                        definition: workflow.definition,
+                        workflow_path: workflow.path.display().to_string(),
+                        registered_at: request.registered_at.clone(),
+                        validator_version: request.validator_version.clone(),
+                    },
+                )
+                .map_err(map_workflow_registration_failure)?;
+            registered_workflows.push(ApplicationRegisteredWorkflow {
+                workflow_id: outcome.record.id,
+                workflow_version: outcome.record.version,
+                workflow_digest: outcome.record.workflow_digest,
+            });
+        }
+
+        let record = build_application_record(
+            request,
+            &manifest,
+            registered_components,
+            registered_workflows,
+        );
+        let key = (
+            request.scope,
+            manifest.app_id.clone(),
+            manifest.version.clone(),
+        );
+        let status = staged_apps.reconcile_or_insert(key, record.clone())?;
+
+        *self = staged_apps;
+        *capabilities = staged_capabilities;
+        *workflows = staged_workflows;
+
+        Ok(ApplicationRegistrationOutcome { status, record })
+    }
+
+    #[must_use]
+    pub fn find_exact(
+        &self,
+        scope: RegistryScope,
+        app_id: &str,
+        version: &str,
+    ) -> Option<&ApplicationRegistryRecord> {
+        self.records
+            .get(&(scope, app_id.to_string(), version.to_string()))
+    }
+
+    fn reconcile_or_insert(
+        &mut self,
+        key: (RegistryScope, String, String),
+        record: ApplicationRegistryRecord,
+    ) -> Result<ApplicationRegistrationStatus, ApplicationRegistrationFailure> {
+        if let Some(existing) = self.records.get(&key) {
+            if existing.bundle_digest == record.bundle_digest
+                && existing.components == record.components
+                && existing.workflows == record.workflows
+            {
+                return Ok(ApplicationRegistrationStatus::AlreadyRegistered);
+            }
+            return Err(single_registration_error(
+                ApplicationRegistrationErrorCode::ImmutableApplicationVersionConflict,
+                "$.version",
+                "registered application versions are immutable within a scope",
+            ));
+        }
+
+        self.records.insert(key, record);
+        Ok(ApplicationRegistrationStatus::Created)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApplicationComponent {
     pub reference: ApplicationComponentRef,
     pub manifest_path: PathBuf,
@@ -35,7 +272,13 @@ pub struct ApplicationComponent {
     pub verified_wasm_digest: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LoadedApplicationWorkflow {
+    path: PathBuf,
+    definition: WorkflowDefinition,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ApplicationComponentRef {
     pub component_id: String,
     pub version: String,
@@ -43,14 +286,14 @@ pub struct ApplicationComponentRef {
     pub manifest_path: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ApplicationWorkflowRef {
     pub workflow_id: String,
     pub workflow_version: String,
     pub path: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ApplicationModelDependency {
     pub dependency_id: String,
     pub requirement_ref: String,
@@ -213,6 +456,278 @@ pub fn load_application_bundle_manifest(
         placement_policy: manifest.placement_policy,
         public_surfaces: manifest.public_surfaces,
     })
+}
+
+fn load_application_workflows(
+    manifest_path: &Path,
+    manifest: &ApplicationBundleManifest,
+) -> Result<Vec<LoadedApplicationWorkflow>, ApplicationRegistrationFailure> {
+    let manifest_dir = manifest_path.parent().unwrap_or_else(|| Path::new(""));
+
+    manifest
+        .workflows
+        .iter()
+        .map(|workflow| load_application_workflow(manifest_dir, workflow))
+        .collect()
+}
+
+fn load_application_workflow(
+    manifest_dir: &Path,
+    workflow: &ApplicationWorkflowRef,
+) -> Result<LoadedApplicationWorkflow, ApplicationRegistrationFailure> {
+    let path = manifest_dir.join(&workflow.path);
+    let contents = fs::read_to_string(&path).map_err(|error| {
+        single_registration_error(
+            ApplicationRegistrationErrorCode::WorkflowReadFailed,
+            path.display().to_string(),
+            &format!(
+                "failed to read workflow {}@{} at {}: {error}",
+                workflow.workflow_id,
+                workflow.workflow_version,
+                path.display()
+            ),
+        )
+    })?;
+    let definition = serde_json::from_str::<WorkflowDefinition>(&contents).map_err(|error| {
+        single_registration_error(
+            ApplicationRegistrationErrorCode::WorkflowParseFailed,
+            path.display().to_string(),
+            &format!(
+                "failed to parse workflow {}@{} at {}: {error}",
+                workflow.workflow_id,
+                workflow.workflow_version,
+                path.display()
+            ),
+        )
+    })?;
+    if definition.id != workflow.workflow_id || definition.version != workflow.workflow_version {
+        return Err(single_registration_error(
+            ApplicationRegistrationErrorCode::WorkflowReferenceMismatch,
+            path.display().to_string(),
+            &format!(
+                "workflow reference mismatch: app declared {}@{}, workflow file contains {}@{}",
+                workflow.workflow_id, workflow.workflow_version, definition.id, definition.version
+            ),
+        ));
+    }
+
+    Ok(LoadedApplicationWorkflow { path, definition })
+}
+
+fn validate_component_event_references(
+    events: &EventRegistry,
+    scope: RegistryScope,
+    components: &[ApplicationComponent],
+) -> Result<(), ApplicationRegistrationFailure> {
+    let lookup_scope = if scope == RegistryScope::Private {
+        LookupScope::PreferPrivate
+    } else {
+        LookupScope::PublicOnly
+    };
+    for component in components {
+        for event_ref in component
+            .contract
+            .emits
+            .iter()
+            .chain(component.contract.consumes.iter())
+        {
+            let event_missing = events
+                .find_exact(lookup_scope, &event_ref.event_id, &event_ref.version)
+                .is_none();
+            if !event_missing {
+                continue;
+            }
+            let message = format!(
+                "component {} references missing event {}@{}",
+                component.manifest.component_id, event_ref.event_id, event_ref.version
+            );
+            return Err(single_registration_error(
+                ApplicationRegistrationErrorCode::MissingRequiredEvent,
+                component.contract_path.display().to_string(),
+                &message,
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn build_application_capability_registration(
+    manifest: &ApplicationBundleManifest,
+    component: &ApplicationComponent,
+    request: &ApplicationRegistrationRequest,
+) -> CapabilityRegistration {
+    let artifact_ref = format!(
+        "app:{}:{}:component:{}:{}",
+        manifest.app_id,
+        manifest.version,
+        component.manifest.component_id,
+        component.manifest.version
+    );
+    let artifact = CapabilityArtifactRecord {
+        artifact_ref,
+        implementation_kind: ImplementationKind::Executable,
+        source: SourceReference {
+            kind: SourceKind::Local,
+            location: component.manifest_path.display().to_string(),
+        },
+        binary: Some(BinaryReference {
+            format: BinaryFormat::Wasm,
+            location: component.wasm_binary_path.display().to_string(),
+            signature: None,
+        }),
+        workflow_ref: None,
+        digests: ArtifactDigests {
+            source_digest: governed_content_digest(&component.contract),
+            binary_digest: Some(component.verified_wasm_digest.clone()),
+        },
+        provenance: RegistryProvenance {
+            source: format!("application_bundle:{}", manifest.app_id),
+            author: manifest.app_id.clone(),
+            created_at: request.registered_at.clone(),
+        },
+    };
+
+    CapabilityRegistration {
+        scope: request.scope,
+        contract: component.contract.clone(),
+        contract_path: component.contract_path.display().to_string(),
+        artifact,
+        registered_at: request.registered_at.clone(),
+        tags: vec![format!("app:{}", manifest.app_id)],
+        composability: ComposabilityMetadata {
+            kind: CompositionKind::Atomic,
+            patterns: vec![CompositionPattern::Validation],
+            provides: vec![component.contract.id.clone()],
+            requires: component
+                .manifest
+                .dependencies
+                .iter()
+                .map(|dependency| dependency.component_id.clone())
+                .collect(),
+        },
+        governing_spec: "044-application-bundle-manifest".to_string(),
+        validator_version: request.validator_version.clone(),
+    }
+}
+
+fn build_application_record(
+    request: &ApplicationRegistrationRequest,
+    manifest: &ApplicationBundleManifest,
+    components: Vec<ApplicationRegisteredComponent>,
+    workflows: Vec<ApplicationRegisteredWorkflow>,
+) -> ApplicationRegistryRecord {
+    let manifest_digest = application_manifest_digest(manifest);
+    let bundle_digest = application_bundle_digest(manifest, &components, &workflows);
+    ApplicationRegistryRecord {
+        scope: request.scope,
+        workspace_id: request.workspace_id.clone(),
+        app_id: manifest.app_id.clone(),
+        version: manifest.version.clone(),
+        manifest_path: request.manifest_path.display().to_string(),
+        manifest_digest,
+        bundle_digest,
+        registered_at: request.registered_at.clone(),
+        readiness_status: ApplicationReadinessStatus::Ready,
+        components,
+        workflows,
+        inspection_link: format!("/v1/apps/{}/{}", manifest.app_id, manifest.version),
+        execution_links: manifest
+            .workflows
+            .iter()
+            .map(|workflow| {
+                format!(
+                    "/v1/workflows/{}/{}",
+                    workflow.workflow_id, workflow.workflow_version
+                )
+            })
+            .collect(),
+    }
+}
+
+fn application_manifest_digest(manifest: &ApplicationBundleManifest) -> String {
+    let value = serde_json::json!({
+        "app_id": manifest.app_id,
+        "version": manifest.version,
+        "schema_version": manifest.schema_version,
+        "workspace_defaults": manifest.workspace_defaults,
+        "components": manifest.components.iter().map(|component| serde_json::json!({
+            "component_id": component.reference.component_id,
+            "version": component.reference.version,
+            "digest": component.reference.digest,
+            "manifest_path": component.reference.manifest_path,
+        })).collect::<Vec<_>>(),
+        "workflows": manifest.workflows,
+        "model_dependencies": manifest.model_dependencies,
+        "config_schema": manifest.config_schema,
+        "default_config": manifest.default_config,
+        "placement_policy": manifest.placement_policy,
+        "public_surfaces": manifest.public_surfaces,
+    });
+    format!("sha256:{}", sha256_hex(value.to_string().as_bytes()))
+}
+
+fn application_bundle_digest(
+    manifest: &ApplicationBundleManifest,
+    components: &[ApplicationRegisteredComponent],
+    workflows: &[ApplicationRegisteredWorkflow],
+) -> String {
+    let value = serde_json::json!({
+        "app_id": manifest.app_id,
+        "version": manifest.version,
+        "components": components,
+        "workflows": workflows,
+    });
+    format!("sha256:{}", sha256_hex(value.to_string().as_bytes()))
+}
+
+fn map_manifest_failure(failure: ApplicationManifestFailure) -> ApplicationRegistrationFailure {
+    ApplicationRegistrationFailure {
+        errors: failure
+            .errors
+            .into_iter()
+            .map(|error| ApplicationRegistrationError {
+                code: ApplicationRegistrationErrorCode::ManifestValidationFailed,
+                path: error.path,
+                message: error.message,
+                severity: ErrorSeverity::Error,
+            })
+            .collect(),
+    }
+}
+
+fn map_capability_registration_failure(
+    component: &ApplicationComponent,
+    failure: crate::RegistryFailure,
+) -> ApplicationRegistrationFailure {
+    ApplicationRegistrationFailure {
+        errors: failure
+            .errors
+            .into_iter()
+            .map(|error| ApplicationRegistrationError {
+                code: ApplicationRegistrationErrorCode::CapabilityRegistrationFailed,
+                path: component.contract_path.display().to_string(),
+                message: error.message,
+                severity: error.severity,
+            })
+            .collect(),
+    }
+}
+
+fn map_workflow_registration_failure(
+    failure: crate::WorkflowFailure,
+) -> ApplicationRegistrationFailure {
+    ApplicationRegistrationFailure {
+        errors: failure
+            .errors
+            .into_iter()
+            .map(|error| ApplicationRegistrationError {
+                code: ApplicationRegistrationErrorCode::WorkflowRegistrationFailed,
+                path: error.path,
+                message: error.message,
+                severity: error.severity,
+            })
+            .collect(),
+    }
 }
 
 fn ensure_unique_component_refs(
@@ -514,6 +1029,21 @@ fn single_error(
             code,
             path,
             message,
+        }],
+    }
+}
+
+fn single_registration_error(
+    code: ApplicationRegistrationErrorCode,
+    path: impl Into<String>,
+    message: &str,
+) -> ApplicationRegistrationFailure {
+    ApplicationRegistrationFailure {
+        errors: vec![ApplicationRegistrationError {
+            code,
+            path: path.into(),
+            message: message.to_string(),
+            severity: ErrorSeverity::Error,
         }],
     }
 }

--- a/crates/traverse-registry/tests/application_manifest.rs
+++ b/crates/traverse-registry/tests/application_manifest.rs
@@ -7,7 +7,12 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use traverse_registry::{ApplicationManifestErrorCode, load_application_bundle_manifest};
+use traverse_contracts::parse_event_contract;
+use traverse_registry::{
+    ApplicationManifestErrorCode, ApplicationRegistrationErrorCode, ApplicationRegistrationRequest,
+    ApplicationRegistrationStatus, ApplicationRegistry, CapabilityRegistry, EventRegistration,
+    EventRegistry, LookupScope, RegistryScope, WorkflowRegistry, load_application_bundle_manifest,
+};
 
 #[test]
 fn loads_checked_in_application_manifest_with_real_wasm_component() {
@@ -527,6 +532,458 @@ fn rejects_component_dependencies_without_concrete_version_and_digest() {
     );
 }
 
+#[test]
+fn registers_application_bundle_atomically_with_created_status() {
+    let fixture = AppFixture::new("register-created");
+    fixture.write_hello_world_bundle();
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+
+    let outcome = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect("valid application bundle should register atomically");
+
+    assert_eq!(outcome.status, ApplicationRegistrationStatus::Created);
+    assert_eq!(outcome.status.http_status(), 201);
+    assert_eq!(outcome.record.app_id, "hello.world.app");
+    assert_eq!(outcome.record.components.len(), 1);
+    assert_eq!(outcome.record.workflows.len(), 1);
+    assert!(
+        app_registry
+            .find_exact(RegistryScope::Private, "hello.world.app", "1.0.0")
+            .is_some()
+    );
+    assert!(
+        capability_registry
+            .find_exact(LookupScope::PreferPrivate, "hello.world.say-hello", "1.0.0")
+            .is_some()
+    );
+    assert!(
+        workflow_registry
+            .find_exact(LookupScope::PreferPrivate, "hello.world.say-hello", "1.0.0")
+            .is_some()
+    );
+}
+
+#[test]
+fn reregistering_unchanged_application_bundle_returns_stable_200() {
+    let fixture = AppFixture::new("register-idempotent");
+    fixture.write_hello_world_bundle();
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+
+    let first = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect("first application registration should succeed");
+    let second = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect("unchanged application registration should be idempotent");
+
+    assert_eq!(first.status, ApplicationRegistrationStatus::Created);
+    assert_eq!(
+        second.status,
+        ApplicationRegistrationStatus::AlreadyRegistered
+    );
+    assert_eq!(second.status.http_status(), 200);
+    assert_eq!(first.record.bundle_digest, second.record.bundle_digest);
+}
+
+#[test]
+fn failed_application_registration_writes_no_partial_state() {
+    let fixture = AppFixture::new("register-rollback");
+    fixture.write_hello_world_bundle();
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+    let first = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect("baseline registration should succeed");
+    fixture.write_bad_workflow_bundle();
+
+    let failure = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect_err("changed app bundle with invalid workflow must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationRegistrationErrorCode::WorkflowReferenceMismatch
+    );
+    let record = app_registry
+        .find_exact(RegistryScope::Private, "hello.world.app", "1.0.0")
+        .expect("existing app record should remain after failed registration");
+    assert_eq!(record.bundle_digest, first.record.bundle_digest);
+    assert!(
+        capability_registry
+            .find_exact(LookupScope::PreferPrivate, "hello.world.say-hello", "1.0.0")
+            .is_some()
+    );
+    assert!(
+        workflow_registry
+            .find_exact(LookupScope::PreferPrivate, "hello.world.say-hello", "1.0.0")
+            .is_some()
+    );
+    assert!(
+        workflow_registry
+            .find_exact(LookupScope::PreferPrivate, "hello.world.changed", "1.0.0")
+            .is_none()
+    );
+}
+
+#[test]
+fn application_registration_reports_missing_manifest_as_validation_failure() {
+    let fixture = AppFixture::new("register-missing-manifest");
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+
+    let failure = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect_err("missing app manifest should fail through registration");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationRegistrationErrorCode::ManifestValidationFailed
+    );
+}
+
+#[test]
+fn application_registration_rejects_missing_workflow_file() {
+    let fixture = AppFixture::new("register-missing-workflow");
+    let wasm_digest = fixture.write_hello_component("hello world executable bytes");
+    fixture.write_hello_app_manifest(
+        &wasm_digest,
+        &json!([{
+            "workflow_id": "hello.world.say-hello",
+            "workflow_version": "1.0.0",
+            "path": "missing-workflow.json"
+        }]),
+    );
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+
+    let failure = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect_err("missing workflow should fail registration");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationRegistrationErrorCode::WorkflowReadFailed
+    );
+}
+
+#[test]
+fn application_registration_rejects_invalid_workflow_json() {
+    let fixture = AppFixture::new("register-invalid-workflow");
+    let wasm_digest = fixture.write_hello_component("hello world executable bytes");
+    let workflow_path = fixture.root.join("invalid-workflow.json");
+    fs::write(&workflow_path, "{ not json").expect("invalid workflow fixture should write");
+    fixture.write_hello_app_manifest(
+        &wasm_digest,
+        &json!([{
+            "workflow_id": "hello.world.say-hello",
+            "workflow_version": "1.0.0",
+            "path": workflow_path
+        }]),
+    );
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+
+    let failure = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect_err("invalid workflow JSON should fail registration");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationRegistrationErrorCode::WorkflowParseFailed
+    );
+}
+
+#[test]
+fn application_registration_rejects_missing_event_reference() {
+    let fixture = AppFixture::new("register-missing-event");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+
+    let failure = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect_err("missing referenced event should fail registration");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationRegistrationErrorCode::MissingRequiredEvent
+    );
+}
+
+#[test]
+fn application_registration_checks_all_component_event_references() {
+    let fixture = AppFixture::new("register-partial-event");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let mut event_registry = EventRegistry::new();
+    register_event_fixture(
+        &mut event_registry,
+        "team-readiness-validated",
+        "expedition.planning.team-readiness-validated",
+    );
+    let mut workflow_registry = WorkflowRegistry::new();
+
+    let failure = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect_err("second missing event reference should fail registration");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationRegistrationErrorCode::MissingRequiredEvent
+    );
+    assert!(
+        failure.errors[0]
+            .message
+            .contains("conditions-summary-assessed")
+    );
+}
+
+#[test]
+fn application_registration_maps_workflow_registration_failure() {
+    let fixture = AppFixture::new("register-workflow-failure");
+    let wasm_digest = fixture.write_hello_component("hello world executable bytes");
+    let workflow_path = fixture.write_workflow("hello.world.say-hello", "hello.world.missing");
+    fixture.write_hello_app_manifest(
+        &wasm_digest,
+        &json!([{
+            "workflow_id": "hello.world.say-hello",
+            "workflow_version": "1.0.0",
+            "path": workflow_path
+        }]),
+    );
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+
+    let failure = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect_err("workflow missing capability reference should fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationRegistrationErrorCode::WorkflowRegistrationFailed
+    );
+}
+
+#[test]
+fn application_registration_maps_capability_registration_failure() {
+    let fixture = AppFixture::new("register-capability-failure");
+    fixture.write_hello_world_bundle();
+    let mut seed_app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+    seed_app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect("seed application registration should succeed");
+    let changed_digest = fixture.write_hello_component("changed executable bytes");
+    let workflow_path = fixture.write_workflow("hello.world.say-hello", "hello.world.say-hello");
+    fixture.write_hello_app_manifest(
+        &changed_digest,
+        &json!([{
+            "workflow_id": "hello.world.say-hello",
+            "workflow_version": "1.0.0",
+            "path": workflow_path
+        }]),
+    );
+    let mut new_app_registry = ApplicationRegistry::new();
+
+    let failure = new_app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect_err("changed component metadata must fail capability registration");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationRegistrationErrorCode::CapabilityRegistrationFailed
+    );
+    assert!(
+        new_app_registry
+            .find_exact(RegistryScope::Private, "hello.world.app", "1.0.0")
+            .is_none()
+    );
+}
+
+#[test]
+fn application_registration_rejects_changed_bundle_for_same_app_version() {
+    let fixture = AppFixture::new("register-app-conflict");
+    fixture.write_hello_world_bundle();
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+    app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect("baseline registration should succeed");
+    let wasm_digest = fixture.write_hello_component("hello world executable bytes");
+    let workflow_path = fixture.write_workflow("hello.world.say-hello", "hello.world.say-hello");
+    fixture.write_hello_app_manifest(
+        &wasm_digest,
+        &json!([
+            {
+                "workflow_id": "hello.world.say-hello",
+                "workflow_version": "1.0.0",
+                "path": workflow_path
+            },
+            {
+                "workflow_id": "hello.world.say-hello",
+                "workflow_version": "1.0.0",
+                "path": workflow_path
+            }
+        ]),
+    );
+
+    let failure = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+        )
+        .expect_err("changed app bundle for same version must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationRegistrationErrorCode::ImmutableApplicationVersionConflict
+    );
+}
+
+#[test]
+fn application_registration_supports_public_scope_lookup_path() {
+    let fixture = AppFixture::new("register-public");
+    fixture.write_hello_world_bundle();
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+    let mut request = fixture.registration_request();
+    request.scope = RegistryScope::Public;
+
+    let outcome = app_registry
+        .register_bundle(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &request,
+        )
+        .expect("public application bundle should register");
+
+    assert_eq!(outcome.status, ApplicationRegistrationStatus::Created);
+    assert!(
+        app_registry
+            .find_exact(RegistryScope::Public, "hello.world.app", "1.0.0")
+            .is_some()
+    );
+}
+
 struct AppFixture {
     root: PathBuf,
 }
@@ -558,15 +1015,23 @@ impl AppFixture {
     }
 
     fn write_app_manifest(&self, components: &serde_json::Value) {
+        self.write_app_manifest_with_workflows(components, &json!([]));
+    }
+
+    fn write_app_manifest_with_workflows(
+        &self,
+        components: &serde_json::Value,
+        workflows: &serde_json::Value,
+    ) {
         let app = json!({
-            "app_id": "expedition.readiness",
+            "app_id": "hello.world.app",
             "version": "1.0.0",
             "schema_version": "1.0.0",
             "workspace_defaults": {
                 "workspace_id": "test"
             },
             "components": components,
-            "workflows": [],
+            "workflows": workflows,
             "model_dependencies": [],
             "config_schema": {
                 "type": "object"
@@ -643,6 +1108,132 @@ impl AppFixture {
         fs::write(self.wasm_path(), contents.as_bytes()).expect("wasm fixture should write");
         sha256_hex(contents.as_bytes())
     }
+
+    fn registration_request(&self) -> ApplicationRegistrationRequest {
+        ApplicationRegistrationRequest {
+            scope: RegistryScope::Private,
+            workspace_id: "test-workspace".to_string(),
+            manifest_path: self.app_manifest_path(),
+            registered_at: "2026-06-13T00:00:00Z".to_string(),
+            validator_version: "test".to_string(),
+        }
+    }
+
+    fn write_hello_world_bundle(&self) {
+        let wasm_digest = self.write_hello_component("hello world executable bytes");
+        let workflow_path = self.write_workflow("hello.world.say-hello", "hello.world.say-hello");
+        self.write_hello_app_manifest(
+            &wasm_digest,
+            &json!([{
+                "workflow_id": "hello.world.say-hello",
+                "workflow_version": "1.0.0",
+                "path": workflow_path
+            }]),
+        );
+    }
+
+    fn write_bad_workflow_bundle(&self) {
+        let wasm_digest = self.write_hello_component("hello world executable bytes");
+        let workflow_path = self.write_workflow("hello.world.changed", "hello.world.say-hello");
+        self.write_hello_app_manifest(
+            &wasm_digest,
+            &json!([{
+                "workflow_id": "hello.world.say-hello",
+                "workflow_version": "1.0.0",
+                "path": workflow_path
+            }]),
+        );
+    }
+
+    fn write_hello_component(&self, contents: &str) -> String {
+        let wasm_digest = self.write_wasm(contents);
+        let contract_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../contracts/examples/hello-world/capabilities/say-hello/contract.json");
+        self.write_component_manifest(&json!({
+            "component_id": "hello.world.say-hello-component",
+            "capability_id": "hello.world.say-hello",
+            "wasm_digest": format!("sha256:{wasm_digest}"),
+            "contract_path": contract_path,
+            "dependencies": []
+        }));
+        wasm_digest
+    }
+
+    fn write_hello_app_manifest(&self, wasm_digest: &str, workflows: &serde_json::Value) {
+        self.write_app_manifest_with_workflows(
+            &json!([component_ref(
+                "hello.world.say-hello-component",
+                "1.0.0",
+                &format!("sha256:{wasm_digest}"),
+                "components/validate-team-readiness/component.manifest.json",
+            )]),
+            workflows,
+        );
+    }
+
+    fn write_workflow(&self, workflow_id: &str, node_capability_id: &str) -> String {
+        let path = self.root.join("workflow.json");
+        let workflow = json!({
+            "kind": "workflow_definition",
+            "schema_version": "1.0.0",
+            "id": workflow_id,
+            "name": "say-hello",
+            "version": "1.0.0",
+            "lifecycle": "active",
+            "owner": {
+                "team": "traverse-core",
+                "contact": "enrico.piovesan10@gmail.com"
+            },
+            "summary": "Run the minimal hello-world greeting flow as one governed workflow-backed example.",
+            "inputs": {
+                "schema": {
+                    "type": "object",
+                    "required": ["name"],
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "outputs": {
+                "schema": {
+                    "type": "object",
+                    "required": ["name", "greeting"],
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "greeting": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "nodes": [
+                {
+                    "node_id": "say_hello",
+                    "capability_id": node_capability_id,
+                    "capability_version": "1.0.0",
+                    "input": {
+                        "from_workflow_input": ["name"]
+                    },
+                    "output": {
+                        "to_workflow_state": ["name", "greeting"]
+                    }
+                }
+            ],
+            "edges": [],
+            "start_node": "say_hello",
+            "terminal_nodes": ["say_hello"],
+            "tags": ["hello-world", "registration-test"],
+            "governing_spec": "007-workflow-registry-traversal"
+        });
+        fs::write(&path, workflow.to_string()).expect("workflow fixture should write");
+        path.display().to_string()
+    }
 }
 
 fn make_unreadable(path: &PathBuf) {
@@ -660,6 +1251,25 @@ fn component_ref(id: &str, version: &str, digest: &str, manifest_path: &str) -> 
         "digest": digest,
         "manifest_path": manifest_path
     })
+}
+
+fn register_event_fixture(registry: &mut EventRegistry, event_dir: &str, expected_id: &str) {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(format!(
+        "../../contracts/examples/expedition/events/{event_dir}/contract.json"
+    ));
+    let contents = fs::read_to_string(&path).expect("event contract fixture should read");
+    let contract = parse_event_contract(&contents).expect("event contract fixture should parse");
+    assert_eq!(contract.id, expected_id);
+    registry
+        .register(EventRegistration {
+            scope: RegistryScope::Private,
+            contract,
+            contract_path: path.display().to_string(),
+            registered_at: "2026-06-13T00:00:00Z".to_string(),
+            governing_spec: "011-event-registry".to_string(),
+            validator_version: "test".to_string(),
+        })
+        .expect("event fixture should register");
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {


### PR DESCRIPTION
## Summary
- Adds public `ApplicationRegistry` support for atomic application bundle registration over validated app manifests.
- Stages app, capability, and workflow registry changes and swaps them only after the full bundle succeeds.
- Returns Created/AlreadyRegistered registration outcomes with stable app, component, workflow, readiness, inspection, and execution metadata.
- Validates workflow references and component event references, with stable error mapping for manifest, capability, workflow, and immutability failures.

## Governing Spec
- `044-application-bundle-manifest`

## Project Item
- Closes #447
- Tracked in Project 1

## Validation
- `cargo test -p traverse-registry --test application_manifest`
- `cargo test -p traverse-registry`
- `/opt/homebrew/bin/rustup run 1.94.0 cargo clippy -p traverse-registry -- -D warnings`
- `bash scripts/ci/repository_checks.sh`
- `PATH="$HOME/.cargo/bin:$PATH" LLVM_COV=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-cov LLVM_PROFDATA=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata bash scripts/ci/coverage_gate.sh`

## Notes
- No endpoint/OpenAPI shape changed in this slice; this adds the core registry API surface used by downstream app registration flows.