### PR TITLE
docs: record blocker-resolution architecture decisions

### DIFF
--- a/docs/adr/0002-registry-contract-materialization.md
+++ b/docs/adr/0002-registry-contract-materialization.md
@@ -1,6 +1,6 @@
 # ADR-0002: Materialize Public Registrations from Verified Contract Artifacts
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-12
 
 ## Context

--- a/docs/adr/0002-registry-contract-materialization.md
+++ b/docs/adr/0002-registry-contract-materialization.md
@@ -1,0 +1,27 @@
+# ADR-0002: Materialize Public Registrations from Verified Contract Artifacts
+
+- Status: Proposed
+- Date: 2026-07-12
+
+## Context
+
+Public registry entries need enough governed material to reconstruct a valid
+local registration without bypassing contract validation.
+
+## Decision
+
+Publish separate immutable contract URL/digest fields beside artifact metadata.
+Consumers verify and cache both artifacts in a shared content-addressed cache,
+register atomically, reject local public scope, and allow private shadows with
+machine-readable evidence.
+
+## Consequences
+
+Registration performs two verified artifact reads but remains contract-first,
+offline-reusable after caching, and deterministic.
+
+## Alternatives Considered
+
+- Embed whole contracts in the index.
+- Infer contracts from component bundles.
+- Permit pending or unverified registration.

--- a/docs/adr/0003-production-artifact-routing.md
+++ b/docs/adr/0003-production-artifact-routing.md
@@ -1,0 +1,27 @@
+# ADR-0003: Route Production Artifacts Through a Runtime-Owned Router
+
+- Status: Proposed
+- Date: 2026-07-12
+
+## Context
+
+The production server currently relies on a demonstration executor while WASM
+and native execution boundaries are disconnected.
+
+## Decision
+
+Use a runtime-owned `ArtifactRouter` implementing the local execution boundary.
+It routes WASM artifacts to `WasmExecutor`, native artifacts to explicitly
+host-registered handlers, and supplies stable failure classifications. Production
+serve uses this router; the example executor is explicit-only.
+
+## Consequences
+
+Registered capabilities execute through one portable policy boundary. Arbitrary
+native paths and host-specific command execution remain prohibited.
+
+## Alternatives Considered
+
+- Host-specific routing.
+- Making only `WasmExecutor` implement the local executor boundary.
+- Retaining the demonstration executor as default.

--- a/docs/adr/0003-production-artifact-routing.md
+++ b/docs/adr/0003-production-artifact-routing.md
@@ -1,6 +1,6 @@
 # ADR-0003: Route Production Artifacts Through a Runtime-Owned Router
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-12
 
 ## Context

--- a/docs/adr/0004-offline-sigstore-verification.md
+++ b/docs/adr/0004-offline-sigstore-verification.md
@@ -1,0 +1,27 @@
+# ADR-0004: Verify Sigstore Bundles Offline with Pinned Trust Policy
+
+- Status: Proposed
+- Date: 2026-07-12
+
+## Context
+
+String-prefix provenance markers do not provide cryptographic assurance, and
+execution must remain reliable when public transparency services are unavailable.
+
+## Decision
+
+Adopt a narrow verifier interface with a production Rust Sigstore verifier.
+Artifacts carry self-contained bundles verified offline against pinned trust
+roots and explicit issuer/subject publisher policy. Ed25519 remains supported
+where existing policy permits it.
+
+## Consequences
+
+The runtime gains a reviewed supply-chain dependency and an explicit trust-root
+update process, while avoiding live network dependency on execution paths.
+
+## Alternatives Considered
+
+- Shelling out to Cosign.
+- Accepting any Sigstore identity.
+- Deferring Sigstore verification in favor of Ed25519 only.

--- a/docs/adr/0004-offline-sigstore-verification.md
+++ b/docs/adr/0004-offline-sigstore-verification.md
@@ -1,6 +1,6 @@
 # ADR-0004: Verify Sigstore Bundles Offline with Pinned Trust Policy
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-12
 
 ## Context

