### PR TITLE
Raise traverse-mcp line coverage from 86% to 98.55%

### DIFF
--- a/ci/coverage-targets.txt
+++ b/ci/coverage-targets.txt
@@ -9,4 +9,4 @@ traverse-contracts 100
 traverse-registry 100
 traverse-runtime 100
 traverse-cli 78
-traverse-mcp 86
+traverse-mcp 98

--- a/crates/traverse-mcp/src/lib.rs
+++ b/crates/traverse-mcp/src/lib.rs
@@ -544,7 +544,6 @@ fn lifecycle_name(lifecycle: &traverse_contracts::Lifecycle) -> &'static str {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]
-    #![allow(clippy::panic)]
 
     use super::*;
     use serde_json::{Value, json};
@@ -610,34 +609,150 @@ mod tests {
             &runtime,
         );
 
-        let capability = match mcp.get_capability(
-            McpLookupScope::PreferPrivate,
-            "content.comments.create-comment-draft",
-            "1.0.0",
-        ) {
-            Ok(capability) => capability,
-            Err(error) => panic!("capability should resolve: {error:?}"),
-        };
-        let event = match mcp.get_event(
-            McpLookupScope::PreferPrivate,
-            "content.comments.draft-created",
-            "1.0.0",
-        ) {
-            Ok(event) => event,
-            Err(error) => panic!("event should resolve: {error:?}"),
-        };
-        let workflow = match mcp.get_workflow(
-            McpLookupScope::PreferPrivate,
-            "content.comments.publish-comment",
-            "1.0.0",
-        ) {
-            Ok(workflow) => workflow,
-            Err(error) => panic!("workflow should resolve: {error:?}"),
-        };
+        let capability = mcp
+            .get_capability(
+                McpLookupScope::PreferPrivate,
+                "content.comments.create-comment-draft",
+                "1.0.0",
+            )
+            .expect("capability should resolve");
+        let event = mcp
+            .get_event(
+                McpLookupScope::PreferPrivate,
+                "content.comments.draft-created",
+                "1.0.0",
+            )
+            .expect("event should resolve");
+        let workflow = mcp
+            .get_workflow(
+                McpLookupScope::PreferPrivate,
+                "content.comments.publish-comment",
+                "1.0.0",
+            )
+            .expect("workflow should resolve");
 
         assert!(matches!(capability, McpArtifactDetail::Capability(_)));
         assert!(matches!(event, McpArtifactDetail::Event(_)));
         assert!(matches!(workflow, McpArtifactDetail::Workflow(_)));
