### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "semver",
  "serde",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "semver",
  "serde",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "semver",
  "serde",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/enricopiovesan/Traverse"
 rust-version = "1.94"
-version = "0.3.0"
+version = "0.4.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Spec Governed](https://img.shields.io/badge/spec-governed-blueviolet)](specs/governance/approved-specs.json)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
-[![Version](https://img.shields.io/badge/version-v0.3.0-blue)](https://github.com/enricopiovesan/Traverse/releases)
+[![Version](https://img.shields.io/badge/version-v0.4.0-blue)](https://github.com/enricopiovesan/Traverse/releases)
 
 
 
@@ -218,6 +218,7 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 
 #### Consumer and release surfaces
 
+- [docs/releases/v0.4.0.md](docs/releases/v0.4.0.md) — current release notes for the v0.4.0 manifest/model baseline
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/v0.3.0-public-surface-compatibility.md](docs/v0.3.0-public-surface-compatibility.md) — public surface compatibility for the v0.3.0 youaskm3 baseline

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -332,8 +332,7 @@ fn mint_local_dev_token(local_addr: &str) -> String {
 fn unix_timestamp() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |duration| duration.as_secs())
 }
 
 fn configured_idempotency_retention(value: Option<u64>) -> u64 {
@@ -1275,10 +1274,8 @@ fn map_workflow_failure_http(
             WorkflowErrorCode::DeterministicCycleNotAllowed => has_cycle = true,
             WorkflowErrorCode::EdgeSchemaMismatch => has_edge_schema_mismatch = true,
             WorkflowErrorCode::MissingReference => has_missing_reference = true,
-            WorkflowErrorCode::MissingRequiredField => {
-                if err.path == "$.nodes" {
-                    has_empty_nodes = true;
-                }
+            WorkflowErrorCode::MissingRequiredField if err.path == "$.nodes" => {
+                has_empty_nodes = true;
             }
             _ => {}
         }
@@ -2897,8 +2894,7 @@ fn handle_connection<E: LocalExecutor + Clone>(
 
     let peer_ip = stream
         .peer_addr()
-        .map(|a| a.ip())
-        .unwrap_or(IpAddr::from([127, 0, 0, 1]));
+        .map_or(IpAddr::from([127, 0, 0, 1]), |a| a.ip());
     let loopback = peer_ip.is_loopback();
 
     if request.method == "OPTIONS" {

--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -645,7 +645,7 @@ mod tests {
         let broker = InProcessBroker::with_clock(
             make_catalog("dev.traverse.clock", LifecycleStatus::Active),
             BrokerConfig {
-                retention_window: Duration::from_secs(60),
+                retention_window: Duration::from_mins(1),
                 max_queue_len: 16,
             },
             clock.clone(),

--- a/crates/traverse-runtime/tests/event_broker_tests.rs
+++ b/crates/traverse-runtime/tests/event_broker_tests.rs
@@ -240,7 +240,7 @@ fn cursor_expired_is_returned_when_cursor_is_outside_retention_window() -> Resul
     }
 
     // Advance beyond retention window so all buffered events are pruned.
-    clock.advance(Duration::from_secs(60));
+    clock.advance(Duration::from_mins(1));
 
     let Err(err) = broker.subscribe("dev.traverse.retained", "1") else {
         return Err("expected subscribe to fail with cursor_expired".to_string());
@@ -269,7 +269,7 @@ fn bounded_queue_drops_oldest_when_over_capacity() -> Result<(), String> {
     let broker = InProcessBroker::with_clock(
         Arc::clone(&catalog),
         BrokerConfig {
-            retention_window: Duration::from_secs(60),
+            retention_window: Duration::from_mins(1),
             max_queue_len: 2,
         },
         Arc::new(traverse_runtime::events::SystemClock),

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -536,8 +536,7 @@ fn tempfile_path() -> String {
         "/tmp/traverse-test-{}.wasm",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
+            .map_or(0, |d| d.as_nanos())
     )
 }
 

--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -68,6 +68,10 @@ The release-facing downstream compatibility statement for the current `youaskm3`
 
 - `docs/v0.3.0-public-surface-compatibility.md`
 
+The current Traverse release notes are:
+
+- `docs/releases/v0.4.0.md`
+
 ## Specs
 
 Approved specs are immutable once they govern implementation.

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,55 @@
+# Traverse v0.4.0
+
+Release date: 2026-06-22
+
+Traverse v0.4.0 is the manifest and governed model-dependency release. It keeps the v0.3.0 source-build app and MCP consumer baseline intact while adding the application bundle, WASM component manifest, model dependency, local inference provider, trace evidence, and downstream conformance work needed for the next app-facing integration step.
+
+Consumers that need only the first `youaskm3` v0.3.0 baseline can remain pinned to `v0.3.0`. Consumers that need application manifests, component manifests, governed model dependency resolution, or downstream app MVP conformance evidence should move to `v0.4.0`.
+
+## Highlights
+
+- Adds approved Specs `044-application-bundle-manifest` and `045-governed-model-dependency-resolution`.
+- Adds application and WASM component manifest validation, including real example manifests for the expedition readiness app.
+- Adds atomic application bundle registration so an app manifest and its component manifests register together or fail together.
+- Adds Traverse CLI creation flows for new app and component manifest scaffolding.
+- Adds governed model dependency contracts, schema validation, deterministic model selection, and evidence for selected and rejected model candidates.
+- Adds a real local Ollama inference provider path while keeping local-provider execution opt-in for CI safety.
+- Exposes model selection evidence through runtime traces and MCP-facing execution reports.
+- Adds downstream app MVP conformance scripts covering app bundle registration, WASM workflow execution, model dependency evidence, HTTP/JSON trace paths, and MCP reporting.
+- Adds lean Traverse ops guidance so long-running project work remains bounded and inspectable.
+
+## Compatibility Notes
+
+- Traverse remains a `0.x` project. Public surfaces are governed and validated, but compatibility can still move before a `1.0` stability commitment.
+- The v0.3.0 public compatibility documents remain the historical first `youaskm3` release baseline.
+- The v0.4.0 additions are backward-compatible in intent: they add manifest, model, trace, CLI, and conformance surfaces rather than removing the v0.3.0 HTTP/JSON or MCP paths.
+- No cross-platform binary package is attached to this release. The release publishes source, release notes, and supply-chain evidence artifacts.
+
+## Validation
+
+Release preparation must pass these local gates before tagging:
+
+```bash
+bash scripts/ci/repository_checks.sh
+bash scripts/ci/rust_checks.sh
+bash scripts/ci/coverage_gate.sh
+bash scripts/ci/supply_chain_check.sh
+```
+
+The downstream app MVP conformance path should also pass for the v0.4.0 manifest/model baseline:
+
+```bash
+bash scripts/ci/downstream_app_mvp_conformance.sh
+```
+
+The GitHub Release should attach the generated supply-chain evidence from `target/supply-chain/`:
+
+- `traverse-sbom.cdx.json`
+- `supply-chain-summary.json`
+- `artifact-verify-report.json`
+- `traverse-cli.provenance.json`
+
+## Traceability
+
+- Release issue: https://github.com/enricopiovesan/Traverse/issues/470
+- Governing specs: `001-foundation-v0-1`, `004-spec-alignment-gate`, `031-supply-chain-hardening`, `044-application-bundle-manifest`, `045-governed-model-dependency-resolution`

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -344,6 +344,12 @@ grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-source-build-consumer-packaging.md" README.md
 grep -q "docs/v0.3.0-downstream-validation-path.md" README.md
 grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" README.md
+grep -q "docs/releases/v0.4.0.md" README.md
+grep -q "Traverse v0.4.0" docs/releases/v0.4.0.md
+grep -q "044-application-bundle-manifest" docs/releases/v0.4.0.md
+grep -q "045-governed-model-dependency-resolution" docs/releases/v0.4.0.md
+grep -q "bash scripts/ci/downstream_app_mvp_conformance.sh" docs/releases/v0.4.0.md
+grep -q "traverse-sbom.cdx.json" docs/releases/v0.4.0.md
 grep -q "cargo build" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-cli -- serve" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-mcp -- stdio" docs/v0.3.0-source-build-consumer-packaging.md


### PR DESCRIPTION
## Summary
- Prepares Traverse v0.4.0 as the manifest/model release baseline.
- Bumps workspace crate versions and README badge to 0.4.0.
- Adds release notes and repository guardrails for the v0.4.0 release evidence path.
- Applies clippy-required cleanup surfaced by the release Rust gate.

## Governing Spec
- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `031-supply-chain-hardening`
- `044-application-bundle-manifest`
- `045-governed-model-dependency-resolution`

## Project Item
- Closes #470
- Tracked in Project 1

## Validation
- `cargo metadata --locked --format-version 1 --no-deps`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/downstream_app_mvp_conformance.sh`
- `bash scripts/ci/rust_checks.sh`
- `bash scripts/ci/coverage_gate.sh`
- `bash scripts/ci/supply_chain_check.sh`

## Notes
- `rust_checks.sh` was rerun outside the sandbox because local HTTP fixture tests need ephemeral port binds.
- `supply_chain_check.sh` was rerun outside the sandbox because release evidence generation needs crates.io access.