--- a/docs/adr/0005-durable-identity-events.md
+++ b/docs/adr/0005-durable-identity-events.md
@@ -1,0 +1,28 @@
+# ADR-0005: Emit Identity-Aware Events into a Durable Journal
+
+- Status: Proposed
+- Date: 2026-07-12
+
+## Context
+
+Event identity and replay are currently split from runtime execution and are
+limited to in-memory retention.
+
+## Decision
+
+The runtime emits events through a canonical event-sink interface, carrying
+pinned subject and optional actor identity. The first durable store is an
+append-only segmented per-workspace journal with fsync-before-acknowledgement,
+opaque persisted sequence cursors, checkpoints, and bounded retention.
+
+## Consequences
+
+Audit/replay survives restart with clear cursor-expiry behavior. The first
+release deliberately defers a database or storage-provider abstraction, with
+follow-up evaluation work required.
+
+## Alternatives Considered
+
+- Host-created events.
+- Flexible payload/actor filters in the first release.
+- SQLite or a pluggable storage layer from day one.

--- a/docs/adr/0005-durable-identity-events.md
+++ b/docs/adr/0005-durable-identity-events.md
@@ -1,6 +1,6 @@
 # ADR-0005: Emit Identity-Aware Events into a Durable Journal
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-12
 
 ## Context

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -303,3 +303,58 @@ Follow semantic versioning, keep public surfaces explicitly versioned, and requi
 ### Outcome
 
 Release readiness is auditable, and downstream users can reason about compatibility from specs, package artifacts, and release evidence.
+
+## Decision 13: Materialize Public Registrations from Verified Contract Artifacts
+
+- **Date**: 2026-07-12
+- **Status**: Proposed
+- **Governing spec**: draft `063-registry-contract-materialization`
+- **Related issues**: `#551`, `#552`
+
+### Decision
+
+Public records will publish immutable contract URL/digest metadata alongside
+artifact metadata. Consumers will verify both, cache by digest, register
+atomically, reject local `public` scope, and permit private shadows with
+machine-readable evidence.
+
+## Decision 14: Use a Runtime-Owned Production Artifact Router
+
+- **Date**: 2026-07-12
+- **Status**: Proposed
+- **Governing spec**: draft `064-production-artifact-execution`
+- **Related issue**: `#583`
+
+### Decision
+
+The runtime will route resolved WASM and explicitly host-registered native
+artifacts through one production executor boundary. The production server uses
+that router by default; the example executor is explicit-only.
+
+## Decision 15: Verify Sigstore Bundles Offline Against Pinned Trust Policy
+
+- **Date**: 2026-07-12
+- **Status**: Proposed
+- **Governing spec**: draft `065-sigstore-bundle-verification`
+- **Related issue**: `#589`
+
+### Decision
+
+Traverse will use a narrow Rust Sigstore verifier interface. Production
+verification consumes self-contained bundles offline, validates pinned trust
+roots and publisher identity, and never accepts a string-prefix placeholder as
+verification evidence.
+
+## Decision 16: Emit Identity-Aware Events into a Durable Journal
+
+- **Date**: 2026-07-12
+- **Status**: Proposed
+- **Governing spec**: draft `066-durable-identity-event-delivery`
+- **Related issues**: `#591`, `#593`
+
+### Decision
+
+The runtime will emit identity-bearing events through a canonical sink. The
+first durable store uses fsynced append-only journals, opaque persisted cursors,
+and bounded retention; future tickets will evaluate its measured limits and
+evolution path.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -307,8 +307,8 @@ Release readiness is auditable, and downstream users can reason about compatibil
 ## Decision 13: Materialize Public Registrations from Verified Contract Artifacts
 
 - **Date**: 2026-07-12
-- **Status**: Proposed
-- **Governing spec**: draft `063-registry-contract-materialization`
+- **Status**: Accepted
+- **Governing spec**: `063-registry-contract-materialization`
 - **Related issues**: `#551`, `#552`
 
 ### Decision
@@ -321,8 +321,8 @@ machine-readable evidence.
 ## Decision 14: Use a Runtime-Owned Production Artifact Router
 
 - **Date**: 2026-07-12
-- **Status**: Proposed
-- **Governing spec**: draft `064-production-artifact-execution`
+- **Status**: Accepted
+- **Governing spec**: `064-production-artifact-execution`
 - **Related issue**: `#583`
 
 ### Decision
@@ -334,8 +334,8 @@ that router by default; the example executor is explicit-only.
 ## Decision 15: Verify Sigstore Bundles Offline Against Pinned Trust Policy
 
 - **Date**: 2026-07-12
