### PR TITLE
Add app state machine manifest validation

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -1703,6 +1703,7 @@ fn render_app_registration_state(
             }).collect::<Vec<_>>()
         },
         "public_surfaces": manifest.public_surfaces.clone(),
+        "state_machine": manifest.state_machine.clone(),
         "state_scope": "workspace_persisted",
         "state_path": app_registration_relative_state_path(
             workspace_id,
@@ -2048,6 +2049,7 @@ fn render_app_validation_success(
             "redacted_secret_keys": manifest.effective_config.redacted_secret_keys.clone()
         },
         "public_surfaces": manifest.public_surfaces.clone(),
+        "state_machine": manifest.state_machine.clone(),
         "runtime_references": {
             "inspection": format!("/v1/apps/{}/{}", manifest.app_id, manifest.version),
             "workflows": manifest.workflows.iter().map(|workflow| {
@@ -4153,6 +4155,71 @@ mod tests {
     }
 
     #[test]
+    fn app_validate_rejects_invalid_state_machine_transition() {
+        let temp_dir = unique_temp_dir();
+        let manifest_path = write_app_validate_fixture(
+            &temp_dir,
+            "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+            "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+            None,
+        );
+        let mut manifest: Value =
+            serde_json::from_str(&fs::read_to_string(&manifest_path).expect("manifest must read"))
+                .expect("manifest must parse");
+        manifest["state_machine"]["states"][0]["transitions"][0]["to"] =
+            Value::String("missing".to_string());
+        fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&manifest).expect("manifest must serialize"),
+        )
+        .expect("manifest must write");
+
+        let output =
+            app_validate(&manifest_path, true).expect("validation failure is JSON evidence");
+        let json: Value = serde_json::from_str(&output).expect("failure output must be JSON");
+
+        assert_eq!(json["status"], "failed");
+        assert_eq!(
+            json["errors"][0]["code"],
+            "app_state_machine_undefined_state"
+        );
+    }
+
+    #[test]
+    fn app_validate_rejects_state_machine_unknown_capability() {
+        let temp_dir = unique_temp_dir();
+        let manifest_path = write_app_validate_fixture(
+            &temp_dir,
+            "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+            "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+            None,
+        );
+        let mut manifest: Value =
+            serde_json::from_str(&fs::read_to_string(&manifest_path).expect("manifest must read"))
+                .expect("manifest must parse");
+        manifest["state_machine"]["states"][1]["invoke"]["capability_id"] =
+            Value::String("unknown.capability".to_string());
+        fs::write(
+            &manifest_path,
+            serde_json::to_string_pretty(&manifest).expect("manifest must serialize"),
+        )
+        .expect("manifest must write");
+
+        let output =
+            app_validate(&manifest_path, true).expect("validation failure is JSON evidence");
+        let json: Value = serde_json::from_str(&output).expect("failure output must be JSON");
+
+        assert_eq!(json["status"], "failed");
+        let codes = json["errors"]
+            .as_array()
+            .expect("errors must be an array")
+            .iter()
+            .map(|error| error["code"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>();
+        assert!(codes.contains(&"app_state_machine_undefined_capability"));
+    }
+
+    #[test]
     fn app_validate_redacts_workspace_secret_keys() {
         let temp_dir = unique_temp_dir();
         let manifest_path = write_app_validate_fixture(
@@ -4173,6 +4240,7 @@ mod tests {
         let json: Value = serde_json::from_str(&output).expect("validation output must be JSON");
 
         assert_eq!(json["status"], "validated");
+        assert_eq!(json["state_machine"]["initial_state"], "idle");
         assert_eq!(
             json["effective_config"]["redacted_secret_keys"][0],
             "ollama_api_key"
@@ -5255,12 +5323,47 @@ mod tests {
                     "preferred_targets": ["local"],
                     "allow_fallback": false
                 },
+                "state_machine": app_state_machine_fixture(),
                 "public_surfaces": ["cli"]
             }))
             .expect("app manifest must serialize"),
         )
         .expect("app manifest must write");
         manifest_path
+    }
+
+    fn app_state_machine_fixture() -> Value {
+        serde_json::json!({
+            "initial_state": "idle",
+            "states": [
+                {
+                    "id": "idle",
+                    "transitions": [{ "on": "submit", "to": "processing" }]
+                },
+                {
+                    "id": "processing",
+                    "invoke": {
+                        "capability_id": "expedition.planning.validate-team-readiness",
+                        "input_from": "command.payload"
+                    },
+                    "transitions": [
+                        { "on": "capability_succeeded", "to": "results" },
+                        { "on": "capability_failed", "to": "error" }
+                    ]
+                },
+                {
+                    "id": "results",
+                    "transitions": [{ "on": "reset", "to": "idle" }]
+                },
+                {
+                    "id": "error",
+                    "transitions": [
+                        { "on": "retry", "to": "processing", "with_last_payload": true },
+                        { "on": "reset", "to": "idle" }
+                    ]
+                }
+            ]
+        })
     }
 
     fn write_app_validate_component_fixture(

--- a/crates/traverse-registry/src/application_manifest.rs
+++ b/crates/traverse-registry/src/application_manifest.rs
@@ -32,6 +32,33 @@ pub struct ApplicationBundleManifest {
     pub effective_config: ApplicationEffectiveConfig,
     pub placement_policy: Value,
     pub public_surfaces: Vec<String>,
+    pub state_machine: Option<ApplicationStateMachine>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ApplicationStateMachine {
+    pub initial_state: String,
+    pub states: Vec<ApplicationState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ApplicationState {
+    pub id: String,
+    pub invoke: Option<ApplicationStateInvoke>,
+    pub transitions: Vec<ApplicationStateTransition>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ApplicationStateInvoke {
+    pub capability_id: String,
+    pub input_from: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ApplicationStateTransition {
+    pub on: String,
+    pub to: String,
+    pub with_last_payload: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -408,6 +435,10 @@ pub enum ApplicationManifestErrorCode {
     ModelCandidateImplementationInvalid,
     AppConfigImmutableOverride,
     AppConfigInvalid,
+    AppStateMachineInvalid,
+    AppStateMachineUnreachableState,
+    AppStateMachineUndefinedState,
+    AppStateMachineUndefinedCapability,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -435,6 +466,37 @@ struct ApplicationManifestSerde {
     default_config: Value,
     placement_policy: Value,
     public_surfaces: Vec<String>,
+    #[serde(default)]
+    state_machine: Option<ApplicationStateMachineSerde>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplicationStateMachineSerde {
+    initial_state: String,
+    states: Vec<ApplicationStateSerde>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplicationStateSerde {
+    id: String,
+    #[serde(default)]
+    invoke: Option<ApplicationStateInvokeSerde>,
+    #[serde(default)]
+    transitions: Vec<ApplicationStateTransitionSerde>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplicationStateInvokeSerde {
+    capability_id: String,
+    input_from: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplicationStateTransitionSerde {
+    on: String,
+    to: String,
+    #[serde(default)]
+    with_last_payload: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -560,6 +622,7 @@ pub fn load_application_bundle_manifest(
         .iter()
         .map(|component| load_component(manifest_dir, component))
         .collect::<Result<Vec<_>, _>>()?;
+    let state_machine = validate_state_machine(&manifest, &components)?;
 
     Ok(ApplicationBundleManifest {
         app_id: manifest.app_id,
@@ -574,6 +637,7 @@ pub fn load_application_bundle_manifest(
         effective_config,
         placement_policy: manifest.placement_policy,
         public_surfaces: manifest.public_surfaces,
+        state_machine,
     })
 }
 
@@ -784,6 +848,7 @@ fn application_manifest_digest(manifest: &ApplicationBundleManifest) -> String {
         "default_config": manifest.default_config,
         "placement_policy": manifest.placement_policy,
         "public_surfaces": manifest.public_surfaces,
+        "state_machine": manifest.state_machine,
     });
     format!("sha256:{}", sha256_hex(value.to_string().as_bytes()))
 }
@@ -879,6 +944,170 @@ fn ensure_unique_component_refs(
         }
     }
     Ok(())
+}
+
+fn validate_state_machine(
+    manifest: &ApplicationManifestSerde,
+    components: &[ApplicationComponent],
+) -> Result<Option<ApplicationStateMachine>, ApplicationManifestFailure> {
+    let Some(state_machine) = &manifest.state_machine else {
+        return Ok(None);
+    };
+    if state_machine.initial_state.trim().is_empty() || state_machine.states.is_empty() {
+        return Err(single_error(
+            ApplicationManifestErrorCode::AppStateMachineInvalid,
+            "state_machine".to_string(),
+            "state_machine requires initial_state and at least one state".to_string(),
+        ));
+    }
+
+    let state_ids = state_machine_state_ids(state_machine)?;
+    ensure_initial_state_declared(state_machine, &state_ids)?;
+    ensure_state_machine_reachable(state_machine, &state_ids)?;
+    let component_capabilities = components
+        .iter()
+        .map(|component| component.manifest.capability_id.clone())
+        .collect::<BTreeSet<_>>();
+    let states = materialize_state_machine_states(state_machine, &component_capabilities)?;
+
+    Ok(Some(ApplicationStateMachine {
+        initial_state: state_machine.initial_state.clone(),
+        states,
+    }))
+}
+
+fn state_machine_state_ids(
+    state_machine: &ApplicationStateMachineSerde,
+) -> Result<BTreeSet<String>, ApplicationManifestFailure> {
+    let mut state_ids = BTreeSet::new();
+    for state in &state_machine.states {
+        if state.id.trim().is_empty() || !state_ids.insert(state.id.clone()) {
+            return Err(single_error(
+                ApplicationManifestErrorCode::AppStateMachineInvalid,
+                format!("state_machine.states.{}", state.id),
+                "state_machine states must have unique non-empty ids".to_string(),
+            ));
+        }
+    }
+    Ok(state_ids)
+}
+
+fn ensure_initial_state_declared(
+    state_machine: &ApplicationStateMachineSerde,
+    state_ids: &BTreeSet<String>,
+) -> Result<(), ApplicationManifestFailure> {
+    if state_ids.contains(&state_machine.initial_state) {
+        return Ok(());
+    }
+
+    Err(single_error(
+        ApplicationManifestErrorCode::AppStateMachineUndefinedState,
+        "state_machine.initial_state".to_string(),
+        format!(
+            "initial_state '{}' is not declared in state_machine.states",
+            state_machine.initial_state
+        ),
+    ))
+}
+
+fn ensure_state_machine_reachable(
+    state_machine: &ApplicationStateMachineSerde,
+    state_ids: &BTreeSet<String>,
+) -> Result<(), ApplicationManifestFailure> {
+    let mut reachable = BTreeSet::new();
+    let mut pending = vec![state_machine.initial_state.clone()];
+
+    while let Some(state_id) = pending.pop() {
+        if !reachable.insert(state_id.clone()) {
+            continue;
+        }
+        let transitions = state_machine
+            .states
+            .iter()
+            .find(|state| state.id == state_id)
+            .map(|state| (state.id.as_str(), state.transitions.as_slice()))
+            .into_iter()
+            .flat_map(|(source_state_id, transitions)| {
+                transitions
+                    .iter()
+                    .map(move |transition| (source_state_id, transition))
+            });
+        for (source_state_id, transition) in transitions {
+            if !state_ids.contains(&transition.to) {
+                return Err(single_error(
+                    ApplicationManifestErrorCode::AppStateMachineUndefinedState,
+                    format!(
+                        "state_machine.states.{}.transitions.{}",
+                        source_state_id, transition.on
+                    ),
+                    format!(
+                        "transition '{}' targets undefined state '{}'",
+                        transition.on, transition.to
+                    ),
+                ));
+            }
+            pending.push(transition.to.clone());
+        }
+    }
+
+    if let Some(unreachable) = state_ids
+        .iter()
+        .find(|state_id| !reachable.contains(*state_id))
+    {
+        return Err(single_error(
+            ApplicationManifestErrorCode::AppStateMachineUnreachableState,
+            format!("state_machine.states.{unreachable}"),
+            format!("state_machine state '{unreachable}' is unreachable from initial_state"),
+        ));
+    }
+
+    Ok(())
+}
+
+fn materialize_state_machine_states(
+    state_machine: &ApplicationStateMachineSerde,
+    component_capabilities: &BTreeSet<String>,
+) -> Result<Vec<ApplicationState>, ApplicationManifestFailure> {
+    state_machine
+        .states
+        .iter()
+        .map(|state| materialize_state_machine_state(state, component_capabilities))
+        .collect()
+}
+
+fn materialize_state_machine_state(
+    state: &ApplicationStateSerde,
+    component_capabilities: &BTreeSet<String>,
+) -> Result<ApplicationState, ApplicationManifestFailure> {
+    if let Some(invoke) = &state.invoke
+        && !component_capabilities.contains(&invoke.capability_id)
+    {
+        return Err(single_error(
+            ApplicationManifestErrorCode::AppStateMachineUndefinedCapability,
+            format!("state_machine.states.{}.invoke", state.id),
+            format!(
+                "invoke capability '{}' is not declared in app components",
+                invoke.capability_id
+            ),
+        ));
+    }
+
+    Ok(ApplicationState {
+        id: state.id.clone(),
+        invoke: state.invoke.as_ref().map(|invoke| ApplicationStateInvoke {
+            capability_id: invoke.capability_id.clone(),
+            input_from: invoke.input_from.clone(),
+        }),
+        transitions: state
+            .transitions
+            .iter()
+            .map(|transition| ApplicationStateTransition {
+                on: transition.on.clone(),
+                to: transition.to.clone(),
+                with_last_payload: transition.with_last_payload,
+            })
+            .collect(),
+    })
 }
 
 fn load_effective_config(

--- a/crates/traverse-registry/tests/application_manifest.rs
+++ b/crates/traverse-registry/tests/application_manifest.rs
@@ -128,6 +128,161 @@ fn rejects_duplicate_component_references() {
 }
 
 #[test]
+fn loads_valid_application_state_machine() {
+    let fixture = AppFixture::new("valid-state-machine");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest_with_state_machine(
+        &json!([component_ref(
+            "expedition.readiness.validate-team-readiness-component",
+            "1.0.0",
+            &format!("sha256:{wasm_digest}"),
+            "components/validate-team-readiness/component.manifest.json",
+        )]),
+        &json!({
+            "initial_state": "draft",
+            "states": [
+                {
+                    "id": "draft",
+                    "invoke": {
+                        "capability_id": "expedition.planning.validate-team-readiness",
+                        "input_from": "$.team"
+                    },
+                    "transitions": [
+                        {
+                            "on": "ready",
+                            "to": "approved",
+                            "with_last_payload": true
+                        },
+                        {
+                            "on": "revise",
+                            "to": "draft"
+                        }
+                    ]
+                },
+                {
+                    "id": "approved",
+                    "transitions": []
+                }
+            ]
+        }),
+    );
+
+    let bundle = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect("valid app state machine should load");
+    let state_machine = bundle
+        .state_machine
+        .expect("state machine should be materialized");
+
+    assert_eq!(state_machine.initial_state, "draft");
+    assert_eq!(state_machine.states.len(), 2);
+    assert_eq!(
+        state_machine.states[0]
+            .invoke
+            .as_ref()
+            .expect("draft state should invoke capability")
+            .capability_id,
+        "expedition.planning.validate-team-readiness"
+    );
+    assert!(state_machine.states[0].transitions[0].with_last_payload);
+}
+
+#[test]
+fn rejects_invalid_application_state_machine_shapes() {
+    let cases = [
+        (
+            "state-machine-empty-initial",
+            json!({
+                "initial_state": "",
+                "states": [{"id": "draft", "transitions": []}]
+            }),
+            ApplicationManifestErrorCode::AppStateMachineInvalid,
+        ),
+        (
+            "state-machine-duplicate-state",
+            json!({
+                "initial_state": "draft",
+                "states": [
+                    {"id": "draft", "transitions": []},
+                    {"id": "draft", "transitions": []}
+                ]
+            }),
+            ApplicationManifestErrorCode::AppStateMachineInvalid,
+        ),
+        (
+            "state-machine-missing-initial",
+            json!({
+                "initial_state": "missing",
+                "states": [{"id": "draft", "transitions": []}]
+            }),
+            ApplicationManifestErrorCode::AppStateMachineUndefinedState,
+        ),
+        (
+            "state-machine-missing-target",
+            json!({
+                "initial_state": "draft",
+                "states": [{
+                    "id": "draft",
+                    "transitions": [{"on": "submit", "to": "missing"}]
+                }]
+            }),
+            ApplicationManifestErrorCode::AppStateMachineUndefinedState,
+        ),
+        (
+            "state-machine-unreachable",
+            json!({
+                "initial_state": "draft",
+                "states": [
+                    {"id": "draft", "transitions": []},
+                    {"id": "orphan", "transitions": []}
+                ]
+            }),
+            ApplicationManifestErrorCode::AppStateMachineUnreachableState,
+        ),
+    ];
+
+    for (name, state_machine, expected_code) in cases {
+        let fixture = AppFixture::new(name);
+        fixture.write_app_manifest_with_state_machine(&json!([]), &state_machine);
+
+        let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+            .expect_err("invalid state machine should fail");
+
+        assert_eq!(failure.errors[0].code, expected_code);
+    }
+}
+
+#[test]
+fn rejects_state_machine_invoke_capability_not_declared_by_components() {
+    let fixture = AppFixture::new("state-machine-unknown-capability");
+    fixture.write_app_manifest_with_state_machine(
+        &json!([]),
+        &json!({
+            "initial_state": "draft",
+            "states": [{
+                "id": "draft",
+                "invoke": {
+                    "capability_id": "expedition.planning.validate-team-readiness",
+                    "input_from": "$.team"
+                },
+                "transitions": []
+            }]
+        }),
+    );
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("state machine invoke must reference app component capability");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::AppStateMachineUndefinedCapability
+    );
+}
+
+#[test]
 fn loads_valid_governed_model_dependency_schema() {
     let fixture = AppFixture::new("valid-model-dependency");
     fixture.write_app_manifest_with_model_dependencies(
@@ -1784,6 +1939,23 @@ impl AppFixture {
         self.write_app_manifest_full(components, workflows, &json!([]));
     }
 
+    fn write_app_manifest_with_state_machine(
+        &self,
+        components: &serde_json::Value,
+        state_machine: &serde_json::Value,
+    ) {
+        self.write_app_manifest_full_with_state_machine(
+            components,
+            &json!([]),
+            &json!([]),
+            &json!({
+                "type": "object"
+            }),
+            &json!({}),
+            Some(state_machine),
+        );
+    }
+
     fn write_app_manifest_with_config(
         &self,
         components: &serde_json::Value,
@@ -1824,7 +1996,26 @@ impl AppFixture {
         config_schema: &serde_json::Value,
         default_config: &serde_json::Value,
     ) {
-        let app = json!({
+        self.write_app_manifest_full_with_state_machine(
+            components,
+            workflows,
+            model_dependencies,
+            config_schema,
+            default_config,
+            None,
+        );
+    }
+
+    fn write_app_manifest_full_with_state_machine(
+        &self,
+        components: &serde_json::Value,
+        workflows: &serde_json::Value,
+        model_dependencies: &serde_json::Value,
+        config_schema: &serde_json::Value,
+        default_config: &serde_json::Value,
+        state_machine: Option<&serde_json::Value>,
+    ) {
+        let mut app = json!({
             "app_id": "hello.world.app",
             "version": "1.0.0",
             "schema_version": "1.0.0",
@@ -1842,6 +2033,11 @@ impl AppFixture {
             },
             "public_surfaces": ["cli"]
         });
+        if let Some(state_machine) = state_machine {
+            app.as_object_mut()
+                .expect("app manifest should be an object")
+                .insert("state_machine".to_string(), state_machine.clone());
+        }
         fs::write(self.app_manifest_path(), app.to_string()).expect("app manifest should write");
     }
 

--- a/specs/052-app-state-machine/spec.md
+++ b/specs/052-app-state-machine/spec.md
@@ -1,0 +1,62 @@
+# Feature Specification: App State Machine
+
+**Feature Branch**: `052-app-state-machine`
+**Created**: 2026-07-05
+**Status**: Approved
+**Input**: GitHub issue #525, following the app bundle manifest model from `044-application-bundle-manifest`.
+
+## Purpose
+
+Traverse application manifests MAY declare a runtime-owned `state_machine` block. Clients render state and send commands; they do not own duplicated business state-machine logic.
+
+This spec governs the manifest schema and validation slice. HTTP command dispatch, state subscriptions, session listing, and conditional output-based transitions are governed by follow-up Project tickets.
+
+## Requirements
+
+- **FR-001**: Application manifests MAY include `state_machine`.
+- **FR-002**: `state_machine.initial_state` MUST name one declared state.
+- **FR-003**: `state_machine.states[]` MUST contain unique non-empty `id` values.
+- **FR-004**: Every transition `to` target MUST name a declared state.
+- **FR-005**: Every state MUST be reachable from `initial_state`.
+- **FR-006**: `invoke.capability_id`, when present, MUST reference a capability provided by a component declared in the same app manifest.
+- **FR-007**: `invoke.input_from` MUST be explicit; the first supported value is `command.payload`.
+- **FR-008**: `with_last_payload` MUST default to `false` when omitted.
+- **FR-009**: `traverse-cli app validate --json` MUST include the validated state-machine summary on success.
+- **FR-010**: Invalid state machines MUST fail validation before app registration.
+
+## Schema Shape
+
+```json
+{
+  "state_machine": {
+    "initial_state": "idle",
+    "states": [
+      {
+        "id": "idle",
+        "transitions": [
+          { "on": "submit", "to": "processing" }
+        ]
+      },
+      {
+        "id": "processing",
+        "invoke": {
+          "capability_id": "traverse-starter.process",
+          "input_from": "command.payload"
+        },
+        "transitions": [
+          { "on": "capability_succeeded", "to": "results" },
+          { "on": "capability_failed", "to": "error" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Out of Scope
+
+- HTTP state subscription endpoints.
+- HTTP command dispatch endpoints.
+- Multiple app sessions and session listing.
+- Conditional transitions based on capability output values.
+- Durable execution of state-machine sessions.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -552,6 +552,20 @@
       ]
     },
     {
+      "id": "052-app-state-machine",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/052-app-state-machine/spec.md",
+      "governs": [
+        "crates/traverse-cli/",
+        "crates/traverse-registry/",
+        "examples/applications/",
+        "specs/052-app-state-machine/",
+        "specs/governance/"
+      ]
+    },
+    {
       "id": "049-v1-milestone-gate",
       "version": "1.0.0",
       "status": "approved",


### PR DESCRIPTION
## Governing Spec
- `052-app-state-machine`
- `044-application-bundle-manifest`

## Project Item
- Closes #525

## Validation
- `python3 -m json.tool specs/governance/approved-specs.json`
- `cargo test -p traverse-cli app_validate -- --nocapture`
- `bash scripts/ci/rust_checks.sh`
- `bash scripts/ci/repository_checks.sh`
- `git diff --check`

## Notes
- Implements the manifest schema and validation slice. Runtime command dispatch, state subscriptions, session listing, and conditional output-based transitions remain in the follow-up Project tickets already tracking those surfaces.
