### PR TITLE
feat: add local Ollama inference provider

### DIFF
--- a/contracts/inference/traverse.inference.generate/contract.json
+++ b/contracts/inference/traverse.inference.generate/contract.json
@@ -1,0 +1,164 @@
+{
+  "kind": "capability_contract",
+  "schema_version": "1.0.0",
+  "id": "traverse.inference.generate",
+  "namespace": "traverse.inference",
+  "name": "generate",
+  "version": "1.0.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Generate text through a Traverse-governed inference provider implementation.",
+  "description": "Provider-neutral inference interface satisfied first by the real local Ollama implementation. Downstream app product logic depends on this interface rather than direct provider APIs.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "model",
+        "prompt"
+      ],
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "prompt": {
+          "type": "string"
+        },
+        "system_prompt": {
+          "type": "string"
+        },
+        "options": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "interface_id",
+        "provider",
+        "provider_implementation_id",
+        "model",
+        "response",
+        "done",
+        "evidence"
+      ],
+      "properties": {
+        "interface_id": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "provider_implementation_id": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "response": {
+          "type": "string"
+        },
+        "done": {
+          "type": "boolean"
+        },
+        "evidence": {
+          "type": "object",
+          "required": [
+            "placement_target",
+            "selected_provider",
+            "selected_model"
+          ],
+          "properties": {
+            "placement_target": {
+              "type": "string"
+            },
+            "selected_provider": {
+              "type": "string"
+            },
+            "selected_model": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "preconditions": [
+    {
+      "id": "local-provider-configured",
+      "description": "Workspace-local config provides a reachable Ollama base URL without exposing secrets in public evidence."
+    },
+    {
+      "id": "model-installed",
+      "description": "The requested local model is installed and listed by Ollama before generation."
+    }
+  ],
+  "postconditions": [
+    {
+      "id": "inference-output-produced",
+      "description": "A real model response is returned with non-sensitive provider/model evidence."
+    }
+  ],
+  "side_effects": [
+    {
+      "kind": "external_call",
+      "description": "Performs local HTTP requests to the configured Ollama provider."
+    }
+  ],
+  "emits": [],
+  "consumes": [],
+  "permissions": [
+    {
+      "id": "traverse.inference.generate.local"
+    }
+  ],
+  "execution": {
+    "binary_format": "wasm",
+    "entrypoint": {
+      "kind": "wasi-command",
+      "command": "ollama.local.generate"
+    },
+    "preferred_targets": [
+      "local"
+    ],
+    "constraints": {
+      "host_api_access": "none",
+      "network_access": "required",
+      "filesystem_access": "none"
+    }
+  },
+  "policies": [
+    {
+      "id": "no-private-prompt-in-public-evidence"
+    }
+  ],
+  "dependencies": [],
+  "provenance": {
+    "source": "greenfield",
+    "author": "enricopiovesan",
+    "created_at": "2026-06-19T00:00:00Z",
+    "spec_ref": "045-governed-model-dependency-resolution@1.0.0",
+    "adr_refs": [],
+    "exception_refs": []
+  },
+  "evidence": [],
+  "service_type": "stateless",
+  "permitted_targets": [
+    "local"
+  ],
+  "connector_requirements": [
+    {
+      "connector_id": "traverse.http",
+      "version": "^1.0.0"
+    }
+  ],
+  "artifact_type": "native"
+}

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -15,17 +15,18 @@ use std::fs;
 use std::path::Component;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
-use traverse_contracts::ViolationRecord;
 use traverse_contracts::{
     EventContract, EventValidationContext, parse_event_contract, validate_event_contract,
 };
+use traverse_contracts::{ViolationRecord, reference_connector_contracts};
 use traverse_registry::{
     ApplicationRegistrationRequest, ApplicationRegistry, ArtifactDigests, BinaryFormat,
     BinaryReference, CapabilityArtifactRecord, CapabilityRegistration, CapabilityRegistry,
-    ComposabilityMetadata, CompositionKind, CompositionPattern, DiscoveryQuery, EventRegistration,
-    EventRegistry, ImplementationKind, LookupScope, RegistryBundle, RegistryProvenance,
-    RegistryScope, SourceKind, SourceReference, WorkflowDefinition, WorkflowReference,
-    WorkflowRegistration, WorkflowRegistry, load_registry_bundle,
+    ComposabilityMetadata, CompositionKind, CompositionPattern, ConnectorRegistration,
+    DiscoveryQuery, EventRegistration, EventRegistry, ImplementationKind, LookupScope,
+    RegistryBundle, RegistryProvenance, RegistryScope, SourceKind, SourceReference,
+    WorkflowDefinition, WorkflowReference, WorkflowRegistration, WorkflowRegistry,
+    load_registry_bundle,
 };
 use traverse_runtime::executor::{SUPPORTED_HOST_ABI_VERSION, verify_wasm_host_abi_bytes};
 use traverse_runtime::{
@@ -2352,6 +2353,8 @@ fn load_registered_bundle(manifest_path: &Path) -> Result<RegisteredBundle, CliE
     let mut event_records = Vec::new();
     let mut workflow_records = Vec::new();
 
+    register_reference_connectors(&mut capability_registry, &bundle)?;
+
     for event in &bundle.events {
         let outcome = event_registry
             .register(EventRegistration {
@@ -2439,6 +2442,28 @@ fn load_registered_bundle(manifest_path: &Path) -> Result<RegisteredBundle, CliE
         event_records,
         workflow_records,
     })
+}
+
+fn register_reference_connectors(
+    capability_registry: &mut CapabilityRegistry,
+    bundle: &RegistryBundle,
+) -> Result<(), CliError> {
+    for connector in reference_connector_contracts() {
+        capability_registry
+            .register_connector(ConnectorRegistration {
+                scope: RegistryScope::Public,
+                contract_path: format!(
+                    "contracts/connectors/{}/connector_contract.json",
+                    connector.connector_id
+                ),
+                contract: connector,
+                registered_at: bundle_registered_at(bundle),
+                governing_spec: "039-connector-plugin-architecture".to_string(),
+                validator_version: env!("CARGO_PKG_VERSION").to_string(),
+            })
+            .map_err(|f| CliError::RegistrationConflict(render_registry_failure(f)))?;
+    }
+    Ok(())
 }
 
 fn render_violation_records(header: &str, violations: &[ViolationRecord]) -> String {

--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -40,7 +40,7 @@ pub struct BrokerConfig {
 impl Default for BrokerConfig {
     fn default() -> Self {
         Self {
-            retention_window: Duration::from_secs(5 * 60),
+            retention_window: Duration::from_mins(5),
             max_queue_len: 1024,
         }
     }

--- a/crates/traverse-runtime/src/inference.rs
+++ b/crates/traverse-runtime/src/inference.rs
@@ -1,0 +1,429 @@
+//! Governed local inference providers for Traverse.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::fmt;
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+const OLLAMA_PROVIDER: &str = "ollama";
+const GENERATE_INTERFACE: &str = "traverse.inference.generate";
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OllamaProviderConfig {
+    pub base_url: String,
+    #[serde(default)]
+    pub request_timeout_ms: Option<u64>,
+}
+
+impl OllamaProviderConfig {
+    #[must_use]
+    pub fn timeout(&self) -> Duration {
+        Duration::from_millis(self.request_timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OllamaInferenceRequest {
+    pub model: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub system_prompt: Option<String>,
+    #[serde(default)]
+    pub options: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OllamaInferenceOutput {
+    pub interface_id: String,
+    pub provider: String,
+    pub provider_implementation_id: String,
+    pub model: String,
+    pub response: String,
+    pub done: bool,
+    pub evidence: OllamaInferenceEvidence,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OllamaInferenceEvidence {
+    pub placement_target: String,
+    pub selected_provider: String,
+    pub selected_model: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OllamaInferenceProvider {
+    config: OllamaProviderConfig,
+}
+
+impl OllamaInferenceProvider {
+    /// Creates a local Ollama provider backed by the configured HTTP endpoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OllamaInferenceError`] when the endpoint config is invalid.
+    pub fn new(config: OllamaProviderConfig) -> Result<Self, OllamaInferenceError> {
+        parse_base_url(&config.base_url)?;
+        Ok(Self { config })
+    }
+
+    #[must_use]
+    pub fn provider_implementation_id(&self) -> &'static str {
+        "ollama.local.generate"
+    }
+
+    /// Checks whether the configured Ollama endpoint lists the requested model.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OllamaInferenceError`] when the provider is unavailable, the
+    /// response is invalid, or the model is not listed by Ollama.
+    pub fn check_model_available(&self, model: &str) -> Result<(), OllamaInferenceError> {
+        if model.trim().is_empty() {
+            return Err(OllamaInferenceError::new(
+                OllamaInferenceErrorCode::InvalidConfig,
+                "model_identifier is required",
+            ));
+        }
+
+        let response = self.request("GET", "/api/tags", None)?;
+        let models = response
+            .get("models")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                OllamaInferenceError::new(
+                    OllamaInferenceErrorCode::InvalidResponse,
+                    "Ollama tags response must contain models array",
+                )
+            })?;
+
+        if models.iter().any(|entry| model_entry_matches(entry, model)) {
+            return Ok(());
+        }
+
+        Err(OllamaInferenceError::new(
+            OllamaInferenceErrorCode::ModelUnavailable,
+            format!("Ollama model {model} is not installed"),
+        ))
+    }
+
+    /// Invokes real local generation through Ollama.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OllamaInferenceError`] when config, provider availability,
+    /// model availability, provider execution, or response validation fails.
+    pub fn generate(
+        &self,
+        request: &OllamaInferenceRequest,
+    ) -> Result<OllamaInferenceOutput, OllamaInferenceError> {
+        validate_generate_request(request)?;
+        self.check_model_available(&request.model)?;
+
+        let mut body = Map::new();
+        body.insert("model".to_string(), json!(request.model));
+        body.insert("prompt".to_string(), json!(request.prompt));
+        body.insert("stream".to_string(), json!(false));
+        if let Some(system_prompt) = &request.system_prompt {
+            body.insert("system".to_string(), json!(system_prompt));
+        }
+        if !request.options.is_null() {
+            body.insert("options".to_string(), request.options.clone());
+        }
+
+        let response = self.request("POST", "/api/generate", Some(Value::Object(body)))?;
+        parse_generate_response(self.provider_implementation_id(), &request.model, &response)
+    }
+
+    fn request(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<Value>,
+    ) -> Result<Value, OllamaInferenceError> {
+        let endpoint = parse_base_url(&self.config.base_url)?;
+        let body_text = body.map_or_else(String::new, |value| value.to_string());
+        let request_path = endpoint.path_for(path);
+        let response_text = send_http_json(
+            &endpoint.host,
+            endpoint.port,
+            &request_path,
+            method,
+            &body_text,
+            self.config.timeout(),
+        )?;
+        parse_http_json_response(&response_text)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OllamaInferenceErrorCode {
+    InvalidConfig,
+    ModelProviderUnavailable,
+    ModelUnavailable,
+    ProviderFailure,
+    InvalidResponse,
+}
+
+impl OllamaInferenceErrorCode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidConfig => "model_candidate_config_invalid",
+            Self::ModelProviderUnavailable => "model_provider_unavailable",
+            Self::ModelUnavailable => "model_candidate_unavailable",
+            Self::ProviderFailure => "model_provider_failure",
+            Self::InvalidResponse => "model_provider_invalid_response",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OllamaInferenceError {
+    pub code: OllamaInferenceErrorCode,
+    pub message: String,
+}
+
+impl OllamaInferenceError {
+    #[must_use]
+    pub fn new(code: OllamaInferenceErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn machine_code(&self) -> &'static str {
+        self.code.as_str()
+    }
+}
+
+impl fmt::Display for OllamaInferenceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.machine_code(), self.message)
+    }
+}
+
+impl std::error::Error for OllamaInferenceError {}
+
+impl From<std::io::Error> for OllamaInferenceError {
+    fn from(error: std::io::Error) -> Self {
+        provider_unavailable(format!("Ollama I/O failed: {error}"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HttpEndpoint {
+    host: String,
+    port: u16,
+    base_path: String,
+}
+
+impl HttpEndpoint {
+    fn path_for(&self, path: &str) -> String {
+        let base = self.base_path.trim_end_matches('/');
+        let suffix = path.trim_start_matches('/');
+        if base.is_empty() {
+            format!("/{suffix}")
+        } else {
+            format!("{base}/{suffix}")
+        }
+    }
+}
+
+fn validate_generate_request(request: &OllamaInferenceRequest) -> Result<(), OllamaInferenceError> {
+    if request.model.trim().is_empty() {
+        return Err(OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidConfig,
+            "model_identifier is required",
+        ));
+    }
+    if request.prompt.trim().is_empty() {
+        return Err(OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidConfig,
+            "prompt is required for traverse.inference.generate",
+        ));
+    }
+    if !request.options.is_null() && !request.options.is_object() {
+        return Err(OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidConfig,
+            "options must be a JSON object when provided",
+        ));
+    }
+    Ok(())
+}
+
+fn parse_generate_response(
+    provider_implementation_id: &str,
+    requested_model: &str,
+    response: &Value,
+) -> Result<OllamaInferenceOutput, OllamaInferenceError> {
+    let text = response
+        .get("response")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            OllamaInferenceError::new(
+                OllamaInferenceErrorCode::InvalidResponse,
+                "Ollama generate response must contain response text",
+            )
+        })?;
+    let done = response
+        .get("done")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let model = response
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or(requested_model);
+
+    Ok(OllamaInferenceOutput {
+        interface_id: GENERATE_INTERFACE.to_string(),
+        provider: OLLAMA_PROVIDER.to_string(),
+        provider_implementation_id: provider_implementation_id.to_string(),
+        model: model.to_string(),
+        response: text.to_string(),
+        done,
+        evidence: OllamaInferenceEvidence {
+            placement_target: "local".to_string(),
+            selected_provider: OLLAMA_PROVIDER.to_string(),
+            selected_model: model.to_string(),
+        },
+    })
+}
+
+fn model_entry_matches(entry: &Value, model: &str) -> bool {
+    entry
+        .get("name")
+        .or_else(|| entry.get("model"))
+        .and_then(Value::as_str)
+        .is_some_and(|name| name == model)
+}
+
+fn parse_base_url(base_url: &str) -> Result<HttpEndpoint, OllamaInferenceError> {
+    let trimmed = base_url.trim();
+    let remainder = trimmed.strip_prefix("http://").ok_or_else(|| {
+        OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidConfig,
+            "ollama_base_url must use http:// for local Ollama",
+        )
+    })?;
+    let remainder = remainder.trim_end_matches('/');
+    let (authority, path) = remainder.split_once('/').unwrap_or((remainder, ""));
+    if authority.is_empty() {
+        return Err(OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidConfig,
+            "ollama_base_url must include host",
+        ));
+    }
+
+    let (host, port) = parse_authority(authority)?;
+    Ok(HttpEndpoint {
+        host,
+        port,
+        base_path: format!("/{path}").trim_end_matches('/').to_string(),
+    })
+}
+
+fn parse_authority(authority: &str) -> Result<(String, u16), OllamaInferenceError> {
+    let (host, port) = if let Some((host, port_text)) = authority.rsplit_once(':') {
+        let port = port_text.parse::<u16>().map_err(|error| {
+            OllamaInferenceError::new(
+                OllamaInferenceErrorCode::InvalidConfig,
+                format!("ollama_base_url port is invalid: {error}"),
+            )
+        })?;
+        (host.to_string(), port)
+    } else {
+        (authority.to_string(), 11_434)
+    };
+
+    if host.is_empty() {
+        return Err(OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidConfig,
+            "ollama_base_url host is required",
+        ));
+    }
+
+    Ok((host, port))
+}
+
+fn send_http_json(
+    host: &str,
+    port: u16,
+    path: &str,
+    method: &str,
+    body: &str,
+    timeout: Duration,
+) -> Result<String, OllamaInferenceError> {
+    let address = format!("{host}:{port}");
+    let socket_address = address
+        .to_socket_addrs()?
+        .next()
+        .ok_or_else(|| provider_unavailable("Ollama endpoint did not resolve"))?;
+    let mut stream = TcpStream::connect_timeout(&socket_address, timeout)?;
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: {host}:{port}\r\nContent-Type: application/json\r\nAccept: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(request.as_bytes())?;
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    Ok(response)
+}
+
+fn parse_http_json_response(response: &str) -> Result<Value, OllamaInferenceError> {
+    let (head, body) = response.split_once("\r\n\r\n").ok_or_else(|| {
+        OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidResponse,
+            "Ollama HTTP response is missing header separator",
+        )
+    })?;
+    let status_line = head.lines().next().ok_or_else(|| {
+        OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidResponse,
+            "Ollama HTTP response is missing status line",
+        )
+    })?;
+    let status = parse_status_code(status_line)?;
+    if !(200..300).contains(&status) {
+        return Err(OllamaInferenceError::new(
+            OllamaInferenceErrorCode::ProviderFailure,
+            format!("Ollama returned HTTP {status}"),
+        ));
+    }
+
+    serde_json::from_str(body).map_err(|error| {
+        OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidResponse,
+            format!("Ollama response body is not valid JSON: {error}"),
+        )
+    })
+}
+
+fn parse_status_code(status_line: &str) -> Result<u16, OllamaInferenceError> {
+    status_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| {
+            OllamaInferenceError::new(
+                OllamaInferenceErrorCode::InvalidResponse,
+                "Ollama HTTP status line is malformed",
+            )
+        })?
+        .parse::<u16>()
+        .map_err(|error| {
+            OllamaInferenceError::new(
+                OllamaInferenceErrorCode::InvalidResponse,
+                format!("Ollama HTTP status code is invalid: {error}"),
+            )
+        })
+}
+
+fn provider_unavailable(message: impl Into<String>) -> OllamaInferenceError {
+    OllamaInferenceError::new(OllamaInferenceErrorCode::ModelProviderUnavailable, message)
+}

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -5,6 +5,7 @@ pub use workflows::*;
 pub mod data_store;
 pub mod events;
 pub mod executor;
