### PR TITLE
feat: expose model resolution evidence

### DIFF
--- a/crates/traverse-mcp/src/lib.rs
+++ b/crates/traverse-mcp/src/lib.rs
@@ -13,8 +13,8 @@ pub use stdio_server::*;
 
 use std::collections::HashMap;
 use traverse_registry::{
-    CapabilityRegistry, DiscoveryQuery, EventRegistry, LookupScope, RegistryScope,
-    ResolvedCapability, ResolvedEvent, ResolvedWorkflow, WorkflowRegistry,
+    CapabilityRegistry, DiscoveryQuery, EventRegistry, LookupScope, ModelResolutionEvidence,
+    RegistryScope, ResolvedCapability, ResolvedEvent, ResolvedWorkflow, WorkflowRegistry,
 };
 use traverse_runtime::{
     LocalExecutor, Runtime, RuntimeErrorCode, RuntimeExecutionOutcome, RuntimeRequest,
@@ -287,6 +287,7 @@ where
         Ok(McpExecutionResponse {
             result: outcome.result.clone(),
             trace: outcome.trace.clone(),
+            model_resolution: outcome.trace.model_resolution.clone(),
             observation_messages: observation_messages_from_outcome(&outcome),
         })
     }
@@ -385,6 +386,7 @@ pub enum McpArtifactDetail {
 pub struct McpExecutionResponse {
     pub result: RuntimeResult,
     pub trace: RuntimeTrace,
+    pub model_resolution: Vec<ModelResolutionEvidence>,
     pub observation_messages: Vec<McpObservationMessage>,
 }
 
@@ -420,6 +422,7 @@ pub struct McpStateMessage {
 pub struct McpTraceMessage {
     pub sequence: u64,
     pub trace: RuntimeTrace,
+    pub model_resolution: Vec<ModelResolutionEvidence>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -469,6 +472,7 @@ pub fn observation_messages_from_outcome(
     messages.push(McpObservationMessage::Trace(Box::new(McpTraceMessage {
         sequence,
         trace: outcome.trace.clone(),
+        model_resolution: outcome.trace.model_resolution.clone(),
     })));
     sequence += 1;
 
@@ -556,8 +560,11 @@ mod tests {
     use traverse_registry::{
         ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
         CapabilityRegistration, ComposabilityMetadata, CompositionKind, CompositionPattern,
-        EventRegistration, RegistryProvenance, SourceKind, SourceReference, WorkflowDefinition,
-        WorkflowNode, WorkflowNodeInput, WorkflowNodeOutput, WorkflowRegistration,
+        EventRegistration, ModelCandidateEvaluation, ModelCandidateReadiness,
+        ModelCandidateRejectionCode, ModelResolutionEvidence, ModelResolutionPhase,
+        RegistryProvenance, SelectedModelCandidate, SourceKind, SourceReference,
+        WorkflowDefinition, WorkflowNode, WorkflowNodeInput, WorkflowNodeOutput,
+        WorkflowRegistration,
     };
     use traverse_runtime::{
         LocalExecutionFailure, RuntimeContext, RuntimeIntent, RuntimeLookup, RuntimeLookupScope,
@@ -772,6 +779,32 @@ mod tests {
                 ..
             }))
         ));
+    }
+
+    #[test]
+    fn mcp_observation_report_exposes_model_resolution_evidence() {
+        let capability_registry = capability_registry_fixture();
+        let workflow_registry = workflow_registry_fixture(&capability_registry);
+        let runtime = runtime_fixture(&capability_registry, &workflow_registry);
+        let mut outcome = runtime.execute(runtime_request());
+        outcome.trace = outcome
+            .trace
+            .with_model_resolution(vec![model_resolution_evidence()]);
+
+        let messages = observation_messages_from_outcome(&outcome);
+        let trace_message = messages.iter().find_map(|message| match message {
+            McpObservationMessage::Trace(trace) => Some(trace),
+            _ => None,
+        });
+
+        assert_eq!(
+            trace_message.map(|message| message.model_resolution.as_slice()),
+            Some(outcome.trace.model_resolution.as_slice())
+        );
+        assert_eq!(
+            trace_message.map(|message| message.trace.model_resolution.as_slice()),
+            Some(outcome.trace.model_resolution.as_slice())
+        );
     }
 
     fn runtime_fixture<'a>(
@@ -1125,6 +1158,38 @@ mod tests {
                 identity: None,
             },
             governing_spec: "006-runtime-request-execution".to_string(),
+        }
+    }
+
+    fn model_resolution_evidence() -> ModelResolutionEvidence {
+        ModelResolutionEvidence {
+            phase: ModelResolutionPhase::Execution,
+            interface_id: "traverse.inference.generate".to_string(),
+            requested_interface_id: "traverse.inference.generate".to_string(),
+            requested_placement: traverse_contracts::ExecutionTarget::Local,
+            selected: Some(SelectedModelCandidate {
+                candidate_id: "ollama-llama-3-2".to_string(),
+                provider_capability_id: "traverse.inference.generate".to_string(),
+                provider_implementation_id: "ollama.local.generate".to_string(),
+                model_identifier: "llama3.2:3b".to_string(),
+                placement_target: traverse_contracts::ExecutionTarget::Local,
+                priority: 10,
+                selection_reason: "selected highest-priority passing candidate".to_string(),
+            }),
+            candidates: vec![ModelCandidateEvaluation {
+                candidate_id: "ollama-llama-3-2".to_string(),
+                provider_capability_id: "traverse.inference.generate".to_string(),
+                provider_implementation_id: "ollama.local.generate".to_string(),
+                model_identifier: "llama3.2:3b".to_string(),
+                placement_target: traverse_contracts::ExecutionTarget::Local,
+                priority: 10,
+                readiness: ModelCandidateReadiness::Ready,
+                rejection_code: Option::<ModelCandidateRejectionCode>::None,
+                reason: "candidate passed availability, interface, placement, and context checks"
+                    .to_string(),
+                manifest_order: 0,
+            }],
+            failure_code: Option::<ModelCandidateRejectionCode>::None,
         }
     }
 

