### PR TITLE
Document CLI app registration boundary

### DIFF
--- a/docs/app-consumable-entry-path.md
+++ b/docs/app-consumable-entry-path.md
@@ -15,6 +15,7 @@ This is the canonical documentation path for humans and coding agents working on
    - [docs/app-consumable-package-release-pointer.md](app-consumable-package-release-pointer.md)
    - [docs/app-consumable-requirements-traceability.md](app-consumable-requirements-traceability.md)
    - [docs/youaskm3-integration-validation.md](youaskm3-integration-validation.md)
+   - [docs/downstream-app-mvp-conformance.md](downstream-app-mvp-conformance.md)
    - [docs/youaskm3-published-artifact-validation.md](youaskm3-published-artifact-validation.md)
    - [docs/youaskm3-compatibility-conformance-suite.md](youaskm3-compatibility-conformance-suite.md)
    - [docs/youaskm3-real-shell-validation.md](youaskm3-real-shell-validation.md)
@@ -34,6 +35,7 @@ If a new human or agent asks where to begin, point them to the README first and 
 - The package release pointer explains how the governed app-consumable package release is identified downstream.
 - The published-artifact validation explains how `youaskm3` consumes the released runtime and MCP artifacts.
 - The conformance suite explains how the released Traverse and `youaskm3` surfaces are proven together.
+- The downstream app MVP conformance path proves public CLI app validation, public CLI app registration, and runtime loading from durable workspace state.
 - The real-shell validation explains how the browser-hosted `youaskm3` shell is checked against the released Traverse consumer artifacts.
 - The deeper docs explain validation, release, and traceability after the first path is understood.
 - Competing entrypoints should be treated as references, not as the first recommended path.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -34,6 +34,8 @@ Subcommand-level help (full per-command detail with flags and examples):
 traverse-cli bundle inspect --help
 traverse-cli bundle register --help
 traverse-cli app new --help
+traverse-cli app validate --help
+traverse-cli app register --help
 traverse-cli component new --help
 traverse-cli agent inspect --help
 traverse-cli agent execute --help
@@ -54,6 +56,8 @@ consistent with error output behaviour across the CLI.
 | `bundle inspect <manifest-path>` | Validate and summarize a registry bundle manifest. | `cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json` | Prints `bundle_id`, `version`, `scope`, artifact counts, and the discovered capability/event/workflow ids. |
 | `bundle register <manifest-path>` | Load a registry bundle and register its contents into in-memory registries. | `cargo run -p traverse-cli -- bundle register examples/expedition/registry-bundle/manifest.json` | Prints `bundle_id`, `version`, `scope`, registered counts, and registration record summaries. |
 | `app new <app-id> [--register --workspace <workspace-id>]` | Create a governed Traverse app bundle scaffold under `apps/<app-id>`. | `cargo run -p traverse-cli -- app new youaskm3` | Creates `manifest.json`, `workspace.config.json`, component/workflow directories, and a bundle README. `--register` rejects the initial incomplete scaffold until real components and workflows are present. |
+| `app validate --manifest <path> --json` | Validate a downstream app manifest and emit stable setup evidence without writing workspace state. | `cargo run -p traverse-cli -- app validate --manifest examples/applications/expedition-readiness/app.manifest.json --json` | Prints JSON with `status: validated`, app identity, component/workflow ids, verified WASM digests, public surfaces, model readiness, and runtime references. |
+| `app register --manifest <path> --workspace <workspace-id> --json` | Validate a downstream app manifest and atomically persist local workspace registration state. | `cargo run -p traverse-cli -- app register --manifest examples/applications/expedition-readiness/app.manifest.json --workspace local --json` | Prints JSON with `status: registered` or `status: already_registered`, app identity, workspace id, `state_scope: workspace_persisted`, `state_path`, digest evidence, and runtime references. |
 | `component new <component-id>` | Create a governed WASM component package scaffold under `components/<component-id>`. | `cargo run -p traverse-cli -- component new knowledge.retrieve` | Creates a component `manifest.json`, draft capability `contract.json`, Rust package shell, source directory, and artifact directory without creating executable WASM behavior. |
 | `browser-adapter serve [--bind <address>]` | Start the local browser adapter for the governed browser consumer path. | `cargo run -p traverse-cli -- browser-adapter serve --bind 127.0.0.1:4174` | Prints `local browser adapter listening on http://...` and stays running until stopped. |
 | `agent inspect <manifest-path>` | Load and summarize a governed WASM agent package manifest. | `cargo run -p traverse-cli -- agent inspect examples/agents/expedition-intent-agent/manifest.json` | Prints `path`, `package_id`, `package_version`, `capability_id`, binary location, digest, and model/workflow references. |
