### PR TITLE
Classify governed artifacts via approved-specs registry, not path heuristics

### DIFF
--- a/crates/traverse-registry/src/federation.rs
+++ b/crates/traverse-registry/src/federation.rs
@@ -2097,6 +2097,55 @@ mod tests {
     }
 
     #[test]
+    fn governed_path_loader_returns_empty_for_missing_or_invalid_inputs() {
+        assert!(
+            load_governed_path_prefixes_from_path("/definitely-missing/approved-specs.json")
+                .is_empty()
+        );
+        assert!(parse_governed_path_prefixes("{not-json").is_empty());
+    }
+
+    #[test]
+    fn governed_path_prefix_matches_directory_and_normalizes_windows_separators() {
+        // "contracts/" is a real governed prefix declared in
+        // specs/governance/approved-specs.json, so this reads the actual
+        // registry file (same pattern as approved_spec_registry_contains).
+        assert!(is_governed_artifact_path(
+            "contracts/approved/comment-draft.json"
+        ));
+        assert!(is_governed_artifact_path(
+            "contracts\\approved\\comment-draft.json"
+        ));
+    }
+
+    #[test]
+    fn governed_path_prefix_matches_bare_directory_name() {
+        assert!(is_governed_artifact_path("contracts"));
+    }
+
+    #[test]
+    fn governed_path_prefix_matches_exact_governed_file() {
+        assert!(is_governed_artifact_path("Cargo.toml"));
+    }
+
+    #[test]
+    fn ungoverned_path_is_not_governed() {
+        assert!(!is_governed_artifact_path(
+            "workspaces/ws-test/registry/private/comment-draft@1.0.0/contract.json"
+        ));
+        assert!(!is_governed_artifact_path("Cargo.tomlx"));
+    }
+
+    #[test]
+    fn governs_path_matches_directory_prefix_and_exact_file() {
+        assert!(governs_path("contracts/", "contracts/nested/file.json"));
+        assert!(governs_path("contracts/", "contracts"));
+        assert!(!governs_path("contracts/", "not-contracts/file.json"));
+        assert!(governs_path("Cargo.toml", "Cargo.toml"));
+        assert!(!governs_path("Cargo.toml", "Cargo.toml.bak"));
+    }
+
+    #[test]
     fn route_capability_invocation_returns_error_without_matching_snapshot() {
         let mut federation = FederationRegistry::new();
         let origin_peer = peer("peer-route-empty", "Peer Route Empty");

--- a/crates/traverse-registry/src/federation.rs
+++ b/crates/traverse-registry/src/federation.rs
@@ -26,6 +26,7 @@ const APPROVED_SPECS_REGISTRY_PATH: &str = concat!(
 );
 
 static APPROVED_SPEC_IDS: OnceLock<BTreeSet<String>> = OnceLock::new();
+static GOVERNED_PATH_PREFIXES: OnceLock<Vec<String>> = OnceLock::new();
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum FederationRegistryKind {
     Capability,
@@ -1299,6 +1300,59 @@ fn load_approved_spec_ids_from_path(path: &str) -> BTreeSet<String> {
     };
 
     parse_approved_spec_ids(&contents)
+}
+
+/// Returns true when `path` is governed per spec 030-security-identity-model
+/// FR-008: "Published/Governed" is any artifact referenced by an entry in
+/// `contracts/` or `specs/governance/approved-specs.json`. Checked against
+/// every path each approved spec declares in its `governs` list (which
+/// already includes `contracts/` itself), not by pattern-matching the path
+/// string for substrings like `"specs"` or `"approved"`.
+#[must_use]
+pub fn is_governed_artifact_path(path: &str) -> bool {
+    let normalized = path.replace('\\', "/");
+    GOVERNED_PATH_PREFIXES
+        .get_or_init(load_governed_path_prefixes)
+        .iter()
+        .any(|governed| governs_path(governed, &normalized))
+}
+
+/// A `governs` entry is either a directory prefix (trailing `/`) or an exact
+/// file path; match accordingly instead of a blanket substring check.
+fn governs_path(governed: &str, path: &str) -> bool {
+    match governed.strip_suffix('/') {
+        Some(dir) => path == dir || path.starts_with(governed),
+        None => path == governed,
+    }
+}
+
+fn load_governed_path_prefixes() -> Vec<String> {
+    load_governed_path_prefixes_from_path(APPROVED_SPECS_REGISTRY_PATH)
+}
+
+fn load_governed_path_prefixes_from_path(path: &str) -> Vec<String> {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return Vec::new();
+    };
+
+    parse_governed_path_prefixes(&contents)
+}
+
+fn parse_governed_path_prefixes(contents: &str) -> Vec<String> {
+    let Ok(payload) = serde_json::from_str::<Value>(contents) else {
+        return Vec::new();
+    };
+
+    payload
+        .get("specs")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("governs").and_then(Value::as_array))
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect()
 }
 
 fn snapshot_acceptance_decision(snapshot: &PeerRegistrySnapshot) -> GovernanceDecisionRecord {

--- a/crates/traverse-runtime/src/security.rs
+++ b/crates/traverse-runtime/src/security.rs
@@ -232,19 +232,21 @@ fn verify_checksum(
     }
 }
 
