### PR TITLE
Add WASM resource limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Unreleased
+
+- Hardened `WasmExecutor` with per-invocation fuel and store resource limits so
+  runaway WASM guests are classified as timeout or resource-exhausted failures.

--- a/crates/traverse-runtime/src/executor/mod.rs
+++ b/crates/traverse-runtime/src/executor/mod.rs
@@ -14,8 +14,8 @@ pub mod wasm;
 pub use native::NativeExecutor;
 pub use thread_pool::{ConfigError, ThreadPoolExecutor, ThreadPoolExecutorConfig};
 pub use wasm::{
-    HostAbiImport, HostAbiValidation, SUPPORTED_HOST_ABI_VERSION, WasmExecutor,
-    supported_host_abi_versions, verify_wasm_host_abi_bytes,
+    HostAbiImport, HostAbiValidation, SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits,
+    WasmExecutor, supported_host_abi_versions, verify_wasm_host_abi_bytes,
 };
 
 use serde_json::Value;
@@ -70,6 +70,10 @@ pub enum ExecutorError {
     },
     /// The WASM module trapped or returned a non-zero exit code.
     ExecutionFailed(String),
+    /// WASM execution exhausted its configured CPU budget.
+    Timeout(String),
+    /// WASM execution exceeded its configured memory, table, or instance budget.
+    ResourceExhausted(String),
     /// The executor produced output that could not be parsed as JSON.
     OutputDeserializationFailed(String),
     /// The executor type does not support the requested capability.
@@ -105,6 +109,8 @@ impl std::fmt::Display for ExecutorError {
                 "{error_code}: ABI {abi_version} does not allow import {module}::{name}"
             ),
             Self::ExecutionFailed(msg) => write!(f, "execution failed: {msg}"),
+            Self::Timeout(msg) => write!(f, "execution timed out: {msg}"),
+            Self::ResourceExhausted(msg) => write!(f, "resource exhausted: {msg}"),
             Self::OutputDeserializationFailed(msg) => {
                 write!(f, "output deserialization failed: {msg}")
             }

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::fs;
-use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime::{Config, Engine, Linker, Module, Store, StoreLimits, StoreLimitsBuilder};
 use wasmtime_wasi::WasiCtxBuilder;
 use wasmtime_wasi::p1::WasiP1Ctx;
 use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
@@ -19,6 +19,12 @@ use super::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError}
 pub const SUPPORTED_HOST_ABI_VERSION: &str = "1.0.0";
 
 const HOST_ABI_V1_WHITELIST: &str = include_str!("host_abi_v1.json");
