### PR TITLE
Add runtime wasm32 core build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,12 +82,16 @@ jobs:
         with:
           toolchain: 1.94.0
           components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
       - name: Run Rust checks
         run: bash scripts/ci/rust_checks.sh
+
+      - name: Check runtime wasm32 core build
+        run: cargo check -p traverse-runtime --target wasm32-unknown-unknown --no-default-features
 
       - name: Run event-driven workflow smoke path
         run: bash scripts/ci/event_driven_workflow_smoke.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Added a no-default-features `traverse-runtime` core build for
+  `wasm32-unknown-unknown` by feature-gating native Wasmtime and Rayon
+  execution adapters.
 - Added a bounded checksum-keyed `WasmExecutor` compiled-module cache while
   preserving fresh per-invocation stores and checksum/ABI validation.
 - Hardened `WasmExecutor` with per-invocation fuel and store resource limits so

--- a/crates/traverse-runtime/Cargo.toml
+++ b/crates/traverse-runtime/Cargo.toml
@@ -15,11 +15,16 @@ serde_json = "1.0.145"
 sha2 = "0.10"
 ed25519-dalek = "2.2.0"
 zeroize = "1.8"
-wasmtime = { version = "44", features = ["cranelift", "component-model"] }
-wasmtime-wasi = "44"
-uuid = { version = "1", features = ["v4"] }
+wasmtime = { version = "44", features = ["cranelift", "component-model"], optional = true }
+wasmtime-wasi = { version = "44", optional = true }
+uuid = { version = "1", features = ["v4", "js"] }
 chrono = { version = "0.4", features = ["serde"] }
-rayon = "1.11"
+rayon = { version = "1.11", optional = true }
+
+[features]
+default = ["native-executors", "wasmtime-executor"]
+native-executors = ["dep:rayon"]
+wasmtime-executor = ["dep:wasmtime", "dep:wasmtime-wasi"]
 
 [dev-dependencies]
 wat = "1"

--- a/crates/traverse-runtime/src/executor/mod.rs
+++ b/crates/traverse-runtime/src/executor/mod.rs
@@ -4,15 +4,20 @@
 //!
 //! Two concrete implementations:
 //! - [`NativeExecutor`] — executes capabilities implemented as native Rust closures.
-//! - [`WasmExecutor`] — executes capabilities compiled to `wasm32-wasi` binaries via Wasmtime.
-//! - [`ThreadPoolExecutor`] — dispatches native capability execution onto a bounded worker pool.
-
+//! - `WasmExecutor` — executes capabilities compiled to `wasm32-wasi` binaries
+//!   via Wasmtime when the `wasmtime-executor` feature is enabled.
+//! - `ThreadPoolExecutor` — dispatches native capability execution onto a bounded
+//!   worker pool when the `native-executors` feature is enabled.
 pub mod native;
+#[cfg(feature = "native-executors")]
 pub mod thread_pool;
+#[cfg(feature = "wasmtime-executor")]
 pub mod wasm;
 
 pub use native::NativeExecutor;
+#[cfg(feature = "native-executors")]
 pub use thread_pool::{ConfigError, ThreadPoolExecutor, ThreadPoolExecutorConfig};
