### PR TITLE
Bound Ollama inference read/write and response size (#587)

### DIFF
--- a/crates/traverse-runtime/src/inference.rs
+++ b/crates/traverse-runtime/src/inference.rs
@@ -17,18 +17,32 @@ use traverse_registry::{
 const OLLAMA_PROVIDER: &str = "ollama";
 const GENERATE_INTERFACE: &str = "traverse.inference.generate";
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+/// Default cap on the buffered HTTP response from the (operator-configurable,
+/// possibly untrusted) inference endpoint, guarding against unbounded memory
+/// growth (spec 045-governed-model-dependency-resolution).
+const DEFAULT_MAX_RESPONSE_BYTES: u64 = 8 * 1024 * 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OllamaProviderConfig {
     pub base_url: String,
     #[serde(default)]
     pub request_timeout_ms: Option<u64>,
+    /// Maximum number of response bytes read from the endpoint before the
+    /// request is rejected. Defaults to [`DEFAULT_MAX_RESPONSE_BYTES`].
+    #[serde(default)]
+    pub max_response_bytes: Option<u64>,
 }
 
 impl OllamaProviderConfig {
     #[must_use]
     pub fn timeout(&self) -> Duration {
         Duration::from_millis(self.request_timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS))
+    }
+
+    #[must_use]
+    pub fn max_response_bytes(&self) -> u64 {
+        self.max_response_bytes
+            .unwrap_or(DEFAULT_MAX_RESPONSE_BYTES)
     }
 }
 
@@ -234,6 +248,7 @@ impl OllamaInferenceProvider {
             method,
             &body_text,
             self.config.timeout(),
+            self.config.max_response_bytes(),
         )?;
         parse_http_json_response(&response_text)
     }
