### PR TITLE
Approve spec 051-registry-extraction

### DIFF
--- a/specs/051-registry-extraction/spec.md
+++ b/specs/051-registry-extraction/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `051-registry-extraction`
 **Created**: 2026-07-03
-**Status**: Draft
+**Status**: Approved
 **Input**: Brainstorm session establishing `traverse-framework/registry` as a dedicated repo for the public capability registry, extracted from this repo's `crates/traverse-registry`. Full narrative record: `traverse-framework/registry`'s `docs/decision-log.md`. Companion foundation spec: `traverse-framework/registry`'s `specs/001-registry-foundation/spec.md`.
 
 ## Purpose

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -555,6 +555,17 @@
         "docs/v1-milestone.md",
         "docs/compatibility-policy.md"
       ]
+    },
+    {
+      "id": "051-registry-extraction",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/051-registry-extraction/spec.md",
+      "governs": [
+        "Cargo.toml",
+        "specs/governance/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Moves specs/051-registry-extraction from Draft to Approved in specs/governance/approved-specs.json. The repo owner has confirmed the spec faithfully reflects the decisions already made in traverse-framework/registry's docs/decision-log.md during the brainstorm session -- this records an already-made decision, it does not make a new one.

## Governing Spec

- 051-registry-extraction

## Project Item

- Issue #521 (Project 1)

## What Changed

- Contracts changed: none
- Runtime behavior changed: none
- Compatibility impact: none -- governance state change only
- ADR needed or linked: n/a, spec 051 itself is the decision record

## Validation

- [x] specs/governance/approved-specs.json is valid JSON