### PR TITLE
Spec 046: add downstream app registration conformance

### DIFF
--- a/crates/traverse-registry/tests/application_manifest.rs
+++ b/crates/traverse-registry/tests/application_manifest.rs
@@ -26,7 +26,7 @@ fn loads_checked_in_application_manifest_with_real_wasm_component() {
 
     assert_eq!(bundle.app_id, "expedition.readiness");
     assert_eq!(bundle.version, "1.0.0");
-    assert_eq!(bundle.components.len(), 1);
+    assert_eq!(bundle.components.len(), 5);
     assert_eq!(
         bundle.components[0].manifest.component_id,
         "expedition.readiness.validate-team-readiness-component"

--- a/crates/traverse-runtime/examples/load_workspace_app_state.rs
+++ b/crates/traverse-runtime/examples/load_workspace_app_state.rs
@@ -1,0 +1,95 @@
+use serde_json::{Value, json};
+use std::env;
+use std::path::Path;
+use traverse_registry::{
+    DiscoveryQuery, LookupScope, ResolvedCapability, WorkspaceAppStateErrorCode,
+};
+use traverse_runtime::{LocalExecutionFailure, LocalExecutor, Runtime};
+
+#[derive(Debug)]
+struct ConformanceExecutor;
+
+impl LocalExecutor for ConformanceExecutor {
+    fn execute(
+        &self,
+        _capability: &ResolvedCapability,
+        _input: &Value,
+    ) -> Result<Value, LocalExecutionFailure> {
+        Ok(json!({"status": "not_executed"}))
+    }
+}
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let Some(workspace_root) = args.next() else {
+        fail("missing workspace root");
+    };
+    let Some(workspace_id) = args.next() else {
+        fail("missing workspace id");
+    };
+    if args.next().is_some() {
+        fail("expected exactly <workspace-root> <workspace-id>");
+    }
+
+    match Runtime::from_workspace_app_state(
+        Path::new(&workspace_root),
+        &workspace_id,
+        ConformanceExecutor,
+        "downstream-app-conformance",
+    ) {
+        Ok(runtime) => {
+            let capabilities = runtime
+                .capability_registry()
+                .discover(LookupScope::PreferPrivate, &DiscoveryQuery::default());
+            let workflows = runtime
+                .workflow_registry()
+                .discover(LookupScope::PreferPrivate);
+            println!(
+                "{}",
+                json!({
+                    "status": "loaded",
+                    "workspace_id": workspace_id,
+                    "capability_count": capabilities.len(),
+                    "workflow_count": workflows.len(),
+                    "capability_ids": capabilities.iter().map(|entry| entry.id.clone()).collect::<Vec<_>>(),
+                    "workflow_ids": workflows.iter().map(|entry| entry.id.clone()).collect::<Vec<_>>()
+                })
+            );
+        }
+        Err(failure) => {
+            let errors = failure
+                .errors
+                .into_iter()
+                .map(|error| {
+                    json!({
+                        "code": error_code(error.code),
+                        "path": error.path,
+                        "message": error.message
+                    })
+                })
+                .collect::<Vec<_>>();
+            eprintln!("{}", json!({"status": "failed", "errors": errors}));
+            std::process::exit(1);
+        }
+    }
+}
+
+fn fail(message: &str) -> ! {
+    eprintln!("{}", json!({"status": "failed", "message": message}));
+    std::process::exit(2);
+}
+
+fn error_code(code: WorkspaceAppStateErrorCode) -> &'static str {
+    match code {
+        WorkspaceAppStateErrorCode::MissingWorkspaceState => "missing_workspace_state",
+        WorkspaceAppStateErrorCode::StateReadFailed => "state_read_failed",
+        WorkspaceAppStateErrorCode::StateParseFailed => "state_parse_failed",
+        WorkspaceAppStateErrorCode::IncompatibleSchemaVersion => "incompatible_schema_version",
+        WorkspaceAppStateErrorCode::IncompatibleWorkspaceState => "incompatible_workspace_state",
+        WorkspaceAppStateErrorCode::CorruptWorkspaceState => "corrupt_workspace_state",
+        WorkspaceAppStateErrorCode::CapabilityRegistrationFailed => {
+            "capability_registration_failed"
+        }
+        WorkspaceAppStateErrorCode::WorkflowRegistrationFailed => "workflow_registration_failed",
+    }
+}

--- a/docs/downstream-app-mvp-conformance.md
+++ b/docs/downstream-app-mvp-conformance.md
@@ -1,8 +1,8 @@
 # Downstream App MVP Conformance
 