@@ -565,6 +580,7 @@ fn send_http_json(
     method: &str,
     body: &str,
     timeout: Duration,
+    max_response_bytes: u64,
 ) -> Result<String, OllamaInferenceError> {
     let address = format!("{host}:{port}");
     let socket_address = address
@@ -572,15 +588,42 @@ fn send_http_json(
         .next()
         .ok_or_else(|| provider_unavailable("Ollama endpoint did not resolve"))?;
     let mut stream = TcpStream::connect_timeout(&socket_address, timeout)?;
+    // Bound the whole exchange, not just connect: a peer that accepts and then
+    // stalls (or never sends EOF) would otherwise hang the thread forever
+    // despite request_timeout_ms (spec 045-governed-model-dependency-resolution).
+    stream.set_read_timeout(Some(timeout))?;
+    stream.set_write_timeout(Some(timeout))?;
     let request = format!(
         "{method} {path} HTTP/1.1\r\nHost: {host}:{port}\r\nContent-Type: application/json\r\nAccept: application/json\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{body}",
         body.len()
     );
     stream.write_all(request.as_bytes())?;
 
-    let mut response = String::new();
-    stream.read_to_string(&mut response)?;
-    Ok(response)
+    read_capped_response(&mut stream, max_response_bytes)
+}
+
+/// Read the response with an upper size bound so an endpoint that streams
+/// unbounded data cannot drive the host out of memory. The read is one byte
+/// over the cap to distinguish "exactly at cap" from "over cap".
+fn read_capped_response(
+    stream: &mut TcpStream,
+    max_response_bytes: u64,
+) -> Result<String, OllamaInferenceError> {
+    let mut buffer = Vec::new();
+    let limit = max_response_bytes.saturating_add(1);
+    stream.take(limit).read_to_end(&mut buffer)?;
+    if buffer.len() as u64 > max_response_bytes {
+        return Err(OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidResponse,
+            format!("Ollama response exceeded the {max_response_bytes}-byte limit"),
+        ));
+    }
+    String::from_utf8(buffer).map_err(|error| {
+        OllamaInferenceError::new(
+            OllamaInferenceErrorCode::InvalidResponse,
+            format!("Ollama response was not valid UTF-8: {error}"),
+        )
+    })
 }
 
 fn parse_http_json_response(response: &str) -> Result<Value, OllamaInferenceError> {

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -3147,6 +3147,7 @@ mod tests {
             crate::inference::OllamaProviderConfig {
                 base_url: "http://127.0.0.1:9".to_string(),
                 request_timeout_ms: Some(50),
+                max_response_bytes: None,
             },
         );
 

--- a/crates/traverse-runtime/tests/inference_tests.rs
+++ b/crates/traverse-runtime/tests/inference_tests.rs
@@ -7,6 +7,7 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::thread;
+use std::time::{Duration, Instant};
 use traverse_contracts::{
     ExecutionTarget, governed_content_digest, parse_contract, reference_connector_contracts,
 };
@@ -50,6 +51,93 @@ fn ollama_provider_generates_real_response_through_local_http_endpoint() {
     assert!(output.done);
     assert_eq!(output.evidence.selected_provider, "ollama");
     assert_eq!(output.evidence.selected_model, "llama3.2:3b");
+}
+
+#[test]
+fn ollama_generate_rejects_oversize_response() {
+    // The tags probe response is small (under the cap); the generate response
+    // body is padded well past the cap so the capped read rejects it.
+    let oversize_body = json!({
+        "model": "llama3.2:3b",
+        "response": "x".repeat(4096),
+        "done": true
+    })
+    .to_string();
+    let base_url = start_raw_server(vec![
+        http_response(
+            200,
+            &json!({"models": [{"name": "llama3.2:3b"}]}).to_string(),
+        ),
+        http_response(200, &oversize_body),
+    ]);
+    let provider = provider_with_max_bytes(&base_url, 1_024);
+
+    let failure = provider
+        .generate(&OllamaInferenceRequest {
+            model: "llama3.2:3b".to_string(),
+            prompt: "Summarize readiness.".to_string(),
+            system_prompt: None,
+            options: json!({}),
+        })
+        .expect_err("an over-size response must be rejected, not buffered to OOM");
+
+    assert_eq!(failure.code, OllamaInferenceErrorCode::InvalidResponse);
+}
+
+#[test]
+fn ollama_generate_rejects_non_utf8_response() {
+    let tags = http_response(
+        200,
+        &json!({"models": [{"name": "llama3.2:3b"}]}).to_string(),
+    )
+    .into_bytes();
+    let mut bad_response =
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 4\r\nConnection: close\r\n\r\n"
+            .to_string()
+            .into_bytes();
+    bad_response.extend_from_slice(&[0xff, 0xfe, 0xfd, 0xfc]);
+    let base_url = start_raw_bytes_server(vec![tags, bad_response]);
+    let provider = provider(&base_url);
+
+    let failure = provider
+        .generate(&OllamaInferenceRequest {
+            model: "llama3.2:3b".to_string(),
+            prompt: "Summarize readiness.".to_string(),
+            system_prompt: None,
+            options: json!({}),
+        })
+        .expect_err("a non-UTF-8 response body must be rejected");
+
+    assert_eq!(failure.code, OllamaInferenceErrorCode::InvalidResponse);
+}
+
+#[test]
+fn ollama_generate_times_out_on_stalled_read() {
+    let tags = http_response(
+        200,
+        &json!({"models": [{"name": "llama3.2:3b"}]}).to_string(),
+    );
+    let base_url = start_stalling_server(tags);
+    let provider = provider_with_timeout(&base_url, 400);
+
+    let start = Instant::now();
+    let failure = provider
+        .generate(&OllamaInferenceRequest {
+            model: "llama3.2:3b".to_string(),
+            prompt: "Summarize readiness.".to_string(),
+            system_prompt: None,
+            options: json!({}),
+        })
+        .expect_err("a stalled read must time out, not hang the thread");
+
+    assert_eq!(
+        failure.code,
+        OllamaInferenceErrorCode::ModelProviderUnavailable
+    );
+    assert!(
+        start.elapsed() < Duration::from_secs(4),
+        "the call must return within the read timeout budget, not the 5s server stall"
+    );
 }
 
 #[test]
@@ -227,6 +315,7 @@ fn ollama_provider_rejects_invalid_config_and_prompt() {
     let config_failure = OllamaInferenceProvider::new(OllamaProviderConfig {
         base_url: "https://127.0.0.1:11434".to_string(),
         request_timeout_ms: None,
+        max_response_bytes: None,
     })
     .expect_err("https endpoint is not supported by stdlib local provider");
     assert_eq!(config_failure.code, OllamaInferenceErrorCode::InvalidConfig);
@@ -280,6 +369,7 @@ fn ollama_provider_rejects_invalid_endpoint_shapes() {
         let failure = OllamaInferenceProvider::new(OllamaProviderConfig {
             base_url: base_url.to_string(),
             request_timeout_ms: None,
+            max_response_bytes: None,
         })
         .expect_err("invalid endpoint should fail");
         assert_eq!(failure.code, OllamaInferenceErrorCode::InvalidConfig);
@@ -706,6 +796,42 @@ fn provider(base_url: &str) -> OllamaInferenceProvider {
     provider_with_timeout(base_url, 1_000)
 }
 
+fn provider_with_max_bytes(base_url: &str, max_bytes: u64) -> OllamaInferenceProvider {
+    OllamaInferenceProvider::new(OllamaProviderConfig {
+        base_url: base_url.to_string(),
+        request_timeout_ms: Some(2_000),
+        max_response_bytes: Some(max_bytes),
+    })
+    .expect("provider config should be valid")
+}
+
+/// Serves `first_response` on the first connection (so the model-tags probe
+/// succeeds), then accepts a second connection and stalls: it writes a partial
+/// HTTP status line and holds the socket open without sending EOF, so the
+/// client's read must be bounded by its own read timeout rather than hanging.
+fn start_stalling_server(first_response: String) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("test server should bind");
+    let address = listener
+        .local_addr()
+        .expect("test server address should be available");
+    thread::spawn(move || {
+        let (mut first, _) = listener.accept().expect("tags request should arrive");
+        let mut buffer = [0_u8; 2048];
+        let _ = first.read(&mut buffer);
+        let _ = first.write_all(first_response.as_bytes());
+        drop(first);
+
+        let (mut second, _) = listener.accept().expect("generate request should arrive");
+        let _ = second.read(&mut buffer);
+        let _ = second.write_all(b"HTTP/1.1 200 OK\r\n");
+        // Hold the connection open past the client's read timeout without EOF.
+        thread::sleep(Duration::from_secs(5));
+        drop(second);
+    });
+
+    format!("http://{address}")
+}
+
 fn provider_with_timeout(base_url: &str, timeout_ms: u64) -> OllamaInferenceProvider {
     OllamaInferenceProvider::new(provider_config(base_url, timeout_ms))
         .expect("provider config should be valid")
@@ -715,6 +841,7 @@ fn provider_config(base_url: &str, timeout_ms: u64) -> OllamaProviderConfig {
     OllamaProviderConfig {
         base_url: base_url.to_string(),
         request_timeout_ms: Some(timeout_ms),
+        max_response_bytes: None,
     }
 }
 
@@ -789,6 +916,10 @@ fn start_ollama_server(bodies: Vec<String>) -> String {
 }
 
 fn start_raw_server(responses: Vec<String>) -> String {
+    start_raw_bytes_server(responses.into_iter().map(String::into_bytes).collect())
+}
+
+fn start_raw_bytes_server(responses: Vec<Vec<u8>>) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("test server should bind");
     let address = listener
         .local_addr()
@@ -801,7 +932,7 @@ fn start_raw_server(responses: Vec<String>) -> String {
                 .read(&mut buffer)
                 .expect("test request should be readable");
             stream
-                .write_all(response.as_bytes())
+                .write_all(&response)
                 .expect("test response should write");
         }
     });

--- a/specs/045-governed-model-dependency-resolution/spec.md
+++ b/specs/045-governed-model-dependency-resolution/spec.md
@@ -108,6 +108,8 @@ As a UI or auditor, I want public trace evidence to show which model/provider wa
 - **FR-016**: Model candidate metadata MUST be versioned and validated as part of the app manifest and workspace-local config merge governed by `044-application-bundle-manifest`.
 - **FR-017**: The selected inference implementation and placement MUST be visible through both HTTP/JSON execution trace retrieval and MCP execution report surfaces when the workflow is exposed through both.
 - **FR-018**: Model dependency resolution MUST not require downstream app code changes when a new compatible provider implementation is added to the candidate set and app policy permits it.
+- **FR-019**: Inference provider HTTP requests to an operator-configured (and possibly untrusted or remote) endpoint MUST bound the **entire** exchange, not only the TCP connect: read and write timeouts MUST be applied for the connected socket so that a peer which accepts and then stalls cannot block the calling thread past the configured request timeout. A timed-out read or write MUST surface as `model_provider_unavailable`.
+- **FR-020**: The provider response read MUST be bounded by a configurable maximum size with a safe default; a response exceeding the limit MUST fail with a stable error code rather than buffering unbounded data into memory.
 
 ### Non-Functional Requirements
 


### PR DESCRIPTION
## Governing Spec

- `045-governed-model-dependency-resolution`

## Project Item

Project 1 item for issue #587 (Status: In Progress, claimed with `agent:claude`).

## Summary

Bounds the Ollama inference HTTP client so a slow, hung, or hostile (operator-configurable, possibly remote) endpoint cannot hang a runtime thread or exhaust host memory (issue #587).

- **Whole-exchange timeout**: `set_read_timeout`/`set_write_timeout` are applied to the connected socket after `connect_timeout`, so a peer that accepts and then stalls no longer blocks past `request_timeout_ms`. A timed-out read/write surfaces as `model_provider_unavailable`.
- **Bounded response**: the unbounded `read_to_string` is replaced by `read_capped_response`, which reads at most `max_response_bytes` (+1 to detect overflow) and rejects an over-size body with a stable `model_provider_invalid_response` error instead of buffering to OOM. `max_response_bytes` is new provider config with an 8 MiB default.
- Spec `045` amended with **FR-019** (bound the whole exchange, not just connect) and **FR-020** (bounded response size).

## Validation

- New tests: oversize response rejected; stalled-read times out within the budget (a stalling mock server; the call returns in <4s, not the server's 5s hold); non-UTF-8 response body rejected.
- `cargo test -p traverse-runtime` passes; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` applied.
- `bash scripts/ci/coverage_gate.sh` — traverse-runtime 100% (7882/7882).
- No `unwrap()`/`expect()`/`panic!()`/`todo!()`/`unsafe` introduced in non-test code.

Closes #587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
