### PR TITLE
test: add downstream app MVP conformance

### DIFF
--- a/docs/downstream-app-mvp-conformance.md
+++ b/docs/downstream-app-mvp-conformance.md
@@ -1,0 +1,52 @@
+# Downstream App MVP Conformance
+
+This document defines the Traverse-side conformance path for the first downstream app MVP boundary governed by `044-application-bundle-manifest` and `045-governed-model-dependency-resolution`.
+
+The suite proves that a downstream app bundle can be validated and registered, a real WASM workflow can execute, governed model dependency readiness and resolution evidence is present, and the same public behavior is visible through HTTP/JSON and MCP surfaces.
+
+## CI-Safe Suite
+
+Run the deterministic CI-safe suite with:
+
+```bash
+bash scripts/ci/downstream_app_mvp_conformance.sh
+```
+
+That aggregate runs:
+
+```bash
+bash scripts/ci/downstream_app_bundle_registration_smoke.sh
+bash scripts/ci/downstream_wasm_workflow_smoke.sh
+bash scripts/ci/downstream_model_dependency_smoke.sh
+bash scripts/ci/downstream_http_json_smoke.sh
+bash scripts/ci/downstream_mcp_smoke.sh
+```
+
+## Evidence
+
+The CI-safe suite verifies:
+
+- the checked-in downstream application manifest references real component manifests and a real WASM binary
+- app bundle registration is atomic and records effective non-sensitive config
+- model dependency schema and readiness evidence are validated
+- execution-time model dependency resolution emits public non-secret evidence
+- a real WASM workflow executes and writes trace evidence
+- HTTP/JSON execution returns a completed trace and public trace fetch hides internal/private fields
+- MCP consumption and observation reports expose the governed model-resolution evidence
+
+## Local Provider Check
+
+The default model dependency smoke uses deterministic local HTTP provider fixtures. To require a real local Ollama provider in a developer environment, run:
+
+```bash
+TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1 bash scripts/ci/downstream_model_dependency_smoke.sh
+```
+
+Use this local-provider-required mode only when the machine has Ollama available with the expected model. CI should keep the default deterministic mode.
+
+## Expected Outcomes
+
+- All scripts exit with status `0`.
+- Public evidence includes app, workflow, component, and model selection metadata needed for audit.
+- Public evidence does not include workspace-local secrets, private prompts, private source text, or raw model credentials.
+- Failures identify the broken surface: bundle registration, WASM workflow, model dependency resolution, HTTP/JSON, or MCP.

--- a/docs/youaskm3-compatibility-conformance-suite.md
+++ b/docs/youaskm3-compatibility-conformance-suite.md
@@ -15,6 +15,7 @@ The suite covers the released downstream path end to end:
 - the live browser-hosted consumer path
 - the app-facing MCP consumption path
 - the first real `youaskm3` integration path
+- the Traverse-side downstream app MVP conformance suite
 - the browser-hosted `youaskm3` real shell validation path
 
 It does not define new runtime behavior. It verifies that the supported Traverse surfaces continue to fit together as a released consumer set.
