### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/enricopiovesan/Traverse/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
-[![Version](https://img.shields.io/badge/version-v0.4.0-blue)](https://github.com/enricopiovesan/Traverse/releases)
+[![Version](https://img.shields.io/badge/version-v0.5.0-blue)](https://github.com/enricopiovesan/Traverse/releases)
 
 Your business logic runs in the browser, on your server, and in a cloud function.
 They drift. You maintain three versions of the same behavior.
@@ -102,7 +102,7 @@ Scaffolds a governed app bundle. Add your capability contracts, workflows, and W
 
 ### Consumer and release surfaces
 
-- [docs/releases/v0.4.0.md](docs/releases/v0.4.0.md) — current release notes
+- [docs/releases/v0.5.0.md](docs/releases/v0.5.0.md) — current release notes
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) — packaged runtime artifact

--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -70,7 +70,7 @@ The release-facing downstream compatibility statement for the current `youaskm3`
 
 The current Traverse release notes are:
 
-- `docs/releases/v0.4.0.md`
+- `docs/releases/v0.5.0.md`
 
 ## Specs
 

--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -1,0 +1,55 @@
+# Traverse v0.5.0
+
+Release date: 2026-06-26
+
+Traverse v0.5.0 is the public CLI app registration release. It keeps the v0.4.0 manifest and governed model-dependency baseline intact while adding the public downstream app setup commands, durable local workspace registration state, runtime loading from that state, and conformance evidence needed for downstream apps to bootstrap without private Traverse internals.
+
+Consumers that need only application manifests and governed model dependency evidence can remain pinned to `v0.4.0`. Consumers that need stable `traverse-cli app validate` and `traverse-cli app register` setup flows should move to `v0.5.0`.
+
+## Highlights
+
+- Adds approved Spec `046-public-cli-app-registration`.
+- Adds `traverse-cli app validate --manifest <path> --json` as the public read-only downstream app validation surface.
+- Adds `traverse-cli app register --manifest <path> --workspace <workspace-id> --json` as the public local workspace registration surface.
+- Persists validated app registration evidence under `.traverse/workspaces/<workspace-id>/apps/<app-id>/<version>/registration.json`.
+- Adds runtime loading from CLI-produced workspace app state so registered capabilities and workflows can be discovered without private setup code.
+- Adds downstream public app registration smoke coverage and wires it into downstream app MVP conformance.
+- Documents the boundary clearly: CLI app registration is local-dev workspace setup, not an HTTP app registration endpoint, service registry, downstream UI deployment mechanism, or runtime-owned admin API.
+
+## Compatibility Notes
+
+- Traverse remains a `0.x` project. Public surfaces are governed and validated, but compatibility can still move before a `1.0` stability commitment.
+- The v0.3.0 public compatibility documents remain the historical first `youaskm3` release baseline.
+- The v0.4.0 application manifest and governed model dependency surfaces remain available.
+- The v0.5.0 additions are backward-compatible in intent: they add public CLI setup and workspace-state loading surfaces rather than removing the v0.3.0 HTTP/JSON or MCP paths.
+- No cross-platform binary package is attached to this release. The release publishes source, release notes, and supply-chain evidence artifacts.
+
+## Validation
+
+Release preparation must pass these local gates before tagging:
+
+```bash
+bash scripts/ci/repository_checks.sh
+bash scripts/ci/rust_checks.sh
+bash scripts/ci/coverage_gate.sh
+bash scripts/ci/supply_chain_check.sh
+```
+
+The downstream app MVP conformance path should also pass for the v0.5.0 public CLI registration baseline:
+
+```bash
+bash scripts/ci/downstream_app_mvp_conformance.sh
+```
+
+The GitHub Release should attach the generated supply-chain evidence from `target/supply-chain/`:
+
+- `traverse-sbom.cdx.json`
+- `supply-chain-summary.json`
+- `artifact-verify-report.json`
+- `traverse-cli.provenance.json`
+
+## Traceability
+
+- Release issue: https://github.com/enricopiovesan/Traverse/issues/488
+- Governing specs: `001-foundation-v0-1`, `004-spec-alignment-gate`, `031-supply-chain-hardening`, `046-public-cli-app-registration`
+- Implementation issues: #482, #483, #484, #485, #486, #487

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -18,6 +18,7 @@ required_files=(
   "docs/v0.3.0-source-build-consumer-packaging.md"
   "docs/v0.3.0-downstream-validation-path.md"
   "docs/youaskm3-v0.3.0-integration-readiness.md"
+  "docs/releases/v0.5.0.md"
   "docs/troubleshooting.md"
   "docs/adapter-boundaries.md"
   "docs/contract-publication-policy.md"
@@ -354,12 +355,19 @@ grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-source-build-consumer-packaging.md" README.md
 grep -q "docs/v0.3.0-downstream-validation-path.md" README.md
 grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" README.md
-grep -q "docs/releases/v0.4.0.md" README.md
+grep -q "docs/releases/v0.5.0.md" README.md
 grep -q "Traverse v0.4.0" docs/releases/v0.4.0.md
 grep -q "044-application-bundle-manifest" docs/releases/v0.4.0.md
 grep -q "045-governed-model-dependency-resolution" docs/releases/v0.4.0.md
 grep -q "bash scripts/ci/downstream_app_mvp_conformance.sh" docs/releases/v0.4.0.md
 grep -q "traverse-sbom.cdx.json" docs/releases/v0.4.0.md
+grep -q "Traverse v0.5.0" docs/releases/v0.5.0.md
+grep -q "046-public-cli-app-registration" docs/releases/v0.5.0.md
+grep -q "traverse-cli app validate --manifest <path> --json" docs/releases/v0.5.0.md
+grep -q "traverse-cli app register --manifest <path> --workspace <workspace-id> --json" docs/releases/v0.5.0.md
+grep -q "runtime loading from CLI-produced workspace app state" docs/releases/v0.5.0.md
+grep -q "bash scripts/ci/downstream_app_mvp_conformance.sh" docs/releases/v0.5.0.md
+grep -q "traverse-sbom.cdx.json" docs/releases/v0.5.0.md
 grep -q "cargo build" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-cli -- serve" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-mcp -- stdio" docs/v0.3.0-source-build-consumer-packaging.md


### PR DESCRIPTION
## Summary
- Add Traverse v0.5.0 release notes for the public CLI app registration baseline.
- Update current-release pointers in README and compatibility policy from v0.4.0 to v0.5.0.
- Extend repository checks so the v0.5.0 release notes stay discoverable and assert the Spec 046 CLI registration evidence.

## Governing Spec
- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `031-supply-chain-hardening`
- `046-public-cli-app-registration`

## Project Item
- Closes #488
- Issue: #488
- Project item: PVTI_lAHOAEZXvs4BS6Nszgw_UjY

## Validation
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/downstream_app_mvp_conformance.sh`
- `bash scripts/ci/rust_checks.sh`
- `PATH="$HOME/.cargo/bin:$PATH" LLVM_COV=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-cov LLVM_PROFDATA=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata bash scripts/ci/coverage_gate.sh`
- `bash scripts/ci/supply_chain_check.sh`
- `BASE_SHA=3698be0c533e70afffae87d93fcf0fec14b8dfd4 HEAD_SHA=HEAD bash scripts/ci/spec_alignment_check.sh /private/tmp/pr488-body.md`
