### PR TITLE
Add WASM module cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,7 @@
 
 ## Unreleased
 
+- Added a bounded checksum-keyed `WasmExecutor` compiled-module cache while
+  preserving fresh per-invocation stores and checksum/ABI validation.
 - Hardened `WasmExecutor` with per-invocation fuel and store resource limits so
   runaway WASM guests are classified as timeout or resource-exhausted failures.

--- a/crates/traverse-runtime/src/executor/mod.rs
+++ b/crates/traverse-runtime/src/executor/mod.rs
@@ -15,7 +15,8 @@ pub use native::NativeExecutor;
 pub use thread_pool::{ConfigError, ThreadPoolExecutor, ThreadPoolExecutorConfig};
 pub use wasm::{
     HostAbiImport, HostAbiValidation, SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits,
-    WasmExecutor, supported_host_abi_versions, verify_wasm_host_abi_bytes,
+    WasmExecutor, WasmModuleCacheConfig, WasmModuleCacheStats, supported_host_abi_versions,
+    verify_wasm_host_abi_bytes,
 };
 
 use serde_json::Value;

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -7,7 +7,9 @@
 use serde::Deserialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use std::collections::{HashMap, VecDeque};
 use std::fs;
+use std::sync::{LazyLock, Mutex};
 use wasmtime::{Config, Engine, Linker, Module, Store, StoreLimits, StoreLimitsBuilder};
 use wasmtime_wasi::WasiCtxBuilder;
 use wasmtime_wasi::p1::WasiP1Ctx;
@@ -25,6 +27,12 @@ const DEFAULT_TABLE_ELEMENT_LIMIT: usize = 1_024;
 const DEFAULT_INSTANCE_LIMIT: usize = 1;
 const DEFAULT_TABLE_LIMIT: usize = 8;
 const DEFAULT_LINEAR_MEMORY_LIMIT: usize = 1;