+    }
+
+    #[test]
+    fn get_capability_event_workflow_report_not_found_for_missing_ids() {
+        let capability_registry = capability_registry_fixture();
+        let event_registry = event_registry_fixture();
+        let workflow_registry = workflow_registry_fixture(&capability_registry);
+        let runtime = runtime_fixture(&capability_registry, &workflow_registry);
+        let mcp = TraverseMcp::new(
+            &capability_registry,
+            &event_registry,
+            &workflow_registry,
+            &runtime,
+        );
+
+        let capability_error = mcp
+            .get_capability(McpLookupScope::PreferPrivate, "unknown.capability", "1.0.0")
+            .expect_err("unknown capability must not resolve");
+        assert_eq!(capability_error.code, McpErrorCode::NotFound);
+        assert!(capability_error.message.contains("capability"));
+
+        let event_error = mcp
+            .get_event(McpLookupScope::PreferPrivate, "unknown.event", "1.0.0")
+            .expect_err("unknown event must not resolve");
+        assert_eq!(event_error.code, McpErrorCode::NotFound);
+        assert!(event_error.message.contains("event"));
+
+        let workflow_error = mcp
+            .get_workflow(McpLookupScope::PreferPrivate, "unknown.workflow", "1.0.0")
+            .expect_err("unknown workflow must not resolve");
+        assert_eq!(workflow_error.code, McpErrorCode::NotFound);
+        assert!(workflow_error.message.contains("workflow"));
+    }
+
+    #[test]
+    fn lifecycle_name_covers_every_variant() {
+        assert_eq!(lifecycle_name(&Lifecycle::Draft), "draft");
+        assert_eq!(lifecycle_name(&Lifecycle::Active), "active");
+        assert_eq!(lifecycle_name(&Lifecycle::Deprecated), "deprecated");
+        assert_eq!(lifecycle_name(&Lifecycle::Retired), "retired");
+        assert_eq!(lifecycle_name(&Lifecycle::Archived), "archived");
+    }
+
+    #[test]
+    fn map_runtime_error_covers_every_runtime_error_code() {
+        use traverse_runtime::RuntimeErrorCode;
+
+        let cases = [
+            (
+                RuntimeErrorCode::RequestInvalid,
+                McpErrorCode::InvalidRequest,
+            ),
+            (RuntimeErrorCode::CapabilityNotFound, McpErrorCode::NotFound),
+            (RuntimeErrorCode::ArtifactMissing, McpErrorCode::NotFound),
+            (
+                RuntimeErrorCode::CapabilityAmbiguous,
+                McpErrorCode::AmbiguousMatch,
+            ),
+            (
+                RuntimeErrorCode::CapabilityNotRunnable,
+                McpErrorCode::ValidationFailed,
+            ),
+            (
+                RuntimeErrorCode::PlacementUnsupported,
+                McpErrorCode::ValidationFailed,
+            ),
+            (
+                RuntimeErrorCode::OutputValidationFailed,
+                McpErrorCode::ValidationFailed,
+            ),
+            (
+                RuntimeErrorCode::ContractViolation,
+                McpErrorCode::ValidationFailed,
+            ),
+            (
+                RuntimeErrorCode::ExecutionFailed,
+                McpErrorCode::ExecutionFailed,
+            ),
+        ];
+
+        for (runtime_code, expected_mcp_code) in cases {
+            let error = map_runtime_error(runtime_code, "boom");
+            assert_eq!(error.code, expected_mcp_code);
+            assert_eq!(error.message, "boom");
+        }
+    }
+
+    #[test]
+    fn not_found_formats_kind_id_and_version() {
+        let error = not_found("widget", "widget.example", "2.0.0");
+        assert_eq!(error.code, McpErrorCode::NotFound);
+        assert_eq!(error.message, "widget widget.example@2.0.0 was not found");
+    }
+
+    #[test]
+    fn mcp_tool_registry_default_and_debug() {
+        let registry = McpToolRegistry::default();
+        assert_eq!(registry.dispatch("missing", json!({})), None);
+        let rendered = format!("{registry:?}");
+        assert!(rendered.contains("McpToolRegistry"));
+        assert!(rendered.contains("tool_count"));
+    }
+
+    #[test]
+    fn observe_execution_matches_execute_observation_messages() {
+        let capability_registry = capability_registry_fixture();
+        let event_registry = event_registry_fixture();
+        let workflow_registry = workflow_registry_fixture(&capability_registry);
+        let runtime = runtime_fixture(&capability_registry, &workflow_registry);
+        let mcp = TraverseMcp::new(
+            &capability_registry,
+            &event_registry,
+            &workflow_registry,
+            &runtime,
+        );
+
+        let outcome = runtime.execute(runtime_request());
+        let messages = mcp.observe_execution(&outcome);
+        assert!(!messages.is_empty());
     }
 
     #[test]
@@ -653,10 +768,9 @@ mod tests {
             &runtime,
         );
 
-        let response = match mcp.execute(runtime_request()) {
-            Ok(response) => response,
-            Err(error) => panic!("execution should pass: {error:?}"),
-        };
+        let response = mcp
+            .execute(runtime_request())
+            .expect("execution should pass");
 
         assert_eq!(response.result.status, RuntimeResultStatus::Completed);
         assert_eq!(
@@ -703,9 +817,9 @@ mod tests {
             allow_ambiguity: true,
         };
 
-        let Err(error) = mcp.execute(request) else {
-            panic!("invalid request should fail");
-        };
+        let error = mcp
+            .execute(request)
+            .expect_err("invalid request should fail");
 
         assert_eq!(error.code, McpErrorCode::InvalidRequest);
     }
