### PR TITLE
Update README to remove personal author mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Traverse keeps it in one contract and runs it anywhere — with a full execution
 
 Traverse is the working implementation of [Universal Microservices Architecture](https://www.universalmicroservices.com/).
 
-This is personal research and development by [Enrico Piovesan](https://enricopiovesan.com), built to prove in code the ideas behind [Universal Microservices Architecture](https://www.universalmicroservices.com/).
-
 ---
 
 ## Quick Start

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -159,7 +159,6 @@ fi
 
 grep -q "GitHub Project 1" README.md
 grep -q "Apache-2.0" README.md
-grep -q "personal research" README.md
 grep -q "docs/adapter-boundaries.md" README.md
 grep -q "docs/troubleshooting.md" README.md
 grep -q "docs/getting-started.md" README.md


### PR DESCRIPTION
Removed personal attribution from the README and updated the repository check that enforced the removed wording.

## Summary

- Removes the personal author attribution sentence from `README.md`.
- Removes the obsolete `personal research` README assertion from `scripts/ci/repository_checks.sh`.

## Governing Spec

- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `028-schema-alignment-gate-v02`
- `031-supply-chain-hardening`
- `040-contractual-enforcement-gate`

## Project Item

- No dedicated project item; small README hygiene fix on an approved-spec-governed file.

## What Changed

- Contracts changed: no
- Runtime behavior changed: no
- Compatibility impact: none
- ADR needed or linked: no

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing
- [x] Core coverage preserved
- [x] Required validation gates passing

## Notes

This is documentation and repository-gate maintenance only.
