### PR TITLE
spec: approve 048 (semver pipeline), 049 (v1 gate); draft 050 (worker isolation)

### DIFF
--- a/specs/048-semver-publishing-pipeline/spec.md
+++ b/specs/048-semver-publishing-pipeline/spec.md
@@ -1,0 +1,81 @@
+# Feature Specification: Semver Publishing Pipeline
+
+**Feature Branch**: `048-semver-publishing-pipeline`
+**Created**: 2026-07-03
+**Status**: Approved
+**Input**: Cargo.toml workspace version has drifted from the git tag (0.5.0 in Cargo.toml, v0.7.0 tagged). No crates.io publishing is configured. No automated version bump exists. `repository` field still points to old org URL. This spec closes all three gaps.
+
+## Purpose
+
+This spec defines the complete semver lifecycle for Traverse: how versions move from Cargo.toml through git tag to crates.io, enforced by CI so no release can ship without the workspace version, tag, and published crates being in sync.
+
+Three problems to solve:
+
+1. **Version drift**: `Cargo.toml` version must match the git tag on every release. Currently they differ.
+2. **No crates.io publishing**: All six crates are unpublished. `publish` is not set, meaning `cargo publish` would attempt to publish without a gate.
+3. **No automation**: Version bumps are manual and error-prone. A release script must handle bump → commit → tag → publish atomically.
+
+## User Scenarios and Testing
+
+### User Story 1 — Cargo.toml version always matches the git tag (Priority: P0)
+
+As a downstream developer, I want `cargo add traverse-runtime@0.7.0` to work so that I can depend on Traverse without cloning the source.
+
+**Acceptance Scenarios**:
+
+1. **Given** a release is tagged `v0.7.0`, **When** `grep version Cargo.toml` runs, **Then** it prints `0.7.0`.
+2. **Given** the workspace version is `0.7.0`, **When** `git tag --list | grep v0.7.0` runs, **Then** the tag exists.
+3. **Given** CI runs on a tag push, **When** the tag does not match `Cargo.toml` version, **Then** the `version-guard` CI job fails with a clear error message.
+
+### User Story 2 — All six crates published to crates.io on every release tag (Priority: P1)
+
+As a downstream developer, I want all Traverse crates available on crates.io so I can use them without a git dependency.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `v*` tag is pushed, **When** the `publish` CI job runs, **Then** all six crates are published in dependency order: `traverse-contracts` → `traverse-registry` → `traverse-runtime` → `traverse-mcp` → `traverse-cli` → `traverse-expedition-wasm`.
+2. **Given** a crate is already published at that version (idempotent re-run), **When** `cargo publish` runs, **Then** the job skips cleanly rather than failing.
+3. **Given** any crate fails to publish, **When** the job reports, **Then** it names the failing crate and exits non-zero — no partial publish silently succeeds.
+
+### User Story 3 — Version bump is a single script, not manual edits (Priority: P1)
+
+As a release engineer, I want `bash scripts/ci/bump_version.sh <new-version>` to update Cargo.toml, commit, tag, and push so that version bumps have no manual file-editing step.
+
+**Acceptance Scenarios**:
+
+1. **Given** current version `0.7.0`, **When** `bash scripts/ci/bump_version.sh 0.8.0` runs, **Then** `Cargo.toml` contains `version = "0.8.0"`, a commit `chore: bump version to v0.8.0` exists, and tag `v0.8.0` is created locally.
+2. **Given** an invalid semver string like `foo`, **When** the script runs, **Then** it exits non-zero with a clear error before making any changes.
+3. **Given** the working tree has uncommitted changes, **When** the script runs, **Then** it exits non-zero and makes no changes.
+
+### User Story 4 — repository URL and crate metadata are correct (Priority: P0)
+
+As a crates.io consumer, I want the `repository` and `homepage` fields in published crates to point to `traverse-framework/Traverse`.
+
+**Acceptance Scenarios**:
+
+1. **Given** `Cargo.toml` workspace package, **When** `grep repository Cargo.toml` runs, **Then** it prints `https://github.com/traverse-framework/Traverse`.
+2. **Given** a published crate on crates.io, **When** the metadata is inspected, **Then** `repository` resolves to `https://github.com/traverse-framework/Traverse`.
+
+## Functional Requirements
+
+- **FR-001**: `[workspace.package]` in `Cargo.toml` MUST have `repository = "https://github.com/traverse-framework/Traverse"`.
+- **FR-002**: All six crates MUST have `publish = true` (or omit the field, which defaults to true) and `repository.workspace = true`.
+- **FR-003**: CI MUST include a `version-guard` job that runs on every `push` (branch and tag) and fails if `Cargo.toml` version does not match the tag when a `v*` tag is present.
+- **FR-004**: CI MUST include a `publish` job triggered only on `push` of a `v*` tag, publishing crates in dependency order.
+- **FR-005**: `scripts/ci/bump_version.sh <semver>` MUST validate input is a valid semver string before making any changes.
+- **FR-006**: `bump_version.sh` MUST refuse to run on a dirty working tree.
+- **FR-007**: `bump_version.sh` MUST update only `[workspace.package] version` in `Cargo.toml` — no other files.
+- **FR-008**: After `bump_version.sh`, running `cargo build` MUST succeed without manual intervention.
+
+## Non-Functional Requirements
+
+- **NFR-001**: Publish order MUST respect crate dependency graph — no crate is published before its dependencies.
+- **NFR-002**: The `publish` CI job MUST use `CARGO_REGISTRY_TOKEN` from GitHub Actions secrets — no token in code or scripts.
+- **NFR-003**: Publish is idempotent — re-running on an already-published version is a no-op, not an error.
+
+## Files Governed
+
+- `Cargo.toml` (repository URL, version)
+- `scripts/ci/bump_version.sh` (new)
+- `.github/workflows/ci.yml` (version-guard job, publish job)
+- `docs/release-process.md` (new — documents the full release sequence)

