### PR TITLE
feat: resolve governed model dependencies

### DIFF
--- a/crates/traverse-registry/src/application_manifest.rs
+++ b/crates/traverse-registry/src/application_manifest.rs
@@ -13,9 +13,9 @@ use traverse_contracts::{
 use crate::{
     ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
     CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
-    CompositionPattern, EventRegistry, ImplementationKind, LookupScope, RegistryProvenance,
-    RegistryScope, SourceKind, SourceReference, WorkflowDefinition, WorkflowRegistration,
-    WorkflowRegistry,
+    CompositionPattern, EventRegistry, ImplementationKind, LookupScope, ModelResolutionEvidence,
+    RegistryProvenance, RegistryScope, SourceKind, SourceReference, WorkflowDefinition,
+    WorkflowRegistration, WorkflowRegistry,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,6 +44,7 @@ pub struct ApplicationRegistryRecord {
     pub bundle_digest: String,
     pub registered_at: String,
     pub readiness_status: ApplicationReadinessStatus,
+    pub model_readiness: Vec<ModelResolutionEvidence>,
     pub components: Vec<ApplicationRegisteredComponent>,
     pub workflows: Vec<ApplicationRegisteredWorkflow>,
     pub inspection_link: String,
@@ -159,6 +160,29 @@ impl ApplicationRegistry {
         workflows: &mut WorkflowRegistry,
         request: &ApplicationRegistrationRequest,
     ) -> Result<ApplicationRegistrationOutcome, ApplicationRegistrationFailure> {
+        self.register_bundle_with_model_readiness(
+            capabilities,
+            events,
+            workflows,
+            request,
+            Vec::new(),
+        )
+    }
+
+    /// Registers a complete application bundle with setup-time model readiness evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApplicationRegistrationFailure`] when bundle validation or
+    /// atomic registry staging fails.
+    pub fn register_bundle_with_model_readiness(
+        &mut self,
+        capabilities: &mut CapabilityRegistry,
+        events: &EventRegistry,
+        workflows: &mut WorkflowRegistry,
+        request: &ApplicationRegistrationRequest,
+        model_readiness: Vec<ModelResolutionEvidence>,
+    ) -> Result<ApplicationRegistrationOutcome, ApplicationRegistrationFailure> {
         let manifest = load_application_bundle_manifest(&request.manifest_path)
             .map_err(map_manifest_failure)?;
         let workflow_artifacts = load_application_workflows(&request.manifest_path, &manifest)?;
@@ -209,6 +233,7 @@ impl ApplicationRegistry {
         let record = build_application_record(
             request,
             &manifest,
+            model_readiness,
             registered_components,
             registered_workflows,
         );
@@ -685,6 +710,7 @@ fn build_application_capability_registration(
 fn build_application_record(
     request: &ApplicationRegistrationRequest,
     manifest: &ApplicationBundleManifest,
+    model_readiness: Vec<ModelResolutionEvidence>,
     components: Vec<ApplicationRegisteredComponent>,
     workflows: Vec<ApplicationRegisteredWorkflow>,
 ) -> ApplicationRegistryRecord {
@@ -700,6 +726,7 @@ fn build_application_record(
         bundle_digest,
         registered_at: request.registered_at.clone(),
         readiness_status: ApplicationReadinessStatus::Ready,
+        model_readiness,
         components,
         workflows,
         inspection_link: format!("/v1/apps/{}/{}", manifest.app_id, manifest.version),

--- a/crates/traverse-registry/src/lib.rs
+++ b/crates/traverse-registry/src/lib.rs
@@ -6,6 +6,7 @@ pub mod dependency_resolver;
 mod events;
 mod federation;
 mod graph;
+mod model_resolution;
 pub mod semver_resolver;
 mod workflows;
 pub use application_manifest::*;
@@ -17,6 +18,7 @@ pub use dependency_resolver::{
 pub use events::*;
 pub use federation::*;
 pub use graph::*;
+pub use model_resolution::*;
 pub use semver_resolver::{
     AmbiguousCandidate, RangeResolutionError, ResolvedRangeCapability, resolve_version_range,
 };

--- a/crates/traverse-registry/src/model_resolution.rs
+++ b/crates/traverse-registry/src/model_resolution.rs
@@ -1,0 +1,655 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use traverse_contracts::ExecutionTarget;
+
+use crate::{ApplicationModelDependency, ModelCandidate};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelResolutionPhase {
+    Setup,
+    Execution,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ModelResolutionRequest {
+    pub phase: ModelResolutionPhase,
+    pub requested_interface_id: String,
+    pub requested_placement: ExecutionTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelCandidateAvailability {
+    pub provider_available: bool,
+    pub model_available: bool,
+    pub failure_code: Option<ModelCandidateRejectionCode>,
+    pub reason: Option<String>,
+}
+
+impl ModelCandidateAvailability {
+    #[must_use]
+    pub fn ready() -> Self {
+        Self {
+            provider_available: true,
+            model_available: true,
+            failure_code: None,
+            reason: None,
+        }
+    }
+
+    #[must_use]
+    pub fn rejected(code: ModelCandidateRejectionCode, reason: impl Into<String>) -> Self {
+        let provider_available = code != ModelCandidateRejectionCode::ModelProviderUnavailable;
+        let model_available = code != ModelCandidateRejectionCode::ModelCandidateUnavailable;
+        Self {
+            provider_available,
+            model_available,
+            failure_code: Some(code),
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+pub trait ModelAvailabilityProbe {
+    fn check_candidate(
+        &self,
+        dependency: &ApplicationModelDependency,
+        candidate: &ModelCandidate,
+    ) -> ModelCandidateAvailability;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelCandidateReadiness {
+    Ready,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelCandidateRejectionCode {
+    ModelProviderUnavailable,
+    ModelCandidateUnavailable,
+    ModelInterfaceUnsupported,
+    ModelContextWindowInsufficient,
+    ModelCandidateConfigInvalid,
+    ModelDependencyUnsatisfied,
+}
+
+impl ModelCandidateRejectionCode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ModelProviderUnavailable => "model_provider_unavailable",
+            Self::ModelCandidateUnavailable => "model_candidate_unavailable",
+            Self::ModelInterfaceUnsupported => "model_interface_unsupported",
+            Self::ModelContextWindowInsufficient => "model_context_window_insufficient",
+            Self::ModelCandidateConfigInvalid => "model_candidate_config_invalid",
+            Self::ModelDependencyUnsatisfied => "model_dependency_unsatisfied",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ModelCandidateEvaluation {
+    pub candidate_id: String,
+    pub provider_capability_id: String,
+    pub provider_implementation_id: String,
+    pub model_identifier: String,
+    pub placement_target: ExecutionTarget,
+    pub priority: u32,
+    pub readiness: ModelCandidateReadiness,
+    pub rejection_code: Option<ModelCandidateRejectionCode>,
+    pub reason: String,
+    pub manifest_order: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SelectedModelCandidate {
+    pub candidate_id: String,
+    pub provider_capability_id: String,
+    pub provider_implementation_id: String,
+    pub model_identifier: String,
+    pub placement_target: ExecutionTarget,
+    pub priority: u32,
+    pub selection_reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ModelResolutionEvidence {
+    pub phase: ModelResolutionPhase,
+    pub interface_id: String,
+    pub requested_interface_id: String,
+    pub requested_placement: ExecutionTarget,
+    pub selected: Option<SelectedModelCandidate>,
+    pub candidates: Vec<ModelCandidateEvaluation>,
+    pub failure_code: Option<ModelCandidateRejectionCode>,
+}
+
+impl ModelResolutionEvidence {
+    #[must_use]
+    pub fn is_ready(&self) -> bool {
+        self.selected.is_some()
+    }
+
+    #[must_use]
+    pub fn machine_failure_code(&self) -> Option<&'static str> {
+        self.failure_code.map(ModelCandidateRejectionCode::as_str)
+    }
+}
+
+#[must_use]
+pub fn resolve_model_dependency(
+    dependency: &ApplicationModelDependency,
+    request: &ModelResolutionRequest,
+    probe: &impl ModelAvailabilityProbe,
+) -> ModelResolutionEvidence {
+    let mut evaluations = Vec::new();
+    let mut passing = Vec::new();
+
+    for (manifest_order, candidate) in dependency.candidates.iter().enumerate() {
+        let evaluation = evaluate_candidate(dependency, request, candidate, manifest_order, probe);
+        if evaluation.readiness == ModelCandidateReadiness::Ready {
+            passing.push(evaluation.clone());
+        }
+        evaluations.push(evaluation);
+    }
+
+    passing.sort_by(|left, right| {
+        right
+            .priority
+            .cmp(&left.priority)
+            .then_with(|| left.manifest_order.cmp(&right.manifest_order))
+    });
+    let selected = passing.first().map(|candidate| SelectedModelCandidate {
+        candidate_id: candidate.candidate_id.clone(),
+        provider_capability_id: candidate.provider_capability_id.clone(),
+        provider_implementation_id: candidate.provider_implementation_id.clone(),
+        model_identifier: candidate.model_identifier.clone(),
+        placement_target: candidate.placement_target.clone(),
+        priority: candidate.priority,
+        selection_reason: if passing.len() > 1
+            && passing[0].priority == passing.get(1).map_or(0, |next| next.priority)
+        {
+            "selected by priority tie using manifest order".to_string()
+        } else {
+            "selected highest-priority passing candidate".to_string()
+        },
+    });
+
+    let failure_code = selected
+        .is_none()
+        .then_some(ModelCandidateRejectionCode::ModelDependencyUnsatisfied);
+
+    ModelResolutionEvidence {
+        phase: request.phase,
+        interface_id: dependency.interface_id.clone(),
+        requested_interface_id: request.requested_interface_id.clone(),
+        requested_placement: request.requested_placement.clone(),
+        selected,
+        candidates: evaluations,
+        failure_code,
+    }
+}
+
+fn evaluate_candidate(
+    dependency: &ApplicationModelDependency,
+    request: &ModelResolutionRequest,
+    candidate: &ModelCandidate,
+    manifest_order: usize,
+    probe: &impl ModelAvailabilityProbe,
+) -> ModelCandidateEvaluation {
+    let availability = probe.check_candidate(dependency, candidate);
+    if let Some(code) = availability.failure_code {
+        return rejected_candidate(
+            candidate,
+            manifest_order,
+            code,
+            availability
+                .reason
+                .unwrap_or_else(|| code.as_str().to_string()),
+        );
+    }
+    if !availability.provider_available {
+        return rejected_candidate(
+            candidate,
+            manifest_order,
+            ModelCandidateRejectionCode::ModelProviderUnavailable,
+            "provider unavailable",
+        );
+    }
+    if !availability.model_available {
+        return rejected_candidate(
+            candidate,
+            manifest_order,
+            ModelCandidateRejectionCode::ModelCandidateUnavailable,
+            "model unavailable",
+        );
+    }
+    if candidate.provider_capability_id != request.requested_interface_id
+        || candidate.provider_capability_id != dependency.interface_id
+        || !supports_required_capabilities(&candidate.metadata, &dependency.required_capabilities)
+    {
+        return rejected_candidate(
+            candidate,
+            manifest_order,
+            ModelCandidateRejectionCode::ModelInterfaceUnsupported,
+            "candidate does not support requested inference interface",
+        );
+    }
+    if candidate.placement_target != request.requested_placement {
+        return rejected_candidate(
+            candidate,
+            manifest_order,
+            ModelCandidateRejectionCode::ModelCandidateConfigInvalid,
+            "candidate placement does not match requested placement policy",
+        );
+    }
+    let context_window = candidate
+        .metadata
+        .get("model_context_window")
+        .and_then(Value::as_u64)
+        .unwrap_or_default();
+    if context_window < dependency.minimum_context_window {
+        return rejected_candidate(
+            candidate,
+            manifest_order,
+            ModelCandidateRejectionCode::ModelContextWindowInsufficient,
+            format!(
+                "model context window {context_window} is below required {}",
+                dependency.minimum_context_window
+            ),
+        );
+    }
+
+    ModelCandidateEvaluation {
+        candidate_id: candidate.candidate_id.clone(),
+        provider_capability_id: candidate.provider_capability_id.clone(),
+        provider_implementation_id: candidate.provider_implementation_id.clone(),
+        model_identifier: candidate.model_identifier.clone(),
+        placement_target: candidate.placement_target.clone(),
+        priority: candidate.priority,
+        readiness: ModelCandidateReadiness::Ready,
+        rejection_code: None,
+        reason: "candidate passed availability, interface, placement, and context checks"
+            .to_string(),
+        manifest_order,
+    }
+}
+
+fn rejected_candidate(
+    candidate: &ModelCandidate,
+    manifest_order: usize,
+    code: ModelCandidateRejectionCode,
+    reason: impl Into<String>,
+) -> ModelCandidateEvaluation {
+    ModelCandidateEvaluation {
+        candidate_id: candidate.candidate_id.clone(),
+        provider_capability_id: candidate.provider_capability_id.clone(),
+        provider_implementation_id: candidate.provider_implementation_id.clone(),
+        model_identifier: candidate.model_identifier.clone(),
+        placement_target: candidate.placement_target.clone(),
+        priority: candidate.priority,
+        readiness: ModelCandidateReadiness::Rejected,
+        rejection_code: Some(code),
+        reason: reason.into(),
+        manifest_order,
+    }
+}
+
+fn supports_required_capabilities(metadata: &Value, required: &[String]) -> bool {
+    if required.is_empty() {
+        return true;
+    }
+    let Some(capabilities) = metadata.get("capabilities").and_then(Value::as_array) else {
+        return false;
+    };
+    required.iter().all(|required_capability| {
+        capabilities
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|capability| capability == required_capability)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use std::collections::BTreeMap;
+    use traverse_contracts::ExecutionTarget;
+
+    use super::*;
+    use crate::ModelSelectionPolicy;
+
+    #[test]
+    fn selects_highest_priority_available_candidate() {
+        let dependency = dependency(vec![
+            candidate("lower", "llama3.2:3b", 10, 8192),
+            candidate("higher", "mistral:7b", 20, 8192),
+        ]);
+        let evidence = resolve_model_dependency(&dependency, &setup_request(), &ReadyProbe);
+
+        assert_eq!(
+            evidence
+                .selected
+                .as_ref()
+                .map(|selected| selected.candidate_id.as_str()),
+            Some("higher")
+        );
+        assert!(evidence.is_ready());
+        assert!(evidence.failure_code.is_none());
+    }
+
+    #[test]
+    fn falls_back_to_lower_priority_passing_candidate() {
+        let dependency = dependency(vec![
+            candidate("preferred", "llama3.2:3b", 20, 8192),
+            candidate("fallback", "mistral:7b", 10, 8192),
+        ]);
+        let evidence = resolve_model_dependency(
+            &dependency,
+            &setup_request(),
+            &MapProbe::new([(
+                "preferred",
+                ModelCandidateAvailability::rejected(
+                    ModelCandidateRejectionCode::ModelCandidateUnavailable,
+                    "model missing",
+                ),
+            )]),
+        );
+
+        assert_eq!(
+            evidence
+                .selected
+                .as_ref()
+                .map(|selected| selected.candidate_id.as_str()),
+            Some("fallback")
+        );
+        assert_eq!(
+            evidence.candidates[0].rejection_code,
+            Some(ModelCandidateRejectionCode::ModelCandidateUnavailable)
+        );
+    }
+
+    #[test]
+    fn reports_unsatisfied_when_no_candidate_passes() {
+        let dependency = dependency(vec![
+            candidate("missing", "llama3.2:3b", 20, 8192),
+            candidate("small", "tiny:1b", 10, 4096),
+        ]);
+        let evidence = resolve_model_dependency(
+            &dependency,
+            &setup_request(),
+            &MapProbe::new([(
+                "missing",
+                ModelCandidateAvailability::rejected(
+                    ModelCandidateRejectionCode::ModelProviderUnavailable,
+                    "provider stopped",
+                ),
+            )]),
+        );
+
+        assert!(evidence.selected.is_none());
+        assert_eq!(
+            evidence.machine_failure_code(),
+            Some("model_dependency_unsatisfied")
+        );
+        assert_eq!(
+            evidence.candidates[0].rejection_code,
+            Some(ModelCandidateRejectionCode::ModelProviderUnavailable)
+        );
+        assert_eq!(
+            evidence.candidates[1].rejection_code,
+            Some(ModelCandidateRejectionCode::ModelContextWindowInsufficient)
+        );
+    }
+
+    #[test]
+    fn revalidates_execution_and_records_selection_change() {
+        let dependency = dependency(vec![
+            candidate("setup-choice", "llama3.2:3b", 20, 8192),
+            candidate("execution-choice", "mistral:7b", 10, 8192),
+        ]);
+        let setup = resolve_model_dependency(&dependency, &setup_request(), &ReadyProbe);
+        let execution = resolve_model_dependency(
+            &dependency,
+            &ModelResolutionRequest {
+                phase: ModelResolutionPhase::Execution,
+                requested_interface_id: "traverse.inference.generate".to_string(),
+                requested_placement: ExecutionTarget::Local,
+            },
+            &MapProbe::new([(
+                "setup-choice",
+                ModelCandidateAvailability::rejected(
+                    ModelCandidateRejectionCode::ModelProviderUnavailable,
+                    "provider stopped after setup",
+                ),
+            )]),
+        );
+
+        assert_eq!(
+            setup
+                .selected
+                .as_ref()
+                .map(|selected| selected.candidate_id.as_str()),
+            Some("setup-choice")
+        );
+        assert_eq!(
+            execution
+                .selected
+                .as_ref()
+                .map(|selected| selected.candidate_id.as_str()),
+            Some("execution-choice")
+        );
+        assert_eq!(execution.phase, ModelResolutionPhase::Execution);
+    }
+
+    #[test]
+    fn rejects_unsupported_interface_and_uses_manifest_order_for_priority_tie() {
+        let mut unsupported = candidate("unsupported", "llama3.2:3b", 20, 8192);
+        unsupported.provider_capability_id = "private.generate".to_string();
+        let dependency = dependency(vec![
+            unsupported,
+            candidate("first-tie", "mistral:7b", 10, 8192),
+            candidate("second-tie", "gemma:2b", 10, 8192),
+        ]);
+        let evidence = resolve_model_dependency(&dependency, &setup_request(), &ReadyProbe);
+
+        assert_eq!(
+            evidence.candidates[0].rejection_code,
+            Some(ModelCandidateRejectionCode::ModelInterfaceUnsupported)
+        );
+        assert_eq!(
+            evidence
+                .selected
+                .as_ref()
+                .map(|selected| selected.candidate_id.as_str()),
+            Some("first-tie")
+        );
+        assert_eq!(
+            evidence
+                .selected
+                .as_ref()
+                .map(|selected| selected.selection_reason.as_str()),
+            Some("selected by priority tie using manifest order")
+        );
+    }
+
+    #[test]
+    fn covers_stable_codes_direct_availability_and_fit_guards() {
+        assert_eq!(
+            ModelCandidateRejectionCode::ModelProviderUnavailable.as_str(),
+            "model_provider_unavailable"
+        );
+        assert_eq!(
+            ModelCandidateRejectionCode::ModelCandidateUnavailable.as_str(),
+            "model_candidate_unavailable"
+        );
+        assert_eq!(
+            ModelCandidateRejectionCode::ModelInterfaceUnsupported.as_str(),
+            "model_interface_unsupported"
+        );
+        assert_eq!(
+            ModelCandidateRejectionCode::ModelContextWindowInsufficient.as_str(),
+            "model_context_window_insufficient"
+        );
+        assert_eq!(
+            ModelCandidateRejectionCode::ModelCandidateConfigInvalid.as_str(),
+            "model_candidate_config_invalid"
+        );
+        assert_eq!(
+            ModelCandidateRejectionCode::ModelDependencyUnsatisfied.as_str(),
+            "model_dependency_unsatisfied"
+        );
+
+        let availability_dependency = dependency(vec![
+            candidate("provider-bool", "llama3.2:3b", 30, 8192),
+            candidate("model-bool", "mistral:7b", 20, 8192),
+        ]);
+        let evidence = resolve_model_dependency(
+            &availability_dependency,
+            &setup_request(),
+            &MapProbe::new([
+                (
+                    "provider-bool",
+                    ModelCandidateAvailability {
+                        provider_available: false,
+                        model_available: false,
+                        failure_code: None,
+                        reason: None,
+                    },
+                ),
+                (
+                    "model-bool",
+                    ModelCandidateAvailability {
+                        provider_available: true,
+                        model_available: false,
+                        failure_code: None,
+                        reason: None,
+                    },
+                ),
+            ]),
+        );
+        assert_eq!(
+            evidence.candidates[0].rejection_code,
+            Some(ModelCandidateRejectionCode::ModelProviderUnavailable)
+        );
+        assert_eq!(
+            evidence.candidates[1].rejection_code,
+            Some(ModelCandidateRejectionCode::ModelCandidateUnavailable)
+        );
+
+        let mut cloud = candidate("cloud", "llama3.2:3b", 10, 8192);
+        cloud.placement_target = ExecutionTarget::Cloud;
+        let placement =
+            resolve_model_dependency(&dependency(vec![cloud]), &setup_request(), &ReadyProbe);
+        assert_eq!(
+            placement.candidates[0].rejection_code,
+            Some(ModelCandidateRejectionCode::ModelCandidateConfigInvalid)
+        );
+
+        let mut no_capabilities = candidate("no-capabilities", "llama3.2:3b", 10, 8192);
+        no_capabilities.metadata = json!({"model_context_window": 8192});
+        let missing_capabilities = resolve_model_dependency(
+            &dependency(vec![no_capabilities.clone()]),
+            &setup_request(),
+            &ReadyProbe,
+        );
+        assert_eq!(
+            missing_capabilities.candidates[0].rejection_code,
+            Some(ModelCandidateRejectionCode::ModelInterfaceUnsupported)
+        );
+
+        let mut no_required = dependency(vec![no_capabilities]);
+        no_required.required_capabilities = Vec::new();
+        let selected = resolve_model_dependency(&no_required, &setup_request(), &ReadyProbe);
+        assert!(selected.is_ready());
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct ReadyProbe;
+
+    impl ModelAvailabilityProbe for ReadyProbe {
+        fn check_candidate(
+            &self,
+            _dependency: &ApplicationModelDependency,
+            _candidate: &ModelCandidate,
+        ) -> ModelCandidateAvailability {
+            ModelCandidateAvailability::ready()
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct MapProbe {
+        failures: BTreeMap<String, ModelCandidateAvailability>,
+    }
+
+    impl MapProbe {
+        fn new<const N: usize>(failures: [(&str, ModelCandidateAvailability); N]) -> Self {
+            Self {
+                failures: failures
+                    .into_iter()
+                    .map(|(candidate_id, availability)| (candidate_id.to_string(), availability))
+                    .collect(),
+            }
+        }
+    }
+
+    impl ModelAvailabilityProbe for MapProbe {
+        fn check_candidate(
+            &self,
+            _dependency: &ApplicationModelDependency,
+            candidate: &ModelCandidate,
+        ) -> ModelCandidateAvailability {
+            self.failures
+                .get(&candidate.candidate_id)
+                .cloned()
+                .unwrap_or_else(ModelCandidateAvailability::ready)
+        }
+    }
+
+    fn setup_request() -> ModelResolutionRequest {
+        ModelResolutionRequest {
+            phase: ModelResolutionPhase::Setup,
+            requested_interface_id: "traverse.inference.generate".to_string(),
+            requested_placement: ExecutionTarget::Local,
+        }
+    }
+
+    fn dependency(candidates: Vec<ModelCandidate>) -> ApplicationModelDependency {
+        ApplicationModelDependency {
+            interface_id: "traverse.inference.generate".to_string(),
+            version_range: "^1.0".to_string(),
+            selection_policy: ModelSelectionPolicy {
+                strategy: "priority".to_string(),
+                allow_fallback: true,
+            },
+            required_capabilities: vec!["text_generation".to_string()],
+            minimum_context_window: 8192,
+            candidates,
+        }
+    }
+
+    fn candidate(
+        candidate_id: &str,
+        model_identifier: &str,
+        priority: u32,
+        context_window: u64,
+    ) -> ModelCandidate {
+        ModelCandidate {
+            candidate_id: candidate_id.to_string(),
+            provider_capability_id: "traverse.inference.generate".to_string(),
+            provider_implementation_id: "ollama.local.generate".to_string(),
+            model_identifier: model_identifier.to_string(),
+            placement_target: ExecutionTarget::Local,
+            priority,
+            required_provider_config_keys: vec!["ollama_base_url".to_string()],
+            metadata: json!({
+                "implementation_kind": "real_local_provider",
+                "provider": "ollama",
+                "capabilities": ["text_generation"],
+                "model_context_window": context_window
+            }),
+        }
+    }
+}

--- a/crates/traverse-registry/tests/application_manifest.rs
+++ b/crates/traverse-registry/tests/application_manifest.rs
@@ -7,11 +7,13 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use traverse_contracts::parse_event_contract;
+use traverse_contracts::{ExecutionTarget, parse_event_contract};
 use traverse_registry::{
     ApplicationManifestErrorCode, ApplicationRegistrationErrorCode, ApplicationRegistrationRequest,
     ApplicationRegistrationStatus, ApplicationRegistry, CapabilityRegistry, EventRegistration,
-    EventRegistry, LookupScope, RegistryScope, WorkflowRegistry, load_application_bundle_manifest,
+    EventRegistry, LookupScope, ModelCandidateRejectionCode, ModelResolutionEvidence,
+    ModelResolutionPhase, RegistryScope, SelectedModelCandidate, WorkflowRegistry,
+    load_application_bundle_manifest,
 };
 
 #[test]
@@ -877,6 +879,7 @@ fn registers_application_bundle_atomically_with_created_status() {
     assert_eq!(outcome.status, ApplicationRegistrationStatus::Created);
     assert_eq!(outcome.status.http_status(), 201);
     assert_eq!(outcome.record.app_id, "hello.world.app");
+    assert!(outcome.record.model_readiness.is_empty());
     assert_eq!(outcome.record.components.len(), 1);
     assert_eq!(outcome.record.workflows.len(), 1);
     assert!(
@@ -894,6 +897,39 @@ fn registers_application_bundle_atomically_with_created_status() {
             .find_exact(LookupScope::PreferPrivate, "hello.world.say-hello", "1.0.0")
             .is_some()
     );
+}
+
+#[test]
+fn application_registration_records_model_readiness_evidence() {
+    let fixture = AppFixture::new("register-model-readiness");
+    fixture.write_hello_world_bundle();
+    let mut app_registry = ApplicationRegistry::new();
+    let mut capability_registry = CapabilityRegistry::new();
+    let event_registry = EventRegistry::new();
+    let mut workflow_registry = WorkflowRegistry::new();
+
+    let outcome = app_registry
+        .register_bundle_with_model_readiness(
+            &mut capability_registry,
+            &event_registry,
+            &mut workflow_registry,
+            &fixture.registration_request(),
+            vec![model_readiness_evidence("ollama-llama-3-2")],
+        )
+        .expect("valid application bundle should register with readiness evidence");
+
+    assert_eq!(outcome.record.model_readiness.len(), 1);
+    let readiness = &outcome.record.model_readiness[0];
+    assert_eq!(readiness.phase, ModelResolutionPhase::Setup);
+    assert_eq!(
+        readiness
+            .selected
+            .as_ref()
+            .expect("selected candidate should be recorded")
+            .candidate_id,
+        "ollama-llama-3-2"
+    );
+    assert!(readiness.failure_code.is_none());
 }
 
 #[test]
@@ -1652,6 +1688,26 @@ fn model_candidate(
         "required_provider_config_keys": ["ollama_base_url"],
         "metadata": metadata
     })
+}
+
+fn model_readiness_evidence(candidate_id: &str) -> ModelResolutionEvidence {
+    ModelResolutionEvidence {
+        phase: ModelResolutionPhase::Setup,
+        interface_id: "traverse.inference.generate".to_string(),
+        requested_interface_id: "traverse.inference.generate".to_string(),
+        requested_placement: ExecutionTarget::Local,
+        selected: Some(SelectedModelCandidate {
+            candidate_id: candidate_id.to_string(),
+            provider_capability_id: "traverse.inference.generate".to_string(),
+            provider_implementation_id: "ollama.local.generate".to_string(),
+            model_identifier: "llama3.2:3b".to_string(),
+            placement_target: ExecutionTarget::Local,
+            priority: 10,
+            selection_reason: "selected highest-priority passing candidate".to_string(),
+        }),
+        candidates: Vec::new(),
+        failure_code: Option::<ModelCandidateRejectionCode>::None,
+    }
 }
 
 fn register_event_fixture(registry: &mut EventRegistry, event_dir: &str, expected_id: &str) {

--- a/crates/traverse-runtime/src/inference.rs
+++ b/crates/traverse-runtime/src/inference.rs
@@ -2,10 +2,16 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
+use std::collections::BTreeMap;
 use std::fmt;
 use std::io::{Read, Write};
 use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
+use traverse_registry::{
+    ApplicationModelDependency, ModelAvailabilityProbe, ModelCandidate, ModelCandidateAvailability,
+    ModelCandidateRejectionCode, ModelResolutionEvidence, ModelResolutionRequest,
+    resolve_model_dependency,
+};
 
 const OLLAMA_PROVIDER: &str = "ollama";
 const GENERATE_INTERFACE: &str = "traverse.inference.generate";
@@ -156,6 +162,68 @@ impl OllamaInferenceProvider {
         )?;
         parse_http_json_response(&response_text)
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OllamaModelAvailabilityProbe {
+    configs_by_implementation: BTreeMap<String, OllamaProviderConfig>,
+}
+
+impl OllamaModelAvailabilityProbe {
+    #[must_use]
+    pub fn new(config: OllamaProviderConfig) -> Self {
+        let mut configs_by_implementation = BTreeMap::new();
+        configs_by_implementation.insert("ollama.local.generate".to_string(), config);
+        Self {
+            configs_by_implementation,
+        }
+    }
+
+    #[must_use]
+    pub fn with_provider_config(
+        mut self,
+        provider_implementation_id: impl Into<String>,
+        config: OllamaProviderConfig,
+    ) -> Self {
+        self.configs_by_implementation
+            .insert(provider_implementation_id.into(), config);
+        self
+    }
+}
+
+impl ModelAvailabilityProbe for OllamaModelAvailabilityProbe {
+    fn check_candidate(
+        &self,
+        _dependency: &ApplicationModelDependency,
+        candidate: &ModelCandidate,
+    ) -> ModelCandidateAvailability {
+        let Some(config) = self
+            .configs_by_implementation
+            .get(&candidate.provider_implementation_id)
+        else {
+            return ModelCandidateAvailability::rejected(
+                ModelCandidateRejectionCode::ModelCandidateConfigInvalid,
+                "missing provider config for model candidate",
+            );
+        };
+        let provider = match OllamaInferenceProvider::new(config.clone()) {
+            Ok(provider) => provider,
+            Err(error) => return model_candidate_availability_error(&error),
+        };
+        match provider.check_model_available(&candidate.model_identifier) {
+            Ok(()) => ModelCandidateAvailability::ready(),
+            Err(error) => model_candidate_availability_error(&error),
+        }
+    }
+}
+
+#[must_use]
+pub fn resolve_ollama_model_dependency(
+    dependency: &ApplicationModelDependency,
+    request: &ModelResolutionRequest,
+    probe: &OllamaModelAvailabilityProbe,
+) -> ModelResolutionEvidence {
+    resolve_model_dependency(dependency, request, probe)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -426,4 +494,27 @@ fn parse_status_code(status_line: &str) -> Result<u16, OllamaInferenceError> {
 
 fn provider_unavailable(message: impl Into<String>) -> OllamaInferenceError {
     OllamaInferenceError::new(OllamaInferenceErrorCode::ModelProviderUnavailable, message)
+}
+
+fn model_candidate_availability_error(error: &OllamaInferenceError) -> ModelCandidateAvailability {
+    match error.code {
+        OllamaInferenceErrorCode::InvalidConfig => ModelCandidateAvailability::rejected(
+            ModelCandidateRejectionCode::ModelCandidateConfigInvalid,
+            error.message.clone(),
+        ),
+        OllamaInferenceErrorCode::ModelProviderUnavailable => ModelCandidateAvailability::rejected(
+            ModelCandidateRejectionCode::ModelProviderUnavailable,
+            error.message.clone(),
+        ),
+        OllamaInferenceErrorCode::ModelUnavailable => ModelCandidateAvailability::rejected(
+            ModelCandidateRejectionCode::ModelCandidateUnavailable,
+            error.message.clone(),
+        ),
+        OllamaInferenceErrorCode::ProviderFailure | OllamaInferenceErrorCode::InvalidResponse => {
+            ModelCandidateAvailability::rejected(
+                ModelCandidateRejectionCode::ModelProviderUnavailable,
+                error.message.clone(),
+            )
+        }
+    }
 }

--- a/crates/traverse-runtime/tests/inference_tests.rs
+++ b/crates/traverse-runtime/tests/inference_tests.rs
@@ -6,15 +6,19 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::thread;
-use traverse_contracts::{governed_content_digest, parse_contract, reference_connector_contracts};
+use traverse_contracts::{
+    ExecutionTarget, governed_content_digest, parse_contract, reference_connector_contracts,
+};
 use traverse_registry::{
-    ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
-    CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
-    CompositionPattern, ConnectorRegistration, ImplementationKind, RegistryProvenance,
-    RegistryScope, SourceKind, SourceReference,
+    ApplicationModelDependency, ArtifactDigests, BinaryFormat, BinaryReference,
+    CapabilityArtifactRecord, CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata,
+    CompositionKind, CompositionPattern, ConnectorRegistration, ImplementationKind, ModelCandidate,
+    ModelCandidateRejectionCode, ModelResolutionPhase, ModelResolutionRequest,
+    ModelSelectionPolicy, RegistryProvenance, RegistryScope, SourceKind, SourceReference,
 };
 use traverse_runtime::inference::{
-    OllamaInferenceErrorCode, OllamaInferenceProvider, OllamaInferenceRequest, OllamaProviderConfig,
+    OllamaInferenceErrorCode, OllamaInferenceProvider, OllamaInferenceRequest,
+    OllamaModelAvailabilityProbe, OllamaProviderConfig, resolve_ollama_model_dependency,
 };
 
 #[test]
@@ -381,16 +385,245 @@ fn inference_contract_validates_and_registers_with_http_connector() {
     assert_eq!(outcome.record.id, "traverse.inference.generate");
 }
 
+#[test]
+fn ollama_model_resolution_selects_available_candidate_at_setup() {
+    let tags = json!({
+        "models": [{"name": "mistral:7b"}]
+    })
+    .to_string();
+    let base_url = start_ollama_server(vec![tags.clone(), tags]);
+    let dependency = model_dependency(vec![
+        model_candidate("preferred", "llama3.2:3b", 20, 8192),
+        model_candidate("fallback", "mistral:7b", 10, 8192),
+    ]);
+
+    let evidence = resolve_ollama_model_dependency(
+        &dependency,
+        &model_request(ModelResolutionPhase::Setup),
+        &OllamaModelAvailabilityProbe::new(provider_config(&base_url, 1_000)),
+    );
+
+    assert_eq!(
+        evidence
+            .selected
+            .expect("available fallback should be selected")
+            .candidate_id,
+        "fallback"
+    );
+    assert_eq!(
+        evidence.candidates[0].rejection_code,
+        Some(ModelCandidateRejectionCode::ModelCandidateUnavailable)
+    );
+    assert!(evidence.failure_code.is_none());
+}
+
+#[test]
+fn ollama_model_resolution_revalidates_at_execution_time() {
+    let setup_tags = json!({
+        "models": [{"name": "llama3.2:3b"}, {"name": "mistral:7b"}]
+    })
+    .to_string();
+    let execution_tags = json!({
+        "models": [{"name": "mistral:7b"}]
+    })
+    .to_string();
+    let setup_base_url = start_ollama_server(vec![setup_tags.clone(), setup_tags]);
+    let execution_base_url = start_ollama_server(vec![execution_tags.clone(), execution_tags]);
+    let dependency = model_dependency(vec![
+        model_candidate("setup-choice", "llama3.2:3b", 20, 8192),
+        model_candidate("execution-choice", "mistral:7b", 10, 8192),
+    ]);
+
+    let setup = resolve_ollama_model_dependency(
+        &dependency,
+        &model_request(ModelResolutionPhase::Setup),
+        &OllamaModelAvailabilityProbe::new(provider_config(&setup_base_url, 1_000)),
+    );
+    let execution = resolve_ollama_model_dependency(
+        &dependency,
+        &model_request(ModelResolutionPhase::Execution),
+        &OllamaModelAvailabilityProbe::new(provider_config(&execution_base_url, 1_000)),
+    );
+
+    assert_eq!(
+        setup.selected.expect("setup should select").candidate_id,
+        "setup-choice"
+    );
+    assert_eq!(
+        execution
+            .selected
+            .expect("execution should select fallback")
+            .candidate_id,
+        "execution-choice"
+    );
+    assert_eq!(execution.phase, ModelResolutionPhase::Execution);
+}
+
+#[test]
+fn ollama_model_resolution_reports_unsatisfied_dependency() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("ephemeral port should bind");
+    let port = listener
+        .local_addr()
+        .expect("listener address should be readable")
+        .port();
+    drop(listener);
+    let dependency = model_dependency(vec![model_candidate(
+        "unreachable",
+        "llama3.2:3b",
+        20,
+        8192,
+    )]);
+
+    let evidence = resolve_ollama_model_dependency(
+        &dependency,
+        &model_request(ModelResolutionPhase::Execution),
+        &OllamaModelAvailabilityProbe::new(provider_config(
+            &format!("http://127.0.0.1:{port}"),
+            100,
+        )),
+    );
+
+    assert!(evidence.selected.is_none());
+    assert_eq!(
+        evidence.machine_failure_code(),
+        Some("model_dependency_unsatisfied")
+    );
+    assert_eq!(
+        evidence.candidates[0].rejection_code,
+        Some(ModelCandidateRejectionCode::ModelProviderUnavailable)
+    );
+}
+
+#[test]
+fn ollama_model_resolution_maps_provider_config_and_http_failures() {
+    let tags = json!({
+        "models": [{"name": "llama3.2:3b"}]
+    })
+    .to_string();
+    let custom_base_url = start_ollama_server(vec![tags]);
+    let mut custom_candidate = model_candidate("custom", "llama3.2:3b", 20, 8192);
+    custom_candidate.provider_implementation_id = "ollama.custom.generate".to_string();
+    let custom = resolve_ollama_model_dependency(
+        &model_dependency(vec![custom_candidate]),
+        &model_request(ModelResolutionPhase::Setup),
+        &OllamaModelAvailabilityProbe::default().with_provider_config(
+            "ollama.custom.generate",
+            provider_config(&custom_base_url, 1_000),
+        ),
+    );
+    assert_eq!(
+        custom
+            .selected
+            .expect("custom config should select")
+            .candidate_id,
+        "custom"
+    );
+
+    let mut missing_config_candidate = model_candidate("missing-config", "llama3.2:3b", 20, 8192);
+    missing_config_candidate.provider_implementation_id = "ollama.missing.generate".to_string();
+    let missing_config = resolve_ollama_model_dependency(
+        &model_dependency(vec![missing_config_candidate]),
+        &model_request(ModelResolutionPhase::Setup),
+        &OllamaModelAvailabilityProbe::new(provider_config("http://127.0.0.1:11434", 100)),
+    );
+    assert_eq!(
+        missing_config.candidates[0].rejection_code,
+        Some(ModelCandidateRejectionCode::ModelCandidateConfigInvalid)
+    );
+
+    let invalid_config = resolve_ollama_model_dependency(
+        &model_dependency(vec![model_candidate(
+            "invalid-config",
+            "llama3.2:3b",
+            20,
+            8192,
+        )]),
+        &model_request(ModelResolutionPhase::Setup),
+        &OllamaModelAvailabilityProbe::new(provider_config("https://127.0.0.1:11434", 100)),
+    );
+    assert_eq!(
+        invalid_config.candidates[0].rejection_code,
+        Some(ModelCandidateRejectionCode::ModelCandidateConfigInvalid)
+    );
+
+    let provider_failure = resolve_ollama_model_dependency(
+        &model_dependency(vec![model_candidate(
+            "provider-failure",
+            "llama3.2:3b",
+            20,
+            8192,
+        )]),
+        &model_request(ModelResolutionPhase::Setup),
+        &OllamaModelAvailabilityProbe::new(provider_config(
+            &start_raw_server(vec![http_response(500, "{}")]),
+            1_000,
+        )),
+    );
+    assert_eq!(
+        provider_failure.candidates[0].rejection_code,
+        Some(ModelCandidateRejectionCode::ModelProviderUnavailable)
+    );
+}
+
 fn provider(base_url: &str) -> OllamaInferenceProvider {
     provider_with_timeout(base_url, 1_000)
 }
 
 fn provider_with_timeout(base_url: &str, timeout_ms: u64) -> OllamaInferenceProvider {
-    OllamaInferenceProvider::new(OllamaProviderConfig {
+    OllamaInferenceProvider::new(provider_config(base_url, timeout_ms))
+        .expect("provider config should be valid")
+}
+
+fn provider_config(base_url: &str, timeout_ms: u64) -> OllamaProviderConfig {
+    OllamaProviderConfig {
         base_url: base_url.to_string(),
         request_timeout_ms: Some(timeout_ms),
-    })
-    .expect("provider config should be valid")
+    }
+}
+
+fn model_request(phase: ModelResolutionPhase) -> ModelResolutionRequest {
+    ModelResolutionRequest {
+        phase,
+        requested_interface_id: "traverse.inference.generate".to_string(),
+        requested_placement: ExecutionTarget::Local,
+    }
+}
+
+fn model_dependency(candidates: Vec<ModelCandidate>) -> ApplicationModelDependency {
+    ApplicationModelDependency {
+        interface_id: "traverse.inference.generate".to_string(),
+        version_range: "^1.0".to_string(),
+        selection_policy: ModelSelectionPolicy {
+            strategy: "priority".to_string(),
+            allow_fallback: true,
+        },
+        required_capabilities: vec!["text_generation".to_string()],
+        minimum_context_window: 8192,
+        candidates,
+    }
+}
+
+fn model_candidate(
+    candidate_id: &str,
+    model_identifier: &str,
+    priority: u32,
+    context_window: u64,
+) -> ModelCandidate {
+    ModelCandidate {
+        candidate_id: candidate_id.to_string(),
+        provider_capability_id: "traverse.inference.generate".to_string(),
+        provider_implementation_id: "ollama.local.generate".to_string(),
+        model_identifier: model_identifier.to_string(),
+        placement_target: ExecutionTarget::Local,
+        priority,
+        required_provider_config_keys: vec!["ollama_base_url".to_string()],
+        metadata: json!({
+            "implementation_kind": "real_local_provider",
+            "provider": "ollama",
+            "capabilities": ["text_generation"],
+            "model_context_window": context_window
+        }),
+    }
 }
 
 fn start_ollama_server(bodies: Vec<String>) -> String {


### PR DESCRIPTION
## Summary
- Adds a governed model dependency resolver for setup and execution phases, with deterministic availability/interface/placement/context/priority selection.
- Records setup-time model readiness evidence on application registration records through a non-breaking registration overload.
- Adapts the real local Ollama provider into the resolver so execution-time revalidation uses actual `/api/tags` availability checks.

## Governing Spec
- `045-governed-model-dependency-resolution`

## Project Item
- Closes #452
- Tracked in Project 1

## Validation
- `cargo test -p traverse-registry`
- `cargo test -p traverse-runtime`
- `cargo clippy -p traverse-registry -- -D warnings`
- `cargo clippy -p traverse-runtime -- -D warnings`
- `bash scripts/ci/spec_context_check.sh`
- `bash scripts/ci/repository_checks.sh`
- `PATH="$HOME/.cargo/bin:$PATH" LLVM_COV=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-cov LLVM_PROFDATA=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata bash scripts/ci/coverage_gate.sh`

## Notes
- Trace/MCP exposure remains the #453 slice; this PR produces and preserves the model resolution evidence needed by that work.