### PR TITLE
docs: add Traverse minimality ladder

### DIFF
--- a/.agents/skills/traverse-ops/SKILL.md
+++ b/.agents/skills/traverse-ops/SKILL.md
@@ -56,6 +56,22 @@ not waste context on raw logs.
 - In final updates, include merged PRs, validations, and next recommended issue;
   do not restate every command output.
 
+## Minimality Ladder
+
+Before adding code, apply this Traverse-specific minimality ladder:
+
+1. Does this change need to exist for the active issue and governing spec?
+2. Can existing Traverse code, contracts, specs, or docs already satisfy it?
+3. Can the Rust standard library, Cargo workspace, or an existing dependency do it?
+4. Can a schema, validation branch, test, or documentation update solve it without
+   a new abstraction?
+5. Can one focused function, CLI branch, or manifest field solve it?
+6. Only then add the minimum new structure needed for the issue.
+
+Minimality must never weaken spec alignment, contract validation, stable error
+codes, security, traceability, accessibility, or required tests. Create follow-up
+tickets for useful adjacent improvements instead of expanding an active slice.
+
 ## Operating Lanes
 
 - **Ready-ticket worker**: claim one Ready Project 1 issue and implement it end to end.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,20 @@ bash scripts/ci/spec_alignment_check.sh
 - 100% test coverage for core business and runtime logic
 - Deterministic: same inputs must produce same outputs
 
+## Lean Implementation
+
+Before adding code, apply the Traverse minimality ladder:
+
+1. Confirm the change is required by the active issue and governing spec.
+2. Reuse existing Traverse code, contracts, specs, and docs when they already fit.
+3. Prefer the Rust standard library, Cargo workspace, or existing dependencies over new abstractions.
+4. Prefer a schema, validation branch, test, or documentation update when that solves the issue.
+5. Prefer one focused function, CLI branch, or manifest field before adding broader structure.
+6. Add only the minimum new structure needed for the issue.
+
+Minimality must not reduce spec alignment, contract validation, stable error codes,
+security, traceability, accessibility, or required tests.
+
 ## Recent Changes
 
 - 188-codex-agent-coordination: Added Codex claim check and AGENTS.md coordination rules


### PR DESCRIPTION
## Summary
- Adds a Traverse-specific minimality ladder to the Traverse ops skill.
- Mirrors the same lean implementation rule in top-level agent guidance.
- States that minimality cannot weaken governance, validation, security, traceability, accessibility, or required tests.

## Governing Spec
No governing spec required for this instruction-only change.

## Project Item
- Closes #463
- Tracked in Project 1

## Validation
- `git diff --check`

## Notes
- This does not install Ponytail or add a dependency; it adopts the useful minimality practice directly in Traverse guidance.