@@ -40,6 +41,7 @@ bash scripts/ci/youaskm3_compatibility_conformance.sh
 ```
 
 That command runs the release-prep evidence first and then verifies the live browser-hosted and MCP-facing downstream paths.
+It also runs `bash scripts/ci/downstream_app_mvp_conformance.sh` to prove the shared Traverse-side app manifest, WASM workflow, HTTP/JSON, MCP, and model dependency evidence required by the first knowledge-app MVP.
 
 ## Expected Evidence
 
@@ -49,6 +51,7 @@ The suite should prove:
 - the supported browser-hosted path is runnable
 - the supported MCP-facing path is runnable
 - the first real `youaskm3` integration path can be followed without private Traverse knowledge
+- the downstream app MVP conformance path passes
 - the observed runtime outcome is completed
 
 ## Known Failure Modes

--- a/scripts/ci/downstream_app_bundle_registration_smoke.sh
+++ b/scripts/ci/downstream_app_bundle_registration_smoke.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+cargo test -p traverse-registry --test application_manifest \
+  loads_checked_in_application_manifest_with_real_wasm_component
+cargo test -p traverse-registry --test application_manifest \
+  registers_application_bundle_atomically_with_created_status
+cargo test -p traverse-registry --test application_manifest \
+  application_registration_exposes_only_non_sensitive_effective_config
+cargo test -p traverse-registry --test application_manifest \
+  application_registration_records_model_readiness_evidence
+
+echo "downstream app bundle registration smoke passed."

--- a/scripts/ci/downstream_app_mvp_conformance.sh
+++ b/scripts/ci/downstream_app_mvp_conformance.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+bash scripts/ci/downstream_app_bundle_registration_smoke.sh
+bash scripts/ci/downstream_wasm_workflow_smoke.sh
+bash scripts/ci/downstream_model_dependency_smoke.sh
+bash scripts/ci/downstream_http_json_smoke.sh
+bash scripts/ci/downstream_mcp_smoke.sh
+
+echo "downstream app MVP conformance suite passed."

--- a/scripts/ci/downstream_http_json_smoke.sh
+++ b/scripts/ci/downstream_http_json_smoke.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+cargo test -p traverse-cli execute_endpoint_returns_completed_trace_on_success
+cargo test -p traverse-cli trace_fetch_endpoint_returns_public_trace_envelope
+cargo test -p traverse-cli trace_fetch_endpoint_does_not_expose_internal_runtime_trace_fields
+
+echo "downstream HTTP/JSON smoke passed."

--- a/scripts/ci/downstream_mcp_smoke.sh
+++ b/scripts/ci/downstream_mcp_smoke.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+cargo test -p traverse-mcp validates_youaskm3_mcp_consumption_path
+cargo test -p traverse-mcp mcp_observation_report_exposes_model_resolution_evidence
+
+echo "downstream MCP smoke passed."

--- a/scripts/ci/downstream_model_dependency_smoke.sh
+++ b/scripts/ci/downstream_model_dependency_smoke.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+cargo test -p traverse-registry --test application_manifest \
+  loads_valid_governed_model_dependency_schema
+cargo test -p traverse-runtime --test inference_tests \
+  ollama_model_resolution_selects_available_candidate_at_setup
+cargo test -p traverse-runtime --test inference_tests \
+  ollama_model_resolution_revalidates_at_execution_time
+cargo test -p traverse-runtime --test inference_tests \
+  ollama_model_resolution_reports_unsatisfied_dependency
+cargo test -p traverse-runtime --test trace_tests \
+  public_trace_entry_exposes_redacted_model_resolution_evidence
+
+if [[ "${TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE:-0}" == "1" ]]; then
+  cargo test -p traverse-runtime --test inference_tests \
+    ollama_provider_generates_real_response_through_local_http_endpoint
+else
+  echo "Skipping local Ollama conformance; set TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1 to require a reachable local provider."
+fi
+
+echo "downstream model dependency smoke passed."

--- a/scripts/ci/downstream_wasm_workflow_smoke.sh
+++ b/scripts/ci/downstream_wasm_workflow_smoke.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+cargo test -p traverse-runtime --test expedition_wasm_tests \
+  expedition_wasm_execution_writes_trace
+cargo test -p traverse-runtime --test expedition_wasm_tests \
+  placement_router_routes_expedition_to_wasm_executor
+
+echo "downstream WASM workflow smoke passed."

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -38,6 +38,7 @@ required_files=(
   "docs/youaskm3-published-artifact-validation.md"
   "docs/youaskm3-compatibility-conformance-suite.md"
   "docs/youaskm3-real-shell-validation.md"
+  "docs/downstream-app-mvp-conformance.md"
   "docs/wasm-agent-authoring-guide.md"
   "docs/wasm-microservice-authoring-guide.md"
   "specs/023-downstream-publication-strategy/spec.md"
@@ -77,6 +78,12 @@ required_files=(
   "scripts/ci/react_demo_live_adapter_smoke.sh"
   "scripts/ci/mcp_stdio_server_execution_report_smoke.sh"
   "scripts/ci/youaskm3_compatibility_conformance.sh"
+  "scripts/ci/downstream_app_mvp_conformance.sh"
+  "scripts/ci/downstream_app_bundle_registration_smoke.sh"
+  "scripts/ci/downstream_wasm_workflow_smoke.sh"
+  "scripts/ci/downstream_model_dependency_smoke.sh"
+  "scripts/ci/downstream_http_json_smoke.sh"
+  "scripts/ci/downstream_mcp_smoke.sh"
   "scripts/ci/browser_consumer_package_smoke.sh"
   "scripts/ci/youaskm3_integration_validation.sh"
   "scripts/ci/youaskm3_published_artifact_validation.sh"
@@ -366,6 +373,12 @@ grep -q "Traverse Owns" docs/youaskm3-v0.3.0-integration-readiness.md
 grep -q "youaskm3 Owns" docs/youaskm3-v0.3.0-integration-readiness.md
 grep -q "First-Release Readiness Checklist" docs/youaskm3-v0.3.0-integration-readiness.md
 grep -q "bash scripts/ci/youaskm3_compatibility_conformance.sh" docs/youaskm3-v0.3.0-integration-readiness.md
+grep -q "bash scripts/ci/downstream_app_mvp_conformance.sh" docs/downstream-app-mvp-conformance.md
+grep -q "TRAVERSE_RUN_LOCAL_OLLAMA_CONFORMANCE=1" docs/downstream-app-mvp-conformance.md
+grep -q "044-application-bundle-manifest" docs/downstream-app-mvp-conformance.md
+grep -q "045-governed-model-dependency-resolution" docs/downstream-app-mvp-conformance.md
+grep -q "downstream app MVP conformance suite" scripts/ci/downstream_app_mvp_conformance.sh
+grep -q "downstream_app_mvp_conformance.sh" docs/youaskm3-compatibility-conformance-suite.md
 grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" docs/youaskm3-integration-validation.md
 grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-public-surface-compatibility.md" README.md

--- a/scripts/ci/youaskm3_compatibility_conformance.sh
+++ b/scripts/ci/youaskm3_compatibility_conformance.sh
@@ -13,5 +13,6 @@ bash "${repo_root}/scripts/ci/app_consumable_release_prep.sh"
 bash "${repo_root}/scripts/ci/react_demo_live_adapter_smoke.sh"
 bash "${repo_root}/scripts/ci/mcp_consumption_validation.sh"
 bash "${repo_root}/scripts/ci/youaskm3_integration_validation.sh"
+bash "${repo_root}/scripts/ci/downstream_app_mvp_conformance.sh"
 
 echo "youaskm3 compatibility conformance suite passed."


### PR DESCRIPTION
## Summary
- Adds a Traverse-side downstream app MVP conformance suite for Specs 044 and 045.
- Splits evidence into focused smoke scripts for app bundle registration, real WASM workflow execution, model dependency evidence, HTTP/JSON trace paths, and MCP reporting.
- Documents CI-safe checks versus local-provider-required Ollama conformance.
- Wires the suite into repository checks and the existing youaskm3 compatibility conformance wrapper.

## Governing Spec
- `004-spec-alignment-gate`
- `028-schema-alignment-gate-v02`
- `031-supply-chain-hardening`
- `040-contractual-enforcement-gate`
- `044-application-bundle-manifest`
- `045-governed-model-dependency-resolution`

## Project Item
- Closes #454
- Tracked in Project 1

## Validation
- `bash scripts/ci/downstream_app_mvp_conformance.sh`
- `bash scripts/ci/repository_checks.sh`

## Notes
- Local Codex sandbox blocks ephemeral localhost binds used by deterministic model-resolution HTTP fixtures; the downstream conformance suite was validated outside the sandbox with the approved command.