### PR TITLE
docs: define v1 milestone gate conditions (spec 049)

### DIFF
--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -15,3 +15,26 @@ The release-facing downstream compatibility statement for the current `youaskm3`
 The current Traverse release notes are:
 
 - `docs/releases/v0.7.0.md`
+
+## v1 Stability Statement
+
+At `v1.0.0`, Traverse makes the following stability commitments:
+
+**Public API (stable — semver guarantees apply):**
+- `traverse-runtime`: `CapabilityExecutor`, `ExecutorCapability`, `ExecutorError`, `ArtifactType`, `PlacementRouter`, `RouterRequest`, `RouterResponse`, `TraceStore`, `TraceOutcome`
+- `traverse-contracts`: all public contract types (`CapabilityContract`, `EventContract`, etc.)
+- `traverse-registry`: `CapabilityRegistry`, `EventRegistry`, `WorkflowRegistry`
+- `traverse-cli`: all documented CLI subcommands and their `--json` output shapes
+- `traverse-mcp`: `discover_capabilities()`, `execute_capability()` library surface
+
+**Internal (may change between minor versions):**
+- Anything in `mod.rs` private submodules not re-exported at the crate root
+- `TraceStore` internal storage format (inspect via public API only)
+- `InProcessBroker` internal state
+
+**Semver at v1:**
+- PATCH: bug fixes, no API changes
+- MINOR: new public API additions, backward-compatible
+- MAJOR: breaking public API changes (requires new v2.x series)
+
+This v1 stability statement is a gate condition for the v1.0.0 release. See `docs/v1-milestone.md` for the full gate list.

--- a/docs/v1-milestone.md
+++ b/docs/v1-milestone.md
@@ -8,16 +8,16 @@ v1.0.0 signals that Traverse public API surfaces are stable, all six crates are 
 
 | Gate | Condition | Verifiable |
 |---|---|---|
-| G-01 | All 6 crates published on crates.io at `v1.0.0` | `cargo search traverse-runtime` |
-| G-02 | ThreadPoolExecutor stress tests green on all 5 platforms | CI stress-test matrix |
+| G-01 | All 6 crates published on crates.io at `v1.0.0` | `cargo search` for each Traverse crate |
+| G-02 | ThreadPoolExecutor stress tests green on all 5 platforms | `cargo test -p traverse-runtime --test thread_pool_stress -- --ignored` and CI stress-test matrix |
 | G-03 | `docs/compatibility-policy.md` contains v1 stability statement | `grep "v1 stability"` |
-| G-04 | 5-platform CI matrix all green (Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64) | CI run status |
+| G-04 | 5-platform CI matrix all green (Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64) | latest `ci.yml` GitHub Actions run status |
 | G-05 | `cargo audit` clean, SBOM generated | `supply-chain.yml` passing |
 | G-06 | Quickstart command produces documented output on clean clone on Linux + macOS in CI | Smoke test |
 | G-07 | MCP library surface callable without subprocess (`discover_capabilities`, `execute_capability`) | Integration tests |
 | G-08 | 100% test coverage on all governed crate paths | Coverage gate |
-| G-09 | Zero open P0/P1 bugs in Project 1 | `gh issue list --label bug` |
-| G-10 | `Cargo.toml` and all doc badges point to `traverse-framework/Traverse` | `grep traverse-framework/Traverse Cargo.toml` |
+| G-09 | Zero open P0/P1 bugs in Project 1 | `gh issue list --label bug` filtered to P0/P1 priority labels |
+| G-10 | `Cargo.toml` and all doc badges point to `traverse-framework/Traverse` | metadata and documentation grep |
 
 ## How to check locally
 

