### PR TITLE
Implement crates.io publish CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,33 @@ jobs:
       - name: Run coverage gate
         run: bash scripts/ci/coverage_gate.sh
 
+  publish:
+    name: Publish to crates.io
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - version-guard
+      - repository-checks
+      - coverage-gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Publish crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          TRAVERSE_PUBLISH_DRY_RUN_BEFORE: "1"
+        run: bash scripts/ci/publish_crates.sh
+
   pr-hygiene:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/crates/traverse-cli/Cargo.toml
+++ b/crates/traverse-cli/Cargo.toml
@@ -11,9 +11,9 @@ semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.10"
-traverse-contracts = { path = "../traverse-contracts" }
-traverse-registry = { path = "../traverse-registry" }
-traverse-runtime = { path = "../traverse-runtime" }
+traverse-contracts = { path = "../traverse-contracts", version = "0.7.0" }
+traverse-registry = { path = "../traverse-registry", version = "0.7.0" }
+traverse-runtime = { path = "../traverse-runtime", version = "0.7.0" }
 
 [lints]
 workspace = true

--- a/crates/traverse-mcp/Cargo.toml
+++ b/crates/traverse-mcp/Cargo.toml
@@ -13,9 +13,9 @@ path = "src/main.rs"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-traverse-contracts = { path = "../traverse-contracts" }
-traverse-registry = { path = "../traverse-registry" }
-traverse-runtime = { path = "../traverse-runtime" }
+traverse-contracts = { path = "../traverse-contracts", version = "0.7.0" }
+traverse-registry = { path = "../traverse-registry", version = "0.7.0" }
+traverse-runtime = { path = "../traverse-runtime", version = "0.7.0" }
 
 [lints]
 workspace = true

--- a/crates/traverse-registry/Cargo.toml
+++ b/crates/traverse-registry/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-traverse-contracts = { path = "../traverse-contracts" }
+traverse-contracts = { path = "../traverse-contracts", version = "0.7.0" }
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/crates/traverse-runtime/Cargo.toml
+++ b/crates/traverse-runtime/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-traverse-contracts = { path = "../traverse-contracts" }
-traverse-registry = { path = "../traverse-registry" }
+traverse-contracts = { path = "../traverse-contracts", version = "0.7.0" }
+traverse-registry = { path = "../traverse-registry", version = "0.7.0" }
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -21,3 +21,10 @@ commit `chore: bump version to v<version>`, and creates the local tag
 On a tag push, the `version-guard` CI job compares the tag without the leading
 `v` to the workspace version in `Cargo.toml`. Branch and pull-request runs pass
 without a release tag, while mismatched release tags fail before publishing.
+
+The tag-only `publish` CI job runs after `version-guard`, repository checks, and
+coverage pass. It runs `bash scripts/ci/publish_crates.sh` with
+`CARGO_REGISTRY_TOKEN` from GitHub Actions secrets. The script dry-runs each
+crate immediately before publishing it, publishes crates in dependency order,
+and treats an already-uploaded crate version as success so reruns are
+idempotent.

