### PR TITLE
Normalize repository casing references

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Task Board
-    url: https://github.com/users/enricopiovesan/projects/1/
+    url: https://github.com/orgs/traverse-framework/projects/1/
     about: Use the GitHub Project board as the canonical task planning surface for Traverse.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Reference the governing approved spec version.
 
 Link the GitHub issue or project item from:
 
-- https://github.com/users/enricopiovesan/projects/1/
+- https://github.com/orgs/traverse-framework/projects/1/
 
 ## What Changed
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ security, traceability, accessibility, or required tests.
 ### 1. Check for Claude Code claim
 
 ```bash
-gh issue view <NUMBER> --repo traverse-framework/Traverse --json labels
+gh issue view <NUMBER> --repo traverse-framework/traverse --json labels
 ```
 
 If the labels include `agent:claude` → **STOP**. Report:
@@ -87,7 +87,7 @@ If a `claude/issue-<NUMBER>-*` branch exists → **STOP**. Report:
 
 ```bash
 # Add label
-gh issue edit <NUMBER> --repo traverse-framework/Traverse --add-label "agent:codex"
+gh issue edit <NUMBER> --repo traverse-framework/traverse --add-label "agent:codex"
 
 # Get project item ID with bounded output
 gh project item-list 1 --owner traverse-framework --format json --limit 300 \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-repository = "https://github.com/traverse-framework/Traverse"
+repository = "https://github.com/traverse-framework/traverse"
 rust-version = "1.94"
 version = "0.7.0"
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 # Traverse
 
-[![CI](https://github.com/traverse-framework/Traverse/actions/workflows/ci.yml/badge.svg)](https://github.com/traverse-framework/Traverse/actions/workflows/ci.yml)
-[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/traverse-framework/Traverse/actions/workflows/ci.yml)
+[![CI](https://github.com/traverse-framework/traverse/actions/workflows/ci.yml/badge.svg)](https://github.com/traverse-framework/traverse/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/traverse-framework/traverse/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
-[![Version](https://img.shields.io/badge/version-v0.7.0-blue)](https://github.com/traverse-framework/Traverse/releases)
+[![Version](https://img.shields.io/badge/version-v0.7.0-blue)](https://github.com/traverse-framework/traverse/releases)
 
 Your business logic runs in the browser, on your server, and in a cloud function.
 They drift. You maintain three versions of the same behavior.
@@ -22,8 +22,8 @@ Traverse is the working implementation of [Universal Microservices Architecture]
 **Requirements**: Rust 1.94+
 
 ```bash