--- a/docs/v1-milestone.md
+++ b/docs/v1-milestone.md
@@ -1,0 +1,36 @@
+# v1.0.0 Milestone
+
+Governed by `spec 049-v1-milestone-gate`.
+
+v1.0.0 signals that Traverse public API surfaces are stable, all six crates are on crates.io, and the runtime has been stress-tested on all supported platforms. No condition may be waived before the `v1.0.0` tag is created.
+
+## Gate Conditions
+
+| Gate | Condition | Verifiable |
+|---|---|---|
+| G-01 | All 6 crates published on crates.io at `v1.0.0` | `cargo search traverse-runtime` |
+| G-02 | ThreadPoolExecutor stress tests green on all 5 platforms | CI stress-test matrix |
+| G-03 | `docs/compatibility-policy.md` contains v1 stability statement | `grep "v1 stability"` |
+| G-04 | 5-platform CI matrix all green (Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64) | CI run status |
+| G-05 | `cargo audit` clean, SBOM generated | `supply-chain.yml` passing |
+| G-06 | Quickstart command produces documented output on clean clone on Linux + macOS in CI | Smoke test |
+| G-07 | MCP library surface callable without subprocess (`discover_capabilities`, `execute_capability`) | Integration tests |
+| G-08 | 100% test coverage on all governed crate paths | Coverage gate |
+| G-09 | Zero open P0/P1 bugs in Project 1 | `gh issue list --label bug` |
+| G-10 | `Cargo.toml` and all doc badges point to `traverse-framework/Traverse` | `grep traverse-framework/Traverse Cargo.toml` |
+
+## How to check locally
+
+```bash
+bash scripts/ci/v1_gate_check.sh
+```
+
+Exits 0 only when all verifiable conditions pass. Names which gate failed otherwise.
+
+## What v1.0.0 does NOT require
+
+- A reference app in this repo (reference apps live in `traverse-framework/App-References`)
+- An HTTP admin API or service registry
+- A cloud deployment surface
+- A stable WASM ABI beyond what spec 038 already governs
+- Message-passing worker isolation (spec 050, planned for v2)

--- a/scripts/ci/v1_gate_check.sh
+++ b/scripts/ci/v1_gate_check.sh
@@ -27,20 +27,44 @@ echo "=== Traverse v1.0.0 Gate Check ==="
 echo ""
 
 # G-01: crates.io publication
-check G-01 "traverse-runtime on crates.io at v1.0.0" \
-    cargo search traverse-runtime
+check G-01 "all Traverse crates are on crates.io at v1.0.0" bash -c '
+    for crate in \
+        traverse-cli \
+        traverse-contracts \
+        traverse-expedition-wasm \
+        traverse-mcp \
+        traverse-registry \
+        traverse-runtime
+    do
+        cargo search "$crate" --limit 1 | grep -q "^${crate} = \"1\.0\.0\""
+    done
+'
+
+# G-02: thread pool stress evidence
+check G-02 "ThreadPoolExecutor stress tests pass locally" \
+    cargo test -p traverse-runtime --test thread_pool_stress -- --ignored
 
 # G-03: compatibility-policy has v1 stability statement
 check G-03 "docs/compatibility-policy.md has v1 stability statement" \
     grep -q "v1 stability\|v1\.0\.0 stability\|1\.0\.0 stability" docs/compatibility-policy.md
+
+# G-04: cross-platform CI matrix evidence
+check G-04 "latest CI workflow completed successfully" bash -c '
+    gh run list --workflow ci.yml --branch main --limit 1 --json conclusion \
+        | python3 -c "import json,sys; runs=json.load(sys.stdin); sys.exit(0 if runs and runs[0].get(\"conclusion\") == \"success\" else 1)"
+'
 
 # G-05: cargo audit clean
 check G-05 "cargo audit passes" \
     cargo audit
 
 # G-06: quickstart smoke
-check G-06 "quickstart command produces expected output" bash -c \
-    "cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json 2>/dev/null | grep -q 'bundle_id'"
+check G-06 "quickstart command produces documented output" bash -c '
+    output="$(cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json 2>/dev/null)"
+    grep -q "bundle_id: expedition.planning.seed-bundle" <<<"$output"
+    grep -q "capabilities: 6" <<<"$output"
+    grep -q "workflows: 1" <<<"$output"
+'
 
 # G-07: MCP tests pass
 check G-07 "traverse-mcp tests pass" \
@@ -51,21 +75,25 @@ check G-08 "coverage gate passes" \
     bash scripts/ci/coverage_gate.sh
 
 # G-09: no open P0/P1 bugs
-check G-09 "no open P0/P1 bugs (requires gh CLI)" bash -c \
-    "count=\$(gh issue list --label bug --state open --json number | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))'); [ \"\$count\" = '0' ]"
+check G-09 "no open P0/P1 bugs (requires gh CLI)" bash -c '
+    gh issue list --label bug --state open --json number,labels \
+        | python3 -c "import json,sys; issues=json.load(sys.stdin); high=[i for i in issues if any(l.get(\"name\", \"\").lower() in {\"p0\", \"p1\", \"priority:p0\", \"priority:p1\", \"priority: p0\", \"priority: p1\"} for l in i.get(\"labels\", []))]; sys.exit(0 if not high else 1)"
+'
 
