### PR TITLE
Release Traverse v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "semver",
  "serde",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "semver",
  "serde",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "semver",
  "serde",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-repository = "https://github.com/enricopiovesan/Traverse"
+repository = "https://github.com/traverse-framework/Traverse"
 rust-version = "1.94"
-version = "0.5.0"
+version = "0.6.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 # Traverse
 
-[![CI](https://github.com/enricopiovesan/Traverse/actions/workflows/ci.yml/badge.svg)](https://github.com/enricopiovesan/Traverse/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/enricopiovesan/Traverse/actions/workflows/ci.yml)
+[![CI](https://github.com/traverse-framework/Traverse/actions/workflows/ci.yml/badge.svg)](https://github.com/traverse-framework/Traverse/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/traverse-framework/Traverse/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
-[![Version](https://img.shields.io/badge/version-v0.5.0-blue)](https://github.com/enricopiovesan/Traverse/releases)
+[![Version](https://img.shields.io/badge/version-v0.6.0-blue)](https://github.com/traverse-framework/Traverse/releases)
 
 Your business logic runs in the browser, on your server, and in a cloud function.
 They drift. You maintain three versions of the same behavior.
@@ -22,7 +22,7 @@ Traverse is the working implementation of [Universal Microservices Architecture]
 **Requirements**: Rust 1.94+
 
 ```bash
-git clone https://github.com/enricopiovesan/Traverse.git
+git clone https://github.com/traverse-framework/Traverse.git
 cd Traverse
 cargo build
 cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json
@@ -102,7 +102,7 @@ Scaffolds a governed app bundle. Add your capability contracts, workflows, and W
 
 ### Consumer and release surfaces
 
-- [docs/releases/v0.5.0.md](docs/releases/v0.5.0.md) — current release notes
+- [docs/releases/v0.6.0.md](docs/releases/v0.6.0.md) — current release notes
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) — packaged runtime artifact

--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -70,7 +70,7 @@ The release-facing downstream compatibility statement for the current `youaskm3`
 
 The current Traverse release notes are:
 
-- `docs/releases/v0.5.0.md`
+- `docs/releases/v0.6.0.md`
 
 ## Specs
 

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,51 @@
+# Traverse v0.6.0
+
+Release date: 2026-06-27
+
+Traverse v0.6.0 is the governed model dependency execution release. It keeps the v0.5.0 public CLI app registration baseline intact while adding the runtime surface needed for downstream app hosts to execute app-declared model dependencies without provider-specific logic in WASM agents.
+
+Consumers that only need public app validation and registration can remain pinned to `v0.5.0`. Consumers that need provider-neutral governed inference execution from registered app state should move to `v0.6.0`.
+
+## Highlights
+
+- Adds a runtime-owned governed model dependency execution surface for app-declared `traverse.inference.generate` dependencies.
+- Loads persisted app `model_dependencies` from CLI-produced workspace registration state into runtime application registrations.
+- Revalidates model dependencies at execution time, invokes the existing real local Ollama-backed provider, and returns public `ModelResolutionEvidence` with inference output.
+- Updates WASM agent authoring guidance so downstream agents no longer own provider-specific model API calls.
+- Preserves provider selection, provider config, and model readiness evidence inside Traverse-owned runtime boundaries.
+- Updates repository-facing metadata and README links for `traverse-framework/Traverse`.
+
+## Compatibility Notes
+
+- Traverse remains a `0.x` project. Public surfaces are governed and validated, but compatibility can still move before a `1.0` stability commitment.
+- The v0.5.0 public CLI app registration and durable workspace-state loading surfaces remain available.
+- The v0.6.0 additions are backward-compatible in intent: they add a runtime execution bridge for governed model dependencies rather than changing existing app registration, HTTP/JSON, MCP, or workflow semantics.
+- Downstream WASM agents should depend on Traverse's governed inference interface and app manifest model declarations, not provider-specific SDKs, URLs, or credentials.
+- No cross-platform binary package is attached to this release. The release publishes source and release notes.
+
+## Validation
+
+Release preparation must pass these local gates before tagging:
+
+```bash
+cargo test
+cargo clippy -- -D warnings
+bash scripts/ci/repository_checks.sh
+bash scripts/ci/wasm_agent_authoring_guide_smoke.sh
+bash scripts/ci/coverage_gate.sh
+git diff --check
+```
+
+The GitHub PR checks must also pass:
+
+- `repository-checks`
+- `coverage-gate`
+- `pr-hygiene`
+- `spec-alignment`
+
+## Traceability
+
+- Release issue: https://github.com/traverse-framework/Traverse/issues/497
+- Governing specs: `001-foundation-v0-1`, `004-spec-alignment-gate`, `006-runtime-request-execution`, `045-governed-model-dependency-resolution`, `046-public-cli-app-registration`
+- Included PRs: #492, #493, #496
+- Included issues: #491, #495, #494

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -19,6 +19,7 @@ required_files=(
   "docs/v0.3.0-downstream-validation-path.md"
   "docs/youaskm3-v0.3.0-integration-readiness.md"
   "docs/releases/v0.5.0.md"
+  "docs/releases/v0.6.0.md"
   "docs/troubleshooting.md"
   "docs/adapter-boundaries.md"
   "docs/contract-publication-policy.md"
@@ -355,8 +356,8 @@ grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-source-build-consumer-packaging.md" README.md
 grep -q "docs/v0.3.0-downstream-validation-path.md" README.md
 grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" README.md
-grep -q 'version = "0.5.0"' Cargo.toml
-grep -q "docs/releases/v0.5.0.md" README.md
+grep -q 'version = "0.6.0"' Cargo.toml
+grep -q "docs/releases/v0.6.0.md" README.md
 grep -q "Traverse v0.4.0" docs/releases/v0.4.0.md
 grep -q "044-application-bundle-manifest" docs/releases/v0.4.0.md
 grep -q "045-governed-model-dependency-resolution" docs/releases/v0.4.0.md
@@ -369,6 +370,12 @@ grep -q "traverse-cli app register --manifest <path> --workspace <workspace-id> 
 grep -q "runtime loading from CLI-produced workspace app state" docs/releases/v0.5.0.md
 grep -q "bash scripts/ci/downstream_app_mvp_conformance.sh" docs/releases/v0.5.0.md
 grep -q "traverse-sbom.cdx.json" docs/releases/v0.5.0.md
+grep -q "Traverse v0.6.0" docs/releases/v0.6.0.md
+grep -q "045-governed-model-dependency-resolution" docs/releases/v0.6.0.md
+grep -q "046-public-cli-app-registration" docs/releases/v0.6.0.md
+grep -q "governed model dependency execution surface" docs/releases/v0.6.0.md
+grep -q "cargo clippy -- -D warnings" docs/releases/v0.6.0.md
+grep -q "coverage-gate" docs/releases/v0.6.0.md
 grep -q "cargo build" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-cli -- serve" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-mcp -- stdio" docs/v0.3.0-source-build-consumer-packaging.md


### PR DESCRIPTION
## Summary
- Bump Traverse workspace version to `0.6.0`.
- Add v0.6.0 release notes for governed model dependency execution.
- Update README/current release pointers and repository metadata for `traverse-framework/Traverse`.
- Update repository checks for the v0.6.0 release surface.

## Governing Spec
- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `006-runtime-request-execution`
- `031-supply-chain-hardening`
- `045-governed-model-dependency-resolution`
- `046-public-cli-app-registration`

## Project Item
- Closes #497
- Project 1 item: PVTI_lADOEbiBt84Bbyp1zgxBs3I

## Validation
- `cargo test`
- `cargo clippy -- -D warnings`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/wasm_agent_authoring_guide_smoke.sh`
- `bash scripts/ci/coverage_gate.sh`
- `git diff --check`
