### PR TITLE
Implement semver version guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,55 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - "**"
+    tags:
+      - "v*"
   pull_request:
 
 jobs:
+  version-guard:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify tag matches workspace version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          workspace_version="$(awk '
+            /^\[workspace\.package\]$/ { in_workspace_package = 1; next }
+            /^\[/ { in_workspace_package = 0 }
+            in_workspace_package && $1 == "version" {
+              gsub(/"/, "", $3)
+              print $3
+              found = 1
+              exit
+            }
+            END { if (!found) exit 1 }
+          ' Cargo.toml)"
+
+          if [[ "${GITHUB_REF_TYPE:-}" != "tag" ]]; then
+            echo "No release tag present; version guard passes for ${GITHUB_REF:-unknown ref}."
+            exit 0
+          fi
+
+          tag_name="${GITHUB_REF_NAME:-}"
+          if [[ ! "${tag_name}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag ${tag_name} is not a Traverse release tag; version guard passes."
+            exit 0
+          fi
+
+          tag_version="${tag_name#v}"
+          if [[ "${workspace_version}" != "${tag_version}" ]]; then
+            echo "Cargo.toml workspace version ${workspace_version} does not match tag ${tag_name}." >&2
+            exit 1
+          fi
+
+          echo "Cargo.toml workspace version ${workspace_version} matches ${tag_name}."
+
   repository-checks:
     runs-on: ubuntu-latest
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,23 @@
+# Traverse Release Process
+
+Governed by spec `048-semver-publishing-pipeline`.
+
+Use the release helper from a clean `main` checkout after CI is green:
+
+1. Run `bash scripts/ci/bump_version.sh <version>`.
+2. Run `git push origin main`.
+3. Run `git push origin v<version>`.
+4. Confirm the CI publish job starts automatically from the `v<version>` tag push.
+5. Verify crates.io lists all six Traverse crates at the new version:
+   `traverse-contracts`, `traverse-registry`, `traverse-runtime`,
+   `traverse-mcp`, `traverse-cli`, and `traverse-expedition-wasm`.
+
+The version argument is `MAJOR.MINOR.PATCH` without a leading `v`. The helper
+refuses invalid versions, dirty working trees, and pre-existing local release
+tags. It updates only `[workspace.package] version` in `Cargo.toml`, creates the
+commit `chore: bump version to v<version>`, and creates the local tag
+`v<version>`. It does not push commits or tags.
+
+On a tag push, the `version-guard` CI job compares the tag without the leading
+`v` to the workspace version in `Cargo.toml`. Branch and pull-request runs pass
+without a release tag, while mismatched release tags fail before publishing.

--- a/scripts/ci/bump_version.sh
+++ b/scripts/ci/bump_version.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: bash scripts/ci/bump_version.sh <new-semver>" >&2
+}
+
+if [[ "$#" -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+new_version="$1"
+
+if [[ ! "${new_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid semver '${new_version}'. Expected MAJOR.MINOR.PATCH without a leading v." >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Working tree is dirty; commit or discard changes before bumping the version." >&2
+  exit 1
+fi
+
+tag_name="v${new_version}"
+if git rev-parse --verify --quiet "refs/tags/${tag_name}" >/dev/null; then
+  echo "Tag ${tag_name} already exists." >&2
+  exit 1
+fi
+
+tmp_file="$(mktemp)"
+trap 'rm -f "${tmp_file}"' EXIT
+
+awk -v new_version="${new_version}" '
+  BEGIN {
+    in_workspace_package = 0
+    replacements = 0
+  }
+  /^\[workspace\.package\]$/ {
+    in_workspace_package = 1
+    print
+    next
+  }
+  /^\[/ {
+    in_workspace_package = 0
+  }
+  in_workspace_package && $1 == "version" && $2 == "=" {
+    print "version = \"" new_version "\""
+    replacements += 1
+    next
+  }
+  {
+    print
+  }
+  END {
+    if (replacements != 1) {
+      exit 1
+    }
+  }
+' Cargo.toml > "${tmp_file}"
+
+mv "${tmp_file}" Cargo.toml
+
+if git diff --quiet -- Cargo.toml; then
+  echo "Cargo.toml already has workspace version ${new_version}; no bump commit created." >&2
+  exit 1
+fi
+
+changed_files="$(git diff --name-only)"
+if [[ "${changed_files}" != "Cargo.toml" ]]; then
+  echo "Version bump changed unexpected files:" >&2
+  echo "${changed_files}" >&2
+  exit 1
+fi
+
+git add Cargo.toml
+git commit -m "chore: bump version to ${tag_name}"
+git tag "${tag_name}"
+
+echo "Created commit and local tag ${tag_name}."
+echo "Push explicitly with:"
+echo "  git push origin main"
+echo "  git push origin ${tag_name}"


### PR DESCRIPTION
## Governing Spec
- `048-semver-publishing-pipeline`

## Project Item
- Closes #513

## Validation
- `bash scripts/ci/bump_version.sh foo` exits non-zero before changes
- `bash scripts/ci/bump_version.sh 0.8.0` exits non-zero on a dirty tree before changes
- Simulated `version-guard` branch push passes without a tag
- Simulated `version-guard` tag push passes for `v0.7.0` when Cargo.toml is `0.7.0`
- Simulated `version-guard` tag push fails for `v0.7.0` when Cargo.toml is `0.5.0`
- Clean disposable clone: `bash scripts/ci/bump_version.sh 0.8.0` creates commit and tag, then `cargo build` passes
- `bash scripts/ci/repository_checks.sh`