-git clone https://github.com/traverse-framework/Traverse.git
-cd Traverse
+git clone https://github.com/traverse-framework/traverse.git
+cd traverse
 cargo build
 cargo run -p traverse-cli -- bundle inspect examples/expedition/registry-bundle/manifest.json
 ```
@@ -158,7 +158,7 @@ Please read before opening a PR:
 
 All work follows the governance workflow below. Every PR must be backed by an approved spec.
 
-[GitHub Project 1](https://github.com/users/enricopiovesan/projects/1/) is the canonical board. All active work has an issue, a project item, and a PR.
+[GitHub Project 1](https://github.com/orgs/traverse-framework/projects/1/) is the canonical board. All active work has an issue, a project item, and a PR.
 
 ---
 

--- a/docs/ai-review-process.md
+++ b/docs/ai-review-process.md
@@ -78,4 +78,4 @@ Follow-up work should be represented in:
 
 Project board:
 
-- [GitHub Project 1](https://github.com/users/enricopiovesan/projects/1/)
+- [GitHub Project 1](https://github.com/orgs/traverse-framework/projects/1/)

--- a/docs/multi-thread-workflow.md
+++ b/docs/multi-thread-workflow.md
@@ -82,10 +82,10 @@ For parallel work to be valid:
 
 For the current expedition artifact work, the cleanest split is:
 
-- Workstream 1: [#42](https://github.com/traverse-framework/Traverse/issues/42) event contracts
-- Workstream 2: [#44](https://github.com/traverse-framework/Traverse/issues/44) atomic capability contracts
-- Workstream 3: [#43](https://github.com/traverse-framework/Traverse/issues/43) composed capability contract
-- Workstream 4: [#45](https://github.com/traverse-framework/Traverse/issues/45) workflow artifact
+- Workstream 1: [#42](https://github.com/traverse-framework/traverse/issues/42) event contracts
+- Workstream 2: [#44](https://github.com/traverse-framework/traverse/issues/44) atomic capability contracts
+- Workstream 3: [#43](https://github.com/traverse-framework/traverse/issues/43) composed capability contract
+- Workstream 4: [#45](https://github.com/traverse-framework/traverse/issues/45) workflow artifact
 
 If we only have one active dev thread, these should remain `Ready`.
 
@@ -129,13 +129,13 @@ Use this dev thread prompt:
 Act as a Traverse dev thread for issue #NN.
 
 Pre-flight (run before any work):
-1. gh issue view NN --repo traverse-framework/Traverse --json labels
+1. gh issue view NN --repo traverse-framework/traverse --json labels
    If labels include "agent:claude" → STOP. Report: "Issue #NN is claimed by Claude Code."
 2. git ls-remote --heads origin | grep "issue-NN-"
    If a claude/issue-NN-* branch exists → STOP. Report: "A Claude Code branch exists for #NN."
 
 Claim (only if pre-flight passes):
-1. gh issue edit NN --repo traverse-framework/Traverse --add-label "agent:codex"
+1. gh issue edit NN --repo traverse-framework/traverse --add-label "agent:codex"
 2. Set Agent → Codex and Status → In Progress on Project 1 for this issue.
    Project ID: PVT_kwHOAEZXvs4BS6Ns
    Agent field: PVTSSF_lAHOAEZXvs4BS6NszhBK-Qk, Codex option: 34d6db7d

--- a/docs/planning-board.md
+++ b/docs/planning-board.md
@@ -145,4 +145,4 @@ Only tickets with real active execution should appear in this section.
 
 This planning board is mirrored into:
 
-- [GitHub Project 1](https://github.com/users/enricopiovesan/projects/1/)
+- [GitHub Project 1](https://github.com/orgs/traverse-framework/projects/1/)

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -2,7 +2,7 @@
 
 Traverse uses this GitHub Project as the canonical task board:
 
-- [GitHub Project 1](https://github.com/users/enricopiovesan/projects/1/)
+- [GitHub Project 1](https://github.com/orgs/traverse-framework/projects/1/)
 
 ## Working Rule
 

--- a/docs/repo-migration-plan.md
+++ b/docs/repo-migration-plan.md
@@ -1,0 +1,38 @@
+# Repo Migration Status
+
+The repository now lives at:
+
+```text
+https://github.com/traverse-framework/traverse
+```
+
+GitHub redirects the previous cased URL:
+
+```text
+https://github.com/traverse-framework/Traverse
+```
+
+to the current repository.
+
+## Completed
+
+- Repository ownership moved to `traverse-framework`.
+- Repository name normalized to lowercase `traverse`.
+- README badges and clone URL point at `traverse-framework/traverse`.
+- Workspace package metadata points at `traverse-framework/traverse`.
+- Agent coordination examples use `traverse-framework/traverse`.
+- Project state audit uses `traverse-framework/traverse`.
+
+## Post-Rename Validation
+
+- `gh repo view traverse-framework/traverse` succeeds.
+- `gh repo view traverse-framework/Traverse` resolves to `traverse-framework/traverse`.
+- Existing GitHub redirects preserve old links.
+
+## Local Clone Update
+
+Existing local clones can move their remote to the canonical URL with:
+
+```bash
+git remote set-url origin https://github.com/traverse-framework/traverse.git
+```

--- a/docs/v1-milestone.md
+++ b/docs/v1-milestone.md
@@ -17,7 +17,7 @@ v1.0.0 signals that Traverse public API surfaces are stable, all six crates are 
 | G-07 | MCP library surface callable without subprocess (`discover_capabilities`, `execute_capability`) | Integration tests |
 | G-08 | 100% test coverage on all governed crate paths | Coverage gate |
 | G-09 | Zero open P0/P1 bugs in Project 1 | `gh issue list --label bug` filtered to P0/P1 priority labels |
-| G-10 | `Cargo.toml` and all doc badges point to `traverse-framework/Traverse` | metadata and documentation grep |
+| G-10 | `Cargo.toml` and all doc badges point to `traverse-framework/traverse` | metadata and documentation grep |
 
 ## How to check locally
 

--- a/scripts/ci/project_state_audit.sh
+++ b/scripts/ci/project_state_audit.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-repo="traverse-framework/Traverse"
+repo="traverse-framework/traverse"
 
-project_items_json=$(gh project item-list 1 --owner traverse-framework --limit 500 --format json)
+project_items_json=$(gh project item-list 1 --owner traverse-framework --format json --limit 500)
 
 failures=0
 

--- a/scripts/ci/v1_gate_check.sh
+++ b/scripts/ci/v1_gate_check.sh
@@ -81,10 +81,10 @@ check G-09 "no open P0/P1 bugs (requires gh CLI)" bash -c '
 '
 
 # G-10: canonical repository metadata
-check G-10 "Cargo.toml and docs point to traverse-framework/Traverse" bash -c '
-    grep -q "traverse-framework/Traverse" Cargo.toml
-    grep -q "traverse-framework/Traverse/actions/workflows/ci.yml" README.md
-    grep -q "github.com/traverse-framework/Traverse/releases" README.md
+check G-10 "Cargo.toml and docs point to traverse-framework/traverse" bash -c '
+    grep -q "traverse-framework/traverse" Cargo.toml
+    grep -q "traverse-framework/traverse/actions/workflows/ci.yml" README.md
+    grep -q "github.com/traverse-framework/traverse/releases" README.md
     ! grep -R -E "enricopiovesan/Traverse|github.com/users/enricopiovesan/projects/1" README.md docs Cargo.toml >/dev/null
 '
 

--- a/specs/188-codex-agent-coordination/plan.md
+++ b/specs/188-codex-agent-coordination/plan.md
@@ -53,7 +53,7 @@ Two steps prepended to the existing prompt:
 **Pre-flight (runs before any work):**
 ```
 Before starting any work on issue #<NUMBER>:
