### PR TITLE
Default runtime security to Production (spec 030 FR-013, #588)

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -16,10 +16,23 @@ use traverse_registry::{
     WorkflowDefinition, WorkflowRegistration, WorkflowRegistry, WorkspaceAppStateErrorCode,
     load_application_bundle_manifest,
 };
+use traverse_runtime::security::RuntimeSecurityConfig;
 use traverse_runtime::{
     LocalExecutor, Runtime, RuntimeExecutionOutcome, RuntimeRequest, RuntimeResultStatus,
     RuntimeTrace, parse_runtime_request,
 };
+
+/// Map an HTTP auth mode to the runtime security posture: the dev auth modes
+/// run local unsigned example artifacts (development), while the network-facing
+/// `bearer-required` mode enforces the production posture that rejects unsigned
+/// artifacts (spec 030-security-identity-model FR-013).
+fn runtime_security_for_auth_mode(auth_mode: &str) -> RuntimeSecurityConfig {
+    if matches!(auth_mode, "dev-loopback" | "dev-any") {
+        RuntimeSecurityConfig::development()
+    } else {
+        RuntimeSecurityConfig::production()
+    }
+}
 
 const MAX_REQUEST_BODY: usize = 4 * 1024 * 1024; // 4 MiB
 const SYSTEM_WORKSPACE_ID: &str = "system";
@@ -322,7 +335,8 @@ where
         SYSTEM_WORKSPACE_ID.to_string(),
         WorkspaceState {
             runtime: Runtime::new(config.capability_registry, config.executor.clone())
-                .with_workflow_registry(config.workflow_registry),
+                .with_workflow_registry(config.workflow_registry)
+                .with_security_config(runtime_security_for_auth_mode(auth_mode)),
             event_registry: EventRegistry::new(),
             persisted: PersistedWorkspaceRegistryV1 {
                 schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
@@ -517,7 +531,8 @@ where
             SYSTEM_WORKSPACE_ID.to_string(),
             WorkspaceState {
                 runtime: Runtime::new(config.capability_registry, config.executor.clone())
-                    .with_workflow_registry(config.workflow_registry),
+                    .with_workflow_registry(config.workflow_registry)
+                    .with_security_config(RuntimeSecurityConfig::development()),
                 event_registry: EventRegistry::new(),
                 persisted: PersistedWorkspaceRegistryV1 {
                     schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
@@ -621,7 +636,8 @@ where
             .entry(workspace_id.to_string())
             .or_insert_with(|| WorkspaceState {
                 runtime: Runtime::new(CapabilityRegistry::new(), self.executor.clone())
-                    .with_workflow_registry(WorkflowRegistry::new()),
+                    .with_workflow_registry(WorkflowRegistry::new())
+                    .with_security_config(RuntimeSecurityConfig::development()),
                 event_registry: EventRegistry::new(),
                 persisted: PersistedWorkspaceRegistryV1 {
                     schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
@@ -2530,7 +2546,8 @@ fn apply_registration<E: LocalExecutor + Clone>(
         .entry(workspace_id.to_string())
         .or_insert_with(|| WorkspaceState {
             runtime: Runtime::new(CapabilityRegistry::new(), state.executor.clone())
-                .with_workflow_registry(WorkflowRegistry::new()),
+                .with_workflow_registry(WorkflowRegistry::new())
+                .with_security_config(runtime_security_for_auth_mode(&state.auth_mode)),
             event_registry: EventRegistry::new(),
             persisted: PersistedWorkspaceRegistryV1 {
                 schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
@@ -2580,7 +2597,8 @@ fn apply_event_registration<E: LocalExecutor + Clone>(
         .entry(workspace_id.to_string())
         .or_insert_with(|| WorkspaceState {
             runtime: Runtime::new(CapabilityRegistry::new(), state.executor.clone())
-                .with_workflow_registry(WorkflowRegistry::new()),
+                .with_workflow_registry(WorkflowRegistry::new())
+                .with_security_config(runtime_security_for_auth_mode(&state.auth_mode)),
             event_registry: EventRegistry::new(),
             persisted: PersistedWorkspaceRegistryV1 {
                 schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
@@ -6378,7 +6396,8 @@ mod tests {
             workspace_id.to_string(),
             WorkspaceState {
                 runtime: Runtime::new(registry, executor.clone())
-                    .with_workflow_registry(WorkflowRegistry::new()),
+                    .with_workflow_registry(WorkflowRegistry::new())
+                    .with_security_config(RuntimeSecurityConfig::development()),
                 event_registry: EventRegistry::new(),
                 persisted: PersistedWorkspaceRegistryV1 {
                     schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
@@ -6432,7 +6451,8 @@ mod tests {
             workspace_id.to_string(),
             WorkspaceState {
                 runtime: Runtime::new(registry, executor.clone())
-                    .with_workflow_registry(WorkflowRegistry::new()),
+                    .with_workflow_registry(WorkflowRegistry::new())
+                    .with_security_config(RuntimeSecurityConfig::development()),
                 event_registry: EventRegistry::new(),
                 persisted: PersistedWorkspaceRegistryV1 {
                     schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
@@ -6473,7 +6493,8 @@ mod tests {
             workspace_id.to_string(),
             WorkspaceState {
                 runtime: Runtime::new(CapabilityRegistry::new(), executor.clone())
-                    .with_workflow_registry(WorkflowRegistry::new()),
+                    .with_workflow_registry(WorkflowRegistry::new())
+                    .with_security_config(RuntimeSecurityConfig::development()),
                 event_registry: EventRegistry::new(),
                 persisted: PersistedWorkspaceRegistryV1 {
                     schema_version: PERSISTED_REGISTRY_SCHEMA_VERSION.to_string(),
@@ -9047,5 +9068,21 @@ mod tests {
         assert_eq!(env["type"], "https://traverse.dev/problems/unauthorized");
         assert_eq!(env["detail"], "Bearer token required");
         assert_eq!(env["traverse_code"], "unauthorized");
+    }
+
+    #[test]
+    fn runtime_security_follows_auth_mode() {
+        assert_eq!(
+            runtime_security_for_auth_mode("dev-loopback"),
+            RuntimeSecurityConfig::development()
+        );
+        assert_eq!(
+            runtime_security_for_auth_mode("dev-any"),
+            RuntimeSecurityConfig::development()
+        );
+        assert_eq!(
+            runtime_security_for_auth_mode("bearer-required"),
+            RuntimeSecurityConfig::production()
+        );
     }
 }

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -3257,7 +3257,8 @@ fn execute_agent(manifest_path: &Path, request_path: &Path) -> Result<String, Cl
     registry
         .register(package.capability_registration())
         .map_err(|f| CliError::RegistrationConflict(render_registry_failure(f)))?;
-    let runtime = Runtime::new(registry, AgentPackageExampleExecutor);
+    let runtime = Runtime::new(registry, AgentPackageExampleExecutor)
+        .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development());
     let outcome = runtime.execute(request);
 
     if outcome.result.status == RuntimeResultStatus::Error {
@@ -4376,7 +4377,8 @@ fn execute_expedition_outcome(request_path: &Path) -> Result<RuntimeExecutionOut
     let request = load_runtime_request(request_path)?;
     let registered = load_registered_bundle(&canonical_expedition_bundle_path())?;
     let runtime = Runtime::new(registered.capability_registry, ExpeditionExampleExecutor)
-        .with_workflow_registry(registered.workflow_registry);
+        .with_workflow_registry(registered.workflow_registry)
+        .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development());
     Ok(runtime.execute(request))
 }
 

--- a/crates/traverse-mcp/src/lib.rs
+++ b/crates/traverse-mcp/src/lib.rs
@@ -716,7 +716,8 @@ mod tests {
         let capability_registry_for_mcp = public_capability_registry_fixture();
         let event_registry = EventRegistry::new();
         let workflow_registry = WorkflowRegistry::new();
-        let runtime = Runtime::new(capability_registry_for_runtime, EchoExecutor);
+        let runtime = Runtime::new(capability_registry_for_runtime, EchoExecutor)
+            .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development());
         let mcp = TraverseMcp::new(
             &capability_registry_for_mcp,
             &event_registry,
@@ -815,7 +816,9 @@ mod tests {
         let _ = workflow_registry;
         let registry = capability_registry_fixture();
         let workflows = workflow_registry_fixture(&registry);
-        Runtime::new(registry, EchoExecutor).with_workflow_registry(workflows)
+        Runtime::new(registry, EchoExecutor)
+            .with_workflow_registry(workflows)
+            .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development())
     }
 
     fn capability_registry_fixture() -> CapabilityRegistry {
@@ -1257,8 +1260,9 @@ mod tests {
     fn execute_capability_returns_json_with_status_and_ids() {
         let registry = capability_registry_fixture();
         let workflow_registry = workflow_registry_fixture(&registry);
-        let runtime =
-            Runtime::new(registry, EchoExecutor).with_workflow_registry(workflow_registry);
+        let runtime = Runtime::new(registry, EchoExecutor)
+            .with_workflow_registry(workflow_registry)
+            .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development());
         let result = super::execute_capability(&runtime, runtime_request());
         assert!(result.get("status").is_some(), "must include status");
         assert!(

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -3671,15 +3671,15 @@ mod tests {
     fn runtime_otel_trace_propagates_w3c_context_and_exporter_config() {
         let mut registry = CapabilityRegistry::new();
         assert!(registry.register(public_registration()).is_ok());
-        let runtime = Runtime::new(registry, NoopExecutor).with_observability_config(
-            super::RuntimeObservabilityConfig {
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development())
+            .with_observability_config(super::RuntimeObservabilityConfig {
                 exporter: super::OTelExporterConfig {
                     endpoint: Some("http://collector:4318".to_string()),
                     protocol: super::OtlpProtocol::Http,
                 },
                 ..super::RuntimeObservabilityConfig::deterministic_test("seed-1")
-            },
-        );
+            });
         let mut request = valid_request();
         request.context.traceparent =
             Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string());
@@ -4206,7 +4206,8 @@ mod tests {
 
     #[test]
     fn collect_candidates_handles_missing_target_and_public_discovery() {
-        let runtime = super::Runtime::new(CapabilityRegistry::new(), NoopExecutor);
+        let runtime = super::Runtime::new(CapabilityRegistry::new(), NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
         let mut request = valid_request();
         request.intent.capability_id = None;
         request.intent.capability_version = None;
@@ -4222,7 +4223,8 @@ mod tests {
         let outcome = registry.register(public_registration());
         assert!(outcome.is_ok());
 
-        let runtime = super::Runtime::new(registry, NoopExecutor);
+        let runtime = super::Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
         let mut request = valid_request();
         request.lookup.scope = PublicOnly;
         request.intent.capability_id = None;
@@ -4355,7 +4357,8 @@ mod tests {
     fn runtime_outcome_for_browser_subscription() -> super::RuntimeExecutionOutcome {
         let mut registry = CapabilityRegistry::new();
         assert!(registry.register(public_registration()).is_ok());
-        let runtime = Runtime::new(registry, NoopExecutor);
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
         runtime.execute(valid_request())
     }
 
@@ -4827,7 +4830,8 @@ mod tests {
     fn failed_trace() -> super::RuntimeTrace {
         let mut registry = CapabilityRegistry::new();
         assert!(registry.register(public_registration()).is_ok());
-        let runtime = Runtime::new(registry, FailingExecutor);
+        let runtime = Runtime::new(registry, FailingExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
         runtime.execute(valid_request()).trace
     }
 
@@ -4844,7 +4848,8 @@ mod tests {
     fn selected_capability_id_returns_none_when_no_selection() {
         let registry = CapabilityRegistry::new();
         // empty registry — no capability matches
-        let runtime = Runtime::new(registry, NoopExecutor);
+        let runtime = Runtime::new(registry, NoopExecutor)
+            .with_security_config(RuntimeSecurityConfig::development());
         let trace = runtime.execute(valid_request()).trace;
         assert!(trace.selected_capability_id().is_none());
     }

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -3810,6 +3810,40 @@ mod tests {
     }
 
     #[test]
+    fn default_security_config_is_production() {
+        assert_eq!(
+            RuntimeSecurityConfig::default(),
+            RuntimeSecurityConfig::production()
+        );
+        assert_ne!(
+            RuntimeSecurityConfig::default(),
+            RuntimeSecurityConfig::development()
+        );
+    }
+
+    #[test]
+    fn unsigned_local_artifact_rejected_under_default_security_config() {
+        let mut registry = CapabilityRegistry::new();
+        assert!(registry.register(public_registration()).is_ok());
+        // No explicit security config: the default (Production) posture must
+        // reject the unsigned local artifact before execution.
+        let runtime = Runtime::new(registry, NoopExecutor);
+
+        let outcome = runtime.execute(valid_request());
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+        assert_eq!(
+            outcome
+                .result
+                .error
+                .as_ref()
+                .and_then(|error| error.details.get("code"))
+                .and_then(serde_json::Value::as_str),
+            Some("missing_signature")
+        );
+    }
+
+    #[test]
     fn governed_artifact_accepts_verified_sigstore_bundle() {
         let path = temp_artifact_path("sigstore-valid");
         assert!(fs::write(&path, b"sigstore governed bytes").is_ok());

--- a/crates/traverse-runtime/src/security.rs
+++ b/crates/traverse-runtime/src/security.rs
@@ -44,8 +44,11 @@ impl RuntimeSecurityConfig {
 }
 
 impl Default for RuntimeSecurityConfig {
+    /// Production is the default security posture: unsigned local artifacts are
+    /// rejected unless a caller explicitly opts into [`Self::development`]
+    /// (spec 030-security-identity-model FR-013).
     fn default() -> Self {
-        Self::development()
+        Self::production()
     }
 }
 

--- a/crates/traverse-runtime/tests/runtime.rs
+++ b/crates/traverse-runtime/tests/runtime.rs
@@ -11,6 +11,7 @@ use traverse_registry::{
     CompositionPattern, ImplementationKind, RegistryProvenance, RegistryScope, SourceKind,
     SourceReference,
 };
+use traverse_runtime::security::RuntimeSecurityConfig;
 use traverse_runtime::{
     BrowserRuntimeSubscriptionLifecycleStatus, BrowserRuntimeSubscriptionMessage,
     BrowserRuntimeSubscriptionRequest, CandidateReason, ExecutionFailureReason, ExecutionStatus,
@@ -44,7 +45,8 @@ fn executes_one_exact_registered_capability_locally() {
             Lifecycle::Active,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
 
     let outcome = runtime.execute(base_request_exact());
 
@@ -121,7 +123,8 @@ fn exact_lookup_uses_private_overlay_before_public() {
             ),
         ]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
 
     let outcome = runtime.execute(base_request_exact());
 
@@ -133,7 +136,8 @@ fn exact_lookup_uses_private_overlay_before_public() {
 
 #[test]
 fn discovers_by_intent_key_and_fails_when_no_candidate_matches() {
-    let runtime = Runtime::new(registry_with(vec![]), EchoExecutor);
+    let runtime = Runtime::new(registry_with(vec![]), EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.intent.capability_id = None;
     request.intent.capability_version = None;
@@ -176,7 +180,8 @@ fn rejects_ambiguous_intent_matches() {
             ),
         ]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.intent.capability_id = None;
     request.intent.capability_version = None;
@@ -194,7 +199,8 @@ fn rejects_ambiguous_intent_matches() {
 
 #[test]
 fn rejects_invalid_request_before_discovery() {
-    let runtime = Runtime::new(registry_with(vec![]), EchoExecutor);
+    let runtime = Runtime::new(registry_with(vec![]), EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.lookup.allow_ambiguity = true;
 
@@ -234,7 +240,8 @@ fn rejects_non_runnable_candidates_before_execution() {
         Lifecycle::Active,
     );
     not_runnable.contract.execution.constraints.network_access = NetworkAccess::Required;
-    let runtime = Runtime::new(registry_with(vec![not_runnable]), EchoExecutor);
+    let runtime = Runtime::new(registry_with(vec![not_runnable]), EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
 
     let outcome = runtime.execute(base_request_exact());
 
@@ -263,7 +270,8 @@ fn rejects_draft_contract_paths_before_execution() {
     draft.contract_path =
         "drafts/contracts/content.comments.create-comment-draft/1.0.0/contract.json".to_string();
 
-    let runtime = Runtime::new(registry_with(vec![draft]), EchoExecutor);
+    let runtime = Runtime::new(registry_with(vec![draft]), EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
     let outcome = runtime.execute(base_request_exact());
 
     assert_eq!(
@@ -292,7 +300,8 @@ fn rejects_non_runtime_lifecycle_candidates() {
             Lifecycle::Archived,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
 
     let outcome = runtime.execute(base_request_exact());
 
@@ -316,7 +325,8 @@ fn rejects_invalid_input_against_contract() {
             Lifecycle::Active,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.input = json!({"resource_id": "res-1"});
 
@@ -342,7 +352,8 @@ fn surfaces_executor_failures() {
             Lifecycle::Active,
         )]),
         FailingExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
 
     let outcome = runtime.execute(base_request_exact());
 
@@ -379,7 +390,8 @@ fn rejects_invalid_executor_output_against_contract() {
             Lifecycle::Active,
         )]),
         WrongOutputExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
 
     let outcome = runtime.execute(base_request_exact());
 
@@ -403,7 +415,8 @@ fn records_local_placement_decision_for_successful_execution() {
             Lifecycle::Active,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
 
     let outcome = runtime.execute(base_request_exact());
 
@@ -440,7 +453,8 @@ fn rejects_unsupported_non_local_placement_requests() {
             Lifecycle::Active,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.context.requested_target = PlacementTarget::Cloud;
 
@@ -487,7 +501,8 @@ fn uses_public_only_scope_when_requested() {
             ),
         ]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.lookup.scope = RuntimeLookupScope::PublicOnly;
 
@@ -513,7 +528,8 @@ fn browser_subscription_by_request_id_emits_ordered_messages() {
             Lifecycle::Active,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
     let outcome = runtime.execute(base_request_exact());
 
     let messages = browser_subscription_messages(
@@ -553,7 +569,8 @@ fn browser_subscription_by_execution_id_emits_trace_artifact() {
             Lifecycle::Active,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
     let outcome = runtime.execute(base_request_exact());
 
     let messages = browser_subscription_messages(
@@ -578,7 +595,8 @@ fn browser_subscription_by_execution_id_emits_trace_artifact() {
 
 #[test]
 fn browser_subscription_rejects_invalid_targeting_requests() {
-    let runtime = Runtime::new(registry_with(vec![]), EchoExecutor);
+    let runtime = Runtime::new(registry_with(vec![]), EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
     let outcome = runtime.execute(base_request_exact());
 
     let both = browser_subscription_messages(
@@ -624,7 +642,8 @@ fn executes_capability_resolved_via_semver_range() {
             Lifecycle::Active,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.intent.capability_version = None;
     request.intent.version_range = Some("^1.0.0".to_string());
@@ -649,7 +668,8 @@ fn returns_capability_not_found_when_no_version_satisfies_range() {
             Lifecycle::Active,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.intent.capability_version = None;
     request.intent.version_range = Some("^1.0.0".to_string());
@@ -666,7 +686,8 @@ fn returns_capability_not_found_when_no_version_satisfies_range() {
 
 #[test]
 fn rejects_version_range_without_capability_id() {
-    let runtime = Runtime::new(registry_with(vec![]), EchoExecutor);
+    let runtime = Runtime::new(registry_with(vec![]), EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.intent.capability_id = None;
     request.intent.capability_version = None;
@@ -690,7 +711,8 @@ fn rejects_version_range_without_capability_id() {
 
 #[test]
 fn rejects_version_range_combined_with_capability_version() {
-    let runtime = Runtime::new(registry_with(vec![]), EchoExecutor);
+    let runtime = Runtime::new(registry_with(vec![]), EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.intent.version_range = Some("^1.0.0".to_string());
     // capability_id and capability_version are both set from base_request_exact()
@@ -723,7 +745,8 @@ fn executes_version_range_resolved_from_public_scope() {
             Lifecycle::Active,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.intent.capability_version = None;
     request.intent.version_range = Some("^1.0.0".to_string());
@@ -750,7 +773,8 @@ fn version_range_with_empty_range_string_falls_through_to_discovery() {
             Lifecycle::Active,
         )]),
         EchoExecutor,
-    );
+    )
+    .with_security_config(RuntimeSecurityConfig::development());
     let mut request = base_request_exact();
     request.intent.capability_version = None;
     request.intent.version_range = Some(String::new());
@@ -834,7 +858,8 @@ fn capability_registry_accessor_returns_registered_capabilities() {
         "1.0.0",
         Lifecycle::Active,
     )]);
-    let runtime = Runtime::new(reg, EchoExecutor);
+    let runtime =
+        Runtime::new(reg, EchoExecutor).with_security_config(RuntimeSecurityConfig::development());
     let cap = runtime.capability_registry().find_exact(
         LookupScope::PublicOnly,
         "content.comments.create-comment-draft",
@@ -858,7 +883,8 @@ fn workflow_registry_accessors_are_accessible() {
         "1.0.0",
         Lifecycle::Active,
     )]);
-    let mut runtime = Runtime::new(reg, EchoExecutor);
+    let mut runtime =
+        Runtime::new(reg, EchoExecutor).with_security_config(RuntimeSecurityConfig::development());
 
     let _reg_ref = runtime.workflow_registry();
     let _reg_mut = runtime.workflow_registry_mut();
@@ -912,7 +938,8 @@ fn workflow_registry_accessors_are_accessible() {
 #[test]
 fn runtime_register_capability_forwards_to_registry_and_is_idempotent() {
     let reg = CapabilityRegistry::new();
-    let mut runtime = Runtime::new(reg, EchoExecutor);
+    let mut runtime =
+        Runtime::new(reg, EchoExecutor).with_security_config(RuntimeSecurityConfig::development());
 
     let first_result = runtime.register_capability(registration(
         RegistryScope::Public,
@@ -1199,7 +1226,8 @@ fn runtime_rejects_execution_when_dependency_missing() {
         "registration with declared dep should succeed"
     );
 
-    let runtime = Runtime::new(registry, EchoExecutor);
+    let runtime = Runtime::new(registry, EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
     let outcome = runtime.execute(base_request_exact());
 
     // Dependency "content.logging.logger" is not in the registry, so execution
@@ -1254,7 +1282,8 @@ fn runtime_rejects_execution_when_circular_dependency_detected() {
         "register B with back-dep should succeed"
     );
 
-    let runtime = Runtime::new(registry, EchoExecutor);
+    let runtime = Runtime::new(registry, EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
     let outcome = runtime.execute(base_request_exact());
 
     assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
@@ -1309,7 +1338,8 @@ fn runtime_rejects_execution_when_max_dep_depth_exceeded() {
         "main capability registration should succeed"
     );
 
-    let runtime = Runtime::new(registry, EchoExecutor);
+    let runtime = Runtime::new(registry, EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
     let outcome = runtime.execute(base_request_exact());
 
     assert_eq!(
@@ -1445,7 +1475,8 @@ fn runtime_executes_successfully_when_all_dependencies_satisfied() {
         "registration with satisfied dep should succeed"
     );
 
-    let runtime = Runtime::new(registry, EchoExecutor);
+    let runtime = Runtime::new(registry, EchoExecutor)
+        .with_security_config(RuntimeSecurityConfig::development());
     let outcome = runtime.execute(base_request_exact());
 
     assert_eq!(


### PR DESCRIPTION
## Governing Spec

- `030-security-identity-model`
- `033-http-json-api`
- `042-mcp-library-surface`

## Project Item

Project 1 item for issue #588 (Status: In Progress, claimed with `agent:claude`).

## Summary

Makes the production security posture the default (issue #588, spec 030 FR-013). Previously `RuntimeSecurityConfig::default()` returned Development, which allows unsigned local artifacts unless a caller opted into Production — the wrong-way-round default.

- **`RuntimeSecurityConfig::default()` now returns `production()`.** Development mode is reachable only through explicit `RuntimeSecurityConfig::development()`.
- **`traverse-cli serve` sets the runtime security mode explicitly from `auth_mode`** via `runtime_security_for_auth_mode`: the dev auth modes (`dev-loopback`, `dev-any`) run local unsigned example artifacts under Development; the network-facing `bearer-required` mode enforces Production (rejects unsigned artifacts). Serve-time workspace runtimes rebuilt during request handling inherit the same posture from `state.auth_mode`.
- **Local CLI dev paths opt in explicitly**: `execute-agent`, the expedition example runner, and the in-process API run unsigned local fixtures, so they now construct their runtimes with `RuntimeSecurityConfig::development()` — visible and testable rather than relying on an implicit default.
- Test/fixture runtimes across `traverse-runtime`, `traverse-mcp`, and `traverse-cli` that exercise unsigned local example artifacts now set Development explicitly (they were previously relying on the old default).

Under the default (Production) posture, an unsigned local artifact is rejected with `missing_signature` before execution; unsigned local artifacts are accepted (with the `unsigned_local_dev_artifact` warning) only when Development is explicitly selected — the existing `verify_artifact` behavior, now reached by the corrected default.

## Validation

- New regression tests: `default_security_config_is_production`; `unsigned_local_artifact_rejected_under_default_security_config` (default-constructed runtime rejects unsigned local artifact with `missing_signature`); `runtime_security_follows_auth_mode` (dev modes → Development, `bearer-required` → Production). The existing `local_dev_unsigned_artifact_warns_and_executes_in_development_mode` continues to prove unsigned artifacts are allowed only under explicit Development.
- `cargo test --workspace` — all 25 suites pass.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — applied.
- Coverage: the only gated-crate (`traverse-runtime`) logic change is the one-line default flip; both `production()` and `development()` paths are covered by existing and new tests, so line coverage is unchanged. (Local llvm-cov tooling unavailable in this environment; CI `coverage_gate.sh` will confirm.)
- No `unwrap()`/`expect()`/`panic!()`/`todo!()`/`unsafe` introduced in production code.

## Note

This is independent of #580 (JWT signature verification) — separate trust boundaries — but both harden the same network-facing surface. When both land, `serve` in `bearer-required` mode verifies JWT signatures **and** enforces the Production artifact posture.

Closes #588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