+const DEFAULT_MODULE_CACHE_MAX_ENTRIES: usize = 64;
+
+static HOST_ABI_V1_WHITELIST_CACHE: LazyLock<Result<HostAbiWhitelist, String>> =
+    LazyLock::new(|| {
+        serde_json::from_str::<HostAbiWhitelist>(HOST_ABI_V1_WHITELIST).map_err(|e| e.to_string())
+    });
 
 /// A host import observed in a WASM module.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,13 +52,13 @@ pub struct HostAbiValidation {
     pub imports: Vec<HostAbiImport>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct HostAbiWhitelist {
     abi_version: String,
     imports: Vec<HostAbiWhitelistImport>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct HostAbiWhitelistImport {
     module: String,
     name: String,
@@ -89,6 +97,7 @@ pub fn verify_wasm_host_abi_bytes(
 pub struct WasmExecutor {
     engine: Engine,
     limits: WasmExecutionLimits,
+    module_cache: Mutex<CompiledModuleCache>,
 }
 
 impl WasmExecutor {
@@ -107,11 +116,37 @@ impl WasmExecutor {
     ///
     /// Returns [`ExecutorError::RuntimeSetupFailed`] if Wasmtime cannot initialise.
     pub fn with_limits(limits: WasmExecutionLimits) -> Result<Self, ExecutorError> {
+        Self::with_limits_and_cache_config(limits, WasmModuleCacheConfig::default())
+    }
+
+    /// Create a [`WasmExecutor`] with explicit resource limits and module cache bounds.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutorError::RuntimeSetupFailed`] if Wasmtime cannot initialise.
+    pub fn with_limits_and_cache_config(
+        limits: WasmExecutionLimits,
+        cache_config: WasmModuleCacheConfig,
+    ) -> Result<Self, ExecutorError> {
         let mut config = Config::new();
         config.consume_fuel(true);
         let engine = Engine::new(&config)
             .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("engine config: {e}")))?;
-        Ok(Self { engine, limits })
+        Ok(Self {
+            engine,
+            limits,
+            module_cache: Mutex::new(CompiledModuleCache::new(cache_config.max_entries)),
+        })
+    }
+
+    /// Return current compiled-module cache counters.
+    #[must_use]
+    pub fn module_cache_stats(&self) -> WasmModuleCacheStats {
+        let cache = self
+            .module_cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        cache.stats()
     }
 }
 
@@ -141,6 +176,95 @@ impl Default for WasmExecutionLimits {
             instances: DEFAULT_INSTANCE_LIMIT,
             tables: DEFAULT_TABLE_LIMIT,
             memories: DEFAULT_LINEAR_MEMORY_LIMIT,
+        }
+    }
+}
+
+/// Bounded compiled-module cache configuration for [`WasmExecutor`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WasmModuleCacheConfig {
+    /// Maximum number of compiled modules retained by checksum.
+    pub max_entries: usize,
+}
+
+impl Default for WasmModuleCacheConfig {
+    fn default() -> Self {
+        Self {
+            max_entries: DEFAULT_MODULE_CACHE_MAX_ENTRIES,
+        }
+    }
+}
+
+/// Snapshot of compiled-module cache counters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WasmModuleCacheStats {
+    /// Current retained compiled modules.
+    pub entries: usize,
+    /// Number of executions served from cache.
+    pub hits: u64,
+    /// Number of executions that compiled a module before insertion.
+    pub misses: u64,
+    /// Number of deterministic oldest-entry evictions.
+    pub evictions: u64,
+}
+
+#[derive(Debug, Clone)]
+struct CachedModule {
+    module: Module,
+    validation: HostAbiValidation,
+}
+
+#[derive(Debug)]
+struct CompiledModuleCache {
+    max_entries: usize,
+    entries: HashMap<String, CachedModule>,
+    insertion_order: VecDeque<String>,
+    hits: u64,
+    misses: u64,
+    evictions: u64,
+}
+
+impl CompiledModuleCache {
+    fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries: max_entries.max(1),
+            entries: HashMap::new(),
+            insertion_order: VecDeque::new(),
+            hits: 0,
+            misses: 0,
+            evictions: 0,
+        }
+    }
+
+    fn get(&mut self, checksum: &str, abi_version: &str) -> Option<CachedModule> {
+        let cached = self.entries.get(checksum)?;
+        if cached.validation.abi_version != abi_version {
+            self.misses += 1;
+            return None;
+        }
+        self.hits += 1;
+        Some(cached.clone())
+    }
+
+    fn insert(&mut self, checksum: String, cached: CachedModule) {
+        self.misses += 1;
+        while self.entries.len() >= self.max_entries {
+            if let Some(oldest) = self.insertion_order.pop_front()
+                && self.entries.remove(&oldest).is_some()
+            {
+                self.evictions += 1;
+            }
+        }
+        self.insertion_order.push_back(checksum.clone());
+        self.entries.insert(checksum, cached);
+    }
+
+    fn stats(&self) -> WasmModuleCacheStats {
+        WasmModuleCacheStats {
+            entries: self.entries.len(),
+            hits: self.hits,
+            misses: self.misses,
+            evictions: self.evictions,
         }
     }
 }
@@ -225,13 +349,7 @@ impl WasmExecutor {
         let input_json = serde_json::to_string(input)
             .map_err(|e| ExecutorError::ExecutionFailed(format!("input serialization: {e}")))?;
 
-        let module = Module::from_binary(&self.engine, wasm_bytes).map_err(|e| {
-            ExecutorError::MalformedWasmArtifact {
-                error_code: "malformed_wasm_artifact".to_string(),
-                detail: format!("module compile: {e}"),
-            }
-        })?;
-        validate_module_imports(&module, abi_version)?;
+        let cached_module = self.compiled_module(wasm_bytes, abi_version)?;
 
         // Clone pipe reference before passing to builder — needed to read output after execution
         let stdout_pipe = MemoryOutputPipe::new(65536);
@@ -261,7 +379,7 @@ impl WasmExecutor {
             .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("set fuel: {e}")))?;
 
         linker
-            .module(&mut store, "", &module)
+            .module(&mut store, "", &cached_module.module)
             .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("module link: {e}")))?;
 
         linker