@@ -70,6 +74,8 @@ The following command families are intended to be the public documented surface 
 - `bundle inspect`
 - `bundle register`
 - `app new`
+- `app validate`
+- `app register`
 - `component new`
 - `browser-adapter serve`
 - `agent inspect`
@@ -80,6 +86,81 @@ The following command families are intended to be the public documented surface 
 - `expedition execute`
 
 These commands are the ones a downstream developer should rely on when working with Traverse from the terminal.
+
+## Downstream App Validation And Registration
+
+The public local-dev app setup flow is governed by `046-public-cli-app-registration` and uses two stable JSON-producing commands:
+
+- `traverse-cli app validate --manifest <path> --json`
+- `traverse-cli app register --manifest <path> --workspace <workspace-id> --json`
+
+```bash
+cargo run -p traverse-cli -- app validate \
+  --manifest examples/applications/expedition-readiness/app.manifest.json \
+  --json
+
+cargo run -p traverse-cli -- app register \
+  --manifest examples/applications/expedition-readiness/app.manifest.json \
+  --workspace local \
+  --json
+```
+
+`app validate` is read-only. It validates the app manifest, component manifests, capability contracts, workflow references, WASM digests, workspace config, public surfaces, and governed model dependency declarations. A concise success response includes:
+
+```json
+{
+  "status": "validated",
+  "app_id": "expedition.readiness",
+  "app_version": "1.0.0",
+  "component_ids": [
+    "expedition.readiness.validate-team-readiness-component",
+    "expedition.readiness.capture-expedition-objective-component"
+  ],
+  "workflow_ids": [
+    "expedition.planning.plan-expedition"
+  ],
+  "digest_verification": [
+    {
+      "status": "verified",
+      "wasm_digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99"
+    }
+  ],
+  "public_surfaces": [
+    "cli",
+    "http_json",
+    "mcp"
+  ]
+}
+```
+
+`app register` performs the same validation and writes durable local workspace state under `.traverse/workspaces/<workspace-id>/apps/<app-id>/<version>/registration.json`. A concise success response includes:
+
+```json
+{
+  "status": "registered",
+  "workspace_id": "local",
+  "app_id": "expedition.readiness",
+  "app_version": "1.0.0",
+  "state_scope": "workspace_persisted",
+  "state_path": ".traverse/workspaces/local/apps/expedition.readiness/1.0.0/registration.json",
+  "manifest_digest": "sha256:498ed9a924cbc46caa48c244fc699b800548b0671faf0cc2aef105ffb7cf1c71",
+  "bundle_digest": "sha256:88ee514f6a18a6c30d6ea17a4110ff49d148f5ba655e2d866a2c1ab3553f5b7e"
+}
+```
+
+Re-registering unchanged state is idempotent and returns `status: already_registered` with the same stable app, workspace, and digest evidence.
+
+Common failure cases return non-zero exit status and JSON with `status: failed` plus actionable error entries:
+
+- missing `--manifest`, `--workspace`, or `--json`
+- invalid workspace id
+- missing or malformed app manifest
+- missing component manifest, contract, workflow, or WASM artifact
+- digest mismatch between the component manifest and the WASM binary
+- placeholder or incomplete governed model dependency declarations
+- workspace state write failure
+
+The CLI registration path is a local-dev setup surface. It is not an HTTP app registration endpoint, service registry, downstream UI deployment mechanism, or runtime-owned admin API. Downstream apps own their UI deployment. Traverse runtime code loads registered workspace state and communicates runtime progress, traceability, and app-facing updates through the governed runtime, workflow, HTTP/JSON, MCP, and eventing-oriented contract surfaces documented for each slice.
 
 ## Internal Or Test-Only Paths
 
@@ -109,6 +190,8 @@ This reference was checked against the live CLI behavior with:
 - `cargo run -p traverse-cli -- bundle inspect --help`
 - `cargo run -p traverse-cli -- bundle register --help`
 - `cargo run -p traverse-cli -- app new --help`
+- `cargo run -p traverse-cli -- app validate --help`
+- `cargo run -p traverse-cli -- app register --help`
 - `cargo run -p traverse-cli -- component new --help`
 - `cargo run -p traverse-cli -- agent inspect --help`
 - `cargo run -p traverse-cli -- agent execute --help`

--- a/docs/youaskm3-canonical-app-http-path.md
+++ b/docs/youaskm3-canonical-app-http-path.md
@@ -33,6 +33,8 @@ The app-facing surfaces `youaskm3` can depend on at `v0.3.0` are:
 
 - `traverse-cli serve`
 - `.traverse/server.json`
+- `traverse-cli app validate --manifest <path> --json`
+- `traverse-cli app register --manifest <path> --workspace <workspace-id> --json`
 - `GET /healthz`
 - `POST /v1/workspaces/{workspace_id}/capabilities`
 - `POST /v1/workspaces/{workspace_id}/execute`