-# G-10: Cargo.toml points to traverse-framework
-check G-10 "Cargo.toml repository points to traverse-framework/Traverse" \
+# G-10: canonical repository metadata
+check G-10 "Cargo.toml and docs point to traverse-framework/Traverse" bash -c '
     grep -q "traverse-framework/Traverse" Cargo.toml
+    grep -q "traverse-framework/Traverse/actions/workflows/ci.yml" README.md
+    grep -q "github.com/traverse-framework/Traverse/releases" README.md
+    ! grep -R -E "enricopiovesan/Traverse|github.com/users/enricopiovesan/projects/1" README.md docs Cargo.toml >/dev/null
+'
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 
 if [[ $FAIL -gt 0 ]]; then
-    echo ""
-    echo "Gates G-02 (stress CI matrix), G-04 (5-platform CI) must be verified via GitHub Actions."
     exit 1
 fi
 
-echo "All verifiable gates pass. Verify G-02 and G-04 via GitHub Actions before tagging v1.0.0."
+echo "All verifiable gates pass. Confirm required CI matrix legs before tagging v1.0.0."
 exit 0

--- a/scripts/ci/v1_gate_check.sh
+++ b/scripts/ci/v1_gate_check.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Checks all verifiable v1.0.0 gate conditions.
+# Governed by spec 049-v1-milestone-gate.
+#
+# Usage: bash scripts/ci/v1_gate_check.sh
+# Exits 0 only when all conditions pass.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+check() {
+    local gate="$1"
+    local description="$2"
+    shift 2
+    if "$@" >/dev/null 2>&1; then
+        echo "[PASS] $gate: $description"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $gate: $description"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Traverse v1.0.0 Gate Check ==="
+echo ""
+
+# G-01: crates.io publication
+check G-01 "traverse-runtime on crates.io at v1.0.0" \
+    cargo search traverse-runtime
+
+# G-03: compatibility-policy has v1 stability statement
+check G-03 "docs/compatibility-policy.md has v1 stability statement" \
+    grep -q "v1 stability\|v1\.0\.0 stability\|1\.0\.0 stability" docs/compatibility-policy.md
+
+# G-05: cargo audit clean
+check G-05 "cargo audit passes" \
+    cargo audit
+
+# G-06: quickstart smoke
+check G-06 "quickstart command produces expected output" bash -c \
+    "cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json 2>/dev/null | grep -q 'bundle_id'"
+
+# G-07: MCP tests pass
+check G-07 "traverse-mcp tests pass" \
+    cargo test -p traverse-mcp --quiet
+
+# G-08: coverage gate
+check G-08 "coverage gate passes" \
+    bash scripts/ci/coverage_gate.sh
+
+# G-09: no open P0/P1 bugs
+check G-09 "no open P0/P1 bugs (requires gh CLI)" bash -c \
+    "count=\$(gh issue list --label bug --state open --json number | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))'); [ \"\$count\" = '0' ]"
+
+# G-10: Cargo.toml points to traverse-framework
+check G-10 "Cargo.toml repository points to traverse-framework/Traverse" \
+    grep -q "traverse-framework/Traverse" Cargo.toml
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo "Gates G-02 (stress CI matrix), G-04 (5-platform CI) must be verified via GitHub Actions."
+    exit 1
+fi
+
+echo "All verifiable gates pass. Verify G-02 and G-04 via GitHub Actions before tagging v1.0.0."
+exit 0


### PR DESCRIPTION
## Summary

- Document the v1.0.0 milestone gate conditions in docs/v1-milestone.md.
- Add scripts/ci/v1_gate_check.sh for locally verifiable gate checks.
- Add the v1 public API stability statement to docs/compatibility-policy.md.

## Governing Spec

- `049-v1-milestone-gate`

## Project Item

Closes #515

## Validation

- `bash -n scripts/ci/v1_gate_check.sh`
- G-06 quickstart assertion passes locally against `cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json`.
- `bash scripts/ci/v1_gate_check.sh` currently fails expected pre-v1 gates such as crates.io v1 publication, missing stress suite, cargo audit, coverage environment, and P0/P1 project state until v1 prerequisites are complete.
