### PR TITLE
fix: make event registry idempotency check ignore registration timestamp

### DIFF
--- a/crates/traverse-registry/src/events.rs
+++ b/crates/traverse-registry/src/events.rs
@@ -255,7 +255,7 @@ impl EventRegistry {
                 ));
             };
 
-            if existing == &record
+            if records_match_ignoring_registration_timestamp(existing, &record)
                 && existing_index == &index_record
                 && existing_contract == &contract
             {
@@ -524,6 +524,26 @@ fn build_index_record(scope: RegistryScope, contract: &EventContract) -> EventRe
         classification: contract.classification.clone(),
         tags: normalized_tags(contract),
     }
+}
+
+/// `registered_at` (and the `validated_at` it seeds on the validation evidence)
+/// is a server-generated wall-clock stamp, not part of the client's request.
+/// Comparing it verbatim made an identical resubmission flip from "already
+/// registered" to a spurious immutable-version conflict whenever the two
+/// calls landed in different seconds.
+fn records_match_ignoring_registration_timestamp(
+    existing: &EventRegistryRecord,
+    candidate: &EventRegistryRecord,
+) -> bool {
+    let mut normalized_existing = existing.clone();
+    normalized_existing
+        .registered_at
+        .clone_from(&candidate.registered_at);
+    normalized_existing
+        .validation_evidence
+        .validated_at
+        .clone_from(&candidate.validation_evidence.validated_at);
+    &normalized_existing == candidate
 }
 
 fn normalized_tags(contract: &EventContract) -> Vec<String> {
@@ -851,6 +871,17 @@ mod tests {
             failure.errors[0].message,
             "published event versions are immutable and cannot be republished with different metadata"
         );
+
+        let mut retried_registration_registry = EventRegistry::new();
+        retried_registration_registry
+            .register(request.clone())
+            .expect("seed registration should pass");
+        let mut retried_with_later_timestamp = request.clone();
+        retried_with_later_timestamp.registered_at = "2026-03-30T00:00:01Z".to_string();
+        let outcome = retried_registration_registry
+            .register(retried_with_later_timestamp)
+            .expect("resubmitting identical content with a newer registration timestamp must be idempotent");
+        assert_eq!(outcome.record.registered_at, request.registered_at);
 
         let mut digest_mismatch_registry = EventRegistry::new();
         digest_mismatch_registry


### PR DESCRIPTION
## Summary
- CI for [PR #635](https://github.com/traverse-framework/traverse/pull/635) hit an intermittent failure in `workspace_event_contract_registration_handles_duplicate_and_conflict` (`crates/traverse-cli/src/http_api.rs`) — a test completely unrelated to that PR's changes, failing on one of two parallel runs of the identical commit.
- Root cause: `registered_at` is a server-generated wall-clock timestamp (`unix:{seconds}`, whole-second granularity), not supplied by the client. `EventRegistry::register` required the *entire* stored record — including that timestamp and the `validated_at` it seeds on validation evidence — to match verbatim before treating a resubmission as idempotent. If two identical registration requests straddled a one-second clock boundary (far more likely under CI's parallel-thread contention), the fast idempotency path failed and the request fell through to a spurious `409 immutable-version conflict`, even though the actual event contract content was byte-identical.
- Reproduced locally by looping the full `traverse-cli` test binary (hit it on run 14/15), confirming it's timing-dependent rather than a shared-state/ordering issue.

## Fix
- `crates/traverse-registry/src/events.rs`: extracted `records_match_ignoring_registration_timestamp`, which normalizes `registered_at`/`validated_at` before comparing records for idempotency, while still treating genuinely different metadata (e.g. `contract_path`) as a real conflict (covered by the existing `register_covers_internal_consistency_and_metadata_immutability_guards` test).
- Added a deterministic regression test: registers identical content twice with different `registered_at` values and asserts the second call succeeds as idempotent — so this can't regress silently via wall-clock luck.

## Governing Spec

- `011-event-registry`

PR #633 fixed the same class of flake for `registered_at` only; `validated_at` still triggered spurious `409` conflicts on identical resubmissions. Bug fix only, no spec change — `no-spec-needed`.

## Project Item

- Issue #641
- Org Project 1 item: `PVTI_lADOEbiBt84Bbyp1zgyjJV4`

## Validation

- `cargo test --workspace` — all green
- `cargo test -p traverse-registry --lib events::` — all green, including the new regression test and the existing metadata-immutability guard
- `cargo clippy -p traverse-registry --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- 20x stress loop of `cargo test -p traverse-cli --bin traverse-cli http_api::` — zero recurrences of the original flake
