### PR TITLE
Enforce governed artifact checksums before execution (#590)

### DIFF
--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -3047,6 +3047,7 @@ mod tests {
     };
     use ed25519_dalek::{Signer, SigningKey};
     use serde_json::json;
+    use sha2::{Digest, Sha256};
     use std::collections::BTreeMap;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -4377,6 +4378,9 @@ mod tests {
             location: path.display().to_string(),
             signature,
         });
+        let bytes = fs::read(path).unwrap_or_default();
+        registration.artifact.digests.binary_digest =
+            Some(format!("sha256:{:x}", Sha256::digest(bytes)));
         registration
     }
 

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -3832,6 +3832,24 @@ mod tests {
     }
 
     #[test]
+    fn local_artifact_checksum_does_not_override_local_development_policy() {
+        let bytes = b"local checksum is advisory";
+        let path = temp_artifact_path("local-checksum");
+        assert!(fs::write(&path, bytes).is_ok());
+        let mut registration = governed_registration(&path, Some(ed25519_signature_for(bytes)));
+        registration.artifact.source.kind = SourceKind::Local;
+        registration.artifact.digests.binary_digest = Some(
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+        );
+        let mut registry = CapabilityRegistry::new();
+        assert!(registry.register(registration).is_ok());
+
+        let outcome = Runtime::new(registry, NoopExecutor).execute(valid_request());
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
+    }
+
+    #[test]
     fn local_dev_unsigned_artifact_warns_and_executes_in_development_mode() {
         let mut registry = CapabilityRegistry::new();
         assert!(registry.register(public_registration()).is_ok());

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -3782,6 +3782,56 @@ mod tests {
     }
 
     #[test]
+    fn governed_artifact_without_checksum_is_rejected_before_execution() {
+        let bytes = b"governed checksum missing";
+        let path = temp_artifact_path("missing-checksum");
+        assert!(fs::write(&path, bytes).is_ok());
+        let mut registration = governed_registration(&path, Some(ed25519_signature_for(bytes)));
+        registration.artifact.digests.binary_digest = None;
+        let mut registry = CapabilityRegistry::new();
+        assert!(registry.register(registration).is_ok());
+
+        let outcome = Runtime::new(registry, NoopExecutor).execute(valid_request());
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+        assert_eq!(
+            outcome
+                .result
+                .error
+                .as_ref()
+                .and_then(|error| error.details.get("code"))
+                .and_then(serde_json::Value::as_str),
+            Some("missing_checksum")
+        );
+    }
+
+    #[test]
+    fn governed_artifact_with_mismatched_checksum_is_rejected_before_execution() {
+        let bytes = b"governed checksum mismatch";
+        let path = temp_artifact_path("checksum-mismatch");
+        assert!(fs::write(&path, bytes).is_ok());
+        let mut registration = governed_registration(&path, Some(ed25519_signature_for(bytes)));
+        registration.artifact.digests.binary_digest = Some(
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+        );
+        let mut registry = CapabilityRegistry::new();
+        assert!(registry.register(registration).is_ok());
+
+        let outcome = Runtime::new(registry, NoopExecutor).execute(valid_request());
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+        assert_eq!(
+            outcome
+                .result
+                .error
+                .as_ref()
+                .and_then(|error| error.details.get("code"))
+                .and_then(serde_json::Value::as_str),
+            Some("checksum_mismatch")
+        );
+    }
+
+    #[test]
     fn local_dev_unsigned_artifact_warns_and_executes_in_development_mode() {
         let mut registry = CapabilityRegistry::new();
         assert!(registry.register(public_registration()).is_ok());

--- a/crates/traverse-runtime/src/security.rs
+++ b/crates/traverse-runtime/src/security.rs
@@ -94,6 +94,8 @@ pub struct RuntimeWarning {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ArtifactVerificationFailure {
+    MissingChecksum(ArtifactVerificationRecord),
+    ChecksumMismatch(ArtifactVerificationRecord),
     MissingSignature(ArtifactVerificationRecord),
     SignatureVerificationFailed(ArtifactVerificationRecord),
     SigstoreUnreachable(ArtifactVerificationRecord),
@@ -103,6 +105,8 @@ impl ArtifactVerificationFailure {
     #[must_use]
     pub fn code(&self) -> &'static str {
         match self {
+            Self::MissingChecksum(_) => "missing_checksum",
+            Self::ChecksumMismatch(_) => "checksum_mismatch",
             Self::MissingSignature(_) => "missing_signature",
             Self::SignatureVerificationFailed(_) => "signature_verification_failed",
             Self::SigstoreUnreachable(_) => "sigstore_unreachable",
@@ -112,7 +116,9 @@ impl ArtifactVerificationFailure {
     #[must_use]
     pub fn record(&self) -> &ArtifactVerificationRecord {
         match self {
-            Self::MissingSignature(record)
+            Self::MissingChecksum(record)
+            | Self::ChecksumMismatch(record)
+            | Self::MissingSignature(record)
             | Self::SignatureVerificationFailed(record)
             | Self::SigstoreUnreachable(record) => record,
         }
@@ -191,9 +197,35 @@ pub fn verify_artifact(
         return Err(ArtifactVerificationFailure::MissingSignature(record));
     };
 
-    match signature.scheme {
+    let verification = match signature.scheme {
         ArtifactSignatureScheme::Ed25519 => verify_ed25519(signature, artifact_bytes, trust_level),
         ArtifactSignatureScheme::Sigstore => verify_sigstore(signature, trust_level),
+    }?;
+    verify_checksum(capability, artifact_bytes, trust_level)?;
+    Ok(verification)
+}
+
+fn verify_checksum(
+    capability: &ResolvedCapability,
+    artifact_bytes: &[u8],
+    trust_level: ArtifactTrustLevel,
+) -> Result<(), ArtifactVerificationFailure> {
+    if trust_level != ArtifactTrustLevel::PublishedGoverned {
+        return Ok(());
+    }
+    let Some(expected) = capability.artifact.digests.binary_digest.as_deref() else {
+        return Err(ArtifactVerificationFailure::MissingChecksum(
+            rejected_record(trust_level, None, "missing_checksum"),
+        ));
+    };
+    let expected = expected.strip_prefix("sha256:").unwrap_or(expected);
+    let actual = sha256_hex(artifact_bytes);
+    if expected.eq_ignore_ascii_case(&actual) {
+        Ok(())
+    } else {
+        Err(ArtifactVerificationFailure::ChecksumMismatch(
+            rejected_record(trust_level, None, "checksum_mismatch"),
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary

Enforces SHA-256 artifact checksums in the runtime verification boundary for governed artifacts before successful execution.

Closes #590.

## Governing Spec

- `006-runtime-request-execution`
- `030-security-identity-model`

## Project Item

- Project 1 item for #590.

## Definition of Done

- Governed artifacts fail with stable `missing_checksum` or `checksum_mismatch` verification errors before successful execution.
- Local development artifacts retain their existing behavior.

## Validation

- `cargo fmt`
- `cargo test -p traverse-runtime security --lib`