### PR TITLE
docs: add lean traverse ops token discipline

### DIFF
--- a/.agents/skills/traverse-ops/SKILL.md
+++ b/.agents/skills/traverse-ops/SKILL.md
@@ -31,6 +31,31 @@ TRAVERSE OPS
 9. Keep work scoped to the claimed issue and governing spec.
 10. Open a dedicated PR with validation evidence.
 
+## Token Discipline
+
+Use a lean-by-default operating style so long-running Traverse ops sessions do
+not waste context on raw logs.
+
+- Prefer targeted GitHub queries over full board dumps. For Ready work, use
+  `gh project item-list 1 --owner enricopiovesan --format json --limit 300 --jq '...'`
+  and return only issue number, title, labels, and item id.
+- Do not paste full `gh project item-list`, `gh pr checks --watch`, test, clippy,
+  coverage, or CI logs into the conversation. Summarize pass/fail counts and
+  only quote the failing lines needed to fix the issue.
+- Use `git diff --stat`, `git diff --name-only`, and focused file hunks before
+  large diffs. Open exact line ranges only when a decision depends on them.
+- Use `rg` with narrow patterns before broad recursive reads. Avoid reading
+  generated files, target directories, lockfile-scale artifacts, and full specs
+  unless the active issue requires them.
+- Keep progress updates short: current action, discovered blocker if any, and
+  next action. Avoid repeating unchanged state.
+- After CI starts, poll with bounded output. If checks are pending, report only
+  changed status; if a job fails, fetch that job log and extract the actionable
+  failure.
+- Prefer local reproduction of a failing gate before fetching large remote logs.
+- In final updates, include merged PRs, validations, and next recommended issue;
+  do not restate every command output.
+
 ## Operating Lanes
 
 - **Ready-ticket worker**: claim one Ready Project 1 issue and implement it end to end.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,14 +75,9 @@ If a `claude/issue-<NUMBER>-*` branch exists → **STOP**. Report:
 # Add label
 gh issue edit <NUMBER> --repo enricopiovesan/Traverse --add-label "agent:codex"
 
-# Get project item ID
-gh project item-list 1 --owner enricopiovesan --format json \
-  | python3 -c "
-import json,sys
-items = json.load(sys.stdin)['items']
-match = [i for i in items if str(i.get('content',{}).get('number','')) == '<NUMBER>']
-if match: print(match[0]['id'])
-"
+# Get project item ID with bounded output
+gh project item-list 1 --owner enricopiovesan --format json --limit 300 \
+  --jq '.items[] | select(.content.number == <NUMBER>) | .id'
 
 # Set Agent → Codex
 gh project item-edit --project-id PVT_kwHOAEZXvs4BS6Ns \

--- a/docs/multi-thread-workflow.md
+++ b/docs/multi-thread-workflow.md
@@ -108,6 +108,9 @@ When Enrico says `TRAVERSE OPS`, Codex should treat it as:
 - Start or resume the PM/PO backlog gardener: audit Project 1 statuses, labels, blockers, and notes; ensure Todo items become `Ready` or `Blocked`; ensure Blocked items have a note; create missing tickets with full Definition of Done.
 - Do all feasible work autonomously and ask only when a product decision is truly required.
 - Do not use labels as status; Project 1 status is the actionability source of truth.
+- Run lean by default: use filtered Project 1 queries, bounded command output,
+  focused diffs, and summarized CI/test results. Quote only actionable failure
+  lines, not full logs or full board JSON.
 
 Use this PM thread prompt:
 


### PR DESCRIPTION
## Summary
- Adds lean-by-default token discipline to the Traverse ops skill.
- Updates the `TRAVERSE OPS` workflow docs to prefer filtered queries, bounded output, focused diffs, and summarized CI/test results.
- Replaces the raw Project 1 item lookup example in `AGENTS.md` with a bounded `--jq` query.

## Governing Spec
- `001-foundation-v0-1`

## Project Item
- Closes #460
- Tracked in Project 1

## Validation
- Reviewed diff for instruction-only changes.

## Notes
- No runtime, contract, registry, or CLI behavior changed.