@@ -749,20 +863,18 @@ mod tests {
         assert_eq!(discovered[0].scope, McpRegistryScope::Public);
         assert_eq!(discovered[0].id, "content.comments.create-comment-draft");
 
-        let capability = match mcp.get_capability(
-            McpLookupScope::PublicOnly,
-            "content.comments.create-comment-draft",
-            "1.0.0",
-        ) {
-            Ok(capability) => capability,
-            Err(error) => panic!("public capability should resolve: {error:?}"),
-        };
+        let capability = mcp
+            .get_capability(
+                McpLookupScope::PublicOnly,
+                "content.comments.create-comment-draft",
+                "1.0.0",
+            )
+            .expect("public capability should resolve");
         assert!(matches!(capability, McpArtifactDetail::Capability(_)));
 
-        let response = match mcp.execute(runtime_request()) {
-            Ok(response) => response,
-            Err(error) => panic!("execution should pass: {error:?}"),
-        };
+        let response = mcp
+            .execute(runtime_request())
+            .expect("execution should pass");
         assert_eq!(response.result.status, RuntimeResultStatus::Completed);
         assert_eq!(
             response.observation_messages.first(),

--- a/crates/traverse-mcp/src/main.rs
+++ b/crates/traverse-mcp/src/main.rs
@@ -2,7 +2,13 @@ use std::process::ExitCode;
 use traverse_mcp::run_stdio_server;
 
 fn main() -> ExitCode {
-    let mut args = std::env::args().skip(1);
+    run(std::env::args().skip(1))
+}
+
+/// Testable core of [`main`]: takes the argument iterator directly instead of
+/// reading `std::env::args()` so the CLI parsing branches can be exercised
+/// without spawning a subprocess.
+fn run(mut args: impl Iterator<Item = String>) -> ExitCode {
     let Some(command) = args.next() else {
         eprintln!("Usage: traverse-mcp stdio [--simulate-startup-failure]");
         return ExitCode::from(1);
@@ -20,5 +26,32 @@ fn main() -> ExitCode {
             eprintln!("traverse-mcp stdio server failed: {error:?}");
             ExitCode::from(1)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_command_prints_usage_and_exits_with_failure() {
+        assert_eq!(run(std::iter::empty()), ExitCode::from(1));
+    }
+
+    #[test]
+    fn unsupported_command_exits_with_failure() {
+        assert_eq!(run(["bogus".to_string()].into_iter()), ExitCode::from(1));
+    }
+
+    #[test]
+    fn stdio_command_with_simulated_startup_failure_exits_with_failure() {
+        assert_eq!(
+            run([
+                "stdio".to_string(),
+                "--simulate-startup-failure".to_string()
+            ]
+            .into_iter()),
+            ExitCode::from(1)
+        );
     }
 }

--- a/crates/traverse-mcp/src/stdio_server.rs
+++ b/crates/traverse-mcp/src/stdio_server.rs
@@ -108,7 +108,14 @@ impl StdioAuthConfig {
 
     #[must_use]
     pub fn from_env() -> Self {
-        match std::env::var("TRAVERSE_MCP_STDIO_BEARER_TOKEN") {
+        Self::from_env_var(std::env::var("TRAVERSE_MCP_STDIO_BEARER_TOKEN"))
+    }
+
+    /// Testable core of [`Self::from_env`]: takes the lookup result directly
+    /// instead of reading the process environment, since mutating env vars
+    /// from a test is `unsafe` and this workspace forbids `unsafe` entirely.
+    fn from_env_var(token: Result<String, std::env::VarError>) -> Self {
+        match token {
             Ok(token) if !token.is_empty() => Self::bearer_required(token),
             _ => Self::local_trust(),
         }
@@ -1722,7 +1729,7 @@ impl std::error::Error for StdioServerFailure {}
 
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::panic)]
+    #![allow(clippy::expect_used)]
 
     use super::*;
 
@@ -1750,10 +1757,7 @@ mod tests {
                 .is_ok()
         );
 
-        let output = match String::from_utf8(stdout) {
-            Ok(output) => output,
-            Err(error) => panic!("stdout is not valid UTF-8: {error}"),
-        };
+        let output = String::from_utf8(stdout).expect("stdout must be valid UTF-8");
         assert!(output.contains("\"kind\":\"mcp_stdio_server_startup\""));
         assert!(output.contains("\"kind\":\"mcp_stdio_server_description\""));
         assert!(output.contains("\"kind\":\"mcp_stdio_server_content_group_list\""));
@@ -1830,10 +1834,8 @@ mod tests {
     }
 
     fn build_test_server() -> TraverseMcpStdioServer<'static, ExpeditionExampleExecutor> {
-        let execution = match CanonicalExecutionContext::load_canonical() {
-            Ok(execution) => execution,
-            Err(error) => panic!("failed to load canonical execution context: {error:?}"),
-        };
+        let execution = CanonicalExecutionContext::load_canonical()
+            .expect("failed to load canonical execution context");
         let capability_registry = Box::leak(Box::new(CapabilityRegistry::new()));
         let event_registry = Box::leak(Box::new(EventRegistry::new()));
         let workflow_registry = Box::leak(Box::new(WorkflowRegistry::new()));
@@ -1847,10 +1849,482 @@ mod tests {
             workflow_registry,
             runtime,
         )));
-        let catalog = Box::leak(Box::new(match McpDiscoveryCatalog::load_canonical() {
-            Ok(catalog) => catalog,
-            Err(error) => panic!("failed to load canonical discovery catalog: {error:?}"),
-        }));
+        let catalog = Box::leak(Box::new(
+            McpDiscoveryCatalog::load_canonical()
+                .expect("failed to load canonical discovery catalog"),
+        ));
         TraverseMcpStdioServer::new(mcp, catalog)
+    }
+
+    const PLAN_EXPEDITION_REQUEST_PATH: &str =
+        "examples/expedition/runtime-requests/plan-expedition.json";
+
+    #[test]
+    fn stdio_auth_config_debug_redacts_bearer_token_and_shows_local_trust() {
+        let local = format!("{:?}", StdioAuthConfig::local_trust());
+        assert!(local.contains("local_trust"));
+
+        let bearer = format!("{:?}", StdioAuthConfig::bearer_required("super-secret"));
+        assert!(bearer.contains("bearer_required"));
+        assert!(bearer.contains("<redacted>"));
+        assert!(!bearer.contains("super-secret"));
+    }
+
+    #[test]
+    fn stdio_auth_config_from_env_reads_bearer_token_or_falls_back_to_local_trust() {
+        assert_eq!(
+            StdioAuthConfig::from_env_var(Ok("env-token".to_string())).mode_name(),
+            "bearer_required"
+        );
+        assert_eq!(
+            StdioAuthConfig::from_env_var(Err(std::env::VarError::NotPresent)).mode_name(),
+            "local_trust"
+        );
+        assert_eq!(
+            StdioAuthConfig::from_env_var(Ok(String::new())).mode_name(),
+            "local_trust"
+        );
+    }
+
+    #[test]
+    fn stdio_auth_config_from_env_reads_real_process_environment() {
+        // Exercises StdioAuthConfig::from_env's own body (it just delegates
+        // to from_env_var, which the test above covers exhaustively); this
+        // process normally has no TRAVERSE_MCP_STDIO_BEARER_TOKEN set, so it
+        // falls back to local trust.
+        let _ = StdioAuthConfig::from_env();
+    }
+
+    #[test]
+    fn stdio_server_failure_display_formats_code_and_message() {
+        let failure = StdioServerFailure::new("some_code", "some message");
+        assert_eq!(format!("{failure}"), "some_code: some message");
+    }
+
+    #[test]
+    fn describe_entrypoint_envelope_resolves_capability_kind() {
+        let server = build_test_server();
+        let envelope = server
+            .describe_entrypoint_envelope(
+                "capability",
+                "expedition.planning.capture-expedition-objective",
+                "1.0.0",
+            )
+            .expect("known capability entrypoint must resolve");
+        assert_eq!(
+            envelope["kind"],
+            json!("mcp_stdio_server_entrypoint_description")
+        );
+        assert_eq!(envelope["entrypoint"]["artifact_kind"], json!("capability"));
+    }
+
+    #[test]
+    fn describe_entrypoint_envelope_rejects_unsupported_kind() {
+        let server = build_test_server();
+        let error = server
+            .describe_entrypoint_envelope("bogus", "id", "1.0.0")
+            .expect_err("unsupported entrypoint kind must be rejected");
+        assert_eq!(error.code, "invalid_request");
+    }
+
+    #[test]
+    fn describe_content_group_envelope_reports_not_found_for_unknown_group() {
+        let server = build_test_server();
+        let error = server
+            .describe_content_group_envelope("unknown-content-group")
+            .expect_err("unknown content group must not resolve");
+        assert_eq!(error.code, "not_found");
+    }
+
+    #[test]
+    fn entrypoint_artifacts_requires_kind_id_version_and_request_path() {
+        let server = build_test_server();
+
+        let missing_kind =
+            parse_command(r#"{"command":"validate_entrypoint"}"#).expect("command must parse");
+        assert!(server.entrypoint_artifacts(&missing_kind).is_err());
+
+        let missing_id =
+            parse_command(r#"{"command":"validate_entrypoint","entrypoint_kind":"workflow"}"#)
+                .expect("command must parse");
+        assert!(server.entrypoint_artifacts(&missing_id).is_err());
+
+        let missing_version = parse_command(
+            r#"{"command":"validate_entrypoint","entrypoint_kind":"workflow","id":"expedition.planning.plan-expedition"}"#,
+        )
+        .expect("command must parse");
+        assert!(server.entrypoint_artifacts(&missing_version).is_err());
+
+        let missing_request_path = parse_command(
+            r#"{"command":"validate_entrypoint","entrypoint_kind":"workflow","id":"expedition.planning.plan-expedition","version":"1.0.0"}"#,
+        )
+        .expect("command must parse");
+        assert!(server.entrypoint_artifacts(&missing_request_path).is_err());
+    }
+
+    #[test]
+    fn validate_runtime_request_covers_capability_and_workflow_branches() {
+        let server = build_test_server();
+        let mut request = load_runtime_request(PLAN_EXPEDITION_REQUEST_PATH)
+            .expect("plan-expedition fixture must load");
+
+        // Capability kind: missing capability_id / capability_version.
+        request.intent.capability_id = None;
+        assert!(
+            server
+                .validate_runtime_request("capability", "any.id", "1.0.0", &request)
+                .is_err()
+        );
+        request.intent.capability_id = Some("expedition.planning.plan-expedition".to_string());
+        request.intent.capability_version = None;
+        assert!(
+            server
+                .validate_runtime_request("capability", "any.id", "1.0.0", &request)
+                .is_err()
+        );
+        request.intent.capability_version = Some("1.0.0".to_string());
+        assert!(
+            server
+                .validate_runtime_request("capability", "different.id", "1.0.0", &request)
+                .is_err()
+        );
+
+        // Workflow kind: missing capability_id / capability_version, unknown
+        // workflow, and target mismatch.
+        request.intent.capability_id = None;
+        assert!(
+            server
+                .validate_runtime_request(
+                    "workflow",
+                    "expedition.planning.plan-expedition",
+                    "1.0.0",
+                    &request
+                )
+                .is_err()
+        );
+        request.intent.capability_id = Some("expedition.planning.plan-expedition".to_string());
+        request.intent.capability_version = None;
+        assert!(
+            server
+                .validate_runtime_request(
+                    "workflow",
+                    "expedition.planning.plan-expedition",
+                    "1.0.0",
+                    &request
+                )
+                .is_err()
+        );
+        request.intent.capability_version = Some("1.0.0".to_string());
+        assert!(
+            server
+                .validate_runtime_request("workflow", "unknown.workflow", "9.9.9", &request)
+                .is_err()
+        );
+        // Workflow resolves by id/version, but the request's own intent target
+        // does not match it.
+        request.intent.capability_id = Some("different.workflow".to_string());
+        assert!(
+            server
+                .validate_runtime_request(
+                    "workflow",
+                    "expedition.planning.plan-expedition",
+                    "1.0.0",
+                    &request
+                )
+                .is_err()
+        );
+        request.intent.capability_id = Some("expedition.planning.plan-expedition".to_string());
+        assert!(
+            server
+                .validate_runtime_request(
+                    "workflow",
+                    "expedition.planning.plan-expedition",
+                    "1.0.0",
+                    &request
+                )
+                .is_ok()
+        );
+
+        // Unsupported entrypoint_kind.
+        assert!(
+            server
+                .validate_runtime_request(
+                    "bogus",
+                    "expedition.planning.plan-expedition",
+                    "1.0.0",
+                    &request
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn missing_content_group_id_and_entrypoint_fields_are_rejected_over_stdio() {
+        let server = build_test_server();
+
+        let cases: [&[u8]; 4] = [
+            b"{\"command\":\"describe_content_group\"}\n",
+            b"{\"command\":\"describe_entrypoint\"}\n",
+            b"{\"command\":\"describe_entrypoint\",\"entrypoint_kind\":\"workflow\"}\n",
+            b"{\"command\":\"describe_entrypoint\",\"entrypoint_kind\":\"workflow\",\"id\":\"expedition.planning.plan-expedition\"}\n",
+        ];
+        for case in cases {
+            let mut stdout = Vec::new();
+            let mut stderr = Vec::new();
+            let result =
+                server.run_stdio(std::io::Cursor::new(case), &mut stdout, &mut stderr, false);
+            assert!(result.is_err(), "expected rejection for {case:?}");
+        }
+    }
+
+    #[test]
+    fn run_stdio_server_reports_simulated_startup_failure() {
+        let result = run_stdio_server(true);
+        assert!(result.is_err());
+    }
+
+    /// Writer that fails exactly once, on the `target`-th time it is asked to
+    /// write a lone `\n` byte. `write_json_line` always ends an envelope with
+    /// a dedicated `write_all(b"\n")` call, so counting those calls lets a
+    /// test target one specific envelope write (and its `io_error` branch)
+    /// without depending on how many raw `write` calls the JSON body itself
+    /// takes.
+    struct FailOnNthNewline {
+        target: usize,
+        seen: std::cell::Cell<usize>,
+    }
+
+    impl Write for FailOnNthNewline {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if buf == b"\n" {
+                let index = self.seen.get();
+                self.seen.set(index + 1);
+                if index == self.target {
+                    return Err(io::Error::other("simulated stdout write failure"));
+                }
+            }
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_failures_are_reported_as_io_errors_for_every_stdio_response() {
+        let server = build_test_server();
+        let session: &[u8] = br#"{"command":"describe_server"}
+{"command":"list_content_groups"}
+{"command":"describe_content_group","content_group_id":"core-runtime-example"}
+{"command":"list_entrypoints"}
+{"command":"describe_entrypoint","entrypoint_kind":"workflow","id":"expedition.planning.plan-expedition","version":"1.0.0"}
+{"command":"validate_entrypoint","entrypoint_kind":"workflow","id":"expedition.planning.plan-expedition","version":"1.0.0","request_path":"examples/expedition/runtime-requests/plan-expedition.json"}
+{"command":"execute_entrypoint","entrypoint_kind":"workflow","id":"expedition.planning.plan-expedition","version":"1.0.0","request_path":"examples/expedition/runtime-requests/plan-expedition.json"}
+{"command":"render_execution_report","entrypoint_kind":"workflow","id":"expedition.planning.plan-expedition","version":"1.0.0","request_path":"examples/expedition/runtime-requests/plan-expedition.json"}
+{"command":"shutdown"}
+"#;
+
+        // index 0 = startup envelope, 1..=9 = the nine command responses in order.
+        for target in 0..=9 {
+            let mut stdout = FailOnNthNewline {
+                target,
+                seen: std::cell::Cell::new(0),
+            };
+            let mut stderr = Vec::new();
+            let result = server.run_stdio(
+                std::io::Cursor::new(session),
+                &mut stdout,
+                &mut stderr,
+                false,
+            );
+            assert!(result.is_err(), "expected write failure at index {target}");
+        }
+    }
+
+    #[test]
+    fn write_failure_on_stdin_closed_shutdown_envelope_is_reported() {
+        let server = build_test_server();
+        let mut stdout = FailOnNthNewline {
+            target: 1,
+            seen: std::cell::Cell::new(0),
+        };
+        let mut stderr = Vec::new();
+        let result = server.run_stdio(
+            std::io::Cursor::new(b"" as &[u8]),
+            &mut stdout,
+            &mut stderr,
+            false,
+        );
+        assert!(result.is_err());
+        assert!(stdout.flush().is_ok());
+    }
+
+    #[test]
+    fn simulated_startup_failure_stderr_write_error_is_reported() {
+        let server = build_test_server();
+        let mut stdout = Vec::new();
+        let mut stderr = FailOnNthNewline {
+            target: 0,
+            seen: std::cell::Cell::new(0),
+        };
+        let result = server.run_stdio(
+            std::io::Cursor::new(b"" as &[u8]),
+            &mut stdout,
+            &mut stderr,
+            true,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn stdin_closed_shutdown_envelope_completes_successfully_without_a_shutdown_command() {
+        let server = build_test_server();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        // Blank lines between commands must be skipped, not treated as commands.
+        let input = std::io::Cursor::new(b"\n{\"command\":\"describe_server\"}\n\n" as &[u8]);
+        let result = server.run_stdio(input, &mut stdout, &mut stderr, false);
+        assert!(result.is_ok());
+        let output = String::from_utf8(stdout).expect("stdout must be valid UTF-8");
+        assert!(output.contains("\"kind\":\"mcp_stdio_server_shutdown\""));
+    }
+
+    #[test]
+    fn malformed_json_command_line_is_rejected() {
+        let server = build_test_server();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let input = std::io::Cursor::new(b"not json\n" as &[u8]);
+        let result = server.run_stdio(input, &mut stdout, &mut stderr, false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_utf8_command_line_is_reported_as_io_error() {
+        let server = build_test_server();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let input = std::io::Cursor::new(vec![0xFF, 0xFE, b'\n']);
+        let result = server.run_stdio(input, &mut stdout, &mut stderr, false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unsupported_stdio_command_is_rejected() {
+        let server = build_test_server();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let input = std::io::Cursor::new(b"{\"command\":\"bogus_command\"}\n" as &[u8]);
+        let result = server.run_stdio(input, &mut stdout, &mut stderr, false);
+        assert!(result.is_err());
+        let errors = String::from_utf8(stderr).expect("stderr must be valid UTF-8");
+        assert!(errors.contains("\"code\":\"unsupported_command\""));
+    }
+
+    #[test]
+    fn validate_and_render_execution_report_commands_report_underlying_failures() {
+        let server = build_test_server();
+
+        for command in ["validate_entrypoint", "render_execution_report"] {
+            let mut stdout = Vec::new();
+            let mut stderr = Vec::new();
+            let input = std::io::Cursor::new(
+                format!("{{\"command\":\"{command}\",\"entrypoint_kind\":\"workflow\"}}\n")
+                    .into_bytes(),
+            );
+            let result = server.run_stdio(input, &mut stdout, &mut stderr, false);
+            assert!(result.is_err(), "expected {command} to fail on missing id");
+        }
+    }
+
+    #[test]
+    fn derive_composability_metadata_requires_workflow_ref_for_workflow_kind() {
+        let capability = test_capability_bundle_artifact();
+        let error = derive_composability_metadata(ImplementationKind::Workflow, None, &capability)
+            .expect_err("workflow-backed capability without workflow_ref must be rejected");
+        assert_eq!(error.code, "invalid_request");
+    }
+
+    fn test_capability_bundle_artifact() -> traverse_registry::CapabilityBundleArtifact {
+        let server = build_test_server();
+        server.catalog.bundle.capabilities[0].clone()
+    }
+
+    #[test]
+    fn parse_workflow_ref_requires_workflow_id_and_version() {
+        let error = parse_workflow_ref(&json!({})).expect_err("missing workflow_id must fail");
+        assert_eq!(error.code, "invalid_request");
+
+        let error = parse_workflow_ref(&json!({"workflow_id": "wf"}))
+            .expect_err("missing workflow_version must fail");
+        assert_eq!(error.code, "invalid_request");
+
+        let reference =
+            parse_workflow_ref(&json!({"workflow_id": "wf", "workflow_version": "1.0.0"}))
+                .expect("fully specified workflow_ref must parse");
+        assert_eq!(reference.workflow_id, "wf");
+        assert_eq!(reference.workflow_version, "1.0.0");
+    }
+
+    #[test]
+    fn load_runtime_request_reports_missing_file_and_invalid_json() {
+        let missing = load_runtime_request("/definitely/missing/runtime-request.json")
+            .expect_err("missing file must fail");
+        assert_eq!(missing.code, "io_error");
+
+        let temp_path = std::env::temp_dir().join(format!(
+            "traverse-mcp-invalid-runtime-request-{}.json",
+            std::process::id()
+        ));
+        fs::write(&temp_path, b"not json").expect("temp file must write");
+        let invalid = load_runtime_request(&temp_path.display().to_string())
+            .expect_err("invalid JSON runtime request must fail");
+        assert_eq!(invalid.code, "invalid_request");
+        let _ = fs::remove_file(&temp_path);
+    }
+
+    #[test]
+    fn provenance_source_label_covers_every_variant() {
+        assert_eq!(
+            provenance_source_label(&traverse_contracts::ProvenanceSource::Greenfield),
+            "greenfield"
+        );
+        assert_eq!(
+            provenance_source_label(&traverse_contracts::ProvenanceSource::BrownfieldExtracted),
+            "brownfield-extracted"
+        );
+        assert_eq!(
+            provenance_source_label(&traverse_contracts::ProvenanceSource::AiGenerated),
+            "ai-generated"
+        );
+        assert_eq!(
+            provenance_source_label(&traverse_contracts::ProvenanceSource::AiAssisted),
+            "ai-assisted"
+        );
+    }
+
+    #[test]
+    fn execute_validate_team_readiness_covers_ready_and_needs_action_branches() {
+        let not_ready = execute_validate_team_readiness(&json!({
+            "objective": {"objective_id": "obj-1"},
+            "team_profile": {"equipment_ready": false}
+        }))
+        .expect("valid input must execute");
+        assert_eq!(
+            not_ready["readiness_result"]["status"],
+            json!("needs_action")
+        );
+        assert_eq!(
+            not_ready["readiness_result"]["required_actions"],
+            json!(["complete equipment verification"])
+        );
+
+        let missing_field = execute_validate_team_readiness(&json!({}))
+            .expect_err("missing objective field must fail");
+        assert_eq!(
+            missing_field.code,
+            traverse_runtime::LocalExecutionFailureCode::ExecutionFailed
+        );
     }
 }


### PR DESCRIPTION
## Summary

- #594 added `traverse-mcp` to the coverage gate with a measured phased floor (86.07%) so it couldn't regress while a larger test tranche was completed. This closes most of that gap.
- `lib.rs` 74.6%→99.9%: `not_found`/`map_runtime_error`/`lifecycle_name` exercised directly and exhaustively (every `RuntimeErrorCode` and `Lifecycle` variant), `McpToolRegistry` `Default`/`Debug`, `observe_execution`, and `get_capability`/`get_event`/`get_workflow`'s not-found paths.
- `stdio_server.rs` 74.6%→94.2%: `StdioAuthConfig`'s `Debug` impl and `from_env` (refactored into an injectable `from_env_var` core, since mutating env vars from a test is `unsafe` and this workspace forbids `unsafe` entirely); `describe_entrypoint`/`describe_content_group`/`entrypoint_artifacts`/`validate_runtime_request`'s validation branches driven directly or via crafted stdio commands; `run_stdio_server`'s own body via `simulate_startup_failure` (which returns before ever reading real stdin, so it's safe to call directly); every `write_json_line` call site's `io_error` branch, exercised with a writer that fails on the Nth `\n`-terminated envelope so each branch can be targeted individually; malformed-JSON and invalid-UTF8 command lines; unsupported commands; and several free helper functions called directly.
- `main.rs` 0%→75%: extracted a testable `run(args)` core from `main`, covering the usage/unsupported-command/simulated-failure branches.
- Converted several test-only `Err(e) => panic!(...)` match arms into single-line `.expect()`/`.expect_err()` calls: those arms are unreachable in a passing test and llvm-cov's line coverage counts the never-taken arm as a separate missed line.
- `ci/coverage-targets.txt`'s `traverse-mcp` threshold moves from 86 to 98 (measured 98.55%, kept a small margin for tooling variance, matching the convention of the original phased floors).
- Remaining gap (98.55%→100%) is registry-bundle-load failure paths with no test injection point, one genuinely unreachable executor match arm, and a `get_capability` double-lookup branch that doesn't appear reachable through the public registry API — filed as [#622](https://github.com/traverse-framework/traverse/issues/622) per the Definition of Done.

## Governing Spec

- 015-capability-discovery-mcp
- 042-mcp-library-surface

## Project Item

Closes #617

## Validation

- `cargo test --workspace` — all tests pass (47 new/updated `traverse-mcp` tests).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `bash scripts/ci/coverage_gate.sh` (with `LLVM_COV`/`LLVM_PROFDATA` pointed at brew llvm) — passes; `traverse-mcp` measured at 98.55%, threshold set to 98.
- `bash scripts/ci/spec_alignment_check.sh` — passes locally against this branch.
