### PR TITLE
feat: validate governed model dependency schema

### DIFF
--- a/crates/traverse-registry/src/application_manifest.rs
+++ b/crates/traverse-registry/src/application_manifest.rs
@@ -293,10 +293,32 @@ pub struct ApplicationWorkflowRef {
     pub path: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ApplicationModelDependency {
-    pub dependency_id: String,
-    pub requirement_ref: String,
+    pub interface_id: String,
+    pub version_range: String,
+    pub selection_policy: ModelSelectionPolicy,
+    pub required_capabilities: Vec<String>,
+    pub minimum_context_window: u64,
+    pub candidates: Vec<ModelCandidate>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ModelSelectionPolicy {
+    pub strategy: String,
+    pub allow_fallback: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ModelCandidate {
+    pub candidate_id: String,
+    pub provider_capability_id: String,
+    pub provider_implementation_id: String,
+    pub model_identifier: String,
+    pub placement_target: ExecutionTarget,
+    pub priority: u32,
+    pub required_provider_config_keys: Vec<String>,
+    pub metadata: Value,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -344,6 +366,11 @@ pub enum ApplicationManifestErrorCode {
     InvalidDigestMetadata,
     ComponentDigestMismatch,
     ComponentDependencyMustBeConcrete,
+    UnsupportedModelInterface,
+    ModelDependencyMissingCandidates,
+    DuplicateModelCandidate,
+    ModelCandidateConfigInvalid,
+    ModelCandidateImplementationInvalid,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -366,7 +393,7 @@ struct ApplicationManifestSerde {
     workspace_defaults: Value,
     components: Vec<ApplicationComponentRef>,
     workflows: Vec<ApplicationWorkflowRef>,
-    model_dependencies: Vec<ApplicationModelDependency>,
+    model_dependencies: Vec<ApplicationModelDependencySerde>,
     config_schema: Value,
     default_config: Value,
     placement_policy: Value,
@@ -388,6 +415,50 @@ struct WasmComponentManifestSerde {
     dependencies: Vec<WasmComponentDependency>,
     connector_requirements: Vec<ConnectorRequirement>,
     validation_evidence: Vec<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplicationModelDependencySerde {
+    #[serde(default)]
+    interface_id: Option<String>,
+    #[serde(default)]
+    version_range: Option<String>,
+    #[serde(default)]
+    selection_policy: Option<ModelSelectionPolicySerde>,
+    #[serde(default)]
+    required_capabilities: Option<Vec<String>>,
+    #[serde(default)]
+    minimum_context_window: Option<u64>,
+    #[serde(default)]
+    candidates: Option<Vec<ModelCandidateSerde>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelSelectionPolicySerde {
+    #[serde(default)]
+    strategy: Option<String>,
+    #[serde(default)]
+    allow_fallback: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModelCandidateSerde {
+    #[serde(default)]
+    candidate_id: Option<String>,
+    #[serde(default)]
+    provider_capability_id: Option<String>,
+    #[serde(default)]
+    provider_implementation_id: Option<String>,
+    #[serde(default)]
+    model_identifier: Option<String>,
+    #[serde(default)]
+    placement_target: Option<ExecutionTarget>,
+    #[serde(default)]
+    priority: Option<u32>,
+    #[serde(default)]
+    required_provider_config_keys: Option<Vec<String>>,
+    #[serde(default)]
+    metadata: Option<Value>,
 }
 
 /// Loads and validates a Traverse application manifest plus its referenced
@@ -436,6 +507,7 @@ pub fn load_application_bundle_manifest(
         })?;
 
     ensure_unique_component_refs(&manifest.components)?;
+    let model_dependencies = parse_model_dependencies(&manifest.model_dependencies)?;
 
     let components = manifest
         .components
@@ -450,7 +522,7 @@ pub fn load_application_bundle_manifest(
         workspace_defaults: manifest.workspace_defaults,
         components,
         workflows: manifest.workflows,
-        model_dependencies: manifest.model_dependencies,
+        model_dependencies,
         config_schema: manifest.config_schema,
         default_config: manifest.default_config,
         placement_policy: manifest.placement_policy,
@@ -745,6 +817,228 @@ fn ensure_unique_component_refs(
         }
     }
     Ok(())
+}
+
+fn parse_model_dependencies(
+    dependencies: &[ApplicationModelDependencySerde],
+) -> Result<Vec<ApplicationModelDependency>, ApplicationManifestFailure> {
+    let mut parsed = Vec::new();
+    for dependency in dependencies {
+        let interface_id = required_text(
+            dependency.interface_id.as_deref(),
+            "$.model_dependencies[].interface_id",
+            "model dependency interface_id is required",
+        )?;
+        let version_range = required_text(
+            dependency.version_range.as_deref(),
+            "$.model_dependencies[].version_range",
+            "model dependency version_range is required",
+        )?;
+        let selection_policy = parse_selection_policy(dependency.selection_policy.as_ref())?;
+        let required_capabilities = dependency.required_capabilities.clone().ok_or_else(|| {
+            single_error(
+                ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+                "$.model_dependencies[].required_capabilities".to_string(),
+                "model dependency required_capabilities is required".to_string(),
+            )
+        })?;
+        let minimum_context_window = dependency.minimum_context_window.unwrap_or_default();
+        let candidates = parse_model_candidates(dependency.candidates.as_deref())?;
+
+        let model_dependency = ApplicationModelDependency {
+            interface_id,
+            version_range,
+            selection_policy,
+            required_capabilities,
+            minimum_context_window,
+            candidates,
+        };
+
+        if model_dependency.interface_id != "traverse.inference.generate" {
+            return Err(single_error(
+                ApplicationManifestErrorCode::UnsupportedModelInterface,
+                "$.model_dependencies[].interface_id".to_string(),
+                format!(
+                    "unsupported model dependency interface: {}",
+                    model_dependency.interface_id
+                ),
+            ));
+        }
+        if model_dependency.selection_policy.strategy != "priority"
+            || model_dependency.minimum_context_window == 0
+            || model_dependency
+                .required_capabilities
+                .iter()
+                .any(|value| !has_text(value))
+        {
+            return Err(single_error(
+                ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+                "$.model_dependencies[]".to_string(),
+                "model dependency must declare version_range, priority selection policy, minimum_context_window, and non-empty required_capabilities".to_string(),
+            ));
+        }
+        parsed.push(model_dependency);
+    }
+    Ok(parsed)
+}
+
+fn parse_selection_policy(
+    policy: Option<&ModelSelectionPolicySerde>,
+) -> Result<ModelSelectionPolicy, ApplicationManifestFailure> {
+    let policy = policy.ok_or_else(|| {
+        single_error(
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+            "$.model_dependencies[].selection_policy".to_string(),
+            "model dependency selection_policy is required".to_string(),
+        )
+    })?;
+    Ok(ModelSelectionPolicy {
+        strategy: required_text(
+            policy.strategy.as_deref(),
+            "$.model_dependencies[].selection_policy.strategy",
+            "model dependency selection_policy.strategy is required",
+        )?,
+        allow_fallback: policy.allow_fallback.unwrap_or(false),
+    })
+}
+
+fn parse_model_candidates(
+    candidates: Option<&[ModelCandidateSerde]>,
+) -> Result<Vec<ModelCandidate>, ApplicationManifestFailure> {
+    let candidates = candidates.ok_or_else(|| {
+        single_error(
+            ApplicationManifestErrorCode::ModelDependencyMissingCandidates,
+            "$.model_dependencies[].candidates".to_string(),
+            "model dependency candidates are required".to_string(),
+        )
+    })?;
+    if candidates.is_empty() {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ModelDependencyMissingCandidates,
+            "$.model_dependencies[].candidates".to_string(),
+            "model dependency must declare at least one real candidate".to_string(),
+        ));
+    }
+
+    let mut parsed = Vec::new();
+    let mut seen = BTreeSet::new();
+    for candidate in candidates {
+        let model_candidate = parse_model_candidate(candidate)?;
+        if !seen.insert(model_candidate.candidate_id.clone()) {
+            return Err(single_error(
+                ApplicationManifestErrorCode::DuplicateModelCandidate,
+                "$.model_dependencies[].candidates[].candidate_id".to_string(),
+                format!(
+                    "duplicate model candidate id: {}",
+                    model_candidate.candidate_id
+                ),
+            ));
+        }
+        if !valid_model_candidate(&model_candidate) {
+            return Err(single_error(
+                ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+                "$.model_dependencies[].candidates[]".to_string(),
+                format!(
+                    "model candidate {} must declare provider ids, model_identifier, priority, config keys, and metadata object",
+                    model_candidate.candidate_id
+                ),
+            ));
+        }
+        if looks_like_placeholder(&model_candidate.provider_implementation_id)
+            || model_candidate
+                .metadata
+                .get("implementation_kind")
+                .and_then(Value::as_str)
+                .is_some_and(looks_like_placeholder)
+        {
+            return Err(single_error(
+                ApplicationManifestErrorCode::ModelCandidateImplementationInvalid,
+                "$.model_dependencies[].candidates[].provider_implementation_id".to_string(),
+                format!(
+                    "model candidate {} must reference a real provider implementation, not a fake, stub, placeholder, or documentation-only implementation",
+                    model_candidate.candidate_id
+                ),
+            ));
+        }
+        parsed.push(model_candidate);
+    }
+    Ok(parsed)
+}
+
+fn parse_model_candidate(
+    candidate: &ModelCandidateSerde,
+) -> Result<ModelCandidate, ApplicationManifestFailure> {
+    Ok(ModelCandidate {
+        candidate_id: required_text(
+            candidate.candidate_id.as_deref(),
+            "$.model_dependencies[].candidates[].candidate_id",
+            "model candidate candidate_id is required",
+        )?,
+        provider_capability_id: required_text(
+            candidate.provider_capability_id.as_deref(),
+            "$.model_dependencies[].candidates[].provider_capability_id",
+            "model candidate provider_capability_id is required",
+        )?,
+        provider_implementation_id: required_text(
+            candidate.provider_implementation_id.as_deref(),
+            "$.model_dependencies[].candidates[].provider_implementation_id",
+            "model candidate provider_implementation_id is required",
+        )?,
+        model_identifier: required_text(
+            candidate.model_identifier.as_deref(),
+            "$.model_dependencies[].candidates[].model_identifier",
+            "model candidate model_identifier is required",
+        )?,
+        placement_target: candidate.placement_target.clone().ok_or_else(|| {
+            single_error(
+                ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+                "$.model_dependencies[].candidates[].placement_target".to_string(),
+                "model candidate placement_target is required".to_string(),
+            )
+        })?,
+        priority: candidate.priority.unwrap_or_default(),
+        required_provider_config_keys: candidate
+            .required_provider_config_keys
+            .clone()
+            .unwrap_or_default(),
+        metadata: candidate.metadata.clone().unwrap_or(Value::Null),
+    })
+}
+
+fn required_text(
+    value: Option<&str>,
+    path: &str,
+    message: &str,
+) -> Result<String, ApplicationManifestFailure> {
+    if let Some(value) = value.filter(|value| has_text(value)) {
+        Ok(value.to_string())
+    } else {
+        Err(single_error(
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+            path.to_string(),
+            message.to_string(),
+        ))
+    }
+}
+
+fn valid_model_candidate(candidate: &ModelCandidate) -> bool {
+    has_text(&candidate.candidate_id)
+        && has_text(&candidate.provider_capability_id)
+        && has_text(&candidate.provider_implementation_id)
+        && has_text(&candidate.model_identifier)
+        && candidate.priority > 0
+        && candidate
+            .required_provider_config_keys
+            .iter()
+            .all(|key| has_text(key))
+        && candidate.metadata.is_object()
+}
+
+fn looks_like_placeholder(value: &str) -> bool {
+    let lowered = value.to_ascii_lowercase();
+    ["fake", "stub", "placeholder", "documentation-only"]
+        .iter()
+        .any(|marker| lowered.contains(marker))
 }
 
 fn load_component(

--- a/crates/traverse-registry/tests/application_manifest.rs
+++ b/crates/traverse-registry/tests/application_manifest.rs
@@ -126,6 +126,330 @@ fn rejects_duplicate_component_references() {
 }
 
 #[test]
+fn loads_valid_governed_model_dependency_schema() {
+    let fixture = AppFixture::new("valid-model-dependency");
+    fixture.write_app_manifest_with_model_dependencies(
+        &json!([]),
+        &json!([model_dependency(json!([model_candidate(
+            "ollama-llama-3-2",
+            json!({})
+        )]))]),
+    );
+
+    let bundle = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect("model dependency schema should validate");
+
+    assert_eq!(bundle.model_dependencies.len(), 1);
+    let dependency = &bundle.model_dependencies[0];
+    assert_eq!(dependency.interface_id, "traverse.inference.generate");
+    assert_eq!(dependency.version_range, "^1.0");
+    assert_eq!(dependency.selection_policy.strategy, "priority");
+    assert!(dependency.selection_policy.allow_fallback);
+    assert_eq!(dependency.minimum_context_window, 8192);
+    assert_eq!(dependency.candidates[0].candidate_id, "ollama-llama-3-2");
+    assert_eq!(dependency.candidates[0].priority, 10);
+}
+
+#[test]
+fn rejects_unsupported_model_dependency_interface() {
+    let fixture = AppFixture::new("unsupported-model-interface");
+    fixture.write_app_manifest_with_model_dependencies(
+        &json!([]),
+        &json!([
+            model_dependency(json!([model_candidate("ollama-llama-3-2", json!({}))]))
+                .as_object()
+                .map(|object| {
+                    let mut object = object.clone();
+                    object.insert(
+                        "interface_id".to_string(),
+                        json!("downstream.private.generate"),
+                    );
+                    serde_json::Value::Object(object)
+                })
+                .expect("model dependency object")
+        ]),
+    );
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("unsupported model interface must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::UnsupportedModelInterface
+    );
+}
+
+#[test]
+fn rejects_model_dependency_without_candidates() {
+    let fixture = AppFixture::new("missing-model-candidates");
+    fixture.write_app_manifest_with_model_dependencies(
+        &json!([]),
+        &json!([model_dependency(json!([]))]),
+    );
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("missing model candidates must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ModelDependencyMissingCandidates
+    );
+}
+
+#[test]
+fn rejects_duplicate_model_candidate_ids() {
+    let fixture = AppFixture::new("duplicate-model-candidates");
+    fixture.write_app_manifest_with_model_dependencies(
+        &json!([]),
+        &json!([model_dependency(json!([
+            model_candidate("ollama-llama-3-2", json!({})),
+            model_candidate("ollama-llama-3-2", json!({"model_context_window": 16384}))
+        ]))]),
+    );
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("duplicate model candidate must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::DuplicateModelCandidate
+    );
+}
+
+#[test]
+fn rejects_invalid_model_candidate_config() {
+    let fixture = AppFixture::new("invalid-model-candidate-config");
+    let mut invalid_candidate = model_candidate("ollama-llama-3-2", json!({}));
+    invalid_candidate
+        .as_object_mut()
+        .expect("candidate object")
+        .insert("priority".to_string(), json!(0));
+    fixture.write_app_manifest_with_model_dependencies(
+        &json!([]),
+        &json!([model_dependency(json!([invalid_candidate]))]),
+    );
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("invalid model candidate config must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ModelCandidateConfigInvalid
+    );
+}
+
+#[test]
+fn rejects_missing_model_dependency_fields_with_stable_errors() {
+    let cases = vec![
+        (
+            {
+                let mut dependency =
+                    model_dependency(json!([model_candidate("ollama-llama-3-2", json!({}),)]));
+                dependency
+                    .as_object_mut()
+                    .expect("dependency object")
+                    .remove("interface_id");
+                dependency
+            },
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+        ),
+        (
+            {
+                let mut dependency =
+                    model_dependency(json!([model_candidate("ollama-llama-3-2", json!({}),)]));
+                dependency
+                    .as_object_mut()
+                    .expect("dependency object")
+                    .remove("version_range");
+                dependency
+            },
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+        ),
+        (
+            {
+                let mut dependency =
+                    model_dependency(json!([model_candidate("ollama-llama-3-2", json!({}),)]));
+                dependency
+                    .as_object_mut()
+                    .expect("dependency object")
+                    .remove("required_capabilities");
+                dependency
+            },
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+        ),
+        (
+            {
+                let mut dependency =
+                    model_dependency(json!([model_candidate("ollama-llama-3-2", json!({}),)]));
+                dependency
+                    .as_object_mut()
+                    .expect("dependency object")
+                    .remove("selection_policy");
+                dependency
+            },
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+        ),
+        (
+            {
+                let mut dependency =
+                    model_dependency(json!([model_candidate("ollama-llama-3-2", json!({}),)]));
+                dependency["selection_policy"]
+                    .as_object_mut()
+                    .expect("selection policy object")
+                    .remove("strategy");
+                dependency
+            },
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+        ),
+        (
+            {
+                let mut dependency =
+                    model_dependency(json!([model_candidate("ollama-llama-3-2", json!({}),)]));
+                dependency
+                    .as_object_mut()
+                    .expect("dependency object")
+                    .remove("candidates");
+                dependency
+            },
+            ApplicationManifestErrorCode::ModelDependencyMissingCandidates,
+        ),
+    ];
+
+    assert_model_dependency_rejections("missing-model-dependency", cases);
+}
+
+#[test]
+fn rejects_invalid_model_dependency_values_with_stable_errors() {
+    let cases = vec![
+        (
+            {
+                let mut dependency =
+                    model_dependency(json!([model_candidate("ollama-llama-3-2", json!({}),)]));
+                dependency["selection_policy"]["strategy"] = json!("random");
+                dependency
+            },
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+        ),
+        (
+            {
+                let mut dependency =
+                    model_dependency(json!([model_candidate("ollama-llama-3-2", json!({}),)]));
+                dependency["minimum_context_window"] = json!(0);
+                dependency
+            },
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+        ),
+        (
+            {
+                let mut dependency =
+                    model_dependency(json!([model_candidate("ollama-llama-3-2", json!({}),)]));
+                dependency["required_capabilities"] = json!([""]);
+                dependency
+            },
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid,
+        ),
+    ];
+
+    assert_model_dependency_rejections("invalid-model-dependency", cases);
+}
+
+#[test]
+fn rejects_incomplete_model_candidate_fields_with_stable_errors() {
+    let candidate_fields = vec![
+        "candidate_id",
+        "provider_capability_id",
+        "provider_implementation_id",
+        "model_identifier",
+        "placement_target",
+    ];
+
+    for field in candidate_fields {
+        let fixture = AppFixture::new(&format!("incomplete-model-candidate-{field}"));
+        let mut candidate = model_candidate("ollama-llama-3-2", json!({}));
+        candidate
+            .as_object_mut()
+            .expect("candidate object")
+            .remove(field);
+        fixture.write_app_manifest_with_model_dependencies(
+            &json!([]),
+            &json!([model_dependency(json!([candidate]))]),
+        );
+
+        let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+            .expect_err("incomplete model candidate must fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            ApplicationManifestErrorCode::ModelCandidateConfigInvalid
+        );
+    }
+}
+
+#[test]
+fn rejects_model_candidate_without_metadata_object() {
+    let fixture = AppFixture::new("invalid-model-candidate-metadata");
+    let mut candidate = model_candidate("ollama-llama-3-2", json!({}));
+    candidate
+        .as_object_mut()
+        .expect("candidate object")
+        .insert("metadata".to_string(), json!(null));
+    fixture.write_app_manifest_with_model_dependencies(
+        &json!([]),
+        &json!([model_dependency(json!([candidate]))]),
+    );
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("model candidate without metadata object must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ModelCandidateConfigInvalid
+    );
+}
+
+#[test]
+fn rejects_placeholder_model_candidate_metadata() {
+    let fixture = AppFixture::new("placeholder-model-metadata");
+    fixture.write_app_manifest_with_model_dependencies(
+        &json!([]),
+        &json!([model_dependency(json!([model_candidate(
+            "ollama-llama-3-2",
+            json!({"implementation_kind": "documentation-only"})
+        )]))]),
+    );
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("placeholder model candidate metadata must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ModelCandidateImplementationInvalid
+    );
+}
+
+#[test]
+fn rejects_placeholder_model_candidate_implementation() {
+    let fixture = AppFixture::new("placeholder-model-implementation");
+    let mut candidate = model_candidate("ollama-llama-3-2", json!({}));
+    candidate.as_object_mut().expect("candidate object").insert(
+        "provider_implementation_id".to_string(),
+        json!("placeholder.ollama-provider"),
+    );
+    fixture.write_app_manifest_with_model_dependencies(
+        &json!([]),
+        &json!([model_dependency(json!([candidate]))]),
+    );
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("placeholder model candidate must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ModelCandidateImplementationInvalid
+    );
+}
+
+#[test]
 fn rejects_unreadable_component_manifest() {
     let fixture = AppFixture::new("unreadable-component-manifest");
     fixture.write_app_manifest(&json!([component_ref(
@@ -1018,10 +1342,27 @@ impl AppFixture {
         self.write_app_manifest_with_workflows(components, &json!([]));
     }
 
+    fn write_app_manifest_with_model_dependencies(
+        &self,
+        components: &serde_json::Value,
+        model_dependencies: &serde_json::Value,
+    ) {
+        self.write_app_manifest_full(components, &json!([]), model_dependencies);
+    }
+
     fn write_app_manifest_with_workflows(
         &self,
         components: &serde_json::Value,
         workflows: &serde_json::Value,
+    ) {
+        self.write_app_manifest_full(components, workflows, &json!([]));
+    }
+
+    fn write_app_manifest_full(
+        &self,
+        components: &serde_json::Value,
+        workflows: &serde_json::Value,
+        model_dependencies: &serde_json::Value,
     ) {
         let app = json!({
             "app_id": "hello.world.app",
@@ -1032,7 +1373,7 @@ impl AppFixture {
             },
             "components": components,
             "workflows": workflows,
-            "model_dependencies": [],
+            "model_dependencies": model_dependencies,
             "config_schema": {
                 "type": "object"
             },
@@ -1250,6 +1591,66 @@ fn component_ref(id: &str, version: &str, digest: &str, manifest_path: &str) -> 
         "version": version,
         "digest": digest,
         "manifest_path": manifest_path
+    })
+}
+
+fn assert_model_dependency_rejections(
+    prefix: &str,
+    cases: Vec<(serde_json::Value, ApplicationManifestErrorCode)>,
+) {
+    for (index, (dependency, expected_code)) in cases.into_iter().enumerate() {
+        let fixture = AppFixture::new(&format!("{prefix}-{index}"));
+        fixture.write_app_manifest_with_model_dependencies(&json!([]), &json!([dependency]));
+
+        let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+            .expect_err("model dependency rejection case must fail");
+
+        assert_eq!(failure.errors[0].code, expected_code);
+    }
+}
+
+fn model_dependency(candidates: impl Into<serde_json::Value>) -> serde_json::Value {
+    let candidates = candidates.into();
+    json!({
+        "interface_id": "traverse.inference.generate",
+        "version_range": "^1.0",
+        "selection_policy": {
+            "strategy": "priority",
+            "allow_fallback": true
+        },
+        "required_capabilities": ["text_generation"],
+        "minimum_context_window": 8192,
+        "candidates": candidates
+    })
+}
+
+fn model_candidate(
+    candidate_id: &str,
+    metadata_overrides: impl Into<serde_json::Value>,
+) -> serde_json::Value {
+    let metadata_overrides = metadata_overrides.into();
+    let mut metadata = json!({
+        "implementation_kind": "real_local_provider",
+        "provider": "ollama",
+        "model_context_window": 8192,
+        "supports_streaming": true
+    });
+    if let (Some(base), Some(overrides)) =
+        (metadata.as_object_mut(), metadata_overrides.as_object())
+    {
+        for (key, value) in overrides {
+            base.insert(key.clone(), value.clone());
+        }
+    }
+    json!({
+        "candidate_id": candidate_id,
+        "provider_capability_id": "traverse.inference.generate",
+        "provider_implementation_id": "ollama.local.generate",
+        "model_identifier": "llama3.2:3b",
+        "placement_target": "local",
+        "priority": 10,
+        "required_provider_config_keys": ["ollama_base_url"],
+        "metadata": metadata
     })
 }
 

--- a/docs/model-dependency-authoring-guide.md
+++ b/docs/model-dependency-authoring-guide.md
@@ -1,0 +1,71 @@
+# Governed Model Dependency Authoring Guide
+
+Spec `045-governed-model-dependency-resolution` defines app manifest model
+dependencies for real inference. These declarations belong in application
+manifests, not inside downstream product code.
+
+## Inference Interface
+
+The first governed inference interface is:
+
+```text
+traverse.inference.generate
+```
+
+Downstream apps declare this abstract interface plus concrete model candidates.
+Traverse owns provider selection and later execution. Product code must not
+hardcode Ollama, llama.cpp, WebLLM, cloud APIs, or provider-specific paths.
+
+## App Manifest Shape
+
+```json
+{
+  "model_dependencies": [
+    {
+      "interface_id": "traverse.inference.generate",
+      "version_range": "^1.0",
+      "selection_policy": {
+        "strategy": "priority",
+        "allow_fallback": true
+      },
+      "required_capabilities": ["text_generation"],
+      "minimum_context_window": 8192,
+      "candidates": [
+        {
+          "candidate_id": "ollama-llama-3-2",
+          "provider_capability_id": "traverse.inference.generate",
+          "provider_implementation_id": "ollama.local.generate",
+          "model_identifier": "llama3.2:3b",
+          "placement_target": "local",
+          "priority": 10,
+          "required_provider_config_keys": ["ollama_base_url"],
+          "metadata": {
+            "implementation_kind": "real_local_provider",
+            "provider": "ollama",
+            "model_context_window": 8192,
+            "supports_streaming": true
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Validation Rules
+
+- `interface_id` must be `traverse.inference.generate`.
+- `selection_policy.strategy` must be `priority`.
+- `minimum_context_window` must be greater than zero.
+- Each dependency must declare at least one candidate.
+- Candidate ids must be unique within one dependency.
+- Candidate provider ids, model identifier, config keys, priority, placement,
+  and metadata must be concrete.
+- Candidate metadata must be non-sensitive and safe for readiness/trace
+  evidence.
+- Fake, stub, placeholder, or documentation-only provider implementations do
+  not satisfy Spec 045.
+
+Provider availability checks and execution-time resolution are implemented in
+later Spec 045 slices. This schema slice makes app manifests precise enough for
+those runtime paths to be deterministic and testable.

--- a/docs/tutorial-index.md
+++ b/docs/tutorial-index.md
@@ -66,3 +66,4 @@ These docs are not part of the linear onboarding sequence but are essential refe
 - [docs/workflow-contract-authoring-guide.md](workflow-contract-authoring-guide.md) — node/edge model, direct vs event edges, authoring steps
 - [docs/registry-bundle-authoring-guide.md](registry-bundle-authoring-guide.md) — how to author a bundle manifest for a new domain
 - [docs/wasm-agent-authoring-guide.md](wasm-agent-authoring-guide.md) — stub vs. real implementation, build-fixture.sh, model_dependencies
+- [docs/model-dependency-authoring-guide.md](model-dependency-authoring-guide.md) — governed app manifest schema for real model candidates

--- a/examples/applications/expedition-readiness/app.manifest.json
+++ b/examples/applications/expedition-readiness/app.manifest.json
@@ -23,8 +23,35 @@
   ],
   "model_dependencies": [
     {
-      "dependency_id": "expedition-readiness-validation-v1",
-      "requirement_ref": "045-governed-model-dependency-resolution"
+      "interface_id": "traverse.inference.generate",
+      "version_range": "^1.0",
+      "selection_policy": {
+        "strategy": "priority",
+        "allow_fallback": true
+      },
+      "required_capabilities": [
+        "text_generation"
+      ],
+      "minimum_context_window": 8192,
+      "candidates": [
+        {
+          "candidate_id": "ollama-llama-3-2-readiness",
+          "provider_capability_id": "traverse.inference.generate",
+          "provider_implementation_id": "ollama.local.generate",
+          "model_identifier": "llama3.2:3b",
+          "placement_target": "local",
+          "priority": 10,
+          "required_provider_config_keys": [
+            "ollama_base_url"
+          ],
+          "metadata": {
+            "implementation_kind": "real_local_provider",
+            "provider": "ollama",
+            "model_context_window": 8192,
+            "supports_streaming": true
+          }
+        }
+      ]
     }
   ],
   "config_schema": {


### PR DESCRIPTION
## Summary
- Defines governed app manifest model dependency and model candidate structs for `traverse.inference.generate`.
- Validates supported interface, priority selection policy, context window, concrete candidates, duplicate candidate ids, invalid config, and fake/stub/documentation-only implementations.
- Migrates the checked-in expedition readiness app manifest to the governed Spec 045 candidate shape.
- Adds a model dependency authoring guide and links it from the tutorial index.

## Governing Spec
- `044-application-bundle-manifest`
- `045-governed-model-dependency-resolution`

## Project Item
- Closes #450
- Tracked in Project 1

## Validation
- `cargo test -p traverse-registry --test application_manifest`
- `cargo test -p traverse-registry`
- `/opt/homebrew/bin/rustup run 1.94.0 cargo clippy -p traverse-registry -- -D warnings`
- `bash scripts/ci/spec_context_check.sh`
- `bash scripts/ci/repository_checks.sh`
- `PATH="$HOME/.cargo/bin:$PATH" LLVM_COV=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-cov LLVM_PROFDATA=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata bash scripts/ci/coverage_gate.sh`

## Notes
- Provider availability calls, Ollama execution, and trace/MCP rendering remain in follow-on Spec 045 issues.