+#[cfg(feature = "wasmtime-executor")]
 pub use wasm::{
     HostAbiImport, HostAbiValidation, SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits,
     WasmExecutor, WasmModuleCacheConfig, WasmModuleCacheStats, supported_host_abi_versions,

--- a/docs/runtime-target-matrix.md
+++ b/docs/runtime-target-matrix.md
@@ -1,0 +1,21 @@
+# Runtime Target Matrix
+
+Traverse separates runtime orchestration from native execution adapters so the
+core runtime can be embedded in browser and edge-WASM environments.
+
+| Target | Cargo flags | Supported surface |
+| --- | --- | --- |
+| Native host (`x86_64`/`aarch64` Linux, macOS, Windows) | default features | Full runtime orchestration, `NativeExecutor`, `ThreadPoolExecutor`, and Wasmtime-backed `WasmExecutor`. |
+| Browser/edge core (`wasm32-unknown-unknown`) | `--no-default-features` | Core contracts, registry resolution, routing types, traces, events, security helpers, and host-provided executors. Native Wasmtime and Rayon adapters are excluded. |
+| WASI guest capability (`wasm32-wasip1`) | capability crate target | Capability binaries authored for `WasmExecutor`; this is not the host runtime target. |
+
+Default features preserve the native behavior expected by existing consumers.
+Consumers embedding the runtime in a browser or edge-WASM guest should depend on
+`traverse-runtime` with `default-features = false` and provide their own
+executor implementation behind the existing `CapabilityExecutor` trait.
+
+CI enforces the browser/edge core build with:
+
+```bash
+cargo check -p traverse-runtime --target wasm32-unknown-unknown --no-default-features
+```

--- a/specs/062-runtime-target-matrix/spec.md
+++ b/specs/062-runtime-target-matrix/spec.md
@@ -1,0 +1,58 @@
+# Feature Specification: Runtime Target Matrix
+
+**Spec ID**: 062
+**Status**: Approved
+**Created**: 2026-07-11
+**Input**: GitHub issue #586
+
+## Context
+
+Traverse needs the core runtime to compile for browser and edge-WASM hosts while
+preserving full native execution behavior by default. Native execution adapters
+such as Wasmtime and Rayon are valuable on host platforms but are not portable
+to `wasm32-unknown-unknown`.
+
+This spec defines the target matrix and feature boundary for the runtime crate.
+
+## Target Matrix
+
+- **Native host**: default Cargo features. Supports runtime orchestration,
+  native execution, thread-pool execution, and Wasmtime-backed WASM execution.
+- **Browser/edge core**: `wasm32-unknown-unknown` with
+  `--no-default-features`. Supports contracts, registry resolution, routing
+  types, traces, events, security helpers, and host-provided executors. Excludes
+  Wasmtime and Rayon.
+- **WASI guest capability**: `wasm32-wasip1` capability crates. These are
+  executable artifacts loaded by native `WasmExecutor`, not the host runtime.
+
+## Requirements
+
+- **FR-001**: `traverse-runtime` default features MUST preserve existing native
+  behavior, including `WasmExecutor` and `ThreadPoolExecutor`.
+- **FR-002**: `wasmtime` and `wasmtime-wasi` MUST be optional behind a
+  `wasmtime-executor` feature.
+- **FR-003**: `rayon` MUST be optional behind a `native-executors` feature.
+- **FR-004**: `traverse-runtime --no-default-features` MUST exclude native-only
+  execution dependencies.
+- **FR-005**: The no-default core runtime MUST compile for
+  `wasm32-unknown-unknown`.
+- **FR-006**: CI MUST check the wasm32 no-default runtime build.
+- **FR-007**: Documentation MUST state which target and Cargo feature shape
+  consumers should use.
+
+## Out of Scope
+
+- Running Wasmtime inside `wasm32-unknown-unknown`.
+- Providing a JavaScript host executor implementation.
+- Moving native execution adapters into separate crates.
+- Changing runtime request, trace, registry, or contract semantics.
+
+## Verification
+
+- `cargo test -p traverse-runtime --test executor_tests -- --nocapture` MUST pass
+  with default features.
+- `cargo check -p traverse-runtime --no-default-features` MUST pass.
+- `cargo check -p traverse-runtime --target wasm32-unknown-unknown
+  --no-default-features` MUST pass.
+- Repository checks, Rust checks, coverage gate, and spec-alignment checks MUST
+  pass with this spec declared in the PR body.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -709,6 +709,21 @@
         "specs/061-wasm-module-cache/",
         "specs/governance/"
       ]
+    },
+    {
+      "id": "062-runtime-target-matrix",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/062-runtime-target-matrix/spec.md",
+      "governs": [
+        ".github/workflows/",
+        "crates/traverse-runtime/",
+        "docs/runtime-target-matrix.md",
+        "CHANGELOG.md",
+        "specs/062-runtime-target-matrix/",
+        "specs/governance/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Make `traverse-runtime` portable as a browser/edge core crate by feature-gating native-only execution adapters while preserving existing native defaults.

## Governing Spec

- `062-runtime-target-matrix`
- `025-wasm-executor-adapter`
- `047-thread-pool-executor`

## Project Item

- Closes #586

## Definition of Done

- Default `traverse-runtime` features preserve native `WasmExecutor` and `ThreadPoolExecutor` behavior.
- `wasmtime` and `wasmtime-wasi` are optional behind `wasmtime-executor`.
- `rayon` is optional behind `native-executors`.
- `traverse-runtime --no-default-features` excludes native-only execution dependencies.
- `traverse-runtime --no-default-features` compiles for `wasm32-unknown-unknown`.
- CI checks the wasm32 no-default runtime build.
- Runtime target matrix docs define native host, browser/edge core, and WASI guest capability targets.

## Validation

- `python3 -m json.tool specs/governance/approved-specs.json`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p traverse-runtime --test executor_tests -- --nocapture`
- `cargo check -p traverse-runtime --no-default-features`
- `PATH="/opt/homebrew/opt/rustup/bin:$HOME/.cargo/bin:$PATH" cargo check -p traverse-runtime --target wasm32-unknown-unknown --no-default-features`
- `bash scripts/ci/repository_checks.sh`
- `bash scripts/ci/rust_checks.sh`
- `PATH="$HOME/.cargo/bin:/opt/homebrew/opt/rustup/bin:$PATH" bash scripts/ci/coverage_gate.sh`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh /private/tmp/pr-body-586.md`
