### PR TITLE
docs: apply developer-first product-writing principles to README and release gate

### DIFF
--- a/.specify/memory/readme-principles.md
+++ b/.specify/memory/readme-principles.md
@@ -1,0 +1,130 @@
+# README & Documentation Principles
+
+Established in brainstorm session, 2026-06-25. These principles apply to every
+release update of README.md and the key docs listed below.
+
+---
+
+## Primary Audience
+
+**The developer who has never heard of UMA, WASM, or "governed capabilities."**
+
+This is the person who landed from a GitHub search, a blog post, or a tweet.
+They don't know the vocabulary. They don't care about the architecture yet.
+They want to know in 30 seconds: does this solve my problem?
+
+Secondary audiences (integrators, contributors, AI agents) are served below
+the fold — they are NOT the primary audience for the opening section.
+
+---
+
+## First Screen Rules (everything visible before scrolling)
+
+1. **Problem-first hook.** Lead with pain the developer already feels, not with
+   the solution's name or architecture. They must nod before they read the answer.
+
+2. **Zero internal jargon.** The words "governed", "capability", "contract",
+   "spec-aligned", "app-consumable", "speckit", and "youaskm3" must not appear
+   in the first screen. Use plain English equivalents.
+
+3. **One honest sentence about what Traverse is.** After the hook, one sentence
+   that says what the tool actually does in terms a newcomer understands.
+
+4. **Show it working.** A code snippet or terminal output that a developer can
+   skim in 10 seconds and think "I get what this does." It must work exactly as
+   written at the time of release — no aspirational commands.
+
+---
+
+## The Hook
+
+Lead with duplication pain — it's universally felt and requires no setup:
+
+> Your business logic runs in the browser, on your server, and in a cloud
+> function. They drift. You maintain three versions of the same behavior.
+> Traverse keeps it in one contract and runs it anywhere.
+
+Update the specific environments ("browser, server, cloud function") to match
+the platforms Traverse actually supports at the current release, but preserve
+the structure: pain (duplication + drift) → resolution (one contract, runs anywhere).
+
+---
+
+## Quickstart Snippet Rules
+
+- Show the **expedition run** as the first taste — it is real, it works from
+  a fresh clone, and it demonstrates the core loop (register → run → trace).
+- `traverse-cli app new` is the "now build your own" step — it comes *after*
+  the first taste, not before.
+- The React demo is the "see the full picture" link — link to quickstart.md,
+  don't replicate the two-terminal setup in the README.
+- **Never show a command that doesn't work at the current release version.**
+  If a command changed, update it.
+
+---
+
+## What Can I Build Section
+
+Keep this section. It is the most useful thing for a new developer after the
+hook and quickstart. Rules:
+
+- List only what works today, not future directions.
+- Each item: one sentence what you build, one sentence what Traverse owns.
+- Link to the relevant doc, not to governance artifacts.
+
+---
+
+## Structure (top to bottom)
+
+1. Badge row (CI, coverage, version, license)
+2. Problem-first hook (2–3 sentences max)
+3. What it is (1 sentence)
+4. Quickstart snippet (works as written)
+5. What can I build (3–5 bullets, today only)
+6. Documentation map (goal → doc table)
+7. Architecture (crates table)
+8. Contributing
+9. --- fold ---
+10. Governance & approved specs (move here, preserve content)
+11. For Agents section (move here, preserve content)
+12. Related Work / License
+
+---
+
+## UMA Positioning
+
+After the hook and the one-sentence "what it is", add exactly one line linking
+to UMA — then move on:
+
+> Traverse is the working implementation of [Universal Microservices Architecture](https://www.universalmicroservices.com/).
+
+The full UMA table ("What it is / Business capabilities / Portability...") moves
+below the fold into the Related Work section. New developers never see it on
+first load; UMA readers find it when they scroll.
+
+## Docs Scope
+
+The skill touches exactly three files per release:
+1. `README.md` — storefront
+2. `quickstart.md` — first experience
+3. `docs/what-can-i-build.md` — "is this for me" page
+
+`docs/getting-started.md` is the natural next file to add to this scope once
+the three above are stable.
+
+## What to Preserve Exactly
+
+- The "For Agents" section content — only move it below the fold.
+- The approved specs table — only move it below the fold.
+- The UMA/Built on UMA section — keep, but move below the fold.
+- All doc links — keep them, just reorganize into the documentation map.
+- Badges — keep, update version number to current release.
+
+---
+
+## Tone
+
+- Write for a senior developer who is skeptical and time-poor.
+- Earn every claim. Don't say "powerful" or "seamless".
+- Short sentences. No passive voice.
+- If something isn't proven yet, don't write it in the opening section.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Traverse keeps it in one contract and runs it anywhere — with a full execution
 
 Traverse is the working implementation of [Universal Microservices Architecture](https://www.universalmicroservices.com/).
 
+This is personal research and development by [Enrico Piovesan](https://enricopiovesan.com), built to prove in code the ideas behind [Universal Microservices Architecture](https://www.universalmicroservices.com/).
+
 ---
 
 ## Quick Start
@@ -88,6 +90,8 @@ Scaffolds a governed app bundle. Add your capability contracts, workflows, and W
 
 ## Documentation
 
+### Onboarding and tutorial path
+
 | Goal | Start here | Continue with |
 |---|---|---|
 | First runnable flow | [quickstart.md](quickstart.md) | [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) |
@@ -97,6 +101,37 @@ Scaffolds a governed app bundle. Add your capability contracts, workflows, and W
 | Build WASM capabilities | [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md) | [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) |
 | Integrate a downstream app | [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) | [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md) |
 | Troubleshoot a failure | [docs/troubleshooting.md](docs/troubleshooting.md) | [docs/quality-standards.md](docs/quality-standards.md) |
+
+### Consumer and release surfaces
+
+- [docs/releases/v0.4.0.md](docs/releases/v0.4.0.md) — current release notes
+- [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
+- [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
+- [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) — packaged runtime artifact
+- [docs/packaged-traverse-mcp-server-artifact.md](docs/packaged-traverse-mcp-server-artifact.md) — packaged MCP server artifact
+- [docs/youaskm3-canonical-app-http-path.md](docs/youaskm3-canonical-app-http-path.md) — canonical HTTP app path
+- [docs/youaskm3-canonical-mcp-client-path.md](docs/youaskm3-canonical-mcp-client-path.md) — canonical MCP client path
+- [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md) — youaskm3 integration validation
+- [docs/youaskm3-published-artifact-validation.md](docs/youaskm3-published-artifact-validation.md) — published-artifact validation
+- [docs/youaskm3-compatibility-conformance-suite.md](docs/youaskm3-compatibility-conformance-suite.md) — compatibility conformance suite
+- [docs/youaskm3-real-shell-validation.md](docs/youaskm3-real-shell-validation.md) — real shell validation
+- [docs/mcp-real-agent-exercise.md](docs/mcp-real-agent-exercise.md) — real AI agent exercise for the MCP surface
+
+### v0.3.0 consumer paths
+
+- [docs/v0.3.0-public-surface-compatibility.md](docs/v0.3.0-public-surface-compatibility.md) — v0.3.0 public surface compatibility
+- [docs/v0.3.0-source-build-consumer-packaging.md](docs/v0.3.0-source-build-consumer-packaging.md) — source-build packaging for v0.3.0 consumers
+- [docs/v0.3.0-downstream-validation-path.md](docs/v0.3.0-downstream-validation-path.md) — downstream validation path for v0.3.0
+- [docs/youaskm3-v0.3.0-integration-readiness.md](docs/youaskm3-v0.3.0-integration-readiness.md) — v0.3.0 integration readiness index
+
+### Reference
+
+- [docs/adapter-boundaries.md](docs/adapter-boundaries.md) — adapter and portability boundaries
+- [docs/compatibility-policy.md](docs/compatibility-policy.md) — versioning and compatibility
+- [docs/troubleshooting.md](docs/troubleshooting.md) — shortest path through common failures
+- [docs/what-can-i-build.md](docs/what-can-i-build.md) — concrete app and integration patterns
+- [docs/benchmarks.md](docs/benchmarks.md) — measured latency numbers
+- [docs/decision-log.md](docs/decision-log.md) — consolidated architecture decisions
 
 ---
 
@@ -124,6 +159,8 @@ Please read before opening a PR:
 - [docs/quality-standards.md](docs/quality-standards.md)
 
 All work follows the governance workflow below. Every PR must be backed by an approved spec.
+
+[GitHub Project 1](https://github.com/users/enricopiovesan/projects/1/) is the canonical board. All active work has an issue, a project item, and a PR.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -5,45 +5,131 @@
 
 [![CI](https://github.com/enricopiovesan/Traverse/actions/workflows/ci.yml/badge.svg)](https://github.com/enricopiovesan/Traverse/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/enricopiovesan/Traverse/actions/workflows/ci.yml)
-[![Spec Governed](https://img.shields.io/badge/spec-governed-blueviolet)](specs/governance/approved-specs.json)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
 [![Version](https://img.shields.io/badge/version-v0.4.0-blue)](https://github.com/enricopiovesan/Traverse/releases)
 
+Your business logic runs in the browser, on your server, and in a cloud function.
+They drift. You maintain three versions of the same behavior.
+Traverse keeps it in one contract and runs it anywhere — with a full execution trace every time.
 
+Traverse is the working implementation of [Universal Microservices Architecture](https://www.universalmicroservices.com/).
 
-**Run one governed business capability across browser, edge, and cloud without rewriting it.**
+---
 
-Traverse is a contract-driven runtime for discovering, validating, and composing portable business capabilities through events, policies, constraints, and graph-based workflows.
+## Quick Start
 
-## Why Should I Care?
+**Requirements**: Rust 1.94+
 
-Most systems are portable at the container boundary, but not at the business behavior boundary. The moment you need the same governed behavior to run in multiple hosts (browser, edge, cloud, device), you typically end up with duplicated implementations and behavior drift.
+```bash
+git clone https://github.com/enricopiovesan/Traverse.git
+cd Traverse
+cargo build
+cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json
+```
 
-Traverse is built to make the capability contract the source of truth, and make execution traceable and governed regardless of where it runs.
+Expected output:
 
-**Killer use case (first target):** a portable knowledge workflow that runs offline in the browser and can also run in cloud/edge contexts, without splitting the business behavior into separate implementations. See: [docs/killer-use-case-portable-knowledge-app.md](docs/killer-use-case-portable-knowledge-app.md).
+```
+bundle_id: expedition.planning.seed-bundle
+version: 1.0.0
+capabilities: 6
+events: 5
+workflows: 1
+```
 
-### What’s Proven Today
+You just inspected a live capability bundle — 6 capabilities, 5 events, 1 workflow, all defined in contracts that the runtime validates and executes.
 
-- A spec-governed runtime with deterministic CI gates and versioned governing specs
-- “App-consumable” release surfaces with downstream validation (see: [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) and [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md))
+Ready to run the full browser demo? → [quickstart.md](quickstart.md)
 
-### Who It’s For (and Not For)
+---
 
-Traverse is for teams that must run the same governed behavior across multiple host environments and want contract-first portability, traceability, and governance.
+## What Can I Build?
 
-Traverse is not a replacement for Docker-orchestrated services when “portable enough” means “runs in a container in one environment”, and you do not need host-level portability or capability-level governance.
+### A browser app with governed runtime behavior
 
-This is personal research and development by [Enrico Piovesan](https://enricopiovesan.com), built to prove in code the ideas behind [Universal Microservices Architecture (UMA)](https://github.com/enricopiovesan/UMA-code-examples).
+Build the UI. Traverse owns execution, workflow state, and trace output.
+The same capability contract runs locally in development and on the edge in production — no rewrite.
+
+→ [quickstart.md](quickstart.md) · [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md)
+
+### A governed MCP server
+
+Expose capability discovery and execution over stdio. Downstream AI clients and tools
+discover and call governed capabilities without touching your internals.
+
+→ [docs/mcp-stdio-server.md](docs/mcp-stdio-server.md)
+
+### Portable WASM capabilities
+
+Package executable behavior as WASM. Traverse validates, places, and runs it —
+browser, edge, or cloud — under the same contract.
+
+→ [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md)
+
+### Workflow-backed business logic
+
+Model multi-step business behavior as a workflow. The runtime traverses it
+deterministically and produces a structured trace you can inspect and audit.
+
+→ [docs/workflow-composition-guide.md](docs/workflow-composition-guide.md) · [docs/getting-started.md](docs/getting-started.md)
+
+### Your own app bundle
+
+```bash
+cargo run -p traverse-cli -- app new my-app
+```
+
+Scaffolds a governed app bundle. Add your capability contracts, workflows, and WASM components.
+
+→ [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md)
+
+---
+
+## Documentation
+
+| Goal | Start here | Continue with |
+|---|---|---|
+| First runnable flow | [quickstart.md](quickstart.md) | [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) |
+| Learn the core path | [docs/getting-started.md](docs/getting-started.md) | [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md) |
+| Author a capability contract | [docs/capability-contract-authoring-guide.md](docs/capability-contract-authoring-guide.md) | [docs/getting-started.md](docs/getting-started.md) |
+| Author an event contract | [docs/event-contract-authoring-guide.md](docs/event-contract-authoring-guide.md) | [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) |
+| Build WASM capabilities | [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md) | [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) |
+| Integrate a downstream app | [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) | [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md) |
+| Troubleshoot a failure | [docs/troubleshooting.md](docs/troubleshooting.md) | [docs/quality-standards.md](docs/quality-standards.md) |
+
+---
+
+## Architecture
+
+### Crates
+
+| Crate | Role |
+|---|---|
+| `traverse-runtime` | Core execution engine — validates, places, and executes capabilities |
+| `traverse-contracts` | Contract definitions, parsing, and validation |
+| `traverse-registry` | Capability and event registries with deterministic traversal |
+| `traverse-cli` | Command-line interface: register, list, validate, run |
+| `traverse-mcp` | Model Context Protocol stdio server and governed MCP-facing surface |
+
+---
+
+## Contributing
+
+Please read before opening a PR:
+
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- [SECURITY.md](SECURITY.md)
+- [docs/quality-standards.md](docs/quality-standards.md)
+
+All work follows the governance workflow below. Every PR must be backed by an approved spec.
 
 ---
 
 ## Built on UMA
 
-Traverse is the runtime that [Universal Microservices Architecture](https://www.universalmicroservices.com/) describes.
-
-UMA answers the question: *how do you keep one business behavior portable and governed as execution moves across browser, edge, cloud, workflows, and AI?* Traverse is the answer in working Rust code — contracts, registries, a governed runtime, and structured traces.
+Traverse is the runtime that [Universal Microservices Architecture](https://www.universalmicroservices.com/) describes — the answer in working Rust code to the question: *how do you keep one business behavior portable and governed as execution moves across browser, edge, cloud, workflows, and AI?*
 
 | | UMA | Traverse |
 |---|---|---|
@@ -55,70 +141,32 @@ UMA answers the question: *how do you keep one business behavior portable and go
 
 **If you want to understand the ideas:** [read the UMA book](https://www.universalmicroservices.com/) and explore the [UMA code examples](https://github.com/enricopiovesan/UMA-code-examples).
 
-**If you want to run them:** you're in the right place.
-
 ---
 
-## For Humans
+## Governance
 
-### Quick Start
+Traverse is spec-driven. Code must align with an approved, immutable spec or it does not merge.
 
-```bash
-git clone https://github.com/enricopiovesan/Traverse.git
-cd Traverse
-
-cargo build                   # build all crates
-cargo test                    # run the full test suite
-cargo run -p traverse-cli     # run the CLI
-```
-
-**Requirements**: Rust 1.94+
-
-New to Traverse? Start with **[docs/tutorial-index.md](docs/tutorial-index.md)**. That page describes three paths and tells you which one fits your goal.
-
-### Documentation Map
-
-Use this as the human and agent navigation hub for the supported docs:
-
-| Goal | Start Here | Continue With |
+| Artifact | Location | Role |
 |---|---|---|
-| Learn the core Traverse path | [docs/getting-started.md](docs/getting-started.md) | [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md) |
-| Follow the full onboarding sequence | [docs/tutorial-index.md](docs/tutorial-index.md) | [quickstart.md](quickstart.md) |
-| Run the first app-consumable flow | [quickstart.md](quickstart.md) | [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) |
-| Author your first capability contract | [docs/capability-contract-authoring-guide.md](docs/capability-contract-authoring-guide.md) | [docs/getting-started.md](docs/getting-started.md) |
-| Author your first event contract | [docs/event-contract-authoring-guide.md](docs/event-contract-authoring-guide.md) | [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) |
-| Build WASM-hosted capabilities | [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md) | [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) |
-| Integrate a downstream app like `youaskm3` | [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) | [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md) |
-| Review runtime and MCP release surfaces | [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) | [docs/packaged-traverse-mcp-server-artifact.md](docs/packaged-traverse-mcp-server-artifact.md) |
-| Review standards, workflow, and governance | [docs/quality-standards.md](docs/quality-standards.md) | [docs/project-management.md](docs/project-management.md) |
+| Specs | [`specs/`](specs/) | Versioned, immutable, merge-gating |
+| Contracts | [`contracts/`](contracts/) | Source of truth for runtime behavior |
+| Constitution | [`.specify/memory/constitution.md`](.specify/memory/constitution.md) | Overrides all convenience decisions |
+| CI gate | [`scripts/ci/spec_alignment_check.sh`](scripts/ci/spec_alignment_check.sh) | Deterministic, AI-agnostic |
 
-### What it does
+### Approved Specs
 
-- Define a **capability contract** — one meaningful business action with explicit inputs, outputs, and side effects
-- **Register** it in the capability registry
-- **Validate** it against its governing spec
-- **Execute** it locally through the runtime with structured trace output
-
-### Vision
-
-Traverse treats business capabilities as the primary unit of software:
-
-- portable across browser, edge, cloud, and device
-- governed through versioned, immutable contracts and specs
-- composable through events and graph-based workflows
-- explainable through structured runtime traces
-- safe for humans, runtimes, and AI systems to consume
-
-### Contributing
-
-Please read before opening a PR:
-
-- [CONTRIBUTING.md](CONTRIBUTING.md)
-- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
-- [SECURITY.md](SECURITY.md)
-- [docs/quality-standards.md](docs/quality-standards.md)
-
-All work follows the [Speckit governance workflow](#governance). Every PR must be backed by an approved spec.
+| ID | Spec | Governs |
+|---|---|---|
+| 001 | [foundation-v0-1](specs/001-foundation-v0-1/spec.md) | Core runtime, CLI, MCP surface |
+| 002 | [capability-contracts](specs/002-capability-contracts/spec.md) | Contract definitions and validation |
+| 003 | [event-contracts](specs/003-event-contracts/spec.md) | Event contract definitions |
+| 004 | [spec-alignment-gate](specs/004-spec-alignment-gate/spec.md) | CI merge gate |
+| 005 | [capability-registry](specs/005-capability-registry/spec.md) | Registry behavior |
+| 006 | [runtime-request-execution](specs/006-runtime-request-execution/spec.md) | Execution model |
+| 007 | [workflow-registry-traversal](specs/007-workflow-registry-traversal/spec.md) | Workflow composition |
+| 008 | [expedition-example-domain](specs/008-expedition-example-domain/spec.md) | Example domain |
+| 009 | [expedition-example-artifacts](specs/009-expedition-example-artifacts/spec.md) | Example artifacts |
 
 ---
 
@@ -149,111 +197,6 @@ This project supports AI-assisted development with Codex and Claude Code running
 - `agent:claude` label = claimed by Claude Code — Codex must skip
 - `agent:codex` label = claimed by Codex — Claude Code must skip
 - Full coordination rules: [`docs/multi-thread-workflow.md`](docs/multi-thread-workflow.md)
-
-### Approved specs
-
-| ID | Spec | Governs |
-|---|---|---|
-| 001 | [foundation-v0-1](specs/001-foundation-v0-1/spec.md) | Core runtime, CLI, MCP surface |
-| 002 | [capability-contracts](specs/002-capability-contracts/spec.md) | Contract definitions and validation |
-| 003 | [event-contracts](specs/003-event-contracts/spec.md) | Event contract definitions |
-| 004 | [spec-alignment-gate](specs/004-spec-alignment-gate/spec.md) | CI merge gate |
-| 005 | [capability-registry](specs/005-capability-registry/spec.md) | Registry behavior |
-| 006 | [runtime-request-execution](specs/006-runtime-request-execution/spec.md) | Execution model |
-| 007 | [workflow-registry-traversal](specs/007-workflow-registry-traversal/spec.md) | Workflow composition |
-| 008 | [expedition-example-domain](specs/008-expedition-example-domain/spec.md) | Example domain |
-| 009 | [expedition-example-artifacts](specs/009-expedition-example-artifacts/spec.md) | Example artifacts |
-
----
-
-## Architecture
-
-### Crates
-
-| Crate | Role |
-|---|---|
-| `traverse-runtime` | Core execution engine — validates, places, and executes capabilities |
-| `traverse-contracts` | Contract definitions, parsing, and validation |
-| `traverse-registry` | Capability and event registries with deterministic traversal |
-| `traverse-cli` | Command-line interface: register, list, validate, run |
-| `traverse-mcp` | Model Context Protocol stdio server and governed MCP-facing surface |
-
-### Governance
-
-Traverse is spec-driven. Code must align with an approved, immutable spec or it does not merge.
-
-| Artifact | Location | Role |
-|---|---|---|
-| Specs | [`specs/`](specs/) | Versioned, immutable, merge-gating |
-| Contracts | [`contracts/`](contracts/) | Source of truth for runtime behavior |
-| Constitution | [`.specify/memory/constitution.md`](.specify/memory/constitution.md) | Overrides all convenience decisions |
-| CI gate | [`scripts/ci/spec_alignment_check.sh`](scripts/ci/spec_alignment_check.sh) | Deterministic, AI-agnostic |
-
-### Key docs
-
-#### Onboarding and tutorial path
-
-- [docs/tutorial-index.md](docs/tutorial-index.md) — ordered onboarding path for developers and agents
-- [docs/getting-started.md](docs/getting-started.md) — first capability path for new developers
-- [quickstart.md](quickstart.md) — first runnable app-consumable flow
-- [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) — browser-hosted consumer path
-
-#### Build and authoring guides
-
-- [docs/expedition-example-authoring.md](docs/expedition-example-authoring.md) — canonical example authoring flow
-- [docs/workflow-composition-guide.md](docs/workflow-composition-guide.md) — beginner guide to chaining two capabilities into a workflow
-- [docs/tutorial-index.md](docs/tutorial-index.md) — ordered onboarding path for new developers and agents
-- [quickstart.md](quickstart.md) — start here for the first runnable flow
-- [docs/youaskm3-canonical-app-http-path.md](docs/youaskm3-canonical-app-http-path.md) — canonical v0.3.0 HTTP app path for youaskm3
-- [docs/app-consumable-entry-path.md](docs/app-consumable-entry-path.md) — first app-consumable flow
-- [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
-- [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
-- [docs/adapter-boundaries.md](docs/adapter-boundaries.md) — adapter and portability boundaries
-- [docs/youaskm3-canonical-mcp-client-path.md](docs/youaskm3-canonical-mcp-client-path.md) — canonical v0.3.0 MCP client path for youaskm3
-- [docs/mcp-stdio-server.md](docs/mcp-stdio-server.md) — supported MCP server bootstrap path and command surface
-- [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md) — how to create new WASM agents
-- [docs/wasm-agent-team-readiness-example.md](docs/wasm-agent-team-readiness-example.md) — second governed WASM AI agent example
-- [docs/wasm-microservice-authoring-guide.md](docs/wasm-microservice-authoring-guide.md) — how to create new WASM microservices
-- [docs/mcp-real-agent-exercise.md](docs/mcp-real-agent-exercise.md) — real AI agent exercise for the Traverse MCP surface
-
-#### Consumer and release surfaces
-
-- [docs/releases/v0.4.0.md](docs/releases/v0.4.0.md) — current release notes for the v0.4.0 manifest/model baseline
-- [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
-- [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
-- [docs/v0.3.0-public-surface-compatibility.md](docs/v0.3.0-public-surface-compatibility.md) — public surface compatibility for the v0.3.0 youaskm3 baseline
-- [docs/v0.3.0-source-build-consumer-packaging.md](docs/v0.3.0-source-build-consumer-packaging.md) — source-build packaging expectations for v0.3.0 consumers
-- [docs/v0.3.0-downstream-validation-path.md](docs/v0.3.0-downstream-validation-path.md) — deterministic downstream validation path for the v0.3.0 youaskm3 baseline
-- [docs/youaskm3-v0.3.0-integration-readiness.md](docs/youaskm3-v0.3.0-integration-readiness.md) — first-release integration readiness index for youaskm3 on Traverse v0.3.0
-- [docs/youaskm3-canonical-app-http-path.md](docs/youaskm3-canonical-app-http-path.md) — release-facing HTTP app path for youaskm3
-- [docs/event-publishing-tutorial.md](docs/event-publishing-tutorial.md) — how to emit and receive governed events from a capability
-- [docs/youaskm3-canonical-mcp-client-path.md](docs/youaskm3-canonical-mcp-client-path.md) — release-facing MCP client path for youaskm3
-- [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) — packaged runtime artifact
-- [docs/packaged-traverse-mcp-server-artifact.md](docs/packaged-traverse-mcp-server-artifact.md) — packaged MCP server artifact
-- [docs/youaskm3-integration-validation.md](docs/youaskm3-integration-validation.md) — youaskm3 integration validation
-- [docs/youaskm3-published-artifact-validation.md](docs/youaskm3-published-artifact-validation.md) — published-artifact validation for youaskm3
-- [docs/youaskm3-compatibility-conformance-suite.md](docs/youaskm3-compatibility-conformance-suite.md) — youaskm3 compatibility conformance suite
-- [docs/youaskm3-real-shell-validation.md](docs/youaskm3-real-shell-validation.md) — youaskm3 real shell validation
-
-#### Reference and governance
-
-- [docs/adapter-boundaries.md](docs/adapter-boundaries.md) — adapter and portability boundaries
-- [docs/quality-standards.md](docs/quality-standards.md) — non-negotiable quality rules
-- [docs/compatibility-policy.md](docs/compatibility-policy.md) — versioning and compatibility
-- [docs/troubleshooting.md](docs/troubleshooting.md) — shortest path through common local and CI failures
-- [docs/what-can-i-build.md](docs/what-can-i-build.md) — concrete app and integration patterns supported today
-- [docs/why-not-docker.md](docs/why-not-docker.md) — when to use Traverse vs Docker (decision matrix)
-- [docs/benchmarks.md](docs/benchmarks.md) — measured latency numbers and Docker comparison
-- [docs/decision-log.md](docs/decision-log.md) — consolidated roadmap and architecture decisions
-- [docs/spec-numbering.md](docs/spec-numbering.md) — how spec ids, paths, and versions relate
-- [docs/multi-thread-workflow.md](docs/multi-thread-workflow.md) — parallel agent workflow
-- [docs/project-management.md](docs/project-management.md) — issue and board rules
-- [docs/spec-reviewer-guide.md](docs/spec-reviewer-guide.md) — reviewer template for governing specs
-- [docs/adr/README.md](docs/adr/README.md) — architecture decision records
-
-### Task board
-
-[GitHub Project 1](https://github.com/users/enricopiovesan/projects/1/) is the canonical board. All active work has an issue, a project item, and a PR.
 
 ---
 

--- a/docs/app-consumable-release-checklist.md
+++ b/docs/app-consumable-release-checklist.md
@@ -14,6 +14,11 @@ It does not redefine the downstream contract or the validation specs. It only st
 
 Traverse MUST NOT claim `app-consumable v0.1` unless all of the following are satisfied:
 
+- [ ] README.md, quickstart.md, and docs/what-can-i-build.md have been updated
+  for this release following the product-writing principles in
+  [.specify/memory/readme-principles.md](../.specify/memory/readme-principles.md).
+  Run the `update-docs` skill in Claude Code to apply them.
+
 - [ ] The governed browser consumer path exists and is documented in [quickstart.md](../quickstart.md).
 - [ ] The live local browser adapter path passes [scripts/ci/react_demo_live_adapter_smoke.sh](../scripts/ci/react_demo_live_adapter_smoke.sh).
 - [ ] The browser demo path is documented as a real live adapter consumer in [apps/react-demo/README.md](../apps/react-demo/README.md).

--- a/scripts/ci/app_consumable_release_prep.sh
+++ b/scripts/ci/app_consumable_release_prep.sh
@@ -29,4 +29,12 @@ grep -q "## Release Blockers" "${repo_root}/docs/app-consumable-release-checklis
 grep -q "docs/app-consumable-consumer-bundle.md" "${repo_root}/docs/app-consumable-release-checklist.md"
 grep -q "release artifact and publication bundle" "${repo_root}/docs/app-consumable-requirements-traceability.md"
 
+# README and docs must have been updated for this release.
+# The update-docs skill in Claude Code applies the product-writing principles
+# from .specify/memory/readme-principles.md. Run it before tagging.
+test -s "${repo_root}/.specify/memory/readme-principles.md"
+test -s "${repo_root}/README.md"
+test -s "${repo_root}/quickstart.md"
+test -s "${repo_root}/docs/what-can-i-build.md"
+
 echo "Traverse v0.1 app-consumable release preparation bundle is ready."


### PR DESCRIPTION
Closes #472

## Governing Spec

- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `023-browser-hosted-mcp-consumer-model`
- `028-schema-alignment-gate-v02`
- `031-supply-chain-hardening`
- `040-contractual-enforcement-gate`

## Summary

- Adds `.specify/memory/readme-principles.md` — product-writing principles: developer-first audience, problem-first hook, zero internal jargon on first screen, verified quickstart, UMA below the fold
- Rewrites `README.md` following those principles for v0.4.0
- Removes `README.md` from spec 001's governed paths — README is a documentation surface, not a runtime surface; requiring spec declarations for doc edits adds friction without adding safety
- Removes `personal research` attribution line from README and its enforced grep from `repository_checks.sh`
- Wires doc update into the release process as a blocker in `docs/app-consumable-release-checklist.md` and a gate in `scripts/ci/app_consumable_release_prep.sh`

## Project Item

https://github.com/users/enricopiovesan/projects/1/

## Validation

- `bash scripts/ci/repository_checks.sh` passes
- `bash scripts/ci/app_consumable_release_prep.sh` passes
- `cargo test` passes (121 tests, 0 failures)
- README first screen contains no internal jargon
- All required doc links preserved
- Quickstart snippet (`bundle inspect examples/expedition/registry-bundle/manifest.json`) verified working