--- a/crates/traverse-registry/src/model_resolution.rs
+++ b/crates/traverse-registry/src/model_resolution.rs
@@ -11,7 +11,7 @@ pub enum ModelResolutionPhase {
     Execution,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModelResolutionRequest {
     pub phase: ModelResolutionPhase,
     pub requested_interface_id: String,
@@ -90,7 +90,7 @@ impl ModelCandidateRejectionCode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModelCandidateEvaluation {
     pub candidate_id: String,
     pub provider_capability_id: String,
@@ -104,7 +104,7 @@ pub struct ModelCandidateEvaluation {
     pub manifest_order: usize,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SelectedModelCandidate {
     pub candidate_id: String,
     pub provider_capability_id: String,
@@ -115,7 +115,7 @@ pub struct SelectedModelCandidate {
     pub selection_reason: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModelResolutionEvidence {
     pub phase: ModelResolutionPhase,
     pub interface_id: String,

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -25,9 +25,9 @@ use traverse_contracts::{
 };
 use traverse_registry::{
     CapabilityRegistration, CapabilityRegistry, DiscoveryQuery, ImplementationKind, LookupScope,
-    RegistrationOutcome, RegistryFailure, RegistryScope, ResolutionError, ResolvedCapability,
-    WorkflowFailure, WorkflowRegistration, WorkflowRegistrationOutcome, WorkflowRegistry,
-    resolve_dependencies, resolve_version_range,
+    ModelResolutionEvidence, RegistrationOutcome, RegistryFailure, RegistryScope, ResolutionError,
+    ResolvedCapability, WorkflowFailure, WorkflowRegistration, WorkflowRegistrationOutcome,
+    WorkflowRegistry, resolve_dependencies, resolve_version_range,
 };
 
 const RUNTIME_REQUEST_KIND: &str = "runtime_request";
@@ -433,6 +433,8 @@ pub struct RuntimeTrace {
     pub emitted_events: Vec<traverse_contracts::EventReference>,
     #[serde(default)]
     pub workflow_evidence: Option<WorkflowTraversalEvidence>,
+    #[serde(default)]
+    pub model_resolution: Vec<ModelResolutionEvidence>,
     pub state_transitions: Vec<RuntimeTransitionRecord>,
     pub state_machine_validation: RuntimeStateMachineValidationEvidence,
     pub candidate_collection: CandidateCollectionRecord,
@@ -504,6 +506,16 @@ pub struct OTelSpanEvent {
 }
 
 impl RuntimeTrace {
+    /// Returns a trace with synchronized public model resolution evidence.
+    #[must_use]
+    pub fn with_model_resolution(mut self, evidence: Vec<ModelResolutionEvidence>) -> Self {
+        self.decision_evidence
+            .model_resolution
+            .clone_from(&evidence);
+        self.model_resolution = evidence;
+        self
+    }
+
     /// Returns the ID of the selected capability, or `None` if no capability was selected.
     #[must_use]
     pub fn selected_capability_id(&self) -> Option<&str> {
@@ -539,6 +551,8 @@ impl RuntimeTrace {
 pub struct TraceDecisionEvidence {
     pub candidate_collection: CandidateCollectionRecord,
     pub selection: SelectionRecord,
+    #[serde(default)]
+    pub model_resolution: Vec<ModelResolutionEvidence>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1445,6 +1459,7 @@ fn terminal_failure(context: FailureContext) -> RuntimeExecutionOutcome {
         decision_evidence: TraceDecisionEvidence {
             candidate_collection: context.candidate_collection.clone(),
             selection: context.selection.clone(),
+            model_resolution: Vec::new(),
         },
         state_progression: TraceStateProgression {
             state_events: context.state_events.clone(),
@@ -1459,6 +1474,7 @@ fn terminal_failure(context: FailureContext) -> RuntimeExecutionOutcome {
         },
         emitted_events: context.emitted_events,
         workflow_evidence: context.workflow_evidence,
+        model_resolution: Vec::new(),
         state_transitions: context.state_transitions,
         state_machine_validation: context.state_machine_validation,
         candidate_collection: context.candidate_collection,
@@ -2013,6 +2029,7 @@ fn successful_execution_outcome(
         decision_evidence: TraceDecisionEvidence {
             candidate_collection: candidate_collection.clone(),
             selection: selection.clone(),
+            model_resolution: Vec::new(),
         },
         state_progression: TraceStateProgression {
             state_events: finished.events.clone(),
@@ -2027,6 +2044,7 @@ fn successful_execution_outcome(
         },
         emitted_events,
         workflow_evidence,
+        model_resolution: Vec::new(),
         state_transitions: finished.transitions.clone(),
         state_machine_validation: finished.validation.clone(),
         candidate_collection,
@@ -2962,8 +2980,10 @@ mod tests {
         ArtifactDigests, ArtifactSignature, ArtifactSignatureScheme, BinaryFormat, BinaryReference,
         CapabilityArtifactRecord, CapabilityRegistration, CapabilityRegistry,
         CapabilityRegistryRecord, ComposabilityMetadata, CompositionKind, CompositionPattern,
-        DiscoveryIndexEntry, ImplementationKind, RegistryProvenance, RegistryScope,
-        ResolvedCapability, SourceKind, SourceReference,
+        DiscoveryIndexEntry, ImplementationKind, ModelCandidateReadiness,
+        ModelCandidateRejectionCode, ModelResolutionEvidence, ModelResolutionPhase,
+        RegistryProvenance, RegistryScope, ResolvedCapability, SelectedModelCandidate, SourceKind,
+        SourceReference,
     };
 
     const HEX_TABLE: &[u8; 16] = b"0123456789abcdef";
@@ -4453,6 +4473,24 @@ mod tests {
     }
 
     #[test]
+    fn runtime_trace_exposes_non_sensitive_model_resolution_evidence() {
+        let trace = successful_trace().with_model_resolution(vec![model_resolution_evidence()]);
+        let serialized = serde_json::to_string(&trace).unwrap_or_default();
+
+        assert_eq!(trace.model_resolution.len(), 1);
+        assert_eq!(
+            trace.decision_evidence.model_resolution,
+            trace.model_resolution
+        );
+        assert!(serialized.contains("model_resolution"));
+        assert!(serialized.contains("ollama.local.generate"));
+        assert!(serialized.contains("llama3.2:3b"));
+        assert!(!serialized.contains("private prompt"));
+        assert!(!serialized.contains("raw source text"));
+        assert!(!serialized.contains("sk-local-secret"));
+    }
+
+    #[test]
     fn output_returns_value_on_success() {
         let trace = successful_trace();
         assert_eq!(trace.output(), Some(&json!({"draft_id": "draft"})));
@@ -4474,5 +4512,37 @@ mod tests {
     fn is_success_false_on_error() {
         let trace = failed_trace();
         assert!(!trace.is_success());
+    }
+
+    fn model_resolution_evidence() -> ModelResolutionEvidence {
+        ModelResolutionEvidence {
+            phase: ModelResolutionPhase::Execution,
+            interface_id: "traverse.inference.generate".to_string(),
+            requested_interface_id: "traverse.inference.generate".to_string(),
+            requested_placement: ExecutionTarget::Local,
+            selected: Some(SelectedModelCandidate {
+                candidate_id: "ollama-llama-3-2".to_string(),
+                provider_capability_id: "traverse.inference.generate".to_string(),
+                provider_implementation_id: "ollama.local.generate".to_string(),
+                model_identifier: "llama3.2:3b".to_string(),
+                placement_target: ExecutionTarget::Local,
+                priority: 10,
+                selection_reason: "selected highest-priority passing candidate".to_string(),
+            }),
+            candidates: vec![traverse_registry::ModelCandidateEvaluation {
+                candidate_id: "ollama-llama-3-2".to_string(),
+                provider_capability_id: "traverse.inference.generate".to_string(),
+                provider_implementation_id: "ollama.local.generate".to_string(),
+                model_identifier: "llama3.2:3b".to_string(),
+                placement_target: ExecutionTarget::Local,
+                priority: 10,
+                readiness: ModelCandidateReadiness::Ready,
+                rejection_code: Option::<ModelCandidateRejectionCode>::None,
+                reason: "candidate passed availability, interface, placement, and context checks"
+                    .to_string(),
+                manifest_order: 0,
+            }],
+            failure_code: Option::<ModelCandidateRejectionCode>::None,
+        }
     }
 }

--- a/crates/traverse-runtime/src/trace/public.rs
+++ b/crates/traverse-runtime/src/trace/public.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use traverse_contracts::ViolationRecord;
+use traverse_registry::ModelResolutionEvidence;
 
 /// Outcome of a capability execution recorded in the public trace.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -38,6 +39,9 @@ pub struct PublicTraceEntry {
     /// Aggregate contractual enforcement violations (if any).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub violations: Vec<ViolationRecord>,
+    /// Non-sensitive governed model selection evidence, when inference was resolved.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub model_resolution: Vec<ModelResolutionEvidence>,
 }
 
 impl PublicTraceEntry {
@@ -63,6 +67,7 @@ impl PublicTraceEntry {
             outcome,
             duration_ms,
             violations: Vec::new(),
+            model_resolution: Vec::new(),
         }
     }
 }

--- a/crates/traverse-runtime/tests/trace_tests.rs
+++ b/crates/traverse-runtime/tests/trace_tests.rs
@@ -1,3 +1,8 @@
+use traverse_contracts::ExecutionTarget;
+use traverse_registry::{
+    ModelCandidateEvaluation, ModelCandidateReadiness, ModelCandidateRejectionCode,
+    ModelResolutionEvidence, ModelResolutionPhase, SelectedModelCandidate,
+};
 use traverse_runtime::trace::{
     PrivateTraceEntry, PublicTraceEntry, TraceOutcome, TraceStore, new_trace_id_and_time,
 };
@@ -106,6 +111,21 @@ fn no_raw_input_in_any_trace_field() {
 }
 
 #[test]
+fn public_trace_entry_exposes_redacted_model_resolution_evidence() {
+    let mut public = make_public("traverse.inference.generate");
+    public.model_resolution.push(model_resolution_evidence());
+
+    let serialized = serde_json::to_string(&public).unwrap_or_default();
+
+    assert!(serialized.contains("model_resolution"));
+    assert!(serialized.contains("ollama.local.generate"));
+    assert!(serialized.contains("llama3.2:3b"));
+    assert!(!serialized.contains("private prompt"));
+    assert!(!serialized.contains("raw source text"));
+    assert!(!serialized.contains("sk-local-secret"));
+}
+
+#[test]
 fn get_trace_without_private_flag_returns_public_only() -> Result<(), String> {
     let mut store = TraceStore::new();
     let pub_entry = make_public("cap.a");
@@ -174,4 +194,36 @@ fn list_traces_filtered_by_capability_id() {
 fn unknown_trace_id_returns_none() {
     let store = TraceStore::new();
     assert!(store.get("nonexistent-id").is_none());
+}
+
+fn model_resolution_evidence() -> ModelResolutionEvidence {
+    ModelResolutionEvidence {
+        phase: ModelResolutionPhase::Execution,
+        interface_id: "traverse.inference.generate".to_string(),
+        requested_interface_id: "traverse.inference.generate".to_string(),
+        requested_placement: ExecutionTarget::Local,
+        selected: Some(SelectedModelCandidate {
+            candidate_id: "ollama-llama-3-2".to_string(),
+            provider_capability_id: "traverse.inference.generate".to_string(),
+            provider_implementation_id: "ollama.local.generate".to_string(),
+            model_identifier: "llama3.2:3b".to_string(),
+            placement_target: ExecutionTarget::Local,
+            priority: 10,
+            selection_reason: "selected highest-priority passing candidate".to_string(),
+        }),
+        candidates: vec![ModelCandidateEvaluation {
+            candidate_id: "ollama-llama-3-2".to_string(),
+            provider_capability_id: "traverse.inference.generate".to_string(),
+            provider_implementation_id: "ollama.local.generate".to_string(),
+            model_identifier: "llama3.2:3b".to_string(),
+            placement_target: ExecutionTarget::Local,
+            priority: 10,
+            readiness: ModelCandidateReadiness::Ready,
+            rejection_code: Option::<ModelCandidateRejectionCode>::None,
+            reason: "candidate passed availability, interface, placement, and context checks"
+                .to_string(),
+            manifest_order: 0,
+        }],
+        failure_code: Option::<ModelCandidateRejectionCode>::None,
+    }
 }


### PR DESCRIPTION
## Summary
- Adds additive model resolution evidence to runtime traces and public trace entries.
- Mirrors model resolution evidence into MCP execution responses and trace observation messages.
- Keeps evidence non-sensitive and default-empty for backward compatibility.

## Governing Spec
- `045-governed-model-dependency-resolution`

## Project Item
- Closes #453
- Tracked in Project 1

## Validation
- `cargo fmt`
- `cargo test -p traverse-runtime`
- `cargo test -p traverse-mcp`
- `/opt/homebrew/opt/rustup/bin/rustup run 1.94.0 cargo clippy -p traverse-registry --all-targets -- -D warnings`
- `/opt/homebrew/opt/rustup/bin/rustup run 1.94.0 cargo clippy -p traverse-runtime --lib -- -D warnings`
- `/opt/homebrew/opt/rustup/bin/rustup run 1.94.0 cargo clippy -p traverse-mcp --all-targets -- -D warnings`
- `bash scripts/ci/mcp_consumption_validation.sh`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/coverage_gate.sh`

## Notes
- Runtime executions default to empty model evidence; model resolution producers attach evidence through `RuntimeTrace::with_model_resolution`.
- Full runtime all-target clippy currently hits an unrelated pre-existing test lint; runtime lib clippy and repository checks pass.