### PR TITLE
Document traverse-starter app registration pin

### DIFF
--- a/docs/releases/v0.5.0.md
+++ b/docs/releases/v0.5.0.md
@@ -6,6 +6,14 @@ Traverse v0.5.0 is the public CLI app registration release. It keeps the v0.4.0 
 
 Consumers that need only application manifests and governed model dependency evidence can remain pinned to `v0.4.0`. Consumers that need stable `traverse-cli app validate` and `traverse-cli app register` setup flows should move to `v0.5.0`.
 
+`traverse-framework/App-References` consumers that exercise the
+`traverse-starter` app registration path should pin Traverse to `v0.5.0` or
+newer for Phase 2 CLI registration. The `cargo run -p traverse-cli -- serve`
+startup sequence continues to write `.traverse/server.json` with the same
+schema version and discovery fields as `v0.3.0`, so existing local server
+discovery remains backward-compatible while app registration moves to the
+public CLI setup surface.
+
 ## Highlights
 
 - Adds approved Spec `046-public-cli-app-registration`.

--- a/quickstart.md
+++ b/quickstart.md
@@ -98,3 +98,31 @@ bash scripts/ci/repository_checks.sh
 ```
 
 If one of those commands fails and you need the shortest diagnosis path, use [docs/troubleshooting.md](docs/troubleshooting.md).
+
+## Downstream App Registration Consumers
+
+Downstream reference apps that use `traverse-cli app validate` or
+`traverse-cli app register` should pin Traverse to `v0.5.0` or newer. `v0.5.0`
+is the first release that includes the public local-dev app registration surface,
+durable workspace app state, and runtime loading from CLI-produced registration
+state.
+
+For the `traverse-starter` reference app, validate and register the app bundle
+from the Traverse repository root:
+
+```bash
+cargo run -p traverse-cli -- app validate \
+  --manifest apps/traverse-starter/app.manifest.json \
+  --json
+
+cargo run -p traverse-cli -- app register \
+  --manifest apps/traverse-starter/app.manifest.json \
+  --workspace local-default \
+  --json
+```
+
+The local HTTP server discovery file remains backward-compatible with the
+`v0.3.0` schema. `cargo run -p traverse-cli -- serve` writes
+`.traverse/server.json` with `schema_version: "1.0.0"`, `base_url`,
+`health_url`, `workspace_default`, `pid`, `started_at`, `auth_mode`, and an
+optional `local_dev_token` for loopback development.

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -386,6 +386,15 @@ grep -q "traverse-cli app register --manifest <path> --workspace <workspace-id> 
 grep -q "runtime loading from CLI-produced workspace app state" docs/releases/v0.5.0.md
 grep -q "bash scripts/ci/downstream_app_mvp_conformance.sh" docs/releases/v0.5.0.md
 grep -q "traverse-sbom.cdx.json" docs/releases/v0.5.0.md
+grep -q "traverse-framework/App-References" docs/releases/v0.5.0.md
+grep -q "pin Traverse to \`v0.5.0\` or" docs/releases/v0.5.0.md
+grep -q "newer for Phase 2 CLI registration" docs/releases/v0.5.0.md
+grep -q ".traverse/server.json" docs/releases/v0.5.0.md
+grep -q "schema version and discovery fields as \`v0.3.0\`" docs/releases/v0.5.0.md
+grep -q "Downstream App Registration Consumers" quickstart.md
+grep -q "apps/traverse-starter/app.manifest.json" quickstart.md
+grep -q "schema_version: \"1.0.0\"" quickstart.md
+grep -q "optional \`local_dev_token\`" quickstart.md
 grep -q "Traverse v0.6.0" docs/releases/v0.6.0.md
 grep -q "045-governed-model-dependency-resolution" docs/releases/v0.6.0.md
 grep -q "046-public-cli-app-registration" docs/releases/v0.6.0.md


### PR DESCRIPTION
## Summary

- Document `v0.5.0` as the minimum Traverse version for downstream apps using `traverse-cli app validate/register`.
- Add `traverse-starter` validate/register commands to the quickstart.
- Record that `cargo run -p traverse-cli -- serve` keeps the `.traverse/server.json` discovery schema compatible with `v0.3.0`.
- Add repository-check assertions for the App-References pin guidance.

## Governing Spec

- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `028-schema-alignment-gate-v02`
- `031-supply-chain-hardening`
- `040-contractual-enforcement-gate`

## Project Item

- Closes #500
- Project 1 item: PVTI_lADOEbiBt84Bbyp1zgxXpl0

## Validation

- `bash scripts/ci/repository_checks.sh`
- `git diff --check`