+const DEFAULT_FUEL_BUDGET: u64 = 5_000_000;
+const DEFAULT_MEMORY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
+const DEFAULT_TABLE_ELEMENT_LIMIT: usize = 1_024;
+const DEFAULT_INSTANCE_LIMIT: usize = 1;
+const DEFAULT_TABLE_LIMIT: usize = 8;
+const DEFAULT_LINEAR_MEMORY_LIMIT: usize = 1;
 
 /// A host import observed in a WASM module.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,6 +88,7 @@ pub fn verify_wasm_host_abi_bytes(
 #[derive(Debug)]
 pub struct WasmExecutor {
     engine: Engine,
+    limits: WasmExecutionLimits,
 }
 
 impl WasmExecutor {
@@ -91,9 +98,56 @@ impl WasmExecutor {
     ///
     /// Returns [`ExecutorError::RuntimeSetupFailed`] if Wasmtime cannot initialise.
     pub fn new() -> Result<Self, ExecutorError> {
-        let engine = Engine::default();
-        Ok(Self { engine })
+        Self::with_limits(WasmExecutionLimits::default())
     }
+
+    /// Create a [`WasmExecutor`] with explicit per-invocation resource limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutorError::RuntimeSetupFailed`] if Wasmtime cannot initialise.
+    pub fn with_limits(limits: WasmExecutionLimits) -> Result<Self, ExecutorError> {
+        let mut config = Config::new();
+        config.consume_fuel(true);
+        let engine = Engine::new(&config)
+            .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("engine config: {e}")))?;
+        Ok(Self { engine, limits })
+    }
+}
+
+/// Per-invocation resource limits for [`WasmExecutor`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WasmExecutionLimits {
+    /// Fuel units available for guest code before it traps as a timeout.
+    pub fuel_budget: u64,
+    /// Maximum bytes for each guest linear memory.
+    pub memory_bytes: usize,
+    /// Maximum elements for each guest table.
+    pub table_elements: usize,
+    /// Maximum instances in the store.
+    pub instances: usize,
+    /// Maximum tables in the store.
+    pub tables: usize,
+    /// Maximum linear memories in the store.
+    pub memories: usize,
+}
+
+impl Default for WasmExecutionLimits {
+    fn default() -> Self {
+        Self {
+            fuel_budget: DEFAULT_FUEL_BUDGET,
+            memory_bytes: DEFAULT_MEMORY_LIMIT_BYTES,
+            table_elements: DEFAULT_TABLE_ELEMENT_LIMIT,
+            instances: DEFAULT_INSTANCE_LIMIT,
+            tables: DEFAULT_TABLE_LIMIT,
+            memories: DEFAULT_LINEAR_MEMORY_LIMIT,
+        }
+    }
+}
+
+struct WasmStoreState {
+    wasi: WasiP1Ctx,
+    limits: StoreLimits,
 }
 
 impl CapabilityExecutor for WasmExecutor {
@@ -190,11 +244,21 @@ impl WasmExecutor {
             .stdout(stdout_pipe)
             .build_p1();
 
-        let mut linker: Linker<WasiP1Ctx> = Linker::new(&self.engine);
-        wasmtime_wasi::p1::add_to_linker_sync(&mut linker, |s| s)
+        let mut linker: Linker<WasmStoreState> = Linker::new(&self.engine);
+        wasmtime_wasi::p1::add_to_linker_sync(&mut linker, |s| &mut s.wasi)
             .map_err(|e| ExecutorError::RuntimeSetupFailed(e.to_string()))?;
 
-        let mut store: Store<WasiP1Ctx> = Store::new(&self.engine, wasi_ctx);
+        let mut store = Store::new(
+            &self.engine,
+            WasmStoreState {
+                wasi: wasi_ctx,
+                limits: self.store_limits(),
+            },
+        );
+        store.limiter(|state| &mut state.limits);
+        store
+            .set_fuel(self.limits.fuel_budget)
+            .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("set fuel: {e}")))?;
 
         linker
             .module(&mut store, "", &module)
@@ -206,7 +270,7 @@ impl WasmExecutor {
             .typed::<(), ()>(&store)
             .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("typed: {e}")))?
             .call(&mut store, ())
-            .map_err(|e| ExecutorError::ExecutionFailed(e.to_string()))?;
+            .map_err(|error| classify_wasm_execution_error(&error))?;
 
         // Extract captured stdout — contents() reads the buffer without consuming it
         let raw_output = stdout_ref.contents();
@@ -218,6 +282,32 @@ impl WasmExecutor {
             ))
         })
     }
