### PR TITLE
ci: enforce coverage floors for CLI and MCP

### DIFF
--- a/ci/coverage-targets.txt
+++ b/ci/coverage-targets.txt
@@ -8,3 +8,5 @@
 traverse-contracts 100
 traverse-registry 100
 traverse-runtime 100
+traverse-cli 78
+traverse-mcp 84

--- a/ci/coverage-targets.txt
+++ b/ci/coverage-targets.txt
@@ -9,4 +9,4 @@ traverse-contracts 100
 traverse-registry 100
 traverse-runtime 100
 traverse-cli 78
-traverse-mcp 84
+traverse-mcp 86

--- a/docs/quality-standards.md
+++ b/docs/quality-standards.md
@@ -17,6 +17,22 @@ Coverage gate implementation, specific to this repo's crates:
 - protected crate list: `ci/coverage-targets.txt`
 
 The coverage gate is merge-safe even before core logic exists. It passes when no protected crates are configured, and becomes enforcing as soon as core crates are added to `ci/coverage-targets.txt`.
+The gate runs crate tests with `--test-threads=1` so coverage instrumentation is
+measured against deterministic package-local state.
+
+### Phased Coverage Floors
+
+The constitution target for core logic remains 100% line coverage. When a crate
+is added to the gate below 100%, the configured value is a ratchet floor: future
+changes must not reduce coverage, and follow-up work must raise the crate toward
+the full target.
+
+Current phased floors:
+
+| Crate | Gate floor | Measured baseline | Follow-up |
+|---|---:|---:|---|
+| `traverse-cli` | 78% | 78.77% | [#618](https://github.com/traverse-framework/traverse/issues/618) |
+| `traverse-mcp` | 84% | 84.87% | [#617](https://github.com/traverse-framework/traverse/issues/617) |
 
 ## Nightly CI Gate
 

--- a/docs/quality-standards.md
+++ b/docs/quality-standards.md
@@ -32,7 +32,7 @@ Current phased floors:
 | Crate | Gate floor | Measured baseline | Follow-up |
 |---|---:|---:|---|
 | `traverse-cli` | 78% | 78.77% | [#618](https://github.com/traverse-framework/traverse/issues/618) |
-| `traverse-mcp` | 84% | 84.87% | [#617](https://github.com/traverse-framework/traverse/issues/617) |
+| `traverse-mcp` | 86% | 86.07% | [#617](https://github.com/traverse-framework/traverse/issues/617) |
 
 ## Nightly CI Gate
 

--- a/scripts/ci/coverage_gate.sh
+++ b/scripts/ci/coverage_gate.sh
@@ -37,7 +37,7 @@ for entry in "${targets[@]}"; do
   fi
 
   echo "Measuring line coverage for ${crate_name} with threshold ${minimum_percent}%"
-  coverage_output="$(cargo llvm-cov --package "${crate_name}" --lcov)"
+  coverage_output="$(cargo llvm-cov --package "${crate_name}" --lcov -- --test-threads=1)"
   line_counts="$(
     awk -F '[:,]' '
       /^SF:/ { current_file = substr($0, 4); next }


### PR DESCRIPTION
## Summary

- Add `traverse-cli` and `traverse-mcp` to the protected coverage gate target list.
- Document phased ratchet floors with measured baselines and follow-up issues to raise both crates to the constitution's 100% core-logic target.
- Run package coverage tests serially in the gate so instrumented tests use deterministic package-local state.

## Governing Spec

- `001-foundation-v0-1`
- `004-spec-alignment-gate`

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `PATH="/opt/homebrew/opt/rustup/bin:$HOME/.cargo/bin:$PATH" bash scripts/ci/coverage_gate.sh`
- `bash scripts/ci/repository_checks.sh`

## Coverage Baselines

- `traverse-cli`: 78.77% line coverage, gated at 78%, follow-up #618 raises toward 100%.
- `traverse-mcp`: 86.07% line coverage, gated at 86%, follow-up #617 raises toward 100%.
- Existing protected crates remain at 100%: `traverse-contracts`, `traverse-registry`, and `traverse-runtime`.

Closes #594.