@@ -41,6 +43,25 @@ The app-facing surfaces `youaskm3` can depend on at `v0.3.0` are:
 - RFC 9457 Problem Details error envelopes
 
 Implementation details inside `crates/traverse-cli/src/http_api.rs`, in-memory stores, test helpers, and private registry internals are not downstream app API.
+
+## Local App Registration Boundary
+
+Downstream app setup uses the CLI/local-dev registration path, not an HTTP app registration endpoint:
+
+```bash
+cargo run -p traverse-cli -- app validate \
+  --manifest examples/applications/expedition-readiness/app.manifest.json \
+  --json
+
+cargo run -p traverse-cli -- app register \
+  --manifest examples/applications/expedition-readiness/app.manifest.json \
+  --workspace "$WORKSPACE_ID" \
+  --json
+```
+
+`app validate` emits read-only JSON setup evidence. `app register` writes durable local state at `.traverse/workspaces/<workspace-id>/apps/<app-id>/<version>/registration.json` so Traverse runtime code can load the registered app capability and workflow from workspace state.
+
+This slice deliberately does not provide HTTP app registration, runtime-owned downstream UI deployment, deployment orchestration, or a service registry. `youaskm3` owns its browser-hosted UI and deployment. Traverse owns validation, registration evidence, runtime loading, execution, traces, and eventing-oriented contracts used for runtime communication.
 
 ## Start From The Released Tag
 
@@ -174,11 +195,13 @@ Run the deterministic app-consumable validation commands from the Traverse repos
 
 ```bash
 bash scripts/ci/app_consumable_acceptance.sh
+bash scripts/ci/downstream_public_app_registration_smoke.sh
+bash scripts/ci/downstream_app_mvp_conformance.sh
 bash scripts/ci/browser_consumer_package_smoke.sh
 bash scripts/ci/repository_checks.sh
 ```
 
-These checks prove that the released app-consumable path remains documented, the browser-consumer package remains discoverable, and the repository-level documentation assertions still include the canonical HTTP path.
+These checks prove that the released app-consumable path remains documented, public CLI app registration writes durable workspace state that the runtime can load, the browser-consumer package remains discoverable, and the repository-level documentation assertions still include the canonical HTTP path.
 
 ## Related Docs
 