-- **Status**: Proposed
-- **Governing spec**: draft `065-sigstore-bundle-verification`
+- **Status**: Accepted
+- **Governing spec**: `065-sigstore-bundle-verification`
 - **Related issue**: `#589`
 
 ### Decision
@@ -348,8 +348,8 @@ verification evidence.
 ## Decision 16: Emit Identity-Aware Events into a Durable Journal
 
 - **Date**: 2026-07-12
-- **Status**: Proposed
-- **Governing spec**: draft `066-durable-identity-event-delivery`
+- **Status**: Accepted
+- **Governing spec**: `066-durable-identity-event-delivery`
 - **Related issues**: `#591`, `#593`
 
 ### Decision

--- a/specs/063-registry-contract-materialization/spec.md
+++ b/specs/063-registry-contract-materialization/spec.md
@@ -1,0 +1,51 @@
+# Feature Specification: Registry Contract Materialization
+
+**Spec ID**: 063
+**Status**: Draft
+**Created**: 2026-07-12
+**Input**: User-approved blocker-resolution decisions for issues #551 and #552.
+
+## Context
+
+Public registry references currently identify a binary artifact but do not make
+the governed capability contract available to a consumer. Traverse must never
+materialize an executable registration without first obtaining and validating
+its immutable contract.
+
+## Requirements
+
+- **FR-001**: Every publishable public capability record MUST include a
+  `contract_url` and SHA-256 `contract_digest`, in addition to the binary
+  artifact URL and digest.
+- **FR-002**: A registry-reference registration MUST fetch, digest-verify, and
+  validate the contract before it fetches or materializes the binary artifact.
+- **FR-003**: Verified public contracts and artifacts MUST be cached in the
+  shared content-addressed path `.traverse/cache/sha256/<digest>`.
+- **FR-004**: A cache hit MUST still verify that the cached bytes match the
+  expected digest before reuse.
+- **FR-005**: Registration MUST be atomic: contract resolution, artifact
+  retrieval, digest verification, validation, and local registry mutation MUST
+  either all succeed or leave no pending or partial workspace state.
+- **FR-006**: A local bundle declaring `scope: public` MUST be rejected with a
+  stable error directing callers to private registration or the governed
+  publication flow.
+- **FR-007**: A private registration that shadows a synced public identity MUST
+  succeed and emit machine-readable shadow evidence. `PreferPrivate` lookup
+  MUST resolve the private registration.
+- **FR-008**: Missing sync state, missing contract, digest mismatch, invalid
+  contract, unavailable artifact, and yanked-only resolution MUST each produce
+  stable actionable errors.
+
+## Out of Scope
+
+- Cache eviction and storage quotas.
+- Mirrored registries or distributed cache replication.
+- Changing approved public contract versions in place.
+
+## Verification
+
+- Tests MUST cover cache miss and hit paths, contract and artifact digest
+  mismatches, rollback on every failure phase, public-scope rejection, and
+  private-shadow evidence.
+- A compatibility test MUST prove existing `contract_path` registration remains
+  unchanged.

--- a/specs/063-registry-contract-materialization/spec.md
+++ b/specs/063-registry-contract-materialization/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Registry Contract Materialization
 
 **Spec ID**: 063
-**Status**: Draft
+**Status**: Approved
 **Created**: 2026-07-12
 **Input**: User-approved blocker-resolution decisions for issues #551 and #552.
 

--- a/specs/064-production-artifact-execution/spec.md
+++ b/specs/064-production-artifact-execution/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Production Artifact Execution Routing
 
 **Spec ID**: 064
-**Status**: Draft
+**Status**: Approved
 **Created**: 2026-07-12
 **Input**: User-approved blocker-resolution decisions for issue #583.
 