+/// Classifies an artifact's trust level per spec 030-security-identity-model
+/// FR-007/FR-008.
+///
+/// `SourceKind::Local` is a structured provenance field set at registration
+/// time (for example, the canonical bundled example capabilities), not a
+/// path heuristic; it always yields `LocalDev`. Everything else is resolved
+/// against the governed-path registry (`contracts/` and every path declared
+/// in `specs/governance/approved-specs.json`'s `governs` lists) rather than
+/// pattern-matching the contract path or source URL for substrings, which a
+/// registrant fully controls and could spoof in either direction.
 fn artifact_trust_level(capability: &ResolvedCapability) -> ArtifactTrustLevel {
     if capability.artifact.source.kind == SourceKind::Local {
         return ArtifactTrustLevel::LocalDev;
     }
-    let governed_path = capability.record.contract_path.replace('\\', "/");
-    if governed_path.starts_with("contracts/")
-        || governed_path.starts_with("specs/")
-        || governed_path.contains("/contracts/")
-        || governed_path.contains("/specs/")
-        || capability.artifact.source.kind == SourceKind::Git
-            && capability.artifact.source.location.starts_with("https://")
-            && governed_path.contains("approved")
-    {
+    if traverse_registry::is_governed_artifact_path(&capability.record.contract_path) {
         ArtifactTrustLevel::PublishedGoverned
     } else {
         ArtifactTrustLevel::LocalDev
@@ -460,4 +462,335 @@ fn base64url_decode(input: &str) -> Result<Vec<u8>, ()> {
         out.push(((n >> 8) & 0xff) as u8);
     }
     Ok(out)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+    use serde_json::json;
+    use traverse_contracts::{
+        CapabilityContract, Entrypoint, EntrypointKind, Execution, ExecutionConstraints,
+        ExecutionTarget, FilesystemAccess, HostApiAccess, Lifecycle, NetworkAccess, Owner,
+        Provenance, ProvenanceSource, SchemaContainer, ServiceType,
+    };
+    use traverse_registry::{
+        ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
+        CapabilityRegistryRecord, ComposabilityMetadata, CompositionKind, CompositionPattern,
+        DiscoveryIndexEntry, ImplementationKind, RegistrationEvidence, RegistrationResult,
+        RegistryProvenance, RegistryScope, SourceReference,
+    };
+
+    #[allow(clippy::too_many_lines)]
+    fn test_capability(
+        contract_path: &str,
+        source_kind: SourceKind,
+        binary: Option<BinaryReference>,
+    ) -> ResolvedCapability {
+        let owner = Owner {
+            team: "comments".to_string(),
+            contact: "comments@example.com".to_string(),
+        };
+        let contract = CapabilityContract {
+            kind: "capability_contract".to_string(),
+            schema_version: "1.0.0".to_string(),
+            id: "content.comments.create-comment-draft".to_string(),
+            namespace: "content.comments".to_string(),
+            name: "create-comment-draft".to_string(),
+            version: "1.0.0".to_string(),
+            lifecycle: Lifecycle::Active,
+            owner: owner.clone(),
+            summary: "Create a comment draft for a resource".to_string(),
+            description: "Creates a draft comment and returns the generated draft identifier."
+                .to_string(),
+            inputs: SchemaContainer {
+                schema: json!({"type": "object"}),
+            },
+            outputs: SchemaContainer {
+                schema: json!({"type": "object"}),
+            },
+            preconditions: Vec::new(),
+            postconditions: Vec::new(),
+            side_effects: vec![traverse_contracts::SideEffect {
+                kind: traverse_contracts::SideEffectKind::MemoryOnly,
+                description: "Produces a draft representation in memory.".to_string(),
+            }],
+            emits: Vec::new(),
+            consumes: Vec::new(),
+            permissions: Vec::new(),
+            execution: Execution {
+                binary_format: traverse_contracts::BinaryFormat::Wasm,
+                entrypoint: Entrypoint {
+                    kind: EntrypointKind::WasiCommand,
+                    command: "run".to_string(),
+                },
+                preferred_targets: vec![ExecutionTarget::Local],
+                constraints: ExecutionConstraints {
+                    host_api_access: HostApiAccess::None,
+                    network_access: NetworkAccess::Forbidden,
+                    filesystem_access: FilesystemAccess::None,
+                },
+            },
+            policies: Vec::new(),
+            dependencies: Vec::new(),
+            provenance: Provenance {
+                source: ProvenanceSource::Greenfield,
+                author: "Enrico Piovesan".to_string(),
+                created_at: "2026-03-27T00:00:00Z".to_string(),
+                spec_ref: Some("030-security-identity-model".to_string()),
+                adr_refs: Vec::new(),
+                exception_refs: Vec::new(),
+            },
+            evidence: Vec::new(),
+            service_type: ServiceType::Stateless,
+            permitted_targets: vec![ExecutionTarget::Local],
+            event_trigger: None,
+            connector_requirements: Vec::new(),
+            state_schema: None,
+        };
+        let record = CapabilityRegistryRecord {
+            scope: RegistryScope::Private,
+            id: contract.id.clone(),
+            version: contract.version.clone(),
+            lifecycle: Lifecycle::Active,
+            owner: owner.clone(),
+            contract_path: contract_path.to_string(),
+            contract_digest: "digest".to_string(),
+            implementation_kind: ImplementationKind::Executable,
+            artifact_ref: "artifact:content.comments.create-comment-draft:1.0.0".to_string(),
+            registered_at: "2026-03-27T00:00:00Z".to_string(),
+            provenance: RegistryProvenance {
+                source: "test".to_string(),
+                author: "Enrico Piovesan".to_string(),
+                created_at: "2026-03-27T00:00:00Z".to_string(),
+            },
+            evidence: RegistrationEvidence {
+                evidence_id: "evidence".to_string(),
+                artifact_ref: "artifact:content.comments.create-comment-draft:1.0.0".to_string(),
+                capability_id: contract.id.clone(),
+                capability_version: contract.version.clone(),
+                scope: RegistryScope::Private,
+                governing_spec: "030-security-identity-model".to_string(),
+                validator_version: "0.1.0".to_string(),
+                produced_at: "2026-03-27T00:00:00Z".to_string(),
+                result: RegistrationResult::Passed,
+            },
+        };
+        let artifact = CapabilityArtifactRecord {
+            artifact_ref: "artifact:content.comments.create-comment-draft:1.0.0".to_string(),
+            implementation_kind: ImplementationKind::Executable,
+            source: SourceReference {
+                kind: source_kind,
+                location: "https://github.com/traverse-framework/traverse".to_string(),
+            },
+            binary,
+            workflow_ref: None,
+            digests: ArtifactDigests {
+                source_digest: "src-digest".to_string(),
+                binary_digest: None,
+            },
+            provenance: RegistryProvenance {
+                source: "test".to_string(),
+                author: "Enrico Piovesan".to_string(),
+                created_at: "2026-03-27T00:00:00Z".to_string(),
+            },
+        };
+        let index_entry = DiscoveryIndexEntry {
+            scope: RegistryScope::Private,
+            id: contract.id.clone(),
+            version: contract.version.clone(),
+            lifecycle: Lifecycle::Active,
+            owner,
+            summary: "Create a comment draft for a resource".to_string(),
+            tags: Vec::new(),
+            permissions: Vec::new(),
+            emits: Vec::new(),
+            consumes: Vec::new(),
+            implementation_kind: ImplementationKind::Executable,
+            composability: ComposabilityMetadata {
+                kind: CompositionKind::Atomic,
+                patterns: vec![CompositionPattern::Sequential],
+                provides: Vec::new(),
+                requires: Vec::new(),
+            },
+            artifact_ref: "artifact:content.comments.create-comment-draft:1.0.0".to_string(),
+            registered_at: "2026-03-27T00:00:00Z".to_string(),
+        };
+        ResolvedCapability {
+            contract,
+            record,
+            artifact,
+            index_entry,
+        }
+    }
+
+    fn signed_binary(bytes: &[u8]) -> BinaryReference {
+        let signing_key = SigningKey::from_bytes(&[9_u8; 32]);
+        let signature = signing_key.sign(bytes);
+        BinaryReference {
+            format: BinaryFormat::Wasm,
+            location: "unused.wasm".to_string(),
+            signature: Some(ArtifactSignature {
+                scheme: ArtifactSignatureScheme::Ed25519,
+                public_key_hex: Some(hex_encode(signing_key.verifying_key().as_bytes())),
+                signature_hex: Some(hex_encode(&signature.to_bytes())),
+                sigstore_bundle_ref: None,
+            }),
+        }
+    }
+
+    fn unsigned_binary() -> BinaryReference {
+        BinaryReference {
+            format: BinaryFormat::Wasm,
+            location: "unused.wasm".to_string(),
+            signature: None,
+        }
+    }
+
+    fn hex_encode(bytes: &[u8]) -> String {
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for byte in bytes {
+            out.push(char::from(HEX_TABLE[(byte >> 4) as usize]));
+            out.push(char::from(HEX_TABLE[(byte & 0x0f) as usize]));
+        }
+        out
+    }
+
+    // ------------------------------------------------------------------
+    // artifact_trust_level classification (spec 030 FR-007/FR-008)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn local_source_is_always_local_dev_regardless_of_contract_path() {
+        let capability = test_capability(
+            "contracts/approved/comment-draft.json",
+            SourceKind::Local,
+            None,
+        );
+        assert_eq!(
+            artifact_trust_level(&capability),
+            ArtifactTrustLevel::LocalDev
+        );
+    }
+
+    #[test]
+    fn contract_under_contracts_directory_is_published_governed() {
+        let capability = test_capability(
+            "contracts/approved/comment-draft.json",
+            SourceKind::Git,
+            None,
+        );
+        assert_eq!(
+            artifact_trust_level(&capability),
+            ArtifactTrustLevel::PublishedGoverned
+        );
+    }
+
+    #[test]
+    fn contract_outside_any_governed_path_is_local_dev() {
+        let capability = test_capability(
+            "workspaces/ws-test/registry/private/comment-draft@1.0.0/contract.json",
+            SourceKind::Git,
+            None,
+        );
+        assert_eq!(
+            artifact_trust_level(&capability),
+            ArtifactTrustLevel::LocalDev
+        );
+    }
+
+    #[test]
+    fn path_containing_specs_substring_outside_a_governed_prefix_is_not_governed() {
+        // Regression guard: the old heuristic treated any path containing
+        // "/specs/" anywhere as governed. A workspace-local path that merely
+        // has a "specs" segment must not spoof governed trust.
+        let capability = test_capability("my-app/specs/comment-draft.json", SourceKind::Git, None);
+        assert_eq!(
+            artifact_trust_level(&capability),
+            ArtifactTrustLevel::LocalDev
+        );
+    }
+
+    #[test]
+    fn approved_keyword_in_url_and_path_no_longer_spoofs_governed_trust() {
+        // Regression guard: the old heuristic granted governed trust to any
+        // Git+https source whose contract path merely contained the word
+        // "approved", regardless of whether it was actually registry-governed.
+        let mut capability = test_capability(
+            "workspaces/ws-test/approved/comment-draft.json",
+            SourceKind::Git,
+            None,
+        );
+        capability.artifact.source.location = "https://example.com/not-governed".to_string();
+        assert_eq!(
+            artifact_trust_level(&capability),
+            ArtifactTrustLevel::LocalDev
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // verify_artifact end-to-end trust enforcement
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn published_governed_unsigned_artifact_is_rejected_even_in_development_mode() {
+        let capability = test_capability(
+            "contracts/approved/comment-draft.json",
+            SourceKind::Git,
+            Some(unsigned_binary()),
+        );
+        let result = verify_artifact(&capability, b"bytes", &RuntimeSecurityConfig::development());
+        assert!(matches!(
+            result,
+            Err(ArtifactVerificationFailure::MissingSignature(_))
+        ));
+    }
+
+    #[test]
+    fn published_governed_signed_artifact_with_matching_checksum_verifies() {
+        let bytes = b"wasm-bytes";
+        let mut capability = test_capability(
+            "contracts/approved/comment-draft.json",
+            SourceKind::Git,
+            Some(signed_binary(bytes)),
+        );
+        capability.artifact.digests.binary_digest = Some(format!("sha256:{}", sha256_hex(bytes)));
+        let result = verify_artifact(&capability, bytes, &RuntimeSecurityConfig::production());
+        let record = result.expect("signed governed artifact with matching checksum must verify");
+        assert_eq!(record.status, ArtifactVerificationStatus::Verified);
+        assert_eq!(record.trust_level, ArtifactTrustLevel::PublishedGoverned);
+    }
+
+    #[test]
+    fn local_dev_unsigned_artifact_warns_in_development_mode() {
+        let capability = test_capability(
+            "workspaces/ws-test/registry/private/comment-draft@1.0.0/contract.json",
+            SourceKind::Local,
+            Some(unsigned_binary()),
+        );
+        let result = verify_artifact(&capability, b"bytes", &RuntimeSecurityConfig::development());
+        let record =
+            result.expect("unsigned local artifact must be allowed-but-warned in dev mode");
+        assert_eq!(record.status, ArtifactVerificationStatus::Warning);
+        assert_eq!(record.trust_level, ArtifactTrustLevel::LocalDev);
+        assert_eq!(
+            record.warning_code.as_deref(),
+            Some("unsigned_local_dev_artifact")
+        );
+    }
+
+    #[test]
+    fn local_dev_unsigned_artifact_is_rejected_in_production_mode() {
+        let capability = test_capability(
+            "workspaces/ws-test/registry/private/comment-draft@1.0.0/contract.json",
+            SourceKind::Local,
+            Some(unsigned_binary()),
+        );
+        let result = verify_artifact(&capability, b"bytes", &RuntimeSecurityConfig::production());
+        assert!(matches!(
+            result,
+            Err(ArtifactVerificationFailure::MissingSignature(_))
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

- `artifact_trust_level()` decided "Published/Governed" vs "LocalDev" trust by string-matching the registrant-supplied `contract_path` (prefix/substring checks for `"contracts/"`, `"specs/"`, or a Git+https URL containing the word `"approved"`). All of that is attacker/registrant-controlled, so a crafted `contract_path` could spoof governed trust either way — bypassing the stricter signature/checksum enforcement FR-007 requires for governed artifacts, or evading classification entirely.
- Replaced it with a lookup against the same governed-path data CI already treats as authoritative: every path each approved spec declares in its `governs` list in `specs/governance/approved-specs.json` (spec 030 FR-008 — this list already includes `contracts/` itself, so no separate special case is needed).
- Added `is_governed_artifact_path()` in `traverse-registry` (alongside the existing approved-spec-id lookup it mirrors), and `traverse-runtime`'s `artifact_trust_level()` now calls it instead of pattern-matching.
- `SourceKind::Local` remains a hard short-circuit to `LocalDev` — it's a structured provenance field set at registration time (e.g. the canonical bundled example capabilities), not a path heuristic, so it's out of scope for this fix.
- `security.rs` previously had zero tests; added a test module covering governed vs local-dev classification, the two regression cases the old heuristic was vulnerable to (an unrelated `"specs"` path segment, and the `"approved"` URL/path keyword trick), and `verify_artifact` enforcement in both directions (dev-mode warning vs production rejection).

## Governing Spec

- 030-security-identity-model
- 005-capability-registry

## Project Item

Closes #596

## Validation

- `cargo test -p traverse-runtime` — all tests pass, including 9 new tests in `security.rs` (previously untested).
- `cargo test --workspace` — all tests pass, no regressions in existing governed-artifact fixtures (`contracts/approved/...` still classifies `PublishedGoverned`).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `bash scripts/ci/spec_alignment_check.sh` — passes locally against this branch.
- No `unwrap()`, `expect()` (outside `#[cfg(test)]`), `panic!()`, `todo!()`, or `unsafe` introduced.
