### PR TITLE
Implement spec 057 manifest execution modes

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -2607,12 +2607,15 @@ fn app_registration_components(
             serde_json::json!({
                 "component_id": component.manifest.component_id.clone(),
                 "component_version": component.manifest.version.clone(),
+                "execution_mode": component.manifest.execution_mode.as_str(),
                 "capability_id": component.manifest.capability_id.clone(),
                 "capability_version": component.manifest.capability_version.clone(),
                 "wasm_digest": component.verified_wasm_digest.clone(),
                 "manifest_path": component.manifest_path.display().to_string(),
                 "contract_path": component.contract_path.display().to_string(),
-                "artifact_ref": component.wasm_binary_path.display().to_string()
+                "artifact_ref": component.wasm_binary_path.as_ref().map(|path| path.display().to_string()),
+                "platforms": component.manifest.platforms.clone(),
+                "wrapper_path": component.manifest.wrapper_path.clone()
             })
         })
         .collect()
@@ -2647,13 +2650,15 @@ fn app_registration_digest_verification(
     manifest
         .components
         .iter()
-        .map(|component| {
-            serde_json::json!({
-                "component_id": component.manifest.component_id.clone(),
-                "component_version": component.manifest.version.clone(),
-                "path": component.wasm_binary_path.display().to_string(),
-                "wasm_digest": component.verified_wasm_digest.clone(),
-                "status": "verified"
+        .filter_map(|component| {
+            component.wasm_binary_path.as_ref().map(|wasm_binary_path| {
+                serde_json::json!({
+                    "component_id": component.manifest.component_id.clone(),
+                    "component_version": component.manifest.version.clone(),
+                    "path": wasm_binary_path.display().to_string(),
+                    "wasm_digest": component.verified_wasm_digest.clone(),
+                    "status": "verified"
+                })
             })
         })
         .collect()
@@ -2849,13 +2854,15 @@ fn render_app_validation_success(
     let digest_results = manifest
         .components
         .iter()
-        .map(|component| {
-            serde_json::json!({
-                "component_id": component.manifest.component_id.clone(),
-                "component_version": component.manifest.version.clone(),
-                "path": component.wasm_binary_path.display().to_string(),
-                "wasm_digest": component.verified_wasm_digest.clone(),
-                "status": "verified"
+        .filter_map(|component| {
+            component.wasm_binary_path.as_ref().map(|wasm_binary_path| {
+                serde_json::json!({
+                    "component_id": component.manifest.component_id.clone(),
+                    "component_version": component.manifest.version.clone(),
+                    "path": wasm_binary_path.display().to_string(),
+                    "wasm_digest": component.verified_wasm_digest.clone(),
+                    "status": "verified"
+                })
             })
         })
         .collect::<Vec<_>>();
@@ -2886,11 +2893,14 @@ fn render_app_validation_success(
             serde_json::json!({
                 "component_id": component.manifest.component_id.clone(),
                 "component_version": component.manifest.version.clone(),
+                "execution_mode": component.manifest.execution_mode.as_str(),
                 "capability_id": component.manifest.capability_id.clone(),
                 "capability_version": component.manifest.capability_version.clone(),
                 "manifest_path": component.manifest_path.display().to_string(),
                 "contract_path": component.contract_path.display().to_string(),
-                "wasm_digest": component.verified_wasm_digest.clone()
+                "wasm_digest": component.verified_wasm_digest.clone(),
+                "platforms": component.manifest.platforms.clone(),
+                "wrapper_path": component.manifest.wrapper_path.clone()
             })
         }).collect::<Vec<_>>(),
         "workflows": manifest.workflows.iter().map(|workflow| {

--- a/crates/traverse-registry/src/application_manifest.rs
+++ b/crates/traverse-registry/src/application_manifest.rs
@@ -115,7 +115,7 @@ pub struct ApplicationRegisteredComponent {
     pub component_version: String,
     pub capability_id: String,
     pub capability_version: String,
-    pub wasm_digest: String,
+    pub wasm_digest: Option<String>,
     pub artifact_ref: String,
 }
 
@@ -348,8 +348,8 @@ pub struct ApplicationComponent {
     pub manifest: WasmComponentManifest,
     pub contract_path: PathBuf,
     pub contract: CapabilityContract,
-    pub wasm_binary_path: PathBuf,
-    pub verified_wasm_digest: String,
+    pub wasm_binary_path: Option<PathBuf>,
+    pub verified_wasm_digest: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -412,16 +412,35 @@ pub struct WasmComponentManifest {
     pub component_id: String,
     pub version: String,
     pub schema_version: String,
+    pub execution_mode: ComponentExecutionMode,
     pub capability_id: String,
     pub capability_version: String,
     pub contract_path: String,
-    pub wasm_binary_path: String,
-    pub wasm_digest: String,
+    pub wasm_binary_path: Option<String>,
+    pub wasm_digest: Option<String>,
+    pub platforms: Vec<String>,
+    pub wrapper_path: Option<String>,
     pub runtime_constraints: Value,
     pub permitted_targets: Vec<ExecutionTarget>,
     pub dependencies: Vec<WasmComponentDependency>,
     pub connector_requirements: Vec<ConnectorRequirement>,
     pub validation_evidence: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComponentExecutionMode {
+    Wasm,
+    Compatible,
+}
+
+impl ComponentExecutionMode {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Wasm => "wasm",
+            Self::Compatible => "compatible",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -451,6 +470,11 @@ pub enum ApplicationManifestErrorCode {
     ComponentWasmMissing,
     InvalidDigestMetadata,
     ComponentDigestMismatch,
+    InvalidExecutionMode,
+    CompatibleComponentMissingWrapper,
+    CompatibleComponentMissingPlatforms,
+    CompatibleComponentInvalidWasmFields,
+    WasmComponentMissingWasmFields,
     ComponentDependencyMustBeConcrete,
     UnsupportedModelInterface,
     ModelDependencyMissingCandidates,
@@ -548,11 +572,19 @@ struct WasmComponentManifestSerde {
     component_id: String,
     version: String,
     schema_version: String,
+    #[serde(default)]
+    execution_mode: Option<String>,
     capability_id: String,
     capability_version: String,
     contract_path: String,
-    wasm_binary_path: String,
-    wasm_digest: String,
+    #[serde(default)]
+    wasm_binary_path: Option<String>,
+    #[serde(default)]
+    wasm_digest: Option<String>,
+    #[serde(default)]
+    platforms: Vec<String>,
+    #[serde(default)]
+    wrapper_path: Option<String>,
     runtime_constraints: Value,
     permitted_targets: Vec<ExecutionTarget>,
     dependencies: Vec<WasmComponentDependency>,
@@ -789,15 +821,18 @@ fn build_application_capability_registration(
             kind: SourceKind::Local,
             location: component.manifest_path.display().to_string(),
         },
-        binary: Some(BinaryReference {
-            format: BinaryFormat::Wasm,
-            location: component.wasm_binary_path.display().to_string(),
-            signature: None,
-        }),
+        binary: component
+            .wasm_binary_path
+            .as_ref()
+            .map(|wasm_binary_path| BinaryReference {
+                format: BinaryFormat::Wasm,
+                location: wasm_binary_path.display().to_string(),
+                signature: None,
+            }),
         workflow_ref: None,
         digests: ArtifactDigests {
             source_digest: governed_content_digest(&component.contract),
-            binary_digest: Some(component.verified_wasm_digest.clone()),
+            binary_digest: component.verified_wasm_digest.clone(),
         },
         provenance: RegistryProvenance {
             source: format!("application_bundle:{}", manifest.app_id),
@@ -1713,20 +1748,43 @@ fn load_component(
             )
         })?;
 
-    let expected_wasm_digest =
-        ensure_component_reference_matches(reference, &component, &manifest_path)?;
+    let execution_mode = parse_component_execution_mode(&component, &manifest_path)?;
+    let expected_component_digest =
+        ensure_component_reference_matches(reference, &component, execution_mode, &manifest_path)?;
+    validate_component_execution_mode(&component, execution_mode, &manifest_path)?;
     ensure_concrete_component_dependencies(&component.dependencies, &manifest_path)?;
 
     let component_dir = manifest_path.parent().unwrap_or(manifest_dir);
     let contract_path = component_dir.join(&component.contract_path);
     let contract = load_component_contract(&contract_path, &component)?;
-    let wasm_binary_path = component_dir.join(&component.wasm_binary_path);
-    let verified_wasm_digest = verify_wasm_digest(&wasm_binary_path, &expected_wasm_digest)?;
+    let (wasm_binary_path, verified_wasm_digest) = if execution_mode == ComponentExecutionMode::Wasm
+    {
+        let path = component
+            .wasm_binary_path
+            .as_deref()
+            .filter(|path| has_text(path))
+            .ok_or_else(|| {
+                single_error(
+                    ApplicationManifestErrorCode::WasmComponentMissingWasmFields,
+                    manifest_path.display().to_string(),
+                    format!(
+                        "wasm component {}@{} requires wasm_binary_path",
+                        component.component_id, component.version
+                    ),
+                )
+            })?;
+        let wasm_binary_path = component_dir.join(path);
+        let verified_wasm_digest =
+            verify_wasm_digest(&wasm_binary_path, &expected_component_digest)?;
+        (Some(wasm_binary_path), Some(verified_wasm_digest))
+    } else {
+        (None, None)
+    };
 
     Ok(ApplicationComponent {
         reference: reference.clone(),
         manifest_path,
-        manifest: to_component_manifest(component),
+        manifest: to_component_manifest(component, execution_mode),
         contract_path,
         contract,
         wasm_binary_path,
@@ -1737,6 +1795,7 @@ fn load_component(
 fn ensure_component_reference_matches(
     reference: &ApplicationComponentRef,
     component: &WasmComponentManifestSerde,
+    execution_mode: ComponentExecutionMode,
     manifest_path: &Path,
 ) -> Result<String, ApplicationManifestFailure> {
     if reference.component_id != component.component_id || reference.version != component.version {
@@ -1763,27 +1822,123 @@ fn ensure_component_reference_matches(
             ),
         )
     })?;
-    let component_digest = normalize_sha256_digest(&component.wasm_digest).ok_or_else(|| {
-        single_error(
-            ApplicationManifestErrorCode::InvalidDigestMetadata,
-            "$.wasm_digest".to_string(),
-            format!(
-                "component manifest {}@{} declares invalid wasm_digest metadata",
-                component.component_id, component.version
-            ),
-        )
-    })?;
-    if expected_digest != component_digest {
-        return Err(single_error(
-            ApplicationManifestErrorCode::ComponentDigestMismatch,
-            manifest_path.display().to_string(),
-            format!(
-                "component digest mismatch for {}@{}: app declared {}, component manifest declared {}",
-                component.component_id, component.version, reference.digest, component.wasm_digest
-            ),
-        ));
+    if execution_mode == ComponentExecutionMode::Wasm {
+        let wasm_digest = component.wasm_digest.as_deref().ok_or_else(|| {
+            single_error(
+                ApplicationManifestErrorCode::WasmComponentMissingWasmFields,
+                "$.wasm_digest".to_string(),
+                format!(
+                    "wasm component {}@{} requires wasm_digest",
+                    component.component_id, component.version
+                ),
+            )
+        })?;
+        let component_digest = normalize_sha256_digest(wasm_digest).ok_or_else(|| {
+            single_error(
+                ApplicationManifestErrorCode::InvalidDigestMetadata,
+                "$.wasm_digest".to_string(),
+                format!(
+                    "component manifest {}@{} declares invalid wasm_digest metadata",
+                    component.component_id, component.version
+                ),
+            )
+        })?;
+        if expected_digest != component_digest {
+            return Err(single_error(
+                ApplicationManifestErrorCode::ComponentDigestMismatch,
+                manifest_path.display().to_string(),
+                format!(
+                    "component digest mismatch for {}@{}: app declared {}, component manifest declared {}",
+                    component.component_id, component.version, reference.digest, wasm_digest
+                ),
+            ));
+        }
     }
     Ok(expected_digest)
+}
+
+fn parse_component_execution_mode(
+    component: &WasmComponentManifestSerde,
+    manifest_path: &Path,
+) -> Result<ComponentExecutionMode, ApplicationManifestFailure> {
+    match component.execution_mode.as_deref().unwrap_or("wasm") {
+        "wasm" => Ok(ComponentExecutionMode::Wasm),
+        "compatible" => Ok(ComponentExecutionMode::Compatible),
+        other => Err(single_error(
+            ApplicationManifestErrorCode::InvalidExecutionMode,
+            manifest_path.display().to_string(),
+            format!(
+                "component {}@{} declares unsupported execution_mode {other}",
+                component.component_id, component.version
+            ),
+        )),
+    }
+}
+
+fn validate_component_execution_mode(
+    component: &WasmComponentManifestSerde,
+    execution_mode: ComponentExecutionMode,
+    manifest_path: &Path,
+) -> Result<(), ApplicationManifestFailure> {
+    match execution_mode {
+        ComponentExecutionMode::Wasm => {}
+        ComponentExecutionMode::Compatible => {
+            if component.wasm_binary_path.is_some() || component.wasm_digest.is_some() {
+                return Err(single_error(
+                    ApplicationManifestErrorCode::CompatibleComponentInvalidWasmFields,
+                    manifest_path.display().to_string(),
+                    format!(
+                        "compatible component {}@{} must not declare wasm_binary_path or wasm_digest",
+                        component.component_id, component.version
+                    ),
+                ));
+            }
+            let wrapper_path = match component.wrapper_path.as_deref() {
+                Some(path) if has_text(path) => path,
+                _ => {
+                    return Err(single_error(
+                        ApplicationManifestErrorCode::CompatibleComponentMissingWrapper,
+                        manifest_path.display().to_string(),
+                        format!(
+                            "compatible component {}@{} requires wrapper_path",
+                            component.component_id, component.version
+                        ),
+                    ));
+                }
+            };
+            if !manifest_path
+                .parent()
+                .unwrap_or_else(|| Path::new(""))
+                .join(wrapper_path)
+                .exists()
+            {
+                return Err(single_error(
+                    ApplicationManifestErrorCode::CompatibleComponentMissingWrapper,
+                    manifest_path.display().to_string(),
+                    format!(
+                        "compatible component {}@{} wrapper_path does not exist",
+                        component.component_id, component.version
+                    ),
+                ));
+            }
+            if component.platforms.is_empty()
+                || component
+                    .platforms
+                    .iter()
+                    .any(|platform| !has_text(platform))
+            {
+                return Err(single_error(
+                    ApplicationManifestErrorCode::CompatibleComponentMissingPlatforms,
+                    manifest_path.display().to_string(),
+                    format!(
+                        "compatible component {}@{} requires non-empty platforms",
+                        component.component_id, component.version
+                    ),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn ensure_concrete_component_dependencies(
@@ -1905,16 +2060,22 @@ fn verify_wasm_digest(
     Ok(format!("sha256:{actual}"))
 }
 
-fn to_component_manifest(component: WasmComponentManifestSerde) -> WasmComponentManifest {
+fn to_component_manifest(
+    component: WasmComponentManifestSerde,
+    execution_mode: ComponentExecutionMode,
+) -> WasmComponentManifest {
     WasmComponentManifest {
         component_id: component.component_id,
         version: component.version,
         schema_version: component.schema_version,
+        execution_mode,
         capability_id: component.capability_id,
         capability_version: component.capability_version,
         contract_path: component.contract_path,
         wasm_binary_path: component.wasm_binary_path,
         wasm_digest: component.wasm_digest,
+        platforms: component.platforms,
+        wrapper_path: component.wrapper_path,
         runtime_constraints: component.runtime_constraints,
         permitted_targets: component.permitted_targets,
         dependencies: component.dependencies,

--- a/crates/traverse-registry/tests/application_manifest.rs
+++ b/crates/traverse-registry/tests/application_manifest.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::expect_used)]
 
-use serde_json::json;
+use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::fmt::Write;
 use std::fs;
@@ -37,7 +37,261 @@ fn loads_checked_in_application_manifest_with_real_wasm_component() {
     );
     assert_eq!(
         bundle.components[0].verified_wasm_digest,
-        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99"
+        Some("sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99".to_string())
+    );
+}
+
+#[test]
+fn defaults_component_execution_mode_to_wasm() {
+    let fixture = AppFixture::new("default-wasm-mode");
+    let wasm_digest = fixture.write_wasm("component bytes");
+    fixture.write_component_manifest(&json!({
+        "wasm_digest": format!("sha256:{wasm_digest}"),
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let bundle = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect("omitted execution_mode should preserve wasm compatibility");
+
+    assert_eq!(
+        bundle.components[0].manifest.execution_mode,
+        traverse_registry::ComponentExecutionMode::Wasm
+    );
+    assert_eq!(
+        bundle.components[0].verified_wasm_digest,
+        Some(format!("sha256:{wasm_digest}"))
+    );
+}
+
+#[test]
+fn component_execution_mode_renders_manifest_values() {
+    assert_eq!(
+        traverse_registry::ComponentExecutionMode::Wasm.as_str(),
+        "wasm"
+    );
+    assert_eq!(
+        traverse_registry::ComponentExecutionMode::Compatible.as_str(),
+        "compatible"
+    );
+}
+
+#[test]
+fn loads_compatible_component_manifest_without_wasm_artifact() {
+    let fixture = AppFixture::new("compatible-mode");
+    let wrapper_path = fixture.write_compatible_wrapper();
+    let reference_digest = sha256_hex(b"compatible component manifest reference");
+    fixture.write_component_manifest(&json!({
+        "execution_mode": "compatible",
+        "wasm_binary_path": null,
+        "wasm_digest": null,
+        "platforms": ["linux"],
+        "wrapper_path": wrapper_path,
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{reference_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let bundle = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect("compatible component should validate without wasm fields");
+
+    assert_eq!(
+        bundle.components[0].manifest.execution_mode,
+        traverse_registry::ComponentExecutionMode::Compatible
+    );
+    assert_eq!(bundle.components[0].verified_wasm_digest, None);
+    assert_eq!(bundle.components[0].wasm_binary_path, None);
+    assert_eq!(
+        bundle.components[0].manifest.platforms,
+        vec!["linux".to_string()]
+    );
+}
+
+#[test]
+fn rejects_compatible_component_with_wasm_fields() {
+    let fixture = AppFixture::new("compatible-wasm-fields");
+    let wrapper_path = fixture.write_compatible_wrapper();
+    fixture.write_component_manifest(&json!({
+        "execution_mode": "compatible",
+        "platforms": ["linux"],
+        "wrapper_path": wrapper_path,
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("compatible component must reject wasm fields");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::CompatibleComponentInvalidWasmFields
+    );
+}
+
+#[test]
+fn rejects_unknown_component_execution_mode() {
+    let fixture = AppFixture::new("unknown-execution-mode");
+    fixture.write_component_manifest(&json!({
+        "execution_mode": "native",
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("unknown execution_mode must fail");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::InvalidExecutionMode
+    );
+}
+
+#[test]
+fn rejects_compatible_component_without_platforms() {
+    let fixture = AppFixture::new("compatible-no-platforms");
+    let wrapper_path = fixture.write_compatible_wrapper();
+    fixture.write_component_manifest(&json!({
+        "execution_mode": "compatible",
+        "wasm_binary_path": null,
+        "wasm_digest": null,
+        "platforms": [],
+        "wrapper_path": wrapper_path,
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("compatible component must declare platforms");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::CompatibleComponentMissingPlatforms
+    );
+}
+
+#[test]
+fn rejects_compatible_component_without_wrapper_path() {
+    let fixture = AppFixture::new("compatible-no-wrapper-path");
+    fixture.write_component_manifest(&json!({
+        "execution_mode": "compatible",
+        "wasm_binary_path": null,
+        "wasm_digest": null,
+        "platforms": ["linux"],
+        "wrapper_path": null,
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("compatible component must declare wrapper_path");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::CompatibleComponentMissingWrapper
+    );
+}
+
+#[test]
+fn rejects_compatible_component_with_missing_wrapper_path() {
+    let fixture = AppFixture::new("compatible-missing-wrapper-path");
+    fixture.write_component_manifest(&json!({
+        "execution_mode": "compatible",
+        "wasm_binary_path": null,
+        "wasm_digest": null,
+        "platforms": ["linux"],
+        "wrapper_path": "missing-wrapper",
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("compatible component wrapper path must exist");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::CompatibleComponentMissingWrapper
+    );
+}
+
+#[test]
+fn rejects_wasm_component_without_wasm_digest() {
+    let fixture = AppFixture::new("wasm-no-digest");
+    fixture.write_component_manifest(&json!({
+        "execution_mode": "wasm",
+        "wasm_digest": null,
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("wasm component must declare wasm_digest");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::WasmComponentMissingWasmFields
+    );
+}
+
+#[test]
+fn rejects_wasm_component_without_wasm_binary_path() {
+    let fixture = AppFixture::new("wasm-no-binary-path");
+    fixture.write_component_manifest(&json!({
+        "execution_mode": "wasm",
+        "wasm_binary_path": null,
+        "dependencies": []
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("wasm component must declare wasm_binary_path");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::WasmComponentMissingWasmFields
     );
 }
 
@@ -2251,10 +2505,9 @@ impl AppFixture {
             .get("version")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("1.0.0");
-        let wasm_digest = overrides
-            .get("wasm_digest")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99");
+        let wasm_digest = overrides.get("wasm_digest").cloned().unwrap_or_else(|| {
+            json!("sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99")
+        });
         let capability_id = overrides
             .get("capability_id")
             .and_then(serde_json::Value::as_str)
@@ -2263,6 +2516,10 @@ impl AppFixture {
             .get("capability_version")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("1.0.0");
+        let execution_mode = overrides
+            .get("execution_mode")
+            .cloned()
+            .unwrap_or_else(|| json!("wasm"));
         let dependencies = overrides
             .get("dependencies")
             .cloned()
@@ -2278,15 +2535,26 @@ impl AppFixture {
             .get("wasm_binary_path")
             .cloned()
             .unwrap_or_else(|| json!("component.wasm"));
+        let platforms = overrides
+            .get("platforms")
+            .cloned()
+            .unwrap_or_else(|| json!([]));
+        let wrapper_path = overrides
+            .get("wrapper_path")
+            .cloned()
+            .unwrap_or(Value::Null);
         let component = json!({
             "component_id": component_id,
             "version": version,
             "schema_version": "1.0.0",
+            "execution_mode": execution_mode,
             "capability_id": capability_id,
             "capability_version": capability_version,
             "contract_path": contract_path,
             "wasm_binary_path": wasm_binary_path,
             "wasm_digest": wasm_digest,
+            "platforms": platforms,
+            "wrapper_path": wrapper_path,
             "runtime_constraints": {
                 "host_api_access": "none",
                 "network_access": "forbidden",
@@ -2304,6 +2572,12 @@ impl AppFixture {
     fn write_wasm(&self, contents: &str) -> String {
         fs::write(self.wasm_path(), contents.as_bytes()).expect("wasm fixture should write");
         sha256_hex(contents.as_bytes())
+    }
+
+    fn write_compatible_wrapper(&self) -> String {
+        let wrapper_path = self.root.join("components/validate-team-readiness/wrapper");
+        fs::create_dir_all(&wrapper_path).expect("compatible wrapper should write");
+        "wrapper".to_string()
     }
 
     fn registration_request(&self) -> ApplicationRegistrationRequest {

--- a/scripts/ci/embedder_conformance/reference_cli.sh
+++ b/scripts/ci/embedder_conformance/reference_cli.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+api_id="$(python3 - "${repo_root}/specs/057-embeddable-runtime-host/embedder-api-1.0.0.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print(json.load(handle)["$id"])
+PY
+)"
+
+if [[ "${api_id}" != "https://traverse.dev/embedder-api/1.0.0" ]]; then
+  echo "embedder API id mismatch: ${api_id}" >&2
+  exit 1
+fi
+
+grep -q "init-shutdown" specs/057-embeddable-runtime-host/conformance.md
+grep -q "wasm-capability-submit" specs/057-embeddable-runtime-host/conformance.md
+grep -q "compatible-lifecycle" specs/057-embeddable-runtime-host/conformance.md
+grep -q "platform-guard" specs/057-embeddable-runtime-host/conformance.md
+grep -q "determinism" specs/057-embeddable-runtime-host/conformance.md
+
+cargo test -q -p traverse-registry --test application_manifest \
+  defaults_component_execution_mode_to_wasm
+cargo test -q -p traverse-registry --test application_manifest \
+  loads_compatible_component_manifest_without_wasm_artifact
+cargo test -q -p traverse-registry --test application_manifest \
+  rejects_compatible_component_without_platforms
+
+validation_json="$(
+  cargo run -q -p traverse-cli -- app validate \
+    --manifest apps/traverse-starter/app.manifest.json \
+    --json
+)"
+
+python3 - "${validation_json}" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+components = data.get("components", [])
+if not components:
+    raise SystemExit("app validate returned no components")
+mode = components[0].get("execution_mode")
+if mode != "wasm":
+    raise SystemExit(f"expected starter component execution_mode=wasm, got {mode!r}")
+if not data.get("digest_verification"):
+    raise SystemExit("expected digest verification for wasm component")
+
+print(json.dumps({
+    "traverse_embedder_api": "1.0.0",
+    "conformance_passed": True,
+    "reference": "cli",
+}, sort_keys=True))
+PY


### PR DESCRIPTION
## Summary

Implements the first spec 057 slice for app bundle validation: component manifests now support explicit `execution_mode` values for `wasm` and `compatible`, and `traverse-cli app validate` reports execution-mode metadata without requiring compatible components to declare WASM artifacts.

## Governing Spec

- `057-embeddable-runtime-host`
- `044-application-bundle-manifest`
- `004-spec-alignment-gate`
- `028-schema-alignment-gate-v02`
- `031-supply-chain-hardening`
- `040-contractual-enforcement-gate`

## Project Item

- Closes #553
- Project 1 item: https://github.com/orgs/traverse-framework/projects/1/

## What Changed

- Contracts changed: none.
- Runtime behavior changed: app manifest loading now defaults omitted component `execution_mode` to `wasm`, validates WASM and compatible component field requirements separately, and exposes optional WASM artifact metadata for compatible components.
- Compatibility impact: existing WASM manifests without `execution_mode` remain valid.
- ADR needed or linked: no ADR needed; this is governed by approved spec 057.

## Validation

- [x] Spec alignment checked: implemented spec 057 FR-014 and FR-020 through FR-024; `scripts/ci/spec_alignment_check.sh` requires a PR body file and is expected to run in CI against this body.
- [x] Contract alignment checked: no contract schema changes.
- [x] Tests updated and passing: `cargo test -p traverse-registry --test application_manifest`.
- [x] Core coverage preserved: `cargo test -p traverse-registry -p traverse-cli`.
- [x] Required validation gates passing:
  - `bash scripts/ci/embedder_conformance/reference_cli.sh`
  - `bash scripts/ci/downstream_app_bundle_registration_smoke.sh`
  - `cargo clippy -p traverse-registry -p traverse-cli -- -D warnings`

## Notes

This PR adds `scripts/ci/embedder_conformance/reference_cli.sh` as the initial checked-in conformance entry point. Full platform embedder implementations remain downstream work for the reference-apps platform tickets.