@@ -292,6 +410,39 @@ impl WasmExecutor {
             .memories(self.limits.memories)
             .trap_on_grow_failure(true)
             .build()
+    }
+
+    fn compiled_module(
+        &self,
+        wasm_bytes: &[u8],
+        abi_version: &str,
+    ) -> Result<CachedModule, ExecutorError> {
+        let checksum = sha256_hex(wasm_bytes);
+        {
+            let mut cache = self
+                .module_cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(cached) = cache.get(&checksum, abi_version) {
+                return Ok(cached);
+            }
+        }
+
+        let module = Module::from_binary(&self.engine, wasm_bytes).map_err(|e| {
+            ExecutorError::MalformedWasmArtifact {
+                error_code: "malformed_wasm_artifact".to_string(),
+                detail: format!("module compile: {e}"),
+            }
+        })?;
+        let validation = validate_module_imports(&module, abi_version)?;
+        let cached = CachedModule { module, validation };
+
+        let mut cache = self
+            .module_cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        cache.insert(checksum, cached.clone());
+        Ok(cached)
     }
 }
 
@@ -360,6 +511,8 @@ fn host_abi_whitelist(abi_version: &str) -> Result<HostAbiWhitelist, ExecutorErr
         });
     }
 
-    serde_json::from_str::<HostAbiWhitelist>(HOST_ABI_V1_WHITELIST)
+    HOST_ABI_V1_WHITELIST_CACHE
+        .as_ref()
+        .cloned()
         .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("invalid ABI whitelist: {e}")))
 }

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -1,12 +1,15 @@
 use serde_json::json;
 use sha2::{Digest, Sha256};
+use std::sync::atomic::{AtomicU64, Ordering};
 use traverse_runtime::executor::{
     ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, NativeExecutor,
-    SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits, WasmExecutor, supported_host_abi_versions,
-    verify_wasm_host_abi_bytes,
+    SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits, WasmExecutor, WasmModuleCacheConfig,
+    supported_host_abi_versions, verify_wasm_host_abi_bytes,
 };
 
 // --- NativeExecutor tests ---
+
+static TEMPFILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[test]
 fn native_executor_runs_handler() {
@@ -325,6 +328,140 @@ fn wasm_executor_preserves_generic_traps_as_execution_failed() -> Result<(), Str
 }
 
 #[test]
+fn wasm_executor_reuses_compiled_module_by_checksum() -> Result<(), String> {
+    let executor = WasmExecutor::with_limits_and_cache_config(
+        WasmExecutionLimits::default(),
+        WasmModuleCacheConfig { max_entries: 2 },
+    )
+    .map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;
+
+    let first_input = json!({ "call": 1 });
+    let first = executor
+        .run_bytes(&wasm_bytes, &first_input)
+        .map_err(|e| format!("{e:?}"))?;
+    assert_eq!(first, first_input);
+
+    let after_first = executor.module_cache_stats();
+    assert_eq!(after_first.entries, 1);
+    assert_eq!(after_first.hits, 0);
+    assert_eq!(after_first.misses, 1);
+
+    let second_input = json!({ "call": 2 });
+    let second = executor
+        .run_bytes(&wasm_bytes, &second_input)
+        .map_err(|e| format!("{e:?}"))?;
+    assert_eq!(second, second_input);
+
+    let after_second = executor.module_cache_stats();
+    assert_eq!(after_second.entries, 1);
+    assert_eq!(after_second.hits, 1);
+    assert_eq!(after_second.misses, 1);
+    assert_eq!(after_second.evictions, 0);
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_cached_module_still_uses_fresh_store() -> Result<(), String> {
+    let executor = WasmExecutor::with_limits_and_cache_config(
+        WasmExecutionLimits::default(),
+        WasmModuleCacheConfig { max_entries: 2 },
+    )
+    .map_err(|e| format!("{e:?}"))?;
+    let wat_src = r#"
+        (module
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (global $counter (mut i32) (i32.const 0))
+            (data (i32.const 8) "{\"count\":0}")
+            (func $_start (export "_start")
+                (global.set $counter (i32.add (global.get $counter) (i32.const 1)))
+                (i32.store8 (i32.const 17) (i32.add (global.get $counter) (i32.const 48)))
+                (i32.store (i32.const 0) (i32.const 8))
+                (i32.store (i32.const 4) (i32.const 11))
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 4)))
+            )
+        )
+    "#;
+    let wasm_bytes = wat::parse_str(wat_src).map_err(|e| format!("WAT parse: {e}"))?;
+
+    let first = executor
+        .run_bytes(&wasm_bytes, &json!({}))
+        .map_err(|e| format!("{e:?}"))?;
+    let second = executor
+        .run_bytes(&wasm_bytes, &json!({}))
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert_eq!(first, json!({ "count": 1 }));
+    assert_eq!(second, json!({ "count": 1 }));
+    assert_eq!(executor.module_cache_stats().hits, 1);
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_cache_evicts_oldest_entry_deterministically() -> Result<(), String> {
+    let executor = WasmExecutor::with_limits_and_cache_config(
+        WasmExecutionLimits::default(),
+        WasmModuleCacheConfig { max_entries: 1 },
+    )
+    .map_err(|e| format!("{e:?}"))?;
+    let first_wasm = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;
+    let second_wat = r#"
+        (module
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 8) "{}")
+            (func $_start (export "_start")
+                (i32.store (i32.const 0) (i32.const 8))
+                (i32.store (i32.const 4) (i32.const 2))
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 4)))
+            )
+        )
+    "#;
+    let second_wasm = wat::parse_str(second_wat).map_err(|e| format!("WAT parse: {e}"))?;
+
+    executor
+        .run_bytes(&first_wasm, &json!({ "cached": true }))
+        .map_err(|e| format!("{e:?}"))?;
+    executor
+        .run_bytes(&second_wasm, &json!({}))
+        .map_err(|e| format!("{e:?}"))?;
+    executor
+        .run_bytes(&first_wasm, &json!({ "cached": true }))
+        .map_err(|e| format!("{e:?}"))?;
+
+    let stats = executor.module_cache_stats();
+    assert_eq!(stats.entries, 1);
+    assert_eq!(stats.hits, 0);
+    assert_eq!(stats.misses, 3);
+    assert_eq!(stats.evictions, 2);
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_cache_miss_when_abi_version_differs() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;
+
+    executor
+        .run_bytes(&wasm_bytes, &json!({ "abi": "1.0.0" }))
+        .map_err(|e| format!("{e:?}"))?;
+    let err = expect_err(
+        executor.run_bytes_with_host_abi(&wasm_bytes, &json!({}), "2.0.0"),
+        "expected unsupported ABI version",
+    )?;
+
+    assert!(matches!(err, ExecutorError::UnsupportedAbiVersion { .. }));
+    let stats = executor.module_cache_stats();
+    assert_eq!(stats.entries, 1);
+    assert_eq!(stats.hits, 0);
+    assert_eq!(stats.misses, 2);
+    Ok(())
+}
+
+#[test]
 fn wasm_host_abi_verifier_accepts_sanctioned_stdio_imports() -> Result<(), String> {
     let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;
 
@@ -586,6 +723,47 @@ fn wasm_executor_execute_with_matching_checksum_succeeds() -> Result<(), String>
 }
 
 #[test]