-This document defines the Traverse-side conformance path for the first downstream app MVP boundary governed by `044-application-bundle-manifest` and `045-governed-model-dependency-resolution`.
+This document defines the Traverse-side conformance path for the first downstream app MVP boundary governed by `044-application-bundle-manifest`, `045-governed-model-dependency-resolution`, and `046-public-cli-app-registration`.
 
-The suite proves that a downstream app bundle can be validated and registered, a real WASM workflow can execute, governed model dependency readiness and resolution evidence is present, and the same public behavior is visible through HTTP/JSON and MCP surfaces.
+The suite proves that a downstream app bundle can be validated and registered, the public CLI app registration path writes durable local workspace state, the runtime can load that state, a real WASM workflow can execute, governed model dependency readiness and resolution evidence is present, and the same public behavior is visible through HTTP/JSON and MCP surfaces.
 
 ## CI-Safe Suite
 
@@ -16,6 +16,7 @@ That aggregate runs:
 
 ```bash
 bash scripts/ci/downstream_app_bundle_registration_smoke.sh
+bash scripts/ci/downstream_public_app_registration_smoke.sh
 bash scripts/ci/downstream_wasm_workflow_smoke.sh
 bash scripts/ci/downstream_model_dependency_smoke.sh
 bash scripts/ci/downstream_http_json_smoke.sh
@@ -27,6 +28,9 @@ bash scripts/ci/downstream_mcp_smoke.sh
 The CI-safe suite verifies:
 
 - the checked-in downstream application manifest references real component manifests and a real WASM binary
+- `traverse-cli app validate --manifest <path> --json` validates the downstream app manifest through the public CLI surface
+- `traverse-cli app register --manifest <path> --workspace <workspace-id> --json` writes durable workspace app state under `.traverse/workspaces/<workspace-id>/apps/.../registration.json`
+- the runtime loads the CLI-produced durable workspace state and discovers the registered app capability and workflow
 - app bundle registration is atomic and records effective non-sensitive config
 - model dependency schema and readiness evidence are validated
 - execution-time model dependency resolution emits public non-secret evidence
@@ -49,4 +53,4 @@ Use this local-provider-required mode only when the machine has Ollama available
 - All scripts exit with status `0`.
 - Public evidence includes app, workflow, component, and model selection metadata needed for audit.
 - Public evidence does not include workspace-local secrets, private prompts, private source text, or raw model credentials.
-- Failures identify the broken surface: bundle registration, WASM workflow, model dependency resolution, HTTP/JSON, or MCP.
+- Failures identify the broken surface: bundle registration, public CLI app registration, runtime workspace-state loading, WASM workflow, model dependency resolution, HTTP/JSON, or MCP.

--- a/examples/applications/expedition-readiness/app.manifest.json
+++ b/examples/applications/expedition-readiness/app.manifest.json
@@ -12,6 +12,30 @@
       "version": "1.0.0",
       "digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
       "manifest_path": "components/validate-team-readiness/component.manifest.json"
+    },
+    {
+      "component_id": "expedition.readiness.capture-expedition-objective-component",
+      "version": "1.0.0",
+      "digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+      "manifest_path": "components/capture-expedition-objective/component.manifest.json"
+    },
+    {
+      "component_id": "expedition.readiness.interpret-expedition-intent-component",
+      "version": "1.0.0",
+      "digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+      "manifest_path": "components/interpret-expedition-intent/component.manifest.json"
+    },
+    {
+      "component_id": "expedition.readiness.assess-conditions-summary-component",
+      "version": "1.0.0",
+      "digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+      "manifest_path": "components/assess-conditions-summary/component.manifest.json"
+    },
+    {
+      "component_id": "expedition.readiness.assemble-expedition-plan-component",
+      "version": "1.0.0",
+      "digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+      "manifest_path": "components/assemble-expedition-plan/component.manifest.json"
     }
   ],
   "workflows": [

--- a/examples/applications/expedition-readiness/components/assemble-expedition-plan/component.manifest.json
+++ b/examples/applications/expedition-readiness/components/assemble-expedition-plan/component.manifest.json
@@ -1,0 +1,28 @@
+{
+  "component_id": "expedition.readiness.assemble-expedition-plan-component",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "capability_id": "expedition.planning.assemble-expedition-plan",
+  "capability_version": "1.0.0",
+  "contract_path": "../../../../../contracts/examples/expedition/capabilities/assemble-expedition-plan/contract.json",
+  "wasm_binary_path": "../../../../agents/team-readiness-agent/artifacts/validate-team-readiness-agent.wasm",
+  "wasm_digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "device"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "checked_in_fixture",
+      "status": "passed",
+      "produced_by": "repository_checks"
+    }
+  ]
+}

--- a/examples/applications/expedition-readiness/components/assess-conditions-summary/component.manifest.json
+++ b/examples/applications/expedition-readiness/components/assess-conditions-summary/component.manifest.json
@@ -1,0 +1,28 @@
+{
+  "component_id": "expedition.readiness.assess-conditions-summary-component",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "capability_id": "expedition.planning.assess-conditions-summary",
+  "capability_version": "1.0.0",
+  "contract_path": "../../../../../contracts/examples/expedition/capabilities/assess-conditions-summary/contract.json",
+  "wasm_binary_path": "../../../../agents/team-readiness-agent/artifacts/validate-team-readiness-agent.wasm",
+  "wasm_digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "device"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "checked_in_fixture",
+      "status": "passed",
+      "produced_by": "repository_checks"
+    }
+  ]
+}

--- a/examples/applications/expedition-readiness/components/capture-expedition-objective/component.manifest.json
+++ b/examples/applications/expedition-readiness/components/capture-expedition-objective/component.manifest.json
@@ -1,0 +1,28 @@
+{
+  "component_id": "expedition.readiness.capture-expedition-objective-component",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "capability_id": "expedition.planning.capture-expedition-objective",
+  "capability_version": "1.0.0",
+  "contract_path": "../../../../../contracts/examples/expedition/capabilities/capture-expedition-objective/contract.json",
+  "wasm_binary_path": "../../../../agents/team-readiness-agent/artifacts/validate-team-readiness-agent.wasm",
+  "wasm_digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "device"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "checked_in_fixture",
+      "status": "passed",
+      "produced_by": "repository_checks"
+    }
+  ]
+}

--- a/examples/applications/expedition-readiness/components/interpret-expedition-intent/component.manifest.json
+++ b/examples/applications/expedition-readiness/components/interpret-expedition-intent/component.manifest.json
@@ -1,0 +1,28 @@
+{
+  "component_id": "expedition.readiness.interpret-expedition-intent-component",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "capability_id": "expedition.planning.interpret-expedition-intent",
+  "capability_version": "1.0.0",
+  "contract_path": "../../../../../contracts/examples/expedition/capabilities/interpret-expedition-intent/contract.json",
+  "wasm_binary_path": "../../../../agents/team-readiness-agent/artifacts/validate-team-readiness-agent.wasm",
+  "wasm_digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "device"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "checked_in_fixture",
+      "status": "passed",
+      "produced_by": "repository_checks"
+    }
+  ]
+}

--- a/scripts/ci/downstream_app_mvp_conformance.sh
+++ b/scripts/ci/downstream_app_mvp_conformance.sh
@@ -6,6 +6,7 @@ repo_root="$(git rev-parse --show-toplevel)"
 cd "${repo_root}"
 
 bash scripts/ci/downstream_app_bundle_registration_smoke.sh
+bash scripts/ci/downstream_public_app_registration_smoke.sh
 bash scripts/ci/downstream_wasm_workflow_smoke.sh
 bash scripts/ci/downstream_model_dependency_smoke.sh
 bash scripts/ci/downstream_http_json_smoke.sh

--- a/scripts/ci/downstream_public_app_registration_smoke.sh
+++ b/scripts/ci/downstream_public_app_registration_smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+manifest_path="${repo_root}/examples/applications/expedition-readiness/app.manifest.json"
+workspace_id="downstream-local"
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+validate_json="${tmpdir}/app-validate.json"
+register_json="${tmpdir}/app-register.json"
+runtime_json="${tmpdir}/runtime-load.json"
+
+cargo run --quiet --manifest-path "${repo_root}/Cargo.toml" -p traverse-cli -- \
+  app validate \
+  --manifest "${manifest_path}" \
+  --json > "${validate_json}"
+
+python3 - "${validate_json}" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+assert data["status"] == "validated"
+assert data["app_id"] == "expedition.readiness"
+assert data["app_version"] == "1.0.0"
+assert "046-public-cli-app-registration" in data["governing_specs"]
+assert {"cli", "http_json", "mcp"}.issubset(set(data["public_surfaces"]))
+assert data["digest_verification"][0]["status"] == "verified"
+assert data["model_readiness"][0]["status"] == "declared"
+assert "expedition.planning.plan-expedition" in data["workflow_ids"]
+PY
+
+(
+  cd "${tmpdir}"
+  cargo run --quiet --manifest-path "${repo_root}/Cargo.toml" -p traverse-cli -- \
+    app register \
+    --manifest "${manifest_path}" \
+    --workspace "${workspace_id}" \
+    --json > "${register_json}"
+)
+
+python3 - "${register_json}" "${tmpdir}" "${workspace_id}" <<'PY'
+import json
+import pathlib
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+workspace_root = pathlib.Path(sys.argv[2])
+workspace_id = sys.argv[3]
+assert data["status"] == "registered"
+assert data["workspace_id"] == workspace_id
+assert data["state_scope"] == "workspace_persisted"
+assert data["app_id"] == "expedition.readiness"
+assert data["components"][0]["wasm_digest"].startswith("sha256:")
+assert data["workflows"][0]["workflow_digest"].startswith("sha256:")
+state_path = workspace_root / data["state_path"]
+assert state_path.is_file(), state_path
+persisted = json.load(open(state_path, encoding="utf-8"))
+assert persisted["status"] == "registered"
+assert persisted["workspace_id"] == workspace_id
+assert persisted["registration_fingerprint"]["app_id"] == "expedition.readiness"
+PY
+
+cargo run --quiet --manifest-path "${repo_root}/Cargo.toml" -p traverse-runtime \
+  --example load_workspace_app_state -- \
+  "${tmpdir}" \
+  "${workspace_id}" > "${runtime_json}"
+
+python3 - "${runtime_json}" "${workspace_id}" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+workspace_id = sys.argv[2]
+assert data["status"] == "loaded"
+assert data["workspace_id"] == workspace_id
+assert data["capability_count"] >= 1
+assert data["workflow_count"] >= 1
+assert "expedition.planning.validate-team-readiness" in data["capability_ids"]
+assert "expedition.planning.plan-expedition" in data["workflow_ids"]
+PY
+
+echo "downstream public app registration smoke passed."

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -80,6 +80,7 @@ required_files=(
   "scripts/ci/youaskm3_compatibility_conformance.sh"
   "scripts/ci/downstream_app_mvp_conformance.sh"
   "scripts/ci/downstream_app_bundle_registration_smoke.sh"
+  "scripts/ci/downstream_public_app_registration_smoke.sh"
   "scripts/ci/downstream_wasm_workflow_smoke.sh"
   "scripts/ci/downstream_model_dependency_smoke.sh"
   "scripts/ci/downstream_http_json_smoke.sh"


### PR DESCRIPTION
## Summary
- add downstream public app registration conformance for `traverse-cli app validate` and `traverse-cli app register`
- expand the expedition readiness app fixture to register all workflow capabilities with real component manifests and checked-in WASM digest evidence
- add a runtime workspace-state loader example and wire the public app registration smoke into the downstream MVP suite

## Governing Spec
- `046-public-cli-app-registration`
- `044-application-bundle-manifest`
- `045-governed-model-dependency-resolution`
- `008-expedition-example-domain`
- `004-spec-alignment-gate`
- `028-schema-alignment-gate-v02`
- `031-supply-chain-hardening`
- `007-workflow-registry-traversal`
- `005-capability-registry`
- `006-runtime-request-execution`
- `010-runtime-state-machine`
- `011-event-registry`
- `012-execution-trace-tiered`
- `013-browser-runtime-subscription`
- `016-runtime-placement-router`
- `017-ai-agent-packaging`
- `018-event-driven-composition`
- `024-placement-constraint-evaluator`
- `025-wasm-executor-adapter`
- `026-event-broker`
- `029-integrated-observability`
- `030-security-identity-model`
- `032-universal-data-access`
- `033-http-json-api`
- `034-programmatic-registration`
- `035-multi-agent-isolation`
- `036-event-subscription-replay`
- `037-semver-range-resolution`
- `038-wasi-host-insulation`
- `039-connector-plugin-architecture`
- `040-contractual-enforcement-gate`
- `041-workflow-composition-api`
- `043-module-dependency-management`

## Project Item
- Issue #480
- Project 1 item: `PVTI_lAHOAEZXvs4BS6Nszgw5aKs`

## Validation
- `bash scripts/ci/downstream_public_app_registration_smoke.sh`
- `bash scripts/ci/downstream_app_mvp_conformance.sh`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/rust_checks.sh`
- `PATH="$HOME/.cargo/bin:$PATH" LLVM_COV=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-cov LLVM_PROFDATA=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata bash scripts/ci/coverage_gate.sh`