--- a/scripts/ci/publish_crates.sh
+++ b/scripts/ci/publish_crates.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+crates=(
+  "traverse-contracts"
+  "traverse-registry"
+  "traverse-runtime"
+  "traverse-mcp"
+  "traverse-cli"
+  "traverse-expedition-wasm"
+)
+
+if [[ -n "${TRAVERSE_PUBLISH_CRATES:-}" ]]; then
+  read -r -a crates <<< "${TRAVERSE_PUBLISH_CRATES}"
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+workspace_version="$(awk '
+  /^\[workspace\.package\]$/ { in_workspace_package = 1; next }
+  /^\[/ { in_workspace_package = 0 }
+  in_workspace_package && $1 == "version" {
+    gsub(/"/, "", $3)
+    print $3
+    found = 1
+    exit
+  }
+  END { if (!found) exit 1 }
+' Cargo.toml)"
+
+dry_run="${TRAVERSE_PUBLISH_DRY_RUN:-0}"
+dry_run_before="${TRAVERSE_PUBLISH_DRY_RUN_BEFORE:-0}"
+no_verify="${TRAVERSE_PUBLISH_NO_VERIFY:-0}"
+allow_dirty="${TRAVERSE_PUBLISH_ALLOW_DIRTY:-0}"
+sleep_seconds="${TRAVERSE_PUBLISH_SLEEP_SECONDS:-30}"
+
+publish_args=()
+dry_run_publish_args=("--dry-run" "--no-verify")
+if [[ "${dry_run}" == "1" ]]; then
+  publish_args+=("--dry-run")
+fi
+if [[ "${no_verify}" == "1" ]]; then
+  publish_args+=("--no-verify")
+fi
+if [[ "${allow_dirty}" == "1" ]]; then
+  publish_args+=("--allow-dirty")
+  dry_run_publish_args+=("--allow-dirty")
+fi
+
+if [[ "${dry_run}" != "1" && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+  echo "CARGO_REGISTRY_TOKEN is required for real publishing." >&2
+  exit 1
+fi
+
+publish_one() {
+  local crate="$1"
+  local output_file
+  local dry_run_file
+  local rc
+
+  if [[ "${dry_run}" != "1" && "${dry_run_before}" == "1" ]]; then
+    dry_run_file="$(mktemp)"
+    echo "Dry-running ${crate} ${workspace_version}..."
+    if cargo publish -p "${crate}" "${dry_run_publish_args[@]}" >"${dry_run_file}" 2>&1; then
+      cat "${dry_run_file}"
+      rm -f "${dry_run_file}"
+    else
+      rc="$?"
+      cat "${dry_run_file}" >&2
+      rm -f "${dry_run_file}"
+      return "${rc}"
+    fi
+  fi
+
+  output_file="$(mktemp)"
+
+  echo "Publishing ${crate} ${workspace_version}..."
+  if [[ "${#publish_args[@]}" -gt 0 ]]; then
+    if cargo publish -p "${crate}" "${publish_args[@]}" >"${output_file}" 2>&1; then
+      rc=0
+    else
+      rc="$?"
+    fi
+  else
+    if cargo publish -p "${crate}" >"${output_file}" 2>&1; then
+      rc=0
+    else
+      rc="$?"
+    fi
+  fi
+
+  if [[ "${rc}" -eq 0 ]]; then
+    cat "${output_file}"
+    rm -f "${output_file}"
+    return 0
+  fi
+
+  cat "${output_file}" >&2
+  if grep -Eiq "already uploaded|crate version .* is already uploaded" "${output_file}"; then
+    echo "${crate} ${workspace_version} is already published; continuing."
+    rm -f "${output_file}"
+    return 0
+  fi
+
+  rm -f "${output_file}"
+  return "${rc}"
+}
+
+confirm_published() {
+  local crate="$1"
+
+  if [[ "${dry_run}" == "1" ]]; then
+    return 0
+  fi
+
+  for attempt in {1..20}; do
+    if cargo search "${crate}" --limit 5 2>/dev/null | grep -Eq "^${crate} = \"${workspace_version}\""; then
+      echo "Confirmed ${crate} ${workspace_version} on crates.io."
+      return 0
+    fi
+
+    echo "Waiting for ${crate} ${workspace_version} to appear on crates.io (${attempt}/20)..."
+    sleep "${sleep_seconds}"
+  done
+
+  echo "Timed out waiting for ${crate} ${workspace_version} on crates.io." >&2
+  return 1
+}
+
+for index in "${!crates[@]}"; do
+  crate="${crates[$index]}"
+  publish_one "${crate}"
+  confirm_published "${crate}"
+
+  if [[ "${dry_run}" != "1" && "${index}" -lt "$((${#crates[@]} - 1))" ]]; then
+    echo "Waiting ${sleep_seconds} seconds before publishing the next crate."
+    sleep "${sleep_seconds}"
+  fi
+done
+
+if [[ "${dry_run}" == "1" ]]; then
+  echo "Dry-run publish check completed for ${workspace_version}."
+else
+  echo "Published all Traverse crates at ${workspace_version}."
+fi

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -539,7 +539,14 @@
       "path": "specs/048-semver-publishing-pipeline/spec.md",
       "governs": [
         "Cargo.toml",
+        "crates/traverse-cli/Cargo.toml",
+        "crates/traverse-contracts/Cargo.toml",
+        "crates/traverse-expedition-wasm/Cargo.toml",
+        "crates/traverse-mcp/Cargo.toml",
+        "crates/traverse-registry/Cargo.toml",
+        "crates/traverse-runtime/Cargo.toml",
         "scripts/ci/bump_version.sh",
+        "scripts/ci/publish_crates.sh",
         ".github/workflows/ci.yml",
         "docs/release-process.md"
       ]


### PR DESCRIPTION
## Governing Spec
- `048-semver-publishing-pipeline`
- `004-spec-alignment-gate`

## Project Item
- Closes #514

## Validation
- `bash -n scripts/ci/publish_crates.sh`
- workflow YAML parsed successfully
- `cargo check --workspace`
- `cargo test --workspace`
- packaged all six crates with `cargo package --no-verify --allow-dirty --list`
- one-crate script dry-run: `TRAVERSE_PUBLISH_CRATES=traverse-contracts TRAVERSE_PUBLISH_DRY_RUN=1 TRAVERSE_PUBLISH_NO_VERIFY=1 TRAVERSE_PUBLISH_ALLOW_DIRTY=1 bash scripts/ci/publish_crates.sh`
- no-token real publish path exits non-zero before publishing
- duplicate-upload branch simulated with fake Cargo shim and exits 0
- `python3 -m json.tool specs/governance/approved-specs.json`
- `bash scripts/ci/repository_checks.sh`