--- a/specs/064-production-artifact-execution/spec.md
+++ b/specs/064-production-artifact-execution/spec.md
@@ -1,0 +1,46 @@
+# Feature Specification: Production Artifact Execution Routing
+
+**Spec ID**: 064
+**Status**: Draft
+**Created**: 2026-07-12
+**Input**: User-approved blocker-resolution decisions for issue #583.
+
+## Context
+
+Traverse resolves registered capabilities through `LocalExecutor`, while the
+WASM executor exposes a separate capability-executor boundary. The shipped
+server must route governed registered artifacts through one portable production
+boundary rather than a demonstration executor.
+
+## Requirements
+
+- **FR-001**: The runtime MUST provide an `ArtifactRouter` that implements the
+  local execution boundary and converts resolved capabilities into executor
+  inputs.
+- **FR-002**: The router MUST dispatch WASM artifacts to `WasmExecutor` and
+  native artifacts only to explicitly host-registered native handlers.
+- **FR-003**: The router MUST NOT load arbitrary native binaries, dynamic
+  libraries, or shell commands from artifact paths.
+- **FR-004**: `traverse-cli serve` MUST use the production artifact router by
+  default.
+- **FR-005**: The demonstration executor MUST be available only through an
+  explicit `--example` mode and MUST NOT be the default execution path.
+- **FR-006**: Fuel or epoch exhaustion MUST map to `Timeout`; memory/table
+  exhaustion to `ResourceExhausted`; malformed artifact, checksum, ABI, or
+  host-import violations to `ConstraintViolated`; invalid input/output to
+  `InvalidInput`; and guest traps or host failures to `ExecutionFailed`.
+- **FR-007**: The router MUST emit trace evidence naming the selected artifact
+  type and stable failure classification without exposing host-internal errors.
+
+## Out of Scope
+
+- Dynamic native plugin loading.
+- Remote execution placement.
+- Changing WASM resource-limit defaults defined by spec 060.
+
+## Verification
+
+- End-to-end tests MUST register and execute a WASM artifact through the
+  production server path.
+- Tests MUST prove native handlers require explicit host registration and that
+  unsupported artifact types fail with the documented stable classification.

--- a/specs/065-sigstore-bundle-verification/spec.md
+++ b/specs/065-sigstore-bundle-verification/spec.md
@@ -1,0 +1,43 @@
+# Feature Specification: Sigstore Bundle Verification
+
+**Spec ID**: 065
+**Status**: Draft
+**Created**: 2026-07-12
+**Input**: User-approved blocker-resolution decisions for issue #589.
+
+## Context
+
+A `verified://` string prefix is not provenance evidence. Governed artifacts
+need real, deterministic Sigstore verification without making execution depend
+on live Rekor or Fulcio availability.
+
+## Requirements
+
+- **FR-001**: Traverse MUST expose a narrow artifact-verifier interface with a
+  production Sigstore implementation and injectable test implementation.
+- **FR-002**: Production verification MUST validate a self-contained Sigstore
+  bundle, artifact digest, Fulcio certificate chain, and Rekor inclusion
+  evidence using the Rust `sigstore` client library or a reviewed equivalent.
+- **FR-003**: Verification MUST use a pinned trust root and an explicit
+  publisher policy that validates accepted issuer and subject identities.
+- **FR-004**: Execution MUST verify bundles offline; it MUST NOT require a live
+  Rekor or Fulcio request on the execution path.
+- **FR-005**: Missing bundle, invalid digest, invalid chain, invalid inclusion
+  proof, trust-root mismatch, and publisher-policy mismatch MUST fail closed
+  with stable verification evidence.
+- **FR-006**: The `verified://` placeholder MUST be removed or rejected; it
+  MUST NOT be accepted as cryptographic verification.
+- **FR-007**: The supported Ed25519 path remains available where existing
+  policy permits it.
+
+## Out of Scope
+
+- Interactive OIDC signing flows.
+- Operating a private Fulcio or Rekor service.
+- Automatic trust-root updates without an operator-approved update path.
+
+## Verification
+
+- Tests MUST verify valid and invalid recorded bundles without network access.
+- Tests MUST cover digest, chain, inclusion-proof, issuer, and subject-policy
+  failures and prove no execution occurs after failure.

--- a/specs/065-sigstore-bundle-verification/spec.md
+++ b/specs/065-sigstore-bundle-verification/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Sigstore Bundle Verification
 
 **Spec ID**: 065
-**Status**: Draft
+**Status**: Approved
 **Created**: 2026-07-12
 **Input**: User-approved blocker-resolution decisions for issue #589.
 

