### PR TITLE
Release Traverse v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "semver",
  "serde",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "semver",
  "serde",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1820,7 +1820,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1831,7 +1831,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "semver",
  "serde",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/traverse-framework/Traverse"
 rust-version = "1.94"
-version = "0.6.0"
+version = "0.7.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/traverse-framework/Traverse/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
-[![Version](https://img.shields.io/badge/version-v0.6.0-blue)](https://github.com/traverse-framework/Traverse/releases)
+[![Version](https://img.shields.io/badge/version-v0.7.0-blue)](https://github.com/traverse-framework/Traverse/releases)
 
 Your business logic runs in the browser, on your server, and in a cloud function.
 They drift. You maintain three versions of the same behavior.
@@ -102,7 +102,7 @@ Scaffolds a governed app bundle. Add your capability contracts, workflows, and W
 
 ### Consumer and release surfaces
 
-- [docs/releases/v0.6.0.md](docs/releases/v0.6.0.md) — current release notes
+- [docs/releases/v0.7.0.md](docs/releases/v0.7.0.md) — current release notes
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) — packaged runtime artifact

--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -70,7 +70,7 @@ The release-facing downstream compatibility statement for the current `youaskm3`
 
 The current Traverse release notes are:
 
-- `docs/releases/v0.6.0.md`
+- `docs/releases/v0.7.0.md`
 
 ## Specs
 

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,51 @@
+# Traverse v0.7.0
+
+Release date: 2026-07-03
+
+Traverse v0.7.0 is the traverse-starter reference app release. It adds a governed, executable starter app path that downstream reference apps can use to validate Traverse app registration and local HTTP execution without model-provider setup.
+
+Consumers that only need public app validation and registration can remain pinned to `v0.5.0`. Consumers that need provider-neutral governed inference execution can remain pinned to `v0.6.0`. Consumers validating the `traverse-starter` reference app path should move to `v0.7.0`.
+
+## Highlights
+
+- Adds the `traverse-starter.process` capability contract with deterministic `title`, `tags`, `noteType`, `suggestedNextAction`, and `status` output fields.
+- Adds the `apps/traverse-starter/app.manifest.json` application manifest and the `examples/traverse-starter/process-agent/` WASM agent package.
+- Loads durable CLI-produced workspace app registration state during HTTP workspace execution so registered app capabilities can execute through `/v1/workspaces/local-default/execute`.
+- Adds `bash scripts/ci/traverse_starter_example_smoke.sh` to validate app registration and local HTTP execution end to end.
+- Documents the App-References integration path and confirms `v0.5.0 minimum` for downstream apps using `traverse-cli app validate/register`.
+
+## Compatibility Notes
+
+- Traverse remains a `0.x` project. Public surfaces are governed and validated, but compatibility can still move before a `1.0` stability commitment.
+- The v0.5.0 public CLI app registration and durable workspace-state loading surfaces remain available.
+- The v0.6.0 governed model dependency execution surface remains available.
+- The `traverse-starter` reference app is deterministic by design and does not require model dependency readiness.
+- Local server discovery through `.traverse/server.json` remains compatible with the v0.3.0 schema fields documented for downstream consumers.
+- No cross-platform binary package is attached to this release. The release publishes source and release notes.
+
+## Validation
+
+Release preparation must pass these local gates before tagging:
+
+```bash
+cargo test
+cargo clippy -- -D warnings
+bash scripts/ci/repository_checks.sh
+bash scripts/ci/traverse_starter_example_smoke.sh
+bash scripts/ci/coverage_gate.sh
+git diff --check
+```
+
+The GitHub PR checks must also pass:
+
+- `repository-checks`
+- `coverage-gate`
+- `pr-hygiene`
+- `spec-alignment`
+
+## Traceability
+
+- Release issue: https://github.com/traverse-framework/Traverse/issues/503
+- Governing specs: `001-foundation-v0-1`, `004-spec-alignment-gate`, `006-runtime-request-execution`, `033-http-json-api`, `044-application-bundle-manifest`, `046-public-cli-app-registration`
+- Included PRs: #501, #502
+- Included issues: #499, #500

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -20,6 +20,7 @@ required_files=(
   "docs/youaskm3-v0.3.0-integration-readiness.md"
   "docs/releases/v0.5.0.md"
   "docs/releases/v0.6.0.md"
+  "docs/releases/v0.7.0.md"
   "docs/troubleshooting.md"
   "docs/adapter-boundaries.md"
   "docs/contract-publication-policy.md"
@@ -372,8 +373,8 @@ grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-source-build-consumer-packaging.md" README.md
 grep -q "docs/v0.3.0-downstream-validation-path.md" README.md
 grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" README.md
-grep -q 'version = "0.6.0"' Cargo.toml
-grep -q "docs/releases/v0.6.0.md" README.md
+grep -q 'version = "0.7.0"' Cargo.toml
+grep -q "docs/releases/v0.7.0.md" README.md
 grep -q "Traverse v0.4.0" docs/releases/v0.4.0.md
 grep -q "044-application-bundle-manifest" docs/releases/v0.4.0.md
 grep -q "045-governed-model-dependency-resolution" docs/releases/v0.4.0.md
@@ -401,6 +402,13 @@ grep -q "046-public-cli-app-registration" docs/releases/v0.6.0.md
 grep -q "governed model dependency execution surface" docs/releases/v0.6.0.md
 grep -q "cargo clippy -- -D warnings" docs/releases/v0.6.0.md
 grep -q "coverage-gate" docs/releases/v0.6.0.md
+grep -q "Traverse v0.7.0" docs/releases/v0.7.0.md
+grep -q "traverse-starter reference app" docs/releases/v0.7.0.md
+grep -q "traverse-starter.process" docs/releases/v0.7.0.md
+grep -q "App-References" docs/releases/v0.7.0.md
+grep -q "v0.5.0 minimum" docs/releases/v0.7.0.md
+grep -q "bash scripts/ci/traverse_starter_example_smoke.sh" docs/releases/v0.7.0.md
+grep -q "coverage-gate" docs/releases/v0.7.0.md
 grep -q "cargo build" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-cli -- serve" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-mcp -- stdio" docs/v0.3.0-source-build-consumer-packaging.md


### PR DESCRIPTION
## Summary

- Release Traverse v0.7.0 for the `traverse-starter` reference app path.
- Bump workspace metadata from `0.6.0` to `0.7.0`.
- Add v0.7.0 release notes and make README/compatibility docs point to the current release.
- Extend repository checks for v0.7.0 release metadata.

## Governing Spec

- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `006-runtime-request-execution`
- `025-wasm-executor-adapter`
- `028-schema-alignment-gate-v02`
- `031-supply-chain-hardening`
- `033-http-json-api`
- `038-wasi-host-insulation`
- `040-contractual-enforcement-gate`
- `044-application-bundle-manifest`
- `046-public-cli-app-registration`

## Project Item

- Closes #503
- Project 1 item: PVTI_lADOEbiBt84Bbyp1zgxnkJE

## Validation

- `cargo test`
- `cargo clippy -- -D warnings`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/traverse_starter_example_smoke.sh`
- `PATH="$HOME/.cargo/bin:$PATH" LLVM_COV=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-cov LLVM_PROFDATA=/Users/enricopiovesan/.rustup/toolchains/1.94.0-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata bash scripts/ci/coverage_gate.sh`
- `git diff --check`