+fn wasm_executor_cached_module_does_not_bypass_checksum_mismatch() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes = wat::parse_str(echo_wat()).map_err(|e| format!("WAT parse: {e}"))?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(&wasm_bytes);
+    let checksum = format!("{:x}", hasher.finalize());
+
+    let tmp = tempfile_path();
+    std::fs::write(&tmp, &wasm_bytes).map_err(|e| format!("write: {e}"))?;
+
+    let cap = ExecutorCapability {
+        capability_id: "checksum-cache".to_string(),
+        artifact_type: ArtifactType::Wasm,
+        wasm_binary_path: Some(tmp.clone()),
+        wasm_checksum: Some(checksum),
+        host_abi_version: Some("1.0.0".to_string()),
+    };
+
+    let input = json!({ "cache": true });
+    let result = executor
+        .execute(&cap, &input)
+        .map_err(|e| format!("{e:?}"))?;
+    assert_eq!(result, input);
+    assert_eq!(executor.module_cache_stats().entries, 1);
+
+    std::fs::write(&tmp, b"not-the-same-wasm").map_err(|e| format!("overwrite: {e}"))?;
+    let err = expect_err(
+        executor.execute(&cap, &json!({})),
+        "expected checksum mismatch",
+    )?;
+    std::fs::remove_file(&tmp).ok();
+
+    assert!(
+        matches!(err, ExecutorError::ChecksumMismatch { .. }),
+        "expected ChecksumMismatch, got {err:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn wasm_executor_invalid_binary_triggers_runtime_setup_failed() -> Result<(), String> {
     let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
 
@@ -624,8 +802,9 @@ fn native_capability(id: &str) -> ExecutorCapability {
 }
 
 fn tempfile_path() -> String {
+    let suffix = TEMPFILE_COUNTER.fetch_add(1, Ordering::Relaxed);
     format!(
-        "/tmp/traverse-test-{}.wasm",
+        "/tmp/traverse-test-{}-{suffix}.wasm",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_or(0, |d| d.as_nanos())

--- a/specs/061-wasm-module-cache/spec.md
+++ b/specs/061-wasm-module-cache/spec.md
@@ -1,0 +1,53 @@
+# Feature Specification: WASM Module Cache
+
+**Spec ID**: 061
+**Status**: Approved
+**Created**: 2026-07-11
+**Input**: GitHub issue #585
+
+## Context
+
+Spec `025-wasm-executor-adapter` defines the Wasmtime-backed executor boundary.
+This extension defines the compiled-module cache for that executor so repeated
+invocations of unchanged WASM bytes reuse Cranelift compilation output.
+
+The cache applies only to compiled `wasmtime::Module` values. Every invocation
+still creates a fresh Wasmtime `Store`, WASI context, fuel budget, and store
+limits so guest state and resource consumption do not leak between calls.
+
+## Requirements
+
+- **FR-001**: `WasmExecutor` MUST cache compiled `Module` values by the SHA-256
+  checksum of the loaded WASM bytes.
+- **FR-002**: A repeated execution of identical bytes under the same Traverse
+  Host ABI version MUST reuse the cached module instead of recompiling it.
+- **FR-003**: The compiled-module cache MUST be bounded by entry count and use a
+  deterministic oldest-entry eviction policy.
+- **FR-004**: Cache hits MUST NOT bypass checksum verification for
+  file-backed execution.
+- **FR-005**: Cache hits MUST NOT bypass Host ABI validation; cached entries
+  are reusable only for the ABI version they were validated against.
+- **FR-006**: WASI context, `Store`, fuel, memory, table, and instance limits
+  MUST remain fresh per invocation even when the compiled module is reused.
+- **FR-007**: The embedded Host ABI whitelist MUST be parsed once per process,
+  not on every module validation.
+- **FR-008**: Cache counters MUST expose enough evidence for tests to prove
+  first execution misses, repeated execution hits, and eviction is deterministic.
+
+## Out of Scope
+
+- Persisting compiled modules across process restarts.
+- Disk-backed Wasmtime engine cache configuration.
+- Skipping file reads for checksum-pinned capabilities.
+- Runtime HTTP or CLI configuration surfaces for cache sizing.
+
+## Verification
+
+- A test MUST prove a repeated execution of the same WASM bytes records one
+  cache miss and one cache hit.
+- A test MUST prove cached-module execution still uses a fresh `Store`.
+- A test MUST prove bounded cache eviction removes the oldest entry
+  deterministically.
+- A test MUST prove a cached module does not bypass checksum mismatch detection.
+- Existing executor tests, repository checks, Rust checks, coverage gate, and
+  spec-alignment checks MUST pass with this spec declared in the PR body.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -696,6 +696,19 @@
         "specs/060-wasm-resource-limits/",
         "specs/governance/"
       ]
+    },
+    {
+      "id": "061-wasm-module-cache",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/061-wasm-module-cache/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "CHANGELOG.md",
+        "specs/061-wasm-module-cache/",
+        "specs/governance/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Add a bounded checksum-keyed compiled-module cache to `WasmExecutor` so repeated executions reuse Wasmtime `Module` compilation while preserving fresh per-invocation stores.

## Governing Spec

- `061-wasm-module-cache`
- `025-wasm-executor-adapter`
- `060-wasm-resource-limits`

## Project Item

- Closes #585

## Definition of Done

- Compiled `Module`s are cached by WASM SHA-256 checksum and reused on repeated execution.
- Cache is bounded by entry count with deterministic oldest-entry eviction.
- Each execution still uses a fresh `Store`, WASI context, fuel budget, and store limits.
- File-backed checksum validation still runs before cached execution can proceed.
- Host ABI validation remains tied to the ABI version used for the cached module.
- Host ABI whitelist parsing is process-cached instead of repeated per validation.
- Changelog and approved spec registry document the cache behavior.

## Validation

- `python3 -m json.tool specs/governance/approved-specs.json`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p traverse-runtime --test executor_tests -- --nocapture`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/rust_checks.sh`
- `PATH="$HOME/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH" bash scripts/ci/coverage_gate.sh`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh /private/tmp/pr-body-585.md`