+
+    fn store_limits(&self) -> StoreLimits {
+        StoreLimitsBuilder::new()
+            .memory_size(self.limits.memory_bytes)
+            .table_elements(self.limits.table_elements)
+            .instances(self.limits.instances)
+            .tables(self.limits.tables)
+            .memories(self.limits.memories)
+            .trap_on_grow_failure(true)
+            .build()
+    }
+}
+
+fn classify_wasm_execution_error(error: &wasmtime::Error) -> ExecutorError {
+    let display = error.to_string();
+    let debug = format!("{error:?}");
+    if display.contains("all fuel consumed by WebAssembly")
+        || debug.contains("all fuel consumed by WebAssembly")
+    {
+        return ExecutorError::Timeout(debug);
+    }
+    if display.contains("forcing trap when growing") || debug.contains("forcing trap when growing")
+    {
+        return ExecutorError::ResourceExhausted(debug);
+    }
+    ExecutorError::ExecutionFailed(display)
 }
 
 fn sha256_hex(data: &[u8]) -> String {

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -2,7 +2,7 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use traverse_runtime::executor::{
     ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, NativeExecutor,
-    SUPPORTED_HOST_ABI_VERSION, WasmExecutor, supported_host_abi_versions,
+    SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits, WasmExecutor, supported_host_abi_versions,
     verify_wasm_host_abi_bytes,
 };
 
@@ -241,6 +241,90 @@ fn wasm_executor_rejects_invalid_json_output() -> Result<(), String> {
 }
 
 #[test]
+fn wasm_executor_traps_infinite_loop_as_timeout() -> Result<(), String> {
+    let executor = WasmExecutor::with_limits(WasmExecutionLimits {
+        fuel_budget: 1_000,
+        ..WasmExecutionLimits::default()
+    })
+    .map_err(|e| format!("{e:?}"))?;
+    let wat_src = r#"
+        (module
+            (func $_start (export "_start")
+                (loop $again
+                    br $again
+                )
+            )
+        )
+    "#;
+    let wasm_bytes = wat::parse_str(wat_src).map_err(|e| format!("WAT parse: {e}"))?;
+
+    let err = expect_err(
+        executor.run_bytes(&wasm_bytes, &json!({})),
+        "expected Timeout",
+    )?;
+
+    assert!(
+        matches!(err, ExecutorError::Timeout(_)),
+        "expected Timeout, got {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_traps_memory_growth_as_resource_exhausted() -> Result<(), String> {
+    let executor = WasmExecutor::with_limits(WasmExecutionLimits {
+        fuel_budget: 100_000,
+        memory_bytes: 64 * 1024,
+        ..WasmExecutionLimits::default()
+    })
+    .map_err(|e| format!("{e:?}"))?;
+    let wat_src = r#"
+        (module
+            (memory (export "memory") 1)
+            (func $_start (export "_start")
+                (drop (memory.grow (i32.const 1)))
+            )
+        )
+    "#;
+    let wasm_bytes = wat::parse_str(wat_src).map_err(|e| format!("WAT parse: {e}"))?;
+
+    let err = expect_err(
+        executor.run_bytes(&wasm_bytes, &json!({})),
+        "expected ResourceExhausted",
+    )?;
+
+    assert!(
+        matches!(err, ExecutorError::ResourceExhausted(_)),
+        "expected ResourceExhausted, got {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_preserves_generic_traps_as_execution_failed() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wat_src = r#"
+        (module
+            (func $_start (export "_start")
+                unreachable
+            )
+        )
+    "#;
+    let wasm_bytes = wat::parse_str(wat_src).map_err(|e| format!("WAT parse: {e}"))?;
+
+    let err = expect_err(
+        executor.run_bytes(&wasm_bytes, &json!({})),
+        "expected ExecutionFailed",
+    )?;
+
+    assert!(
+        matches!(err, ExecutorError::ExecutionFailed(_)),
+        "expected ExecutionFailed, got {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn wasm_host_abi_verifier_accepts_sanctioned_stdio_imports() -> Result<(), String> {
     let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;
 
@@ -385,6 +469,14 @@ fn executor_error_display_covers_all_variants() {
         (
             ExecutorError::ExecutionFailed("trapped".to_string()),
             "execution failed: trapped",
+        ),
+        (
+            ExecutorError::Timeout("fuel exhausted".to_string()),
+            "execution timed out: fuel exhausted",
+        ),
+        (
+            ExecutorError::ResourceExhausted("memory cap".to_string()),
+            "resource exhausted: memory cap",
         ),
         (
             ExecutorError::OutputDeserializationFailed("not json".to_string()),

--- a/specs/060-wasm-resource-limits/spec.md
+++ b/specs/060-wasm-resource-limits/spec.md
@@ -1,0 +1,53 @@
+# Feature Specification: WASM Resource Limits
+
+**Spec ID**: 060
+**Status**: Approved
+**Created**: 2026-07-11
+**Input**: GitHub issue #584
+
+## Context
+
+Spec `025-wasm-executor-adapter` defines the Wasmtime-backed executor boundary.
+This extension defines the required resource-limit model for that executor so a
+guest module cannot run without CPU, memory, table, and instance budgets.
+
+The resource limits apply per invocation. Each invocation already uses a fresh
+Wasmtime `Store`; this spec requires that store to receive fresh limits before
+the guest entrypoint is called.
+
+## Requirements
+
+- **FR-001**: `WasmExecutor` MUST create its Wasmtime engine with fuel
+  consumption enabled.
+- **FR-002**: Each WASM invocation MUST set a finite fuel budget before calling
+  the guest entrypoint.
+- **FR-003**: Fuel exhaustion MUST return a stable timeout-classified executor
+  error instead of a generic execution failure.
+- **FR-004**: Each WASM invocation MUST apply finite store limits for linear
+  memory bytes, table elements, instances, tables, and linear memories.
+- **FR-005**: Memory or table growth beyond the configured store limits MUST
+  return a stable resource-exhausted executor error instead of a generic
+  execution failure.
+- **FR-006**: Limits MUST be configurable through the runtime executor API while
+  preserving safe defaults for `WasmExecutor::new`.
+- **FR-007**: Limits MUST be fresh per invocation so one module cannot consume
+  another invocation's budget or mutate future budgets.
+- **FR-008**: Existing checksum validation, host ABI validation, deny-by-default
+  WASI behavior, and stdout JSON handling MUST keep their existing behavior.
+
+## Out of Scope
+
+- HTTP or CLI configuration surfaces for custom WASM limits.
+- Epoch-interruption background tickers.
+- Thread-pool task cancellation for native executors.
+- Registered-WASM dispatch wiring outside the executor boundary.
+
+## Verification
+
+- A test MUST prove an infinite-loop guest is trapped within a small fuel budget
+  and returns the timeout-classified executor error.
+- A test MUST prove a guest memory growth beyond the configured cap returns the
+  resource-exhausted executor error.
+- Existing executor tests MUST continue to pass.
+- Repository formatting, Rust checks, and spec-alignment checks MUST pass with
+  this spec declared in the PR body.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -683,6 +683,19 @@
         "specs/059-http-command-dispatch/",
         "specs/governance/"
       ]
+    },
+    {
+      "id": "060-wasm-resource-limits",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/060-wasm-resource-limits/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "CHANGELOG.md",
+        "specs/060-wasm-resource-limits/",
+        "specs/governance/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add per-invocation resource limits to `WasmExecutor` so guest WASM cannot run without CPU and store budgets.

## Governing Spec

- `060-wasm-resource-limits`
- `025-wasm-executor-adapter`

## Project Item

- Closes #584

## Definition of Done

- Wasmtime engine uses fuel consumption with a finite default fuel budget.
- Each invocation applies finite store limits for memory bytes, table elements, instances, tables, and linear memories.
- Fuel exhaustion is classified as `ExecutorError::Timeout`.
- Memory/table growth beyond configured limits is classified as `ExecutorError::ResourceExhausted`.
- Limits remain configurable through the executor API while `WasmExecutor::new` keeps safe defaults.
- Changelog records the WASM resource-limit hardening.

## Validation

- `python3 -m json.tool specs/governance/approved-specs.json`
- `git diff --check`
- `cargo test -p traverse-runtime --test executor_tests -- --nocapture`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/rust_checks.sh`
- `PATH="$HOME/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH" bash scripts/ci/coverage_gate.sh`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh /private/tmp/pr-body-584.md`
