### PR TITLE
Bump workspace version for v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "semver",
  "serde",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "semver",
  "serde",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "semver",
  "serde",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/enricopiovesan/Traverse"
 rust-version = "1.94"
-version = "0.4.0"
+version = "0.5.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -355,6 +355,7 @@ grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-source-build-consumer-packaging.md" README.md
 grep -q "docs/v0.3.0-downstream-validation-path.md" README.md
 grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" README.md
+grep -q 'version = "0.5.0"' Cargo.toml
 grep -q "docs/releases/v0.5.0.md" README.md
 grep -q "Traverse v0.4.0" docs/releases/v0.4.0.md
 grep -q "044-application-bundle-manifest" docs/releases/v0.4.0.md


### PR DESCRIPTION
## Summary
- Bump the workspace package version to `0.5.0` for the v0.5.0 release tag.
- Refresh `Cargo.lock` for the workspace version change.
- Add a repository-check assertion so the current release docs and workspace package version stay aligned.

## Governing Spec
- `004-spec-alignment-gate`
- `031-supply-chain-hardening`

## Project Item
- Closes #488
- Issue: #488
- Project item: PVTI_lAHOAEZXvs4BS6Nszgw_UjY

## Validation
- `bash scripts/ci/repository_checks.sh`
- `BASE_SHA=1eb99f2c98b41ea96192c4ba4a805bab2b140e81 HEAD_SHA=HEAD bash scripts/ci/spec_alignment_check.sh /private/tmp/pr490-body.md`
