### PR TITLE
Implement registry sync CLI

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -26,9 +26,9 @@ use traverse_registry::{
     BinaryReference, CapabilityArtifactRecord, CapabilityRegistration, CapabilityRegistry,
     ComposabilityMetadata, CompositionKind, CompositionPattern, ConnectorRegistration,
     DiscoveryQuery, EventRegistration, EventRegistry, ImplementationKind, LookupScope,
-    RegistryBundle, RegistryProvenance, RegistryScope, SourceKind, SourceReference,
-    WorkflowDefinition, WorkflowReference, WorkflowRegistration, WorkflowRegistry,
-    load_application_bundle_manifest, load_registry_bundle,
+    PublicRegistryIndex, RegistryBundle, RegistryProvenance, RegistryScope, SourceKind,
+    SourceReference, WorkflowDefinition, WorkflowReference, WorkflowRegistration, WorkflowRegistry,
+    load_application_bundle_manifest, load_registry_bundle, write_synced_public_registry_state,
 };
 use traverse_runtime::executor::{SUPPORTED_HOST_ABI_VERSION, verify_wasm_host_abi_bytes};
 use traverse_runtime::{
@@ -58,6 +58,10 @@ enum Command {
     },
     AppRegister {
         manifest_path: PathBuf,
+        workspace_id: String,
+        json_output: bool,
+    },
+    RegistrySync {
         workspace_id: String,
         json_output: bool,
     },
@@ -241,6 +245,10 @@ fn run_command(command: Command) -> Result<String, CliError> {
             workspace_id,
             json_output,
         } => app_register(&manifest_path, &workspace_id, json_output),
+        Command::RegistrySync {
+            workspace_id,
+            json_output,
+        } => registry_sync(&workspace_id, json_output),
         Command::ComponentNew { component_id } => component_new(&component_id),
         Command::BrowserAdapterServe { .. } | Command::Serve { .. } => {
             Err(CliError::UsageError(usage()))
@@ -314,6 +322,7 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
         (Some("app"), Some("new")) => parse_app_new_command(args),
         (Some("app"), Some("validate")) => parse_app_validate_command(args),
         (Some("app"), Some("register")) => parse_app_register_command(args),
+        (Some("registry"), Some("sync")) => parse_registry_sync_command(args),
         (Some("component"), Some("new")) => parse_component_new_command(args),
         (Some("federation"), Some(_)) => parse_federation_command(args),
         (Some("agent"), Some("execute")) => parse_agent_execute_command(args),
@@ -335,6 +344,8 @@ fn subcommand_help(family: Option<&str>, subcommand: Option<&str>) -> String {
         (Some("app"), Some("validate")) => help_app_validate(),
         (Some("app"), Some("register")) => help_app_register(),
         (Some("app"), _) => help_app(),
+        (Some("registry"), Some("sync")) => help_registry_sync(),
+        (Some("registry"), _) => help_registry(),
         (Some("component"), Some("new")) => help_component_new(),
         (Some("component"), _) => help_component(),
         (Some("agent"), Some("inspect")) => help_agent_inspect(),
@@ -444,6 +455,36 @@ fn help_app() -> String {
     register --manifest <path>   Validate and persist local app registration.
 
   Run `traverse-cli app <subcommand> --help` for subcommand-specific help."
+        .to_string()
+}
+
+fn help_registry_sync() -> String {
+    "traverse-cli registry sync --workspace <workspace-id> --json
+
+  Purpose:
+    Fetch the latest public registry index from traverse-framework/registry and
+    atomically persist it as local workspace public-tier registry state. Runtime
+    execution reads local state only and never live-fetches the registry.
+
+  Required flags:
+    --workspace <id>   Local workspace id to sync into.
+    --json             Emit machine-readable sync evidence.
+
+  Optional flags:
+    --help             Print this help text.
+
+  Example:
+    traverse-cli registry sync --workspace local-default --json"
+        .to_string()
+}
+
+fn help_registry() -> String {
+    "traverse-cli registry <subcommand> [options]
+
+  Subcommands:
+    sync --workspace <id> --json   Sync the public registry index locally.
+
+  Run `traverse-cli registry sync --help` for subcommand-specific help."
         .to_string()
 }
 
@@ -929,6 +970,18 @@ fn parse_app_register_command(args: &[String]) -> Result<Command, String> {
     }
     Ok(Command::AppRegister {
         manifest_path: PathBuf::from(manifest_path),
+        workspace_id,
+        json_output: true,
+    })
+}
+
+fn parse_registry_sync_command(args: &[String]) -> Result<Command, String> {
+    let workspace_id = parse_string_flag(args, "--workspace")
+        .ok_or_else(|| "registry sync requires --workspace <workspace-id>".to_string())?;
+    if !args.iter().any(|a| a == "--json") {
+        return Err("registry sync requires --json for stable sync evidence".to_string());
+    }
+    Ok(Command::RegistrySync {
         workspace_id,
         json_output: true,
     })
@@ -1646,6 +1699,263 @@ fn app_register_at(
 
     serde_json::to_string_pretty(&state)
         .map_err(|e| CliError::IoError(format!("failed to serialize app registration: {e}")))
+}
+
+const DEFAULT_PUBLIC_REGISTRY_SOURCE: &str = "traverse-framework/registry";
+
+#[derive(Debug, Clone)]
+struct FetchedRegistryIndex {
+    source_repo: String,
+    release_tag: String,
+    index: PublicRegistryIndex,
+}
+
+trait RegistryIndexFetcher {
+    fn fetch_latest_index(&self) -> Result<FetchedRegistryIndex, RegistrySyncError>;
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CurlGitHubRegistryIndexFetcher {
+    source_repo: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RegistrySyncError {
+    code: &'static str,
+    message: String,
+}
+
+impl RegistryIndexFetcher for CurlGitHubRegistryIndexFetcher {
+    fn fetch_latest_index(&self) -> Result<FetchedRegistryIndex, RegistrySyncError> {
+        let releases_url = format!(
+            "https://api.github.com/repos/{}/releases?per_page=100",
+            self.source_repo
+        );
+        let releases = curl_text(&releases_url)?;
+        let releases_json: Value = serde_json::from_str(&releases).map_err(|error| {
+            RegistrySyncError::new(
+                "registry_release_parse_failed",
+                format!("failed to parse GitHub Releases response: {error}"),
+            )
+        })?;
+        let (release_tag, index_asset_url) = latest_index_release_asset(&releases_json)?;
+        let index_json = curl_text(&index_asset_url)?;
+        let index: PublicRegistryIndex = serde_json::from_str(&index_json).map_err(|error| {
+            RegistrySyncError::new(
+                "registry_index_parse_failed",
+                format!("failed to parse registry index.json: {error}"),
+            )
+        })?;
+
+        Ok(FetchedRegistryIndex {
+            source_repo: self.source_repo.to_string(),
+            release_tag,
+            index,
+        })
+    }
+}
+
+impl RegistrySyncError {
+    fn new(code: &'static str, message: String) -> Self {
+        Self { code, message }
+    }
+}
+
+fn registry_sync(workspace_id: &str, json_output: bool) -> Result<String, CliError> {
+    let base_dir = std::env::current_dir()
+        .map_err(|e| CliError::IoError(format!("failed to resolve current directory: {e}")))?;
+    registry_sync_at(
+        &base_dir,
+        workspace_id,
+        json_output,
+        &CurlGitHubRegistryIndexFetcher {
+            source_repo: DEFAULT_PUBLIC_REGISTRY_SOURCE,
+        },
+    )
+}
+
+fn registry_sync_at(
+    base_dir: &Path,
+    workspace_id: &str,
+    json_output: bool,
+    fetcher: &dyn RegistryIndexFetcher,
+) -> Result<String, CliError> {
+    if !json_output {
+        return Err(CliError::UsageError(
+            "registry sync requires --json for stable sync evidence".to_string(),
+        ));
+    }
+    if let Some(error) = validate_workspace_id_for_cli(workspace_id) {
+        return registry_sync_failure_json(
+            workspace_id,
+            "registry_sync_invalid_workspace",
+            &error.message,
+        );
+    }
+
+    let remote_index = fetcher
+        .fetch_latest_index()
+        .map_err(|error| CliError::IoError(format!("{}: {}", error.code, error.message)))?;
+    let synced_at = current_unix_timestamp_string()?;
+    let state = write_synced_public_registry_state(
+        base_dir,
+        workspace_id,
+        &remote_index.source_repo,
+        &remote_index.release_tag,
+        &synced_at,
+        remote_index.index,
+    )
+    .map_err(|failure| {
+        CliError::ValidationFailed(
+            failure
+                .errors
+                .iter()
+                .map(|error| error.message.clone())
+                .collect::<Vec<_>>()
+                .join("; "),
+        )
+    })?;
+    let state_path = traverse_registry::synced_public_registry_state_path(base_dir, workspace_id);
+
+    serde_json::to_string_pretty(&serde_json::json!({
+        "status": "synced",
+        "source": state.source_repo,
+        "release_tag": state.release_tag,
+        "index_version": state.index_version,
+        "record_count": state.record_count,
+        "workspace": state.workspace_id,
+        "synced_at": state.synced_at,
+        "validation_status": state.validation_status,
+        "state_path": state_path.display().to_string()
+    }))
+    .map_err(|error| {
+        CliError::IoError(format!("failed to serialize registry sync output: {error}"))
+    })
+}
+
+fn registry_sync_failure_json(
+    workspace_id: &str,
+    code: &str,
+    message: &str,
+) -> Result<String, CliError> {
+    serde_json::to_string_pretty(&serde_json::json!({
+        "status": "failed",
+        "workspace": workspace_id,
+        "errors": [{
+            "code": code,
+            "message": message,
+            "severity": "error"
+        }]
+    }))
+    .map_err(|error| {
+        CliError::IoError(format!(
+            "failed to serialize registry sync failure: {error}"
+        ))
+    })
+}
+
+fn latest_index_release_asset(
+    releases_json: &Value,
+) -> Result<(String, String), RegistrySyncError> {
+    let releases = releases_json.as_array().ok_or_else(|| {
+        RegistrySyncError::new(
+            "registry_release_parse_failed",
+            "GitHub Releases response must be an array".to_string(),
+        )
+    })?;
+
+    let mut selected: Option<(u64, String, String)> = None;
+    for release in releases {
+        let Some(tag) = release.get("tag_name").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some(index_version) = tag.strip_prefix("index-v").and_then(parse_u64) else {
+            continue;
+        };
+        let Some(asset_url) = release
+            .get("assets")
+            .and_then(Value::as_array)
+            .and_then(|assets| index_asset_download_url(assets))
+        else {
+            continue;
+        };
+        match &selected {
+            Some((selected_version, _, _)) if *selected_version >= index_version => {}
+            _ => selected = Some((index_version, tag.to_string(), asset_url)),
+        }
+    }
+
+    selected
+        .map(|(_, tag, asset_url)| (tag, asset_url))
+        .ok_or_else(|| {
+            RegistrySyncError::new(
+                "registry_index_release_missing",
+                "no index-v* release with an index.json asset was found".to_string(),
+            )
+        })
+}
+
+fn index_asset_download_url(assets: &[Value]) -> Option<String> {
+    assets.iter().find_map(|asset| {
+        let name = asset.get("name").and_then(Value::as_str)?;
+        if name != "index.json" {
+            return None;
+        }
+        asset
+            .get("browser_download_url")
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+    })
+}
+
+fn parse_u64(value: &str) -> Option<u64> {
+    value.parse::<u64>().ok()
+}
+
+fn curl_text(url: &str) -> Result<String, RegistrySyncError> {
+    let output = std::process::Command::new("curl")
+        .args([
+            "-fsSL",
+            "-H",
+            "Accept: application/vnd.github+json",
+            "-H",
+            "User-Agent: traverse-cli-registry-sync",
+            url,
+        ])
+        .output()
+        .map_err(|error| {
+            RegistrySyncError::new(
+                "registry_fetch_failed",
+                format!("failed to execute curl for {url}: {error}"),
+            )
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let detail = if stderr.is_empty() {
+            format!("curl exited with status {}", output.status)
+        } else {
+            stderr
+        };
+        return Err(RegistrySyncError::new(
+            "registry_fetch_failed",
+            format!("failed to fetch {url}: {detail}"),
+        ));
+    }
+    String::from_utf8(output.stdout).map_err(|error| {
+        RegistrySyncError::new(
+            "registry_fetch_failed",
+            format!("response from {url} was not valid UTF-8: {error}"),
+        )
+    })
+}
+
+fn current_unix_timestamp_string() -> Result<String, CliError> {
+    let duration = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| {
+            CliError::IoError(format!("system clock is before Unix epoch: {error}"))
+        })?;
+    Ok(format!("unix:{}", duration.as_secs()))
 }
 
 fn render_app_registration_state(
@@ -3039,7 +3349,7 @@ fn render_trace_summary(trace_path: &Path, trace: &RuntimeTrace) -> String {
 }
 
 fn usage() -> String {
-    "usage: traverse-cli app <new|validate|register> [options] | traverse-cli component new <component-id> | traverse-cli <bundle|agent|event|trace|workflow|expedition|federation> <inspect|register|execute|peers|sync|status> <artifact-path> [request-path] [--trace-out <trace-path>] | traverse-cli browser-adapter serve [--bind <address>] | traverse-cli serve [--bind <address>] [--port <N>] [--allow-unauthenticated]".to_string()
+    "usage: traverse-cli app <new|validate|register> [options] | traverse-cli registry sync --workspace <id> --json | traverse-cli component new <component-id> | traverse-cli <bundle|agent|event|trace|workflow|expedition|federation> <inspect|register|execute|peers|sync|status> <artifact-path> [request-path] [--trace-out <trace-path>] | traverse-cli browser-adapter serve [--bind <address>] | traverse-cli serve [--bind <address>] [--port <N>] [--allow-unauthenticated]".to_string()
 }
 
 fn write_trace_artifact(path: &Path, trace: &RuntimeTrace) -> Result<(), CliError> {
@@ -3879,9 +4189,11 @@ mod tests {
     #![allow(clippy::expect_used)]
 
     use super::{
-        Command, app_new_at, app_register_at, app_registration_state_path, app_validate,
-        component_new_at, execute_agent, execute_expedition, inspect_agent, inspect_bundle,
-        inspect_event, inspect_trace, inspect_workflow, parse_command, register_bundle,
+        Command, FetchedRegistryIndex, RegistryIndexFetcher, RegistrySyncError, app_new_at,
+        app_register_at, app_registration_state_path, app_validate, component_new_at,
+        execute_agent, execute_expedition, inspect_agent, inspect_bundle, inspect_event,
+        inspect_trace, inspect_workflow, latest_index_release_asset, parse_command,
+        register_bundle, registry_sync_at,
     };
     use crate::agent_packages::fnv1a64;
     use serde_json::Value;
@@ -3889,7 +4201,10 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
     use traverse_contracts::parse_contract;
-    use traverse_registry::load_application_bundle_manifest;
+    use traverse_registry::{
+        PublicRegistryCapabilityRecord, PublicRegistryIndex, load_application_bundle_manifest,
+        load_synced_public_registry_state,
+    };
 
     #[test]
     fn parse_command_accepts_supported_inspect_commands() {
@@ -3976,7 +4291,6 @@ mod tests {
             "new".to_string(),
             "knowledge.retrieve".to_string(),
         ];
-
         assert!(parse_command(&bundle).is_ok());
         assert!(parse_command(&bundle_register).is_ok());
         assert!(parse_command(&agent_inspect).is_ok());
@@ -4106,6 +4420,48 @@ mod tests {
             "examples/applications/expedition-readiness/app.manifest.json".to_string(),
             "--workspace".to_string(),
             "local-dev".to_string(),
+        ];
+        assert!(parse_command(&missing_json).is_err());
+    }
+
+    #[test]
+    fn parse_registry_sync_requires_workspace_and_json_flags() {
+        let args = vec![
+            "traverse-cli".to_string(),
+            "registry".to_string(),
+            "sync".to_string(),
+            "--workspace".to_string(),
+            "local-default".to_string(),
+            "--json".to_string(),
+        ];
+
+        let command = parse_command(&args).expect("registry sync should parse");
+
+        match command {
+            Command::RegistrySync {
+                workspace_id,
+                json_output,
+            } => {
+                assert_eq!(workspace_id, "local-default");
+                assert!(json_output);
+            }
+            other => assert!(matches!(other, Command::RegistrySync { .. })),
+        }
+
+        let missing_workspace = vec![
+            "traverse-cli".to_string(),
+            "registry".to_string(),
+            "sync".to_string(),
+            "--json".to_string(),
+        ];
+        assert!(parse_command(&missing_workspace).is_err());
+
+        let missing_json = vec![
+            "traverse-cli".to_string(),
+            "registry".to_string(),
+            "sync".to_string(),
+            "--workspace".to_string(),
+            "local-default".to_string(),
         ];
         assert!(parse_command(&missing_json).is_err());
     }
@@ -4367,6 +4723,100 @@ mod tests {
             "ollama_api_key"
         );
         assert!(!output.contains("do-not-render"));
+    }
+
+    #[test]
+    fn registry_sync_writes_public_index_state_and_json_evidence() {
+        let state_root = unique_temp_dir();
+        let fetcher = StaticRegistryFetcher {
+            result: Ok(FetchedRegistryIndex {
+                source_repo: "traverse-framework/registry".to_string(),
+                release_tag: "index-v7".to_string(),
+                index: registry_index_fixture(),
+            }),
+        };
+
+        let output = registry_sync_at(&state_root, "local-default", true, &fetcher)
+            .expect("registry sync should succeed");
+        let json: Value = serde_json::from_str(&output).expect("sync output must be JSON");
+        let state = load_synced_public_registry_state(&state_root, "local-default")
+            .expect("synced public registry state should load");
+
+        assert_eq!(json["status"], "synced");
+        assert_eq!(json["source"], "traverse-framework/registry");
+        assert_eq!(json["release_tag"], "index-v7");
+        assert_eq!(json["index_version"], 7);
+        assert_eq!(json["record_count"], 1);
+        assert_eq!(json["workspace"], "local-default");
+        assert_eq!(state.record_count, 1);
+        assert_eq!(state.capabilities[0].id, "traverse-starter.process");
+    }
+
+    #[test]
+    fn registry_sync_malformed_index_leaves_existing_state_unchanged() {
+        let state_root = unique_temp_dir();
+        let first_fetcher = StaticRegistryFetcher {
+            result: Ok(FetchedRegistryIndex {
+                source_repo: "traverse-framework/registry".to_string(),
+                release_tag: "index-v7".to_string(),
+                index: registry_index_fixture(),
+            }),
+        };
+        registry_sync_at(&state_root, "local-default", true, &first_fetcher)
+            .expect("initial registry sync should succeed");
+        let state_path =
+            traverse_registry::synced_public_registry_state_path(&state_root, "local-default");
+        let before = fs::read_to_string(&state_path).expect("synced state should read");
+
+        let mut malformed = registry_index_fixture();
+        malformed.capabilities[0].artifact_url = String::new();
+        let bad_fetcher = StaticRegistryFetcher {
+            result: Ok(FetchedRegistryIndex {
+                source_repo: "traverse-framework/registry".to_string(),
+                release_tag: "index-v8".to_string(),
+                index: malformed,
+            }),
+        };
+        let failure = registry_sync_at(&state_root, "local-default", true, &bad_fetcher)
+            .expect_err("malformed index should fail");
+        let after = fs::read_to_string(&state_path).expect("synced state should remain");
+
+        assert!(failure.message().contains("artifact_url"));
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn latest_index_release_asset_selects_highest_index_version() {
+        let releases = serde_json::json!([
+            {
+                "tag_name": "index-v7",
+                "assets": [
+                    {
+                        "name": "index.json",
+                        "browser_download_url": "https://example.test/index-v7/index.json"
+                    }
+                ]
+            },
+            {
+                "tag_name": "notes-v1",
+                "assets": []
+            },
+            {
+                "tag_name": "index-v9",
+                "assets": [
+                    {
+                        "name": "index.json",
+                        "browser_download_url": "https://example.test/index-v9/index.json"
+                    }
+                ]
+            }
+        ]);
+
+        let (tag, url) =
+            latest_index_release_asset(&releases).expect("latest release should resolve");
+
+        assert_eq!(tag, "index-v9");
+        assert_eq!(url, "https://example.test/index-v9/index.json");
     }
 
     #[test]
@@ -5238,6 +5688,33 @@ mod tests {
         let path = std::env::temp_dir().join(format!("traverse-cli-test-{nanos}"));
         fs::create_dir_all(&path).expect("temporary directory should create");
         path
+    }
+
+    #[derive(Clone)]
+    struct StaticRegistryFetcher {
+        result: Result<FetchedRegistryIndex, RegistrySyncError>,
+    }
+
+    impl RegistryIndexFetcher for StaticRegistryFetcher {
+        fn fetch_latest_index(&self) -> Result<FetchedRegistryIndex, RegistrySyncError> {
+            self.result.clone()
+        }
+    }
+
+    fn registry_index_fixture() -> PublicRegistryIndex {
+        PublicRegistryIndex {
+            index_version: 7,
+            generated_at: "2026-07-06T00:00:00Z".to_string(),
+            source_commit: Some("abc123".to_string()),
+            capabilities: vec![PublicRegistryCapabilityRecord {
+                namespace: "traverse-starter".to_string(),
+                id: "traverse-starter.process".to_string(),
+                version: "1.0.0".to_string(),
+                digest: "sha256:5647c39a".to_string(),
+                artifact_url: "https://github.com/traverse-framework/registry/releases/download/artifacts/traverse-starter.process-1.0.0/traverse-starter.wasm".to_string(),
+                deprecated: false,
+            }],
+        }
     }
 
     fn write_app_validate_fixture(

--- a/crates/traverse-registry/src/lib.rs
+++ b/crates/traverse-registry/src/lib.rs
@@ -7,6 +7,7 @@ mod events;
 mod federation;
 mod graph;
 mod model_resolution;
+mod public_registry_state;
 pub mod semver_resolver;
 mod workflows;
 mod workspace_app_state;
@@ -20,6 +21,7 @@ pub use events::*;
 pub use federation::*;
 pub use graph::*;
 pub use model_resolution::*;
+pub use public_registry_state::*;
 pub use semver_resolver::{
     AmbiguousCandidate, RangeResolutionError, ResolvedRangeCapability, resolve_version_range,
 };

--- a/crates/traverse-registry/src/public_registry_state.rs
+++ b/crates/traverse-registry/src/public_registry_state.rs
@@ -1,0 +1,768 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const PUBLIC_REGISTRY_STATE_SCHEMA_VERSION: &str = "1.0.0";
+const PUBLIC_REGISTRY_STATE_SCOPE: &str = "public_registry_synced";
+const PUBLIC_REGISTRY_GOVERNING_SPEC: &str = "055-registry-sync";
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct PublicRegistryIndex {
+    pub index_version: u64,
+    pub generated_at: String,
+    #[serde(default)]
+    pub source_commit: Option<String>,
+    pub capabilities: Vec<PublicRegistryCapabilityRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct PublicRegistryCapabilityRecord {
+    pub namespace: String,
+    pub id: String,
+    pub version: String,
+    pub digest: String,
+    pub artifact_url: String,
+    pub deprecated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct SyncedPublicRegistryState {
+    pub schema_version: String,
+    pub workspace_id: String,
+    pub state_scope: String,
+    pub source_repo: String,
+    pub release_tag: String,
+    pub index_version: u64,
+    pub generated_at: String,
+    pub source_commit: Option<String>,
+    pub synced_at: String,
+    pub record_count: usize,
+    pub validation_status: String,
+    pub governing_spec: String,
+    pub capabilities: Vec<PublicRegistryCapabilityRecord>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicRegistryStateErrorCode {
+    EmptyField,
+    DuplicateRecord,
+    MissingSyncedState,
+    StateReadFailed,
+    StateParseFailed,
+    IncompatibleSchemaVersion,
+    IncompatibleWorkspaceState,
+    StateWriteFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicRegistryStateError {
+    pub code: PublicRegistryStateErrorCode,
+    pub path: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PublicRegistryStateFailure {
+    pub errors: Vec<PublicRegistryStateError>,
+}
+
+/// Validates a public registry `index.json` document before it is persisted.
+///
+/// # Errors
+///
+/// Returns [`PublicRegistryStateFailure`] when required index metadata or
+/// capability record fields are empty, or when duplicate
+/// namespace/id/version records are present.
+pub fn validate_public_registry_index(
+    index: &PublicRegistryIndex,
+) -> Result<(), PublicRegistryStateFailure> {
+    let mut errors = Vec::new();
+    if index.generated_at.trim().is_empty() {
+        errors.push(error(
+            PublicRegistryStateErrorCode::EmptyField,
+            "$.generated_at",
+            "registry index generated_at must be non-empty",
+        ));
+    }
+
+    let mut seen = BTreeSet::new();
+    for (position, record) in index.capabilities.iter().enumerate() {
+        validate_record_field(
+            &mut errors,
+            position,
+            "namespace",
+            &record.namespace,
+            "namespace",
+        );
+        validate_record_field(&mut errors, position, "id", &record.id, "id");
+        validate_record_field(&mut errors, position, "version", &record.version, "version");
+        validate_record_field(&mut errors, position, "digest", &record.digest, "digest");
+        validate_record_field(
+            &mut errors,
+            position,
+            "artifact_url",
+            &record.artifact_url,
+            "artifact_url",
+        );
+        if !seen.insert((&record.namespace, &record.id, &record.version)) {
+            errors.push(error(
+                PublicRegistryStateErrorCode::DuplicateRecord,
+                format!("$.capabilities[{position}]"),
+                format!(
+                    "duplicate public registry record {}:{}@{}",
+                    record.namespace, record.id, record.version
+                ),
+            ));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(PublicRegistryStateFailure { errors })
+    }
+}
+
+#[must_use]
+pub fn synced_public_registry_state_path(workspace_root: &Path, workspace_id: &str) -> PathBuf {
+    workspace_root
+        .join(".traverse")
+        .join("workspaces")
+        .join(workspace_id)
+        .join("registry")
+        .join("public")
+        .join("index.json")
+}
+
+/// Atomically writes validated public registry sync state for one workspace.
+///
+/// # Errors
+///
+/// Returns [`PublicRegistryStateFailure`] when the fetched index is invalid,
+/// the state cannot be serialized, the target directory cannot be created, or
+/// the temporary file cannot be atomically moved into place.
+pub fn write_synced_public_registry_state(
+    workspace_root: &Path,
+    workspace_id: &str,
+    source_repo: &str,
+    release_tag: &str,
+    synced_at: &str,
+    index: PublicRegistryIndex,
+) -> Result<SyncedPublicRegistryState, PublicRegistryStateFailure> {
+    validate_public_registry_index(&index)?;
+    let state = SyncedPublicRegistryState {
+        schema_version: PUBLIC_REGISTRY_STATE_SCHEMA_VERSION.to_string(),
+        workspace_id: workspace_id.to_string(),
+        state_scope: PUBLIC_REGISTRY_STATE_SCOPE.to_string(),
+        source_repo: source_repo.to_string(),
+        release_tag: release_tag.to_string(),
+        index_version: index.index_version,
+        generated_at: index.generated_at,
+        source_commit: index.source_commit,
+        synced_at: synced_at.to_string(),
+        record_count: index.capabilities.len(),
+        validation_status: "passed".to_string(),
+        governing_spec: PUBLIC_REGISTRY_GOVERNING_SPEC.to_string(),
+        capabilities: index.capabilities,
+    };
+    write_state_atomically(
+        &synced_public_registry_state_path(workspace_root, workspace_id),
+        &state,
+    )?;
+    Ok(state)
+}
+
+/// Loads previously synced public registry state from local durable storage.
+///
+/// # Errors
+///
+/// Returns [`PublicRegistryStateFailure`] when no sync has run for the
+/// workspace, the state cannot be read or parsed, the schema version is
+/// unsupported, or the state belongs to another workspace.
+pub fn load_synced_public_registry_state(
+    workspace_root: &Path,
+    workspace_id: &str,
+) -> Result<SyncedPublicRegistryState, PublicRegistryStateFailure> {
+    let path = synced_public_registry_state_path(workspace_root, workspace_id);
+    if !path.exists() {
+        return Err(single_error(
+            PublicRegistryStateErrorCode::MissingSyncedState,
+            &path,
+            format!(
+                "workspace {workspace_id} has no synced public registry state; run traverse-cli registry sync"
+            ),
+        ));
+    }
+    let bytes = fs::read(&path).map_err(|error| {
+        single_error(
+            PublicRegistryStateErrorCode::StateReadFailed,
+            &path,
+            format!("failed to read synced public registry state: {error}"),
+        )
+    })?;
+    let state: SyncedPublicRegistryState = serde_json::from_slice(&bytes).map_err(|error| {
+        single_error(
+            PublicRegistryStateErrorCode::StateParseFailed,
+            &path,
+            format!("failed to parse synced public registry state: {error}"),
+        )
+    })?;
+    validate_synced_public_registry_state(&path, workspace_id, &state)?;
+    Ok(state)
+}
+
+/// Resolves an exact non-deprecated public capability record from local state.
+///
+/// # Errors
+///
+/// Returns [`PublicRegistryStateFailure`] when the workspace has no readable
+/// synced public registry state. This function never fetches from the network.
+pub fn resolve_synced_public_registry_record(
+    workspace_root: &Path,
+    workspace_id: &str,
+    namespace: &str,
+    id: &str,
+    version: &str,
+) -> Result<Option<PublicRegistryCapabilityRecord>, PublicRegistryStateFailure> {
+    let state = load_synced_public_registry_state(workspace_root, workspace_id)?;
+    Ok(state.capabilities.into_iter().find(|record| {
+        record.namespace == namespace
+            && record.id == id
+            && record.version == version
+            && !record.deprecated
+    }))
+}
+
+fn validate_synced_public_registry_state(
+    path: &Path,
+    workspace_id: &str,
+    state: &SyncedPublicRegistryState,
+) -> Result<(), PublicRegistryStateFailure> {
+    if state.schema_version != PUBLIC_REGISTRY_STATE_SCHEMA_VERSION {
+        return Err(single_error(
+            PublicRegistryStateErrorCode::IncompatibleSchemaVersion,
+            path,
+            format!(
+                "synced public registry state schema {} is not supported",
+                state.schema_version
+            ),
+        ));
+    }
+    if state.workspace_id != workspace_id || state.state_scope != PUBLIC_REGISTRY_STATE_SCOPE {
+        return Err(single_error(
+            PublicRegistryStateErrorCode::IncompatibleWorkspaceState,
+            path,
+            "synced public registry state does not belong to the requested workspace".to_string(),
+        ));
+    }
+    validate_public_registry_index(&PublicRegistryIndex {
+        index_version: state.index_version,
+        generated_at: state.generated_at.clone(),
+        source_commit: state.source_commit.clone(),
+        capabilities: state.capabilities.clone(),
+    })
+}
+
+fn validate_record_field(
+    errors: &mut Vec<PublicRegistryStateError>,
+    position: usize,
+    field: &str,
+    value: &str,
+    label: &str,
+) {
+    if value.trim().is_empty() {
+        errors.push(error(
+            PublicRegistryStateErrorCode::EmptyField,
+            format!("$.capabilities[{position}].{field}"),
+            format!("registry index capability {label} must be non-empty"),
+        ));
+    }
+}
+
+fn write_state_atomically(
+    path: &Path,
+    state: &SyncedPublicRegistryState,
+) -> Result<(), PublicRegistryStateFailure> {
+    let parent = path.parent().ok_or_else(|| {
+        single_error(
+            PublicRegistryStateErrorCode::StateWriteFailed,
+            path,
+            "synced public registry state path must have a parent directory".to_string(),
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        single_error(
+            PublicRegistryStateErrorCode::StateWriteFailed,
+            parent,
+            format!("failed to create synced public registry state directory: {error}"),
+        )
+    })?;
+
+    let tmp_path = path.with_extension("json.tmp");
+    let serialized = state_json_value(state).to_string();
+    fs::write(&tmp_path, format!("{serialized}\n")).map_err(|error| {
+        single_error(
+            PublicRegistryStateErrorCode::StateWriteFailed,
+            &tmp_path,
+            format!("failed to write temporary synced public registry state: {error}"),
+        )
+    })?;
+    fs::rename(&tmp_path, path).map_err(|error| {
+        let _ = fs::remove_file(&tmp_path);
+        single_error(
+            PublicRegistryStateErrorCode::StateWriteFailed,
+            path,
+            format!("failed to commit synced public registry state atomically: {error}"),
+        )
+    })
+}
+
+fn state_json_value(state: &SyncedPublicRegistryState) -> Value {
+    serde_json::json!({
+        "schema_version": state.schema_version,
+        "workspace_id": state.workspace_id,
+        "state_scope": state.state_scope,
+        "source_repo": state.source_repo,
+        "release_tag": state.release_tag,
+        "index_version": state.index_version,
+        "generated_at": state.generated_at,
+        "source_commit": state.source_commit,
+        "synced_at": state.synced_at,
+        "record_count": state.record_count,
+        "validation_status": state.validation_status,
+        "governing_spec": state.governing_spec,
+        "capabilities": state
+            .capabilities
+            .iter()
+            .map(capability_json_value)
+            .collect::<Vec<_>>()
+    })
+}
+
+fn capability_json_value(record: &PublicRegistryCapabilityRecord) -> Value {
+    serde_json::json!({
+        "namespace": record.namespace,
+        "id": record.id,
+        "version": record.version,
+        "digest": record.digest,
+        "artifact_url": record.artifact_url,
+        "deprecated": record.deprecated
+    })
+}
+
+fn single_error(
+    code: PublicRegistryStateErrorCode,
+    path: &Path,
+    message: String,
+) -> PublicRegistryStateFailure {
+    PublicRegistryStateFailure {
+        errors: vec![PublicRegistryStateError {
+            code,
+            path: path.display().to_string(),
+            message,
+        }],
+    }
+}
+
+fn error(
+    code: PublicRegistryStateErrorCode,
+    path: impl Into<String>,
+    message: impl Into<String>,
+) -> PublicRegistryStateError {
+    PublicRegistryStateError {
+        code,
+        path: path.into(),
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use super::*;
+    use serde_json::Value;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn writes_and_loads_synced_public_registry_state() {
+        let workspace_root = unique_temp_dir();
+
+        let state = write_synced_public_registry_state(
+            &workspace_root,
+            "local",
+            "traverse-framework/registry",
+            "index-v7",
+            "2026-07-06T00:00:00Z",
+            valid_index(),
+        )
+        .expect("public registry state should write");
+
+        let loaded = load_synced_public_registry_state(&workspace_root, "local")
+            .expect("public registry state should load");
+        let record = resolve_synced_public_registry_record(
+            &workspace_root,
+            "local",
+            "traverse-starter",
+            "traverse-starter.process",
+            "1.0.0",
+        )
+        .expect("public record lookup should read local state")
+        .expect("public record should resolve");
+
+        assert_eq!(state, loaded);
+        assert_eq!(loaded.state_scope, "public_registry_synced");
+        assert_eq!(loaded.record_count, 1);
+        assert_eq!(record.digest, "sha256:5647");
+    }
+
+    #[test]
+    fn missing_synced_public_registry_state_is_actionable() {
+        let workspace_root = unique_temp_dir();
+
+        let failure = load_synced_public_registry_state(&workspace_root, "local")
+            .expect_err("missing sync state should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::MissingSyncedState
+        );
+        assert!(failure.errors[0].message.contains("registry sync"));
+    }
+
+    #[test]
+    fn malformed_index_does_not_replace_existing_state() {
+        let workspace_root = unique_temp_dir();
+        let state_path = synced_public_registry_state_path(&workspace_root, "local");
+        write_synced_public_registry_state(
+            &workspace_root,
+            "local",
+            "traverse-framework/registry",
+            "index-v7",
+            "2026-07-06T00:00:00Z",
+            valid_index(),
+        )
+        .expect("initial public registry state should write");
+        let before = fs::read_to_string(&state_path).expect("state should be readable");
+
+        let mut malformed = valid_index();
+        malformed.capabilities[0].digest = " ".to_string();
+        let failure = write_synced_public_registry_state(
+            &workspace_root,
+            "local",
+            "traverse-framework/registry",
+            "index-v8",
+            "2026-07-06T00:01:00Z",
+            malformed,
+        )
+        .expect_err("malformed index should fail");
+        let after = fs::read_to_string(&state_path).expect("state should remain readable");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::EmptyField
+        );
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn incompatible_synced_public_registry_state_fails() {
+        let workspace_root = unique_temp_dir();
+        let state_path = synced_public_registry_state_path(&workspace_root, "local");
+        fs::create_dir_all(state_path.parent().expect("state path must have parent"))
+            .expect("state parent should create");
+        let mut state = serde_json::to_value(
+            write_synced_public_registry_state(
+                &workspace_root,
+                "local",
+                "traverse-framework/registry",
+                "index-v7",
+                "2026-07-06T00:00:00Z",
+                valid_index(),
+            )
+            .expect("state should write"),
+        )
+        .expect("state should serialize");
+        state["schema_version"] = Value::String("9.9.9".to_string());
+        fs::write(
+            &state_path,
+            serde_json::to_string_pretty(&state).expect("state should serialize"),
+        )
+        .expect("state should overwrite");
+
+        let failure = load_synced_public_registry_state(&workspace_root, "local")
+            .expect_err("wrong schema should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::IncompatibleSchemaVersion
+        );
+    }
+
+    #[test]
+    fn invalid_index_reports_empty_metadata_and_duplicates() {
+        let mut index = valid_index();
+        index.generated_at = " ".to_string();
+        index.capabilities.push(index.capabilities[0].clone());
+
+        let failure =
+            validate_public_registry_index(&index).expect_err("invalid index should fail");
+        let codes = failure
+            .errors
+            .iter()
+            .map(|error| error.code)
+            .collect::<Vec<_>>();
+
+        assert!(codes.contains(&PublicRegistryStateErrorCode::EmptyField));
+        assert!(codes.contains(&PublicRegistryStateErrorCode::DuplicateRecord));
+    }
+
+    #[test]
+    fn corrupt_synced_public_registry_state_reports_parse_failure() {
+        let workspace_root = unique_temp_dir();
+        let state_path = synced_public_registry_state_path(&workspace_root, "local");
+        fs::create_dir_all(state_path.parent().expect("state path must have parent"))
+            .expect("state parent should create");
+        fs::write(&state_path, "{not json").expect("corrupt state should write");
+
+        let failure = load_synced_public_registry_state(&workspace_root, "local")
+            .expect_err("corrupt state should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::StateParseFailed
+        );
+    }
+
+    #[test]
+    fn directory_backed_synced_public_registry_state_reports_read_failure() {
+        let workspace_root = unique_temp_dir();
+        let state_path = synced_public_registry_state_path(&workspace_root, "local");
+        fs::create_dir_all(&state_path).expect("directory-backed state path should create");
+
+        let failure = load_synced_public_registry_state(&workspace_root, "local")
+            .expect_err("directory-backed state should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::StateReadFailed
+        );
+    }
+
+    #[test]
+    fn workspace_mismatch_reports_incompatible_state() {
+        let workspace_root = unique_temp_dir();
+        write_synced_public_registry_state(
+            &workspace_root,
+            "local",
+            "traverse-framework/registry",
+            "index-v7",
+            "2026-07-06T00:00:00Z",
+            valid_index(),
+        )
+        .expect("state should write");
+
+        let failure = load_synced_public_registry_state(&workspace_root, "other")
+            .expect_err("wrong workspace should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::MissingSyncedState
+        );
+
+        let state_path = synced_public_registry_state_path(&workspace_root, "local");
+        let mut state: Value = serde_json::from_str(
+            &fs::read_to_string(&state_path).expect("state should be readable"),
+        )
+        .expect("state should parse");
+        state["workspace_id"] = Value::String("other".to_string());
+        fs::write(
+            &state_path,
+            serde_json::to_string_pretty(&state).expect("state should serialize"),
+        )
+        .expect("state should overwrite");
+
+        let failure = load_synced_public_registry_state(&workspace_root, "local")
+            .expect_err("workspace mismatch should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::IncompatibleWorkspaceState
+        );
+    }
+
+    #[test]
+    fn resolve_skips_deprecated_and_missing_public_records() {
+        let workspace_root = unique_temp_dir();
+        let mut index = valid_index();
+        index.capabilities[0].deprecated = true;
+        write_synced_public_registry_state(
+            &workspace_root,
+            "local",
+            "traverse-framework/registry",
+            "index-v7",
+            "2026-07-06T00:00:00Z",
+            index,
+        )
+        .expect("state should write");
+
+        let deprecated = resolve_synced_public_registry_record(
+            &workspace_root,
+            "local",
+            "traverse-starter",
+            "traverse-starter.process",
+            "1.0.0",
+        )
+        .expect("lookup should read local state");
+        let missing = resolve_synced_public_registry_record(
+            &workspace_root,
+            "local",
+            "traverse-starter",
+            "missing",
+            "1.0.0",
+        )
+        .expect("lookup should read local state");
+
+        assert!(deprecated.is_none());
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn write_failure_when_parent_component_is_file_leaves_no_state() {
+        let workspace_root = unique_temp_dir();
+        let registry_path = workspace_root.join(".traverse/workspaces/local/registry");
+        fs::create_dir_all(
+            registry_path
+                .parent()
+                .expect("registry path must have parent"),
+        )
+        .expect("workspace parent should create");
+        fs::write(&registry_path, "not a directory")
+            .expect("conflicting registry file should write");
+
+        let failure = write_synced_public_registry_state(
+            &workspace_root,
+            "local",
+            "traverse-framework/registry",
+            "index-v7",
+            "2026-07-06T00:00:00Z",
+            valid_index(),
+        )
+        .expect_err("parent create should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::StateWriteFailed
+        );
+    }
+
+    #[test]
+    fn write_failure_when_temp_path_is_directory_leaves_no_state() {
+        let workspace_root = unique_temp_dir();
+        let state_path = synced_public_registry_state_path(&workspace_root, "local");
+        let tmp_path = state_path.with_extension("json.tmp");
+        fs::create_dir_all(&tmp_path).expect("conflicting temp directory should create");
+
+        let failure = write_synced_public_registry_state(
+            &workspace_root,
+            "local",
+            "traverse-framework/registry",
+            "index-v7",
+            "2026-07-06T00:00:00Z",
+            valid_index(),
+        )
+        .expect_err("temp write should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::StateWriteFailed
+        );
+        assert!(!state_path.exists());
+    }
+
+    #[test]
+    fn rename_failure_removes_temporary_state_file() {
+        let workspace_root = unique_temp_dir();
+        let state_path = synced_public_registry_state_path(&workspace_root, "local");
+        let tmp_path = state_path.with_extension("json.tmp");
+        fs::create_dir_all(&state_path).expect("conflicting final directory should create");
+
+        let failure = write_synced_public_registry_state(
+            &workspace_root,
+            "local",
+            "traverse-framework/registry",
+            "index-v7",
+            "2026-07-06T00:00:00Z",
+            valid_index(),
+        )
+        .expect_err("rename over directory should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::StateWriteFailed
+        );
+        assert!(!tmp_path.exists());
+    }
+
+    #[test]
+    fn write_state_rejects_path_without_parent() {
+        let failure = write_state_atomically(Path::new(""), &synced_state_fixture())
+            .expect_err("empty state path should fail");
+
+        assert_eq!(
+            failure.errors[0].code,
+            PublicRegistryStateErrorCode::StateWriteFailed
+        );
+    }
+
+    fn synced_state_fixture() -> SyncedPublicRegistryState {
+        SyncedPublicRegistryState {
+            schema_version: PUBLIC_REGISTRY_STATE_SCHEMA_VERSION.to_string(),
+            workspace_id: "local".to_string(),
+            state_scope: PUBLIC_REGISTRY_STATE_SCOPE.to_string(),
+            source_repo: "traverse-framework/registry".to_string(),
+            release_tag: "index-v7".to_string(),
+            index_version: 7,
+            generated_at: "2026-07-06T00:00:00Z".to_string(),
+            source_commit: Some("abc123".to_string()),
+            synced_at: "2026-07-06T00:00:00Z".to_string(),
+            record_count: 1,
+            validation_status: "passed".to_string(),
+            governing_spec: PUBLIC_REGISTRY_GOVERNING_SPEC.to_string(),
+            capabilities: valid_index().capabilities,
+        }
+    }
+
+    fn valid_index() -> PublicRegistryIndex {
+        PublicRegistryIndex {
+            index_version: 7,
+            generated_at: "2026-07-06T00:00:00Z".to_string(),
+            source_commit: Some("abc123".to_string()),
+            capabilities: vec![PublicRegistryCapabilityRecord {
+                namespace: "traverse-starter".to_string(),
+                id: "traverse-starter.process".to_string(),
+                version: "1.0.0".to_string(),
+                digest: "sha256:5647".to_string(),
+                artifact_url: "https://github.com/traverse-framework/registry/releases/download/artifacts/traverse-starter.process-1.0.0/traverse-starter.wasm".to_string(),
+                deprecated: false,
+            }],
+        }
+    }
+
+    fn unique_temp_dir() -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time should be after epoch")
+            .as_nanos();
+        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "traverse-public-registry-state-test-{nanos}-{counter}"
+        ));
+        fs::create_dir_all(&path).expect("temp dir should be created");
+        path
+    }
+}


### PR DESCRIPTION
## Summary

- implement `traverse-cli registry sync --workspace <id> --json`
- persist the fetched public registry index into workspace-local durable state under `.traverse/workspaces/<id>/registry/public/index.json`
- add local-only public registry state loading and exact record resolution helpers with atomic sync writes

## Governing Spec

- `055-registry-sync`
- `054-public-scope-registry-ref`

## Project Item

Closes #542

## Validation

- `cargo test -p traverse-registry`
- `cargo test -p traverse-cli`
- `cargo clippy -p traverse-registry -- -D warnings`
- `cargo clippy -p traverse-cli -- -D warnings`
- `cargo run -p traverse-cli -- registry sync --workspace local-default --json`
- `bash scripts/ci/pr_body_check.sh pr-body.md`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh pr-body.md`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/coverage_gate.sh`
- `git diff --check`