--- a/specs/066-durable-identity-event-delivery/spec.md
+++ b/specs/066-durable-identity-event-delivery/spec.md
@@ -1,0 +1,48 @@
+# Feature Specification: Durable Identity-Aware Event Delivery
+
+**Spec ID**: 066
+**Status**: Draft
+**Created**: 2026-07-12
+**Input**: User-approved blocker-resolution decisions for issues #591 and #593.
+
+## Context
+
+Runtime identity must be propagated into emitted events through one canonical
+runtime boundary. Replay must also survive restart without exposing raw tokens
+or coupling consumers to a file layout.
+
+## Requirements
+
+- **FR-001**: The runtime MUST emit lifecycle events through a runtime-owned
+  event-sink interface; the in-process broker MUST be one compatible sink.
+- **FR-002**: Event envelopes MUST contain pinned `subject_id` and optional
+  `actor_id`, and MUST NOT contain raw JWT material.
+- **FR-003**: Subscriptions MUST support exact `subject_id` filtering. The
+  filter MUST apply identically to live delivery and replay.
+- **FR-004**: A caller MAY subscribe to its own subject only; a distinct
+  audit/admin scope is required to request another subject's events.
+- **FR-005**: Events MUST persist per workspace in an append-only segmented
+  journal with periodic checkpoints.
+- **FR-006**: A durable event MAY be acknowledged only after its journal record
+  is appended and fsynced.
+- **FR-007**: Cursors MUST be opaque, persisted, monotonically increasing
+  sequence identifiers independent of journal segment layout.
+- **FR-008**: Retention MUST be configurable by age and/or size. A request for
+  compacted history MUST return `cursor_expired` and the oldest available
+  cursor; it MUST NOT silently replay from another point.
+- **FR-009**: Journal recovery MUST ignore only an incomplete final record from
+  an interrupted write and MUST fail loudly on any malformed completed record.
+
+## Out of Scope
+
+- Distributed or multi-node event delivery.
+- Arbitrary payload query languages and actor-based subscription filters.
+- A database or pluggable storage abstraction in the first implementation.
+
+## Verification
+
+- Cross-boundary tests MUST prove identity reaches runtime, event envelope,
+  live subscription, and replay without token leakage.
+- Restart tests MUST prove cursor continuity, fsync-backed acknowledgement, and
+  deterministic recovery after an incomplete final record.
+- Retention tests MUST prove the stable `cursor_expired` response.

--- a/specs/066-durable-identity-event-delivery/spec.md
+++ b/specs/066-durable-identity-event-delivery/spec.md
@@ -1,7 +1,7 @@
 # Feature Specification: Durable Identity-Aware Event Delivery
 
 **Spec ID**: 066
-**Status**: Draft
+**Status**: Approved
 **Created**: 2026-07-12
 **Input**: User-approved blocker-resolution decisions for issues #591 and #593.
 

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -724,6 +724,59 @@
         "specs/062-runtime-target-matrix/",
         "specs/governance/"
       ]
+    },
+    {
+      "id": "063-registry-contract-materialization",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/063-registry-contract-materialization/spec.md",
+      "governs": [
+        "crates/traverse-registry/",
+        "crates/traverse-cli/",
+        "specs/063-registry-contract-materialization/",
+        "specs/governance/"
+      ]
+    },
+    {
+      "id": "064-production-artifact-execution",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/064-production-artifact-execution/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "crates/traverse-cli/",
+        "specs/064-production-artifact-execution/",
+        "specs/governance/"
+      ]
+    },
+    {
+      "id": "065-sigstore-bundle-verification",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/065-sigstore-bundle-verification/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "docs/",
+        "specs/065-sigstore-bundle-verification/",
+        "specs/governance/"
+      ]
+    },
+    {
+      "id": "066-durable-identity-event-delivery",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/066-durable-identity-event-delivery/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "crates/traverse-cli/",
+        "crates/traverse-mcp/",
+        "specs/066-durable-identity-event-delivery/",
+        "specs/governance/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Record user-approved architecture decisions as new specs and accepted ADRs, then link the resulting approval dependencies to the previously-blocked implementation queue.

## Governing Spec

- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `063-registry-contract-materialization`
- `064-production-artifact-execution`
- `065-sigstore-bundle-verification`
- `066-durable-identity-event-delivery`

## Project Item

- Closes #628

## Definition of Done

- Four new specs and four accepted ADRs capture the user-approved decisions.
- The four new specs are registered in the approved-spec registry as `approved`/`immutable`, since the user approved them for real (issue #628 originally scoped these as draft-only pending approval; that approval has since happened).
- Existing and future tickets carry accurate blockers and dependencies.

## Validation

- `git diff --check`
- `bash scripts/ci/spec_alignment_check.sh` (BASE_SHA=origin/main)