--- a/docs/youaskm3-integration-validation.md
+++ b/docs/youaskm3-integration-validation.md
@@ -12,6 +12,8 @@ It stays on governed public Traverse surfaces only:
 - the real-agent MCP exercise guide
 - the published-artifact validation path for the released Traverse runtime and MCP artifacts
 - the canonical HTTP/JSON app path at [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
+- the public CLI app validation and local workspace registration path at [docs/cli-reference.md](cli-reference.md)
+- the downstream app MVP conformance path at [docs/downstream-app-mvp-conformance.md](downstream-app-mvp-conformance.md)
 - [docs/youaskm3-published-artifact-validation.md](youaskm3-published-artifact-validation.md)
 - [docs/youaskm3-compatibility-conformance-suite.md](youaskm3-compatibility-conformance-suite.md)
 - the `youaskm3` compatibility conformance suite
@@ -21,6 +23,15 @@ It stays on governed public Traverse surfaces only:
 For the shortest Traverse-side start path, begin with [quickstart.md](../quickstart.md).
 
 For the first release-facing HTTP/JSON app path, use [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md).
+
+For public local-dev app setup, validate and register the downstream app through:
+
+```bash
+cargo run -p traverse-cli -- app validate --manifest <path> --json
+cargo run -p traverse-cli -- app register --manifest <path> --workspace <workspace-id> --json
+```
+
+That flow produces durable workspace state for Traverse runtime loading. It does not create an HTTP app registration endpoint, a service registry, a runtime-owned admin registration API, or a downstream UI deployment path. `youaskm3` owns the UI; Traverse owns validation, local workspace registration evidence, runtime loading, execution, traces, and eventing-oriented runtime contracts.
 
 For the single Traverse `v0.3.0` downstream validation path that `youaskm3` can cite for release evidence, use [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md).
 
@@ -64,6 +75,12 @@ For the broader release-aligned compatibility check, also run:
 bash scripts/ci/youaskm3_compatibility_conformance.sh
 ```
 
+For the downstream app MVP conformance path, including public CLI validation, public CLI registration, and runtime loading of CLI-produced durable workspace state, run:
+
+```bash
+bash scripts/ci/downstream_app_mvp_conformance.sh
+```
+
 For the pinned Traverse `v0.3.0` release evidence sequence, follow [docs/v0.3.0-downstream-validation-path.md](v0.3.0-downstream-validation-path.md).
 
 For the published-artifact validation against the released Traverse runtime and MCP artifacts, also run:
@@ -91,6 +108,8 @@ The validation path should prove:
 - request submission from the approved public consumer path
 - ordered runtime updates and terminal outcome consumption
 - trace visibility through the public Traverse surfaces
+- public CLI app validation and local workspace registration evidence
+- runtime discovery from CLI-produced durable workspace app state
 - `consumer_name: youaskm3`
 - `validated_flow_id: youaskm3_mcp_validation`
 - no dependency on private Traverse internals or undocumented setup
@@ -107,11 +126,16 @@ The path is expected to fail deterministically when:
 - the MCP consumption surface is unavailable
 - the documented quickstart or validation docs are missing
 - the downstream consumer path cannot be followed through the public surfaces
+- the app manifest cannot be validated through `traverse-cli app validate --manifest <path> --json`
+- the app cannot be registered through `traverse-cli app register --manifest <path> --workspace <workspace-id> --json`
+- registered workspace app state cannot be loaded by the runtime
 
 ## Validation
 
 - `bash scripts/ci/react_demo_live_adapter_smoke.sh`
 - `bash scripts/ci/mcp_consumption_validation.sh`
 - `bash scripts/ci/mcp_real_agent_exercise_smoke.sh`
+- `bash scripts/ci/downstream_public_app_registration_smoke.sh`
+- `bash scripts/ci/downstream_app_mvp_conformance.sh`
 - `bash scripts/ci/youaskm3_integration_validation.sh`
 - `bash scripts/ci/repository_checks.sh`

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -208,12 +208,22 @@ grep -q "docs/youaskm3-compatibility-conformance-suite.md" README.md
 grep -q "docs/youaskm3-real-shell-validation.md" README.md
 grep -q "docs/youaskm3-published-artifact-validation.md" README.md
 grep -q "docs/youaskm3-compatibility-conformance-suite.md" docs/app-consumable-entry-path.md
+grep -q "docs/downstream-app-mvp-conformance.md" docs/app-consumable-entry-path.md
 grep -q "docs/youaskm3-real-shell-validation.md" docs/app-consumable-entry-path.md
 grep -q "docs/youaskm3-published-artifact-validation.md" docs/app-consumable-entry-path.md
 grep -q "docs/youaskm3-compatibility-conformance-suite.md" docs/mcp-consumption-validation.md
 grep -q "docs/youaskm3-compatibility-conformance-suite.md" docs/youaskm3-integration-validation.md
 grep -q "docs/youaskm3-real-shell-validation.md" docs/youaskm3-integration-validation.md
 grep -q "docs/youaskm3-published-artifact-validation.md" docs/youaskm3-integration-validation.md
+grep -q "docs/downstream-app-mvp-conformance.md" docs/youaskm3-integration-validation.md
+grep -q "traverse-cli app validate --manifest <path> --json" docs/cli-reference.md
+grep -q "traverse-cli app register --manifest <path> --workspace <workspace-id> --json" docs/cli-reference.md
+grep -q "status: already_registered" docs/cli-reference.md
+grep -q "not an HTTP app registration endpoint" docs/cli-reference.md
+grep -q "traverse-cli app validate --manifest <path> --json" docs/youaskm3-canonical-app-http-path.md
+grep -q "traverse-cli app register --manifest <path> --workspace <workspace-id> --json" docs/youaskm3-canonical-app-http-path.md
+grep -q "eventing-oriented contracts" docs/youaskm3-canonical-app-http-path.md
+grep -q "downstream_public_app_registration_smoke.sh" docs/youaskm3-integration-validation.md
 grep -q "docs/mcp-real-agent-exercise.md" docs/youaskm3-integration-validation.md
 grep -q "youaskm3 compatibility conformance suite" docs/youaskm3-compatibility-conformance-suite.md
 grep -q "version pairing" docs/youaskm3-compatibility-conformance-suite.md


### PR DESCRIPTION
## Summary
- Document the public CLI app validation and registration commands in the CLI reference.
- Clarify that CLI registration is local workspace setup, not an HTTP app registration endpoint, service registry, UI deployment path, or runtime-owned admin API.
- Connect the downstream app MVP conformance path into the app-consumable and youaskm3 integration docs, with repository assertions for the boundary.

## Governing Spec
- `004-spec-alignment-gate`
- `023-browser-hosted-mcp-consumer-model`
- `046-public-cli-app-registration`

## Project Item
- Closes #481
- Issue: #481
- Project item: PVTI_lAHOAEZXvs4BS6Nszgw5aL4

## Validation
- `bash scripts/ci/repository_checks.sh`
- `BASE_SHA=7ef41cd431c948ebf8a7ca32f83aef239ddd7ee3 HEAD_SHA=HEAD bash scripts/ci/spec_alignment_check.sh /private/tmp/pr481-body.md`