--- a/specs/049-v1-milestone-gate/spec.md
+++ b/specs/049-v1-milestone-gate/spec.md
@@ -1,0 +1,80 @@
+# Feature Specification: v1 Milestone Gate
+
+**Feature Branch**: `049-v1-milestone-gate`
+**Created**: 2026-07-03
+**Status**: Approved
+**Input**: No formal v1 definition exists. The project is at v0.7.0 with a growing spec surface but no stated stability promise, no crates.io presence, and no documented exit criteria for the 0.x phase. This spec names the gate conditions that must all be true before `v1.0.0` is tagged.
+
+## Purpose
+
+This spec defines exactly what v1.0.0 means for Traverse. It is not a feature spec — it is a gate spec. It names the conditions and creates the CI/checklist mechanism that enforces them. No condition may be waived; all must be green before the v1.0.0 tag is created.
+
+v1.0.0 signals:
+- Public API surfaces are stable — downstream consumers can depend on them without expecting breaking changes between patch releases.
+- All six crates are published on crates.io at the same version.
+- Thread isolation works correctly on all five supported platforms.
+- The security and supply-chain surface is hardened.
+- Documentation is accurate, complete, and covers the developer entry path end to end.
+
+## Gate Conditions
+
+### G-01: Semver publishing pipeline live
+All six crates are published on crates.io at `v1.0.0`. CI `publish` job runs on tag push with no manual steps. `Cargo.toml` version matches the tag. Governed by `spec 048`.
+
+### G-02: Thread pool executor stable and stress-tested
+`ThreadPoolExecutor` implementation is merged, 100% unit and integration coverage, all 5-platform stress CI matrix green. Governed by `spec 047`.
+
+### G-03: Public API compatibility promise documented
+`docs/compatibility-policy.md` states clearly: what is public API, what semver guarantees apply at v1, what is explicitly internal and may change. No v1 tag until this document exists and is reviewed.
+
+### G-04: Cross-platform CI matrix green on all five targets
+`ci.yml` runs the full test suite on Linux x86_64, Linux aarch64, macOS x86_64, macOS arm64, Windows x86_64. All five legs are required status checks. Governed by `spec 047` stress test job.
+
+### G-05: Security and supply-chain gate passing
+`supply-chain.yml` runs clean: SBOM generated, no critical advisories, dependency audit passes. Governed by `spec 031`.
+
+### G-06: Developer entry path validated end-to-end
+The quickstart in `README.md` (`cargo run -p traverse-cli -- bundle inspect ...`) runs to documented expected output on a clean clone on Linux and macOS in CI. A downstream app can register, execute a workflow, and receive a result without private Traverse internals. Governed by `spec 046` conformance suite.
+
+### G-07: MCP library surface stable
+`traverse-mcp` library surface (`spec 042`) is complete: `discover_capabilities()` and `execute_capability()` are callable from a Rust binary without spawning a subprocess. Thread safety verified.
+
+### G-08: All approved specs have 100% test coverage
+Every spec in `approved-specs.json` that governs `crates/` has corresponding tests with 100% line coverage on the governed files. CI coverage gate enforces this.
+
+### G-09: No open P0 or P1 bugs in the GitHub Project
+Project 1 has zero open issues labelled `bug` at priority P0 or P1 at the time of tagging.
+
+### G-10: `traverse-framework/Traverse` is the canonical repo
+The repo lives at `traverse-framework/Traverse`. Old redirect from `enricopiovesan/Traverse` is in place. All CI badges, docs, and `Cargo.toml` metadata point to the new org. Already complete — included as a gate to verify no regressions.
+
+## v1 Release Checklist Script
+
+`scripts/ci/v1_gate_check.sh` — runs all verifiable gate conditions locally and in CI:
+
+```
+[G-01] cargo search traverse-runtime | grep "^traverse-runtime = \"1.0.0\""
+[G-02] cargo test -p traverse-runtime --test thread_pool_stress -- --ignored
+[G-03] test -f docs/compatibility-policy.md && grep -q "v1 stability" docs/compatibility-policy.md
+[G-04] CI matrix: all 5 legs green (checked via gh run list)
+[G-05] cargo audit — exits 0
+[G-06] cargo run -p traverse-cli -- bundle inspect examples/expedition/... (output matches)
+[G-07] cargo test -p traverse-mcp (all tests pass)
+[G-08] cargo llvm-cov — coverage >= 100% for all governed crate paths
+[G-09] gh issue list --label bug --state open — count = 0
+[G-10] grep "traverse-framework/Traverse" Cargo.toml
+```
+
+## What v1 Does NOT Require
+
+- A reference app in this repo (reference apps live in `traverse-framework/App-References`)
+- An HTTP admin API
+- A service registry or service discovery mechanism
+- A cloud deployment surface
+- A stable WASM ABI beyond what `spec 038` already governs
+
+## Files Governed
+
+- `scripts/ci/v1_gate_check.sh` (new)
+- `docs/v1-milestone.md` (new — human-readable version of this gate list)
+- `docs/compatibility-policy.md` (must be updated to include v1 stability statement)

