### PR TITLE
fix(cli): derive event registration timestamp from contract provenance, not wall clock

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -2136,7 +2136,10 @@ fn parse_event_register_body_for_workspace(
         .and_then(|v| v.as_str())
         .unwrap_or("private")
         .to_string();
-    let registered_at = generated_registered_at().unwrap_or_else(|_| "unix:0".to_string());
+    // Derived from the contract's own provenance rather than wall-clock time so
+    // that re-registering an identical contract produces an identical record for
+    // the duplicate-detection equality check in `EventRegistry::register`.
+    let registered_at = contract.provenance.created_at.clone();
 
     Ok((
         scope,
@@ -10099,6 +10102,38 @@ mod tests {
             parse_response_body(&conflict_out)["traverse_code"],
             "registration_conflict"
         );
+    }
+
+    #[test]
+    fn workspace_event_contract_registration_duplicate_is_stable_across_a_clock_tick() {
+        // Regression test for a CI flake (issue link in PR description): the
+        // duplicate-vs-conflict decision must not depend on wall-clock time, or
+        // two back-to-back identical registrations straddling a second boundary
+        // spuriously return 409 instead of 200. Sleeping past a full second here
+        // reproduces that race deterministically.
+        let state = empty_state();
+        let body = valid_event_registration_body("test.api.event-clock-tick", "1.0.0");
+        let first_req = make_http_request(
+            "POST",
+            "/v1/workspaces/ws-test/event-contracts",
+            body.clone(),
+        );
+        let mut first_out = Vec::new();
+        handle_workspace_operation(&mut first_out, &first_req, &state, true)
+            .expect("first event registration must write a response");
+        assert_eq!(response_status(&first_out), 201);
+
+        thread::sleep(Duration::from_millis(1100));
+
+        let second_req = make_http_request("POST", "/v1/workspaces/ws-test/event-contracts", body);
+        let mut second_out = Vec::new();
+        handle_workspace_operation(&mut second_out, &second_req, &state, true)
+            .expect("second event registration must write a response");
+
+        assert_eq!(response_status(&second_out), 200);
+        let duplicate = parse_response_body(&second_out);
+        assert_eq!(duplicate["registered"], false);
+        assert_eq!(duplicate["already_registered"], true);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`http_api::tests::workspace_event_contract_registration_handles_duplicate_and_conflict` has failed intermittently in CI's `repository-checks` job on unrelated PRs (#612, #631 — attempt 1 of #631's `repository-checks` job failed with `left: 409 / right: 200` at `http_api.rs:10070`, then passed on retry). It passes 10/10 locally.

**Root cause**: `parse_event_register_body_for_workspace` (`http_api.rs`) unconditionally minted a fresh `registered_at` timestamp via `SystemTime::now()` on every registration request. `EventRegistry::register` (`crates/traverse-registry/src/events.rs`) decides "already registered" (200) vs. "conflict" (409) via full struct equality on `EventRegistryRecord`, which embeds that timestamp. Two back-to-back identical registrations that straddle a 1-second wall-clock tick — plausible under CI's parallel/loaded runners — compare unequal and fall through to `ImmutableVersionConflict` → 409, even with byte-identical content.

**Fix**: derive `registered_at` from `contract.provenance.created_at` instead, mirroring the pattern the capability-registration path already uses (`derive_registration`) — a client-supplied, content-derived field that's part of the digested contract body, so identical registration bodies always produce an identical `registered_at`. This is why the capability-registration duplicate test never flaked while the event-registration one did.

Added a regression test, `workspace_event_contract_registration_duplicate_is_stable_across_a_clock_tick`, that sleeps 1.1s between two identical registration calls to reproduce the race deterministically. Verified it fails with the exact `left: 409 / right: 200` signature on the pre-fix code and passes with the fix.

## Governing Spec

- 033-http-json-api

FR-018 requires immutable registry conflicts to use `409`. This PR fixes the flip side: a byte-identical re-registration was spuriously returning `409` instead of the correct `200`/idempotent-duplicate response. Bug fix only, no spec change — `no-spec-needed`.

## Project Item

- Issue #632
- Org Project 1 item: `PVTI_lADOEbiBt84Bbyp1zgyi8fs`

## Validation

- `cargo test -p traverse-cli` — 218/218 passing
- `cargo clippy -p traverse-cli --all-targets -- -D warnings` — clean
- New regression test manually verified to fail on pre-fix code (`left: 409 / right: 200`, matching the CI failure exactly) and pass on post-fix code
- Existing `workspace_event_contract_registration_handles_duplicate_and_conflict` run 30x under `--test-threads=32` locally, all passing