+pub mod inference;
 pub mod placement;
 pub mod router;
 pub mod security;

--- a/crates/traverse-runtime/tests/inference_tests.rs
+++ b/crates/traverse-runtime/tests/inference_tests.rs
@@ -1,0 +1,435 @@
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+use serde_json::json;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::thread;
+use traverse_contracts::{governed_content_digest, parse_contract, reference_connector_contracts};
+use traverse_registry::{
+    ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
+    CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
+    CompositionPattern, ConnectorRegistration, ImplementationKind, RegistryProvenance,
+    RegistryScope, SourceKind, SourceReference,
+};
+use traverse_runtime::inference::{
+    OllamaInferenceErrorCode, OllamaInferenceProvider, OllamaInferenceRequest, OllamaProviderConfig,
+};
+
+#[test]
+fn ollama_provider_generates_real_response_through_local_http_endpoint() {
+    let base_url = start_ollama_server(vec![
+        json!({"models": [{"name": "llama3.2:3b"}]}).to_string(),
+        json!({"model": "llama3.2:3b", "response": "readiness looks good", "done": true})
+            .to_string(),
+    ]);
+    let provider = provider(&base_url);
+
+    let output = provider
+        .generate(&OllamaInferenceRequest {
+            model: "llama3.2:3b".to_string(),
+            prompt: "Summarize readiness.".to_string(),
+            system_prompt: Some("Be concise.".to_string()),
+            options: json!({"temperature": 0}),
+        })
+        .expect("real local server should return generation output");
+
+    assert_eq!(output.interface_id, "traverse.inference.generate");
+    assert_eq!(output.provider, "ollama");
+    assert_eq!(output.provider_implementation_id, "ollama.local.generate");
+    assert_eq!(output.model, "llama3.2:3b");
+    assert_eq!(output.response, "readiness looks good");
+    assert!(output.done);
+    assert_eq!(output.evidence.selected_provider, "ollama");
+    assert_eq!(output.evidence.selected_model, "llama3.2:3b");
+}
+
+#[test]
+fn ollama_provider_reports_model_unavailable_before_generation() {
+    let base_url = start_ollama_server(vec![
+        json!({"models": [{"name": "mistral:7b"}]}).to_string(),
+    ]);
+    let provider = provider(&base_url);
+
+    let failure = provider
+        .generate(&OllamaInferenceRequest {
+            model: "llama3.2:3b".to_string(),
+            prompt: "Summarize readiness.".to_string(),
+            system_prompt: None,
+            options: json!({}),
+        })
+        .expect_err("missing model must fail before generate call");
+
+    assert_eq!(failure.code, OllamaInferenceErrorCode::ModelUnavailable);
+    assert_eq!(failure.machine_code(), "model_candidate_unavailable");
+}
+
+#[test]
+fn ollama_provider_accepts_model_field_from_tags_and_fallback_generate_fields() {
+    let base_url = start_ollama_server(vec![
+        json!({"models": [{"model": "llama3.2:3b"}]}).to_string(),
+        json!({"response": "fallback fields work"}).to_string(),
+    ]);
+    let provider = provider(&base_url);
+
+    let output = provider
+        .generate(&OllamaInferenceRequest {
+            model: "llama3.2:3b".to_string(),
+            prompt: "Summarize readiness.".to_string(),
+            system_prompt: None,
+            options: serde_json::Value::Null,
+        })
+        .expect("model-key tags and missing optional generate fields should work");
+
+    assert_eq!(output.model, "llama3.2:3b");
+    assert_eq!(output.response, "fallback fields work");
+    assert!(!output.done);
+}
+
+#[test]
+fn ollama_provider_supports_base_path_and_default_port_config() {
+    let base_url = start_ollama_server(vec![
+        json!({"models": [{"name": "llama3.2:3b"}]}).to_string(),
+    ]);
+    let provider = provider(&format!("{base_url}/ollama"));
+
+    provider
+        .check_model_available("llama3.2:3b")
+        .expect("base path endpoint should still call tags");
+
+    let default_port_provider = provider_with_timeout("http://127.0.0.1", 100);
+    assert_eq!(
+        default_port_provider.provider_implementation_id(),
+        "ollama.local.generate"
+    );
+}
+
+#[test]
+fn ollama_provider_reports_invalid_tags_response() {
+    let base_url = start_ollama_server(vec![json!({"models": null}).to_string()]);
+    let provider = provider(&base_url);
+
+    let failure = provider
+        .check_model_available("llama3.2:3b")
+        .expect_err("missing models array must fail");
+
+    assert_eq!(failure.code, OllamaInferenceErrorCode::InvalidResponse);
+    assert_eq!(failure.machine_code(), "model_provider_invalid_response");
+}
+
+#[test]
+fn ollama_provider_reports_invalid_generate_response() {
+    let base_url = start_ollama_server(vec![
+        json!({"models": [{"name": "llama3.2:3b"}]}).to_string(),
+        json!({"model": "llama3.2:3b", "done": true}).to_string(),
+    ]);
+    let provider = provider(&base_url);
+
+    let failure = provider
+        .generate(&OllamaInferenceRequest {
+            model: "llama3.2:3b".to_string(),
+            prompt: "Summarize readiness.".to_string(),
+            system_prompt: None,
+            options: json!({}),
+        })
+        .expect_err("generate response without response text must fail");
+
+    assert_eq!(failure.code, OllamaInferenceErrorCode::InvalidResponse);
+}
+
+#[test]
+fn ollama_provider_reports_http_failure_and_malformed_json() {
+    let http_failure = provider(&start_raw_server(vec![http_response(
+        500,
+        &json!({"error": "model load failed"}).to_string(),
+    )]))
+    .check_model_available("llama3.2:3b")
+    .expect_err("non-success status must fail");
+    assert_eq!(http_failure.code, OllamaInferenceErrorCode::ProviderFailure);
+
+    let malformed_json = provider(&start_raw_server(vec![http_response(200, "{not-json}")]))
+        .check_model_available("llama3.2:3b")
+        .expect_err("malformed JSON must fail");
+    assert_eq!(
+        malformed_json.code,
+        OllamaInferenceErrorCode::InvalidResponse
+    );
+}
+
+#[test]
+fn ollama_provider_reports_malformed_http_responses() {
+    let missing_separator = provider(&start_raw_server(vec!["HTTP/1.1 200 OK".to_string()]))
+        .check_model_available("llama3.2:3b")
+        .expect_err("missing header separator must fail");
+    assert_eq!(
+        missing_separator.code,
+        OllamaInferenceErrorCode::InvalidResponse
+    );
+
+    let missing_status = provider(&start_raw_server(vec![http_response_with_status(
+        "HTTP/1.1", "{}",
+    )]))
+    .check_model_available("llama3.2:3b")
+    .expect_err("missing status code must fail");
+    assert_eq!(
+        missing_status.code,
+        OllamaInferenceErrorCode::InvalidResponse
+    );
+
+    let empty_status = provider(&start_raw_server(vec!["\r\n\r\n{}".to_string()]))
+        .check_model_available("llama3.2:3b")
+        .expect_err("empty status line must fail");
+    assert_eq!(empty_status.code, OllamaInferenceErrorCode::InvalidResponse);
+
+    let invalid_status = provider(&start_raw_server(vec![http_response_with_status(
+        "HTTP/1.1 OK",
+        "{}",
+    )]))
+    .check_model_available("llama3.2:3b")
+    .expect_err("invalid status code must fail");
+    assert_eq!(
+        invalid_status.code,
+        OllamaInferenceErrorCode::InvalidResponse
+    );
+}
+
+#[test]
+fn ollama_provider_reports_provider_unavailable() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("ephemeral port should bind");
+    let port = listener
+        .local_addr()
+        .expect("listener address should be readable")
+        .port();
+    drop(listener);
+    let provider = provider_with_timeout(&format!("http://127.0.0.1:{port}"), 100);
+
+    let failure = provider
+        .check_model_available("llama3.2:3b")
+        .expect_err("closed local port must fail as provider unavailable");
+
+    assert_eq!(
+        failure.code,
+        OllamaInferenceErrorCode::ModelProviderUnavailable
+    );
+    assert_eq!(failure.machine_code(), "model_provider_unavailable");
+}
+
+#[test]
+fn ollama_provider_rejects_invalid_config_and_prompt() {
+    let config_failure = OllamaInferenceProvider::new(OllamaProviderConfig {
+        base_url: "https://127.0.0.1:11434".to_string(),
+        request_timeout_ms: None,
+    })
+    .expect_err("https endpoint is not supported by stdlib local provider");
+    assert_eq!(config_failure.code, OllamaInferenceErrorCode::InvalidConfig);
+
+    let provider = provider("http://127.0.0.1:11434");
+    let prompt_failure = provider
+        .generate(&OllamaInferenceRequest {
+            model: "llama3.2:3b".to_string(),
+            prompt: " ".to_string(),
+            system_prompt: None,
+            options: json!({}),
+        })
+        .expect_err("blank prompt must fail before provider call");
+    assert_eq!(prompt_failure.code, OllamaInferenceErrorCode::InvalidConfig);
+
+    let generate_model_failure = provider
+        .generate(&OllamaInferenceRequest {
+            model: " ".to_string(),
+            prompt: "Summarize readiness.".to_string(),
+            system_prompt: None,
+            options: json!({}),
+        })
+        .expect_err("blank model in generate request must fail before provider call");
+    assert_eq!(
+        generate_model_failure.code,
+        OllamaInferenceErrorCode::InvalidConfig
+    );
+
+    let model_failure = provider
+        .check_model_available(" ")
+        .expect_err("blank model must fail before provider call");
+    assert_eq!(model_failure.code, OllamaInferenceErrorCode::InvalidConfig);
+
+    let options_failure = provider
+        .generate(&OllamaInferenceRequest {
+            model: "llama3.2:3b".to_string(),
+            prompt: "Summarize readiness.".to_string(),
+            system_prompt: None,
+            options: json!("invalid"),
+        })
+        .expect_err("non-object options must fail before provider call");
+    assert_eq!(
+        options_failure.code,
+        OllamaInferenceErrorCode::InvalidConfig
+    );
+}
+
+#[test]
+fn ollama_provider_rejects_invalid_endpoint_shapes() {
+    for base_url in ["http://", "http://:11434", "http://127.0.0.1:not-a-port"] {
+        let failure = OllamaInferenceProvider::new(OllamaProviderConfig {
+            base_url: base_url.to_string(),
+            request_timeout_ms: None,
+        })
+        .expect_err("invalid endpoint should fail");
+        assert_eq!(failure.code, OllamaInferenceErrorCode::InvalidConfig);
+    }
+}
+
+#[test]
+fn ollama_error_codes_are_stable() {
+    assert_eq!(
+        OllamaInferenceErrorCode::InvalidConfig.as_str(),
+        "model_candidate_config_invalid"
+    );
+    assert_eq!(
+        OllamaInferenceErrorCode::ProviderFailure.as_str(),
+        "model_provider_failure"
+    );
+}
+
+#[test]
+fn ollama_provider_reports_resolution_failure() {
+    let provider = provider_with_timeout("http://invalid host:11434", 100);
+
+    let failure = provider
+        .check_model_available("llama3.2:3b")
+        .expect_err("invalid hostname should fail during provider resolution");
+
+    assert_eq!(
+        failure.code,
+        OllamaInferenceErrorCode::ModelProviderUnavailable
+    );
+    assert!(failure.to_string().contains("model_provider_unavailable"));
+}
+
+#[test]
+fn inference_contract_validates_and_registers_with_http_connector() {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../contracts/inference/traverse.inference.generate/contract.json");
+    let contract_text =
+        fs::read_to_string(&path).expect("inference contract fixture should be readable");
+    let contract = parse_contract(&contract_text).expect("inference contract should validate");
+    assert_eq!(contract.id, "traverse.inference.generate");
+    assert_eq!(
+        contract.connector_requirements[0].connector_id,
+        "traverse.http"
+    );
+
+    let mut registry = CapabilityRegistry::new();
+    let connector = reference_connector_contracts()
+        .into_iter()
+        .find(|candidate| candidate.connector_id == "traverse.http")
+        .expect("reference http connector should exist");
+    registry
+        .register_connector(ConnectorRegistration {
+            scope: RegistryScope::Public,
+            contract: connector,
+            contract_path: "contracts/connectors/traverse.http/connector_contract.json".to_string(),
+            registered_at: "2026-06-19T00:00:00Z".to_string(),
+            governing_spec: "045-governed-model-dependency-resolution".to_string(),
+            validator_version: "test".to_string(),
+        })
+        .expect("http connector should register");
+
+    let outcome = registry
+        .register(CapabilityRegistration {
+            scope: RegistryScope::Public,
+            contract: contract.clone(),
+            contract_path: path.display().to_string(),
+            artifact: CapabilityArtifactRecord {
+                artifact_ref: "ollama.local.generate".to_string(),
+                implementation_kind: ImplementationKind::Executable,
+                source: SourceReference {
+                    kind: SourceKind::Local,
+                    location: "crates/traverse-runtime/src/inference.rs".to_string(),
+                },
+                binary: Some(BinaryReference {
+                    format: BinaryFormat::Wasm,
+                    location: "providers/ollama.local.generate.wasm".to_string(),
+                    signature: None,
+                }),
+                workflow_ref: None,
+                digests: ArtifactDigests {
+                    source_digest: governed_content_digest(&contract),
+                    binary_digest: Some(
+                        "sha256:ollama-local-generate-provider-artifact".to_string(),
+                    ),
+                },
+                provenance: RegistryProvenance {
+                    source: "greenfield".to_string(),
+                    author: "enricopiovesan".to_string(),
+                    created_at: "2026-06-19T00:00:00Z".to_string(),
+                },
+            },
+            registered_at: "2026-06-19T00:00:00Z".to_string(),
+            tags: vec!["inference".to_string(), "ollama".to_string()],
+            composability: ComposabilityMetadata {
+                kind: CompositionKind::Atomic,
+                patterns: vec![CompositionPattern::Enrichment],
+                provides: vec!["traverse.inference.generate".to_string()],
+                requires: vec!["traverse.http".to_string()],
+            },
+            governing_spec: "045-governed-model-dependency-resolution".to_string(),
+            validator_version: "test".to_string(),
+        })
+        .expect("inference capability should register when http connector exists");
+
+    assert_eq!(outcome.record.id, "traverse.inference.generate");
+}
+
+fn provider(base_url: &str) -> OllamaInferenceProvider {
+    provider_with_timeout(base_url, 1_000)
+}
+
+fn provider_with_timeout(base_url: &str, timeout_ms: u64) -> OllamaInferenceProvider {
+    OllamaInferenceProvider::new(OllamaProviderConfig {
+        base_url: base_url.to_string(),
+        request_timeout_ms: Some(timeout_ms),
+    })
+    .expect("provider config should be valid")
+}
+
+fn start_ollama_server(bodies: Vec<String>) -> String {
+    start_raw_server(
+        bodies
+            .into_iter()
+            .map(|body| http_response(200, &body))
+            .collect(),
+    )
+}
+
+fn start_raw_server(responses: Vec<String>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("test server should bind");
+    let address = listener
+        .local_addr()
+        .expect("test server address should be available");
+    thread::spawn(move || {
+        for response in responses {
+            let (mut stream, _) = listener.accept().expect("test request should arrive");
+            let mut buffer = [0_u8; 2048];
+            let _ = stream
+                .read(&mut buffer)
+                .expect("test request should be readable");
+            stream
+                .write_all(response.as_bytes())
+                .expect("test response should write");
+        }
+    });
+
+    format!("http://{address}")
+}
+
+fn http_response(status: u16, body: &str) -> String {
+    http_response_with_status(&format!("HTTP/1.1 {status} OK"), body)
+}
+
+fn http_response_with_status(status_line: &str, body: &str) -> String {
+    format!(
+        "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    )
+}

--- a/docs/model-dependency-authoring-guide.md
+++ b/docs/model-dependency-authoring-guide.md
@@ -66,6 +66,25 @@ hardcode Ollama, llama.cpp, WebLLM, cloud APIs, or provider-specific paths.
 - Fake, stub, placeholder, or documentation-only provider implementations do
   not satisfy Spec 045.
 
-Provider availability checks and execution-time resolution are implemented in
-later Spec 045 slices. This schema slice makes app manifests precise enough for
-those runtime paths to be deterministic and testable.
+## Local Ollama Provider
+
+The first concrete provider implementation is `ollama.local.generate` behind the
+`traverse.inference.generate` interface. Workspace config supplies
+`ollama_base_url`, usually `http://127.0.0.1:11434`; public readiness and trace
+evidence must report the selected provider and model without exposing prompts or
+secret config values.
+
+The provider checks `/api/tags` before generation and invokes `/api/generate`
+with `stream: false`. It reports stable machine-readable failures:
+
+- `model_candidate_config_invalid` for invalid endpoint, prompt, model, or
+  options config.
+- `model_provider_unavailable` when the local Ollama endpoint cannot be reached.
+- `model_candidate_unavailable` when the requested model is not installed.
+- `model_provider_failure` when Ollama returns a non-success HTTP status.
+- `model_provider_invalid_response` when Ollama returns malformed or incomplete
+  JSON.
+
+Full candidate resolution across multiple manifest entries is implemented in a
+later Spec 045 slice. This provider slice gives that resolver a real local
+implementation to call.


### PR DESCRIPTION
## Summary
- Adds a real local Ollama-backed provider for `traverse.inference.generate` without adding new runtime dependencies.
- Defines stable provider config, model availability, generation output, evidence, and machine-readable error codes.
- Adds a governed inference capability contract requiring the existing `traverse.http` connector.
- Documents the local Ollama provider behavior and stable failures in the model dependency authoring guide.
- Covers provider success, unavailable provider/model, invalid config, malformed provider responses, contract validation, and registry discoverability.

## Governing Spec
- `045-governed-model-dependency-resolution`
- `014-service-type-taxonomy`
- `039-connector-plugin-architecture`

## Project Item
- Closes #451
- Tracked in Project 1

## Validation
- `cargo test -p traverse-runtime --test inference_tests`
- `cargo test -p traverse-runtime`
- `/opt/homebrew/opt/rustup/bin/rustup run 1.94.0 cargo clippy -p traverse-runtime -- -D warnings`
- `bash scripts/ci/spec_context_check.sh`
- `bash scripts/ci/repository_checks.sh`
- `PATH="$HOME/.cargo/bin:$PATH" LLVM_COV=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-cov LLVM_PROFDATA=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata bash scripts/ci/coverage_gate.sh`

## Notes
- Local sandbox validation for the inference tests and coverage gate required permission to bind `127.0.0.1` for the test HTTP server.
- Multi-candidate dependency resolution remains in follow-on issue #452.