--- a/specs/050-message-passing-worker-isolation/spec.md
+++ b/specs/050-message-passing-worker-isolation/spec.md
@@ -1,0 +1,74 @@
+# Feature Specification: Message-Passing Worker Isolation
+
+**Feature Branch**: `050-message-passing-worker-isolation`
+**Created**: 2026-07-03
+**Status**: Draft — architecture decision only, no implementation approved
+**Input**: `spec 047` delivers thread-pool executor (Option A). This spec captures the Option C architecture so that no decision in 047, the HTTP API, or the MCP surface accidentally closes the door on it. Implementation is gated on v1 shipping and real multi-capability production workloads to design against.
+
+## Purpose
+
+This spec records the intended v2 execution isolation architecture for Traverse: each registered capability type gets a dedicated worker with its own mailbox, lifecycle, and failure boundary. A panicking or hanging capability cannot affect any other capability's execution or the runtime's own state.
+
+This is a **draft spec**. It will not move to `approved` until:
+- `spec 047` (thread pool executor) is merged and stable
+- At least one real downstream production workload has been observed to need stronger isolation than a shared thread pool provides
+- A concrete implementation plan is proposed and reviewed
+
+## Architecture
+
+### Current state (post spec-047)
+
+```
+Caller thread
+  └── ThreadPoolExecutor
+        └── Rayon pool thread
+              └── CapabilityExecutor::execute() → Value
+```
+
+All capabilities share the same Rayon pool. A slow capability reduces available threads for others. A panicking capability is caught at the pool boundary but the pool thread cycles back into shared use.
+
+### Target state (this spec)
+
+```
+Caller thread
+  └── WorkerRouter
+        └── CapabilityWorker[capability_id]
+              ├── inbox: mpsc::Sender<WorkerRequest>
+              ├── outbox: oneshot::Sender<WorkerResponse>
+              └── dedicated OS thread (or WASM worker)
+                    └── CapabilityExecutor::execute() → Value
+```
+
+Each capability type has exactly one worker. The worker owns its executor instance. The caller sends a `WorkerRequest` envelope and waits on a `oneshot` channel for the `WorkerResponse`. If the worker thread panics, the worker is restarted and the caller receives `ExecutorError::ExecutionFailed` — no other capability is affected.
+
+### Key properties
+
+| Property | Thread pool (spec 047) | Worker isolation (spec 050) |
+|---|---|---|
+| Slow capability affects others | Yes (shared pool) | No (dedicated thread) |
+| Panicking capability affects pool | No (catch_unwind) | No (worker restarts) |
+| Per-capability resource limits | No | Yes (worker owns its resources) |
+| WASM worker support | No | Yes (browser WASM workers map directly) |
+| Implementation complexity | Low | High |
+| API break from spec 047 | — | None (same CapabilityExecutor trait) |
+
+## Deferral Conditions
+
+This spec moves from Draft to Approved only when:
+
+1. A concrete stress test demonstrates that spec-047 thread pool is insufficient for a real workload
+2. The implementation plan for worker lifecycle management (start, restart, shutdown, drain) is reviewed and approved
+3. WASM worker support on the browser target is validated in `traverse-framework/App-References`
+
+## What Must NOT Be Decided Before This Spec Is Approved
+
+To keep the Option C path open, no other spec may:
+- Assume `CapabilityExecutor::execute()` is always called on a pool thread (the trait must remain agnostic)
+- Hard-code a Rayon dependency into the public `TraverseRuntime` constructor
+- Introduce per-capability mutable state that would be unsafe to move to a dedicated thread
+
+## Files This Spec Will Govern (when approved)
+
+- `crates/traverse-runtime/src/executor/worker.rs` (new)
+- `crates/traverse-runtime/src/executor/worker_router.rs` (new)
+- `crates/traverse-runtime/src/executor/mod.rs` (re-exports)

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -530,6 +530,31 @@
         "specs/047-thread-pool-executor/",
         "specs/governance/"
       ]
+    },
+    {
+      "id": "048-semver-publishing-pipeline",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/048-semver-publishing-pipeline/spec.md",
+      "governs": [
+        "Cargo.toml",
+        "scripts/ci/bump_version.sh",
+        ".github/workflows/ci.yml",
+        "docs/release-process.md"
+      ]
+    },
+    {
+      "id": "049-v1-milestone-gate",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/049-v1-milestone-gate/spec.md",
+      "governs": [
+        "scripts/ci/v1_gate_check.sh",
+        "docs/v1-milestone.md",
+        "docs/compatibility-policy.md"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Approves `048-semver-publishing-pipeline` — governs Cargo.toml version fix, `bump_version.sh`, crates.io publish CI job
- Approves `049-v1-milestone-gate` — defines the 10 gate conditions for v1.0.0
- Commits `050-message-passing-worker-isolation` as a **draft architecture record** — not in `approved-specs.json`

## Governing Spec

- `004-spec-alignment-gate`
- `028-schema-alignment-gate-v02`

## Project Item

Closes #512

## Validation

- `approved-specs.json` contains 048 and 049 as approved
- 050 is committed as a draft spec only — not added to approved-specs.json
- `bash scripts/ci/spec_alignment_check.sh` passes