-1. gh issue view <NUMBER> --repo traverse-framework/Traverse --json labels
+1. gh issue view <NUMBER> --repo traverse-framework/traverse --json labels
    If labels include "agent:claude" → STOP. Report: "Issue #<NUMBER> is claimed by Claude Code."
 2. git ls-remote --heads origin | grep "issue-<NUMBER>-"
    If a claude/issue-<NUMBER>-* branch exists → STOP. Report: "A Claude Code branch exists for #<NUMBER>."
@@ -61,7 +61,7 @@ Before starting any work on issue #<NUMBER>:
 
 **Claim step (runs only if pre-flight passes):**
 ```
-1. gh issue edit <NUMBER> --repo traverse-framework/Traverse --add-label "agent:codex"
+1. gh issue edit <NUMBER> --repo traverse-framework/traverse --add-label "agent:codex"
 2. Retrieve project item ID for issue #<NUMBER> from Project 1, then:
    gh project item-edit --project-id PVT_kwHOAEZXvs4BS6Ns --id <ITEM_ID> \
      --field-id PVTSSF_lAHOAEZXvs4BS6NszhBK-Qk --single-select-option-id 34d6db7d


### PR DESCRIPTION
## Summary

- Normalize active repository metadata and docs from traverse-framework/Traverse to traverse-framework/traverse.
- Move active Project 1 links to the traverse-framework org project.
- Record the post-rename status and local clone update command.

## Governing Spec

- `004-spec-alignment-gate`
- `019-downstream-consumer-contract`
- `048-semver-publishing-pipeline`
- `049-v1-milestone-gate`

## Project Item

Project Item - #534

## What Changed

- README badges, clone URL, and project-board link now point at canonical org URLs.
- Cargo workspace package repository metadata now points at traverse-framework/traverse.
- Agent/project docs and GitHub templates now use canonical repo/project URLs.
- Added docs/repo-migration-plan.md with post-rename validation notes.

## Validation

- gh repo view traverse-framework/traverse --json nameWithOwner,url
- gh repo view traverse-framework/Traverse --json nameWithOwner,url
- cargo metadata --no-deps --format-version 1
- git diff --check
- bash scripts/ci/repository_checks.sh
- bash scripts/ci/pr_body_check.sh <pr-body>
- BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh <pr-body>

Closes #534
