### PR TITLE
Add mobile runtime provisioning URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1798,7 @@ dependencies = [
 name = "traverse-cli"
 version = "0.7.0"
 dependencies = [
+ "qrcode",
  "semver",
  "serde",
  "serde_json",

--- a/crates/traverse-cli/Cargo.toml
+++ b/crates/traverse-cli/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+qrcode = { version = "0.14.1", default-features = false }
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write as FmtWrite;
 use std::io::{Read, Write};
 use std::net::{IpAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
@@ -60,6 +61,7 @@ pub struct ApiServerConfig<E> {
     pub bind_address: String,
     pub allow_unauthenticated: bool,
     pub allowed_origins: Vec<String>,
+    pub render_mobile_qr: bool,
     pub capability_registry: CapabilityRegistry,
     pub workflow_registry: WorkflowRegistry,
     pub registry_root: PathBuf,
@@ -182,6 +184,7 @@ struct ServerDiscoveryV1 {
     pid: u32,
     started_at: String,
     auth_mode: String,
+    mobile_connect_url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     local_dev_token: Option<String>,
 }
@@ -264,12 +267,22 @@ where
     eprintln!(
         "traverse-cli serve: HTTP/JSON API listening on http://{local_addr} (spec 033-http-json-api)"
     );
+    let base_url = format!("http://{local_addr}");
+    let mobile_connect_url = mobile_connect_url(&base_url, DEFAULT_WORKSPACE_ID, auth_mode);
+    eprintln!("traverse-cli serve: mobile connect URL {mobile_connect_url}");
+    if config.render_mobile_qr {
+        eprintln!(
+            "{}",
+            render_mobile_connect_qr(&mobile_connect_url).map_err(ServeError::BindFailed)?
+        );
+    }
     let _ = std::io::stderr().flush();
 
     write_server_discovery(
         Path::new("."),
-        &format!("http://{local_addr}"),
+        &base_url,
         auth_mode,
+        &mobile_connect_url,
         local_dev_token.as_deref(),
     )
     .map_err(ServeError::BindFailed)?;
@@ -345,6 +358,7 @@ fn write_server_discovery(
     repo_root: &Path,
     base_url: &str,
     auth_mode: &str,
+    mobile_connect_url: &str,
     local_dev_token: Option<&str>,
 ) -> Result<PathBuf, String> {
     let traverse_dir = repo_root.join(".traverse");
@@ -359,6 +373,7 @@ fn write_server_discovery(
         pid: std::process::id(),
         started_at: generated_registered_at().map_err(|e| e.message)?,
         auth_mode: auth_mode.to_string(),
+        mobile_connect_url: mobile_connect_url.to_string(),
         local_dev_token: local_dev_token.map(str::to_string),
     };
     let body = serde_json::to_vec_pretty(&discovery)
@@ -369,6 +384,50 @@ fn write_server_discovery(
         set_owner_read_write(&discovery_path)?;
     }
     Ok(discovery_path)
+}
+
+fn mobile_connect_url(base_url: &str, workspace_default: &str, auth_mode: &str) -> String {
+    format!(
+        "traverse://connect?base_url={}&workspace_default={}&auth_mode={}",
+        percent_encode_query_value(base_url),
+        percent_encode_query_value(workspace_default),
+        percent_encode_query_value(auth_mode)
+    )
+}
+
+fn percent_encode_query_value(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            let _ = write!(&mut encoded, "%{byte:02X}");
+        }
+    }
+    encoded
+}
+
+fn render_mobile_connect_qr(url: &str) -> Result<String, String> {
+    let code = qrcode::QrCode::new(url.as_bytes())
+        .map_err(|e| format!("failed to generate mobile provisioning QR code: {e}"))?;
+    let width = code.width();
+    let quiet_zone = 2usize;
+    let total_width = width + quiet_zone * 2;
+    let mut rendered = String::new();
+
+    for y in 0..total_width {
+        for x in 0..total_width {
+            let dark = x >= quiet_zone
+                && x < width + quiet_zone
+                && y >= quiet_zone
+                && y < width + quiet_zone
+                && code[(x - quiet_zone, y - quiet_zone)] == qrcode::types::Color::Dark;
+            rendered.push_str(if dark { "██" } else { "  " });
+        }
+        rendered.push('\n');
+    }
+
+    Ok(rendered)
 }
 
 #[cfg(unix)]
@@ -6096,6 +6155,7 @@ mod tests {
             &repo_root,
             "http://127.0.0.1:8787",
             "dev-loopback",
+            "traverse://connect?base_url=http%3A%2F%2F127.0.0.1%3A8787&workspace_default=local-default&auth_mode=dev-loopback",
             Some("local-token"),
         )
         .expect("discovery file must be written");
@@ -6108,6 +6168,10 @@ mod tests {
         assert_eq!(json["health_url"], "http://127.0.0.1:8787/healthz");
         assert_eq!(json["workspace_default"], DEFAULT_WORKSPACE_ID);
         assert_eq!(json["auth_mode"], "dev-loopback");
+        assert_eq!(
+            json["mobile_connect_url"],
+            "traverse://connect?base_url=http%3A%2F%2F127.0.0.1%3A8787&workspace_default=local-default&auth_mode=dev-loopback"
+        );
         assert_eq!(json["local_dev_token"], "local-token");
         assert!(json["pid"].as_u64().is_some());
         assert!(
@@ -6127,6 +6191,7 @@ mod tests {
             &repo_root,
             "http://127.0.0.1:8787",
             "dev-loopback",
+            "traverse://connect?base_url=http%3A%2F%2F127.0.0.1%3A8787&workspace_default=local-default&auth_mode=dev-loopback",
             Some("local-token"),
         )
         .expect("discovery file must be written");
@@ -6137,6 +6202,27 @@ mod tests {
             .mode()
             & 0o777;
         assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn mobile_connect_url_percent_encodes_runtime_fields() {
+        let url = mobile_connect_url("http://192.168.1.42:8787", "local default", "dev-loopback");
+
+        assert_eq!(
+            url,
+            "traverse://connect?base_url=http%3A%2F%2F192.168.1.42%3A8787&workspace_default=local%20default&auth_mode=dev-loopback"
+        );
+    }
+
+    #[test]
+    fn mobile_connect_qr_renders_ascii_blocks() {
+        let rendered = render_mobile_connect_qr(
+            "traverse://connect?base_url=http%3A%2F%2F127.0.0.1%3A8787&workspace_default=local-default&auth_mode=dev-loopback",
+        )
+        .expect("QR code must render");
+
+        assert!(rendered.contains("██"));
+        assert!(rendered.lines().count() > 10);
     }
 
     // ------------------------------------------------------------------

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -121,6 +121,7 @@ enum Command {
         bind_address: String,
         allow_unauthenticated: bool,
         allowed_origins: Vec<String>,
+        render_mobile_qr: bool,
     },
 }
 
@@ -166,8 +167,14 @@ fn main() -> ExitCode {
             bind_address,
             allow_unauthenticated,
             allowed_origins,
+            render_mobile_qr,
         }) => {
-            if let Err(error) = run_serve(bind_address, allow_unauthenticated, allowed_origins) {
+            if let Err(error) = run_serve(
+                bind_address,
+                allow_unauthenticated,
+                allowed_origins,
+                render_mobile_qr,
+            ) {
                 eprintln!("{error}");
                 ExitCode::FAILURE
             } else {
@@ -946,7 +953,7 @@ fn parse_browser_adapter_command(args: &[String]) -> Result<Command, String> {
 }
 
 fn help_serve() -> String {
-    "traverse-cli serve [--bind <address>] [--port <port>] [--allow-unauthenticated]
+    "traverse-cli serve [--bind <address>] [--port <port>] [--allow-unauthenticated] [--qr]
 
   Purpose:
     Start a long-running HTTP/JSON API server on 127.0.0.1:8787 by default.
@@ -967,6 +974,8 @@ fn help_serve() -> String {
     --allow-unauthenticated    Accept unauthenticated requests from non-loopback
                                addresses. Prints a warning to stderr. Unsafe in
                                production.
+    --qr                       Print an ASCII QR code for the traverse://connect
+                               mobile provisioning URL.
     --help                     Print this help text.
 
   Example:
@@ -978,6 +987,7 @@ fn help_serve() -> String {
 
 fn parse_serve_command(args: &[String]) -> Result<Command, String> {
     let allow_unauthenticated = args.iter().any(|a| a == "--allow-unauthenticated");
+    let render_mobile_qr = args.iter().any(|a| a == "--qr");
     let bind_flag_pos = args.iter().position(|a| a == "--bind");
     let port_flag_pos = args.iter().position(|a| a == "--port");
     let mut allowed_origins = Vec::new();
@@ -1018,6 +1028,7 @@ fn parse_serve_command(args: &[String]) -> Result<Command, String> {
         bind_address,
         allow_unauthenticated,
         allowed_origins,
+        render_mobile_qr,
     })
 }
 
@@ -1025,6 +1036,7 @@ fn run_serve(
     bind_address: String,
     allow_unauthenticated: bool,
     allowed_origins: Vec<String>,
+    render_mobile_qr: bool,
 ) -> Result<(), String> {
     let registered =
         load_registered_bundle(&canonical_expedition_bundle_path()).map_err(|e| e.to_string())?;
@@ -1033,6 +1045,7 @@ fn run_serve(
         bind_address,
         allow_unauthenticated,
         allowed_origins,
+        render_mobile_qr,
         capability_registry: registered.capability_registry,
         workflow_registry: registered.workflow_registry,
         registry_root: std::env::current_dir()
@@ -2612,6 +2625,7 @@ fn build_in_process_api() -> Result<http_api::InProcessApi<ExpeditionExampleExec
         bind_address: "127.0.0.1:0".to_string(),
         allow_unauthenticated: true,
         allowed_origins: Vec::new(),
+        render_mobile_qr: false,
         capability_registry: registered.capability_registry,
         workflow_registry: registered.workflow_registry,
         registry_root: std::env::current_dir()
@@ -4340,10 +4354,12 @@ mod tests {
                 bind_address,
                 allow_unauthenticated,
                 allowed_origins,
+                render_mobile_qr,
             } => {
                 assert_eq!(bind_address, "127.0.0.1:8787");
                 assert!(!allow_unauthenticated);
                 assert!(allowed_origins.is_empty());
+                assert!(!render_mobile_qr);
             }
             other => assert!(matches!(other, Command::Serve { .. })),
         }
@@ -4384,10 +4400,12 @@ mod tests {
             Command::Serve {
                 bind_address,
                 allow_unauthenticated,
+                render_mobile_qr,
                 ..
             } => {
                 assert_eq!(bind_address, "127.0.0.1:9090");
                 assert!(allow_unauthenticated);
+                assert!(!render_mobile_qr);
             }
             other => assert!(matches!(other, Command::Serve { .. })),
         }
@@ -4448,6 +4466,24 @@ mod tests {
 
         let error = parse_command(&args).expect_err("wildcard origin should be rejected");
         assert!(error.contains("--allow-origin '*' is not allowed"));
+    }
+
+    #[test]
+    fn parse_serve_accepts_qr_flag() {
+        let args = vec![
+            "traverse-cli".to_string(),
+            "serve".to_string(),
+            "--qr".to_string(),
+        ];
+
+        let command = parse_command(&args).expect("serve command should parse");
+
+        match command {
+            Command::Serve {
+                render_mobile_qr, ..
+            } => assert!(render_mobile_qr),
+            other => assert!(matches!(other, Command::Serve { .. })),
+        }
     }
 
     #[test]

--- a/specs/033-http-json-api/spec.md
+++ b/specs/033-http-json-api/spec.md
@@ -73,7 +73,19 @@ As a browser app developer, I want Traverse to expose explicit CORS behavior so 
 2. **Given** a production or non-loopback binding, **When** CORS is configured, **Then** only exact configured origins are allowed.
 3. **Given** a production or non-loopback binding, **When** no matching origin is configured, **Then** the API rejects the CORS request.
 
-### User Story 3 - Discover Local Server Without Guesswork (Priority: P1)
+### User Story 3 - Connect Mobile Clients Without Filesystem Discovery (Priority: P1)
+
+As a mobile app developer, I want a copyable Traverse provisioning URL so that iOS, Android, and other sandboxed clients can configure the runtime endpoint without reading `.traverse/server.json`.
+
+**Independent Test**: Start `traverse-cli serve`, read stderr, and verify it prints a `traverse://connect?...` URL containing `base_url`, `workspace_default`, and `auth_mode`. Start with `--qr` and verify the terminal output includes an ASCII QR rendering for the same URL.
+
+**Acceptance Scenarios**:
+
+1. **Given** the server starts successfully, **When** it prints startup metadata, **Then** it includes a `traverse://connect` URL with percent-encoded `base_url`, `workspace_default`, and `auth_mode` query parameters.
+2. **Given** `--qr` is supplied, **When** the server starts successfully, **Then** it renders an ASCII QR code for the same `traverse://connect` URL.
+3. **Given** desktop clients still read `.traverse/server.json`, **When** mobile URL provisioning is added, **Then** existing discovery fields remain backward compatible.
+
+### User Story 4 - Discover Local Server Without Guesswork (Priority: P1)
 
 As a local app or agent, I want a repo-local discovery file so that I can find the Traverse server even if the default port is unavailable.
 
@@ -85,7 +97,7 @@ As a local app or agent, I want a repo-local discovery file so that I can find t
 2. **Given** `.traverse/server.json` exists, **When** a client wants to use it, **Then** the client MUST verify `GET /healthz` before trusting the file.
 3. **Given** dev-loopback mode mints a local token, **When** the token is written to `.traverse/server.json`, **Then** the file MUST be owner-read/write only (`0600`) on Unix-like systems.
 
-### User Story 4 - Receive Machine-Readable Errors (Priority: P1)
+### User Story 5 - Receive Machine-Readable Errors (Priority: P1)
 
 As an agent, I want all API errors to use stable JSON errors so that I can classify failures without regexing strings.
 
@@ -214,6 +226,8 @@ OpenTelemetry export is governed by `029-integrated-observability`.
 - If the default port is unavailable, the server MAY fail clearly or select another local port, but if it selects another port it MUST write the selected address to `.traverse/server.json`.
 - Startup MUST print JSON startup information to stdout or stderr in a machine-readable form.
 - `.traverse/server.json` MUST be repo-local for v0 and MUST be ignored by git.
+- `traverse-cli serve` MUST print the `traverse://connect` URL on startup.
+- `traverse-cli serve --qr` MUST render an ASCII QR code for the `traverse://connect` URL on startup.
 
 Discovery file required fields:
 
@@ -225,11 +239,14 @@ Discovery file required fields:
   "pid": 12345,
   "started_at": "2026-05-27T12:00:00Z",
   "auth_mode": "dev-loopback",
+  "mobile_connect_url": "traverse://connect?base_url=http%3A%2F%2F127.0.0.1%3A8787&workspace_default=local-default&auth_mode=dev-loopback",
   "token": "local-dev-token"
 }
 ```
 
 When `token` is present, the file MUST be owner-read/write only (`0600`) on Unix-like systems.
+Mobile or sandboxed clients MAY use `mobile_connect_url` instead of reading `.traverse/server.json`.
+`traverse://connect` URLs MUST carry `base_url`, `workspace_default`, and `auth_mode`; they MUST NOT include local tokens.
 
 ## Errors
 
@@ -325,6 +342,8 @@ Rules:
 - **FR-022**: The API MUST include stable links for next actions.
 - **FR-023**: CORS MUST follow the dev-loopback and production rules above.
 - **FR-024**: CI MUST validate `specs/033-http-json-api/openapi.yaml`.
+- **FR-025**: The server MUST expose mobile URL provisioning through a `traverse://connect` URL that carries `base_url`, `workspace_default`, and `auth_mode`.
+- **FR-026**: The server MUST render an ASCII QR code for the mobile provisioning URL when `--qr` is supplied.
 
 ## Quality Gates
 


### PR DESCRIPTION
## Governing Spec
- `033-http-json-api`

## Project Item
- Closes #523

## Validation
- `cargo test -p traverse-cli mobile_connect -- --nocapture`
- `cargo test -p traverse-cli parse_serve -- --nocapture`
- `cargo test -p traverse-cli discovery_file -- --nocapture`
- `bash scripts/ci/rust_checks.sh`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/supply_chain_check.sh`
- `git diff --check`
