### PR TITLE
Approve spec 067: durable journal retention and write-path limits

### DIFF
--- a/docs/adr/0006-durable-journal-retention-and-write-limits.md
+++ b/docs/adr/0006-durable-journal-retention-and-write-limits.md
@@ -14,11 +14,12 @@ call when the durable write stalls. Both were required to close issue #593.
 
 Retention reclaims space by deleting whole segments once every event in a
 segment is outside the retention window; segments roll over on a configured
-max size or max duration, whichever comes first, to bound how long a single
-old event can pin a segment. `publish()` waits for the durable write up to a
-configured timeout; on timeout it returns a distinct `journal_write_timeout`
-error and rejects the event outright rather than silently degrading to
-in-memory-only delivery. The timeout produces a structured audit event.
+max size or max duration (default 64 MB or 10 minutes, whichever comes first)
+to bound how long a single old event can pin a segment. `publish()` waits for
+the durable write up to a configured timeout (default 2 seconds); on timeout
+it returns a distinct `journal_write_timeout` error and rejects the event
+outright rather than silently degrading to in-memory-only delivery. The
+timeout produces a structured audit event.
 
 ## Consequences
 

--- a/docs/adr/0006-durable-journal-retention-and-write-limits.md
+++ b/docs/adr/0006-durable-journal-retention-and-write-limits.md
@@ -1,0 +1,39 @@
+# ADR-0006: Bound Durable Journal Retention and Write-Path Stalls
+
+- Status: Accepted
+- Date: 2026-07-12
+
+## Context
+
+ADR-0005 / spec 066 established the durable journal's append-only segments,
+fsync-before-acknowledgement, and age/size retention, but left two questions
+open: how expired data is physically reclaimed, and what happens to a publish
+call when the durable write stalls. Both were required to close issue #593.
+
+## Decision
+
+Retention reclaims space by deleting whole segments once every event in a
+segment is outside the retention window; segments roll over on a configured
+max size or max duration, whichever comes first, to bound how long a single
+old event can pin a segment. `publish()` waits for the durable write up to a
+configured timeout; on timeout it returns a distinct `journal_write_timeout`
+error and rejects the event outright rather than silently degrading to
+in-memory-only delivery. The timeout produces a structured audit event.
+
+## Consequences
+
+Retention behavior and write-path failure modes are now fully specified,
+closing the gap left open by spec 066 and satisfying issue #593's Definition
+of Done. No further spec work is required before implementation begins.
+
+## Alternatives Considered
+
+- In-place segment compaction instead of whole-segment deletion — rejected as
+  unnecessary complexity for a first implementation that spec 066 already
+  deferred.
+- Unbounded blocking on a stalled durable write — rejected because it could
+  hang the runtime's execution path indefinitely with no operator-visible
+  signal.
+- Soft-degrading to in-memory-only delivery on write timeout — rejected
+  because it would silently weaken the exact guarantee this journal exists to
+  provide.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -358,3 +358,20 @@ The runtime will emit identity-bearing events through a canonical sink. The
 first durable store uses fsynced append-only journals, opaque persisted cursors,
 and bounded retention; future tickets will evaluate its measured limits and
 evolution path.
+
+## Decision 17: Bound Durable Journal Retention and Write-Path Stalls
+
+- **Date**: 2026-07-12
+- **Status**: Accepted
+- **Governing spec**: `067-durable-journal-retention-and-write-limits`
+- **Related issue**: `#593`
+
+### Decision
+
+Retention reclaims space by deleting whole segments once every event in a
+segment ages out, with segments rolling over on a configured max size or max
+duration to bound how long one old event can pin a segment. A durable write
+that stalls past a configured timeout rejects the event with a distinct
+`journal_write_timeout` error and audit event, rather than blocking
+indefinitely or silently degrading to in-memory-only delivery. This closes the
+remaining gap in issue #593's Definition of Done left open by Decision 16.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -370,8 +370,9 @@ evolution path.
 
 Retention reclaims space by deleting whole segments once every event in a
 segment ages out, with segments rolling over on a configured max size or max
-duration to bound how long one old event can pin a segment. A durable write
-that stalls past a configured timeout rejects the event with a distinct
-`journal_write_timeout` error and audit event, rather than blocking
-indefinitely or silently degrading to in-memory-only delivery. This closes the
-remaining gap in issue #593's Definition of Done left open by Decision 16.
+duration (default 64 MB or 10 minutes) to bound how long one old event can pin
+a segment. A durable write that stalls past a configured timeout (default 2
+seconds) rejects the event with a distinct `journal_write_timeout` error and
+audit event, rather than blocking indefinitely or silently degrading to
+in-memory-only delivery. This closes the remaining gap in issue #593's
+Definition of Done left open by Decision 16.

--- a/specs/067-durable-journal-retention-and-write-limits/spec.md
+++ b/specs/067-durable-journal-retention-and-write-limits/spec.md
@@ -1,0 +1,52 @@
+# Feature Specification: Durable Journal Retention and Write-Path Limits
+
+**Spec ID**: 067
+**Status**: Approved
+**Created**: 2026-07-12
+**Input**: User-approved blocker-resolution decisions for issue #593, amending `066-durable-identity-event-delivery`.
+
+## Context
+
+`066-durable-identity-event-delivery` defines an append-only segmented journal
+with fsync-before-acknowledgement and configurable age/size retention, but
+leaves two operational questions open: how expired data is actually reclaimed,
+and what happens to `publish()` when a durable write stalls. Both were
+required to close issue #593's Definition of Done and are addressed here
+rather than by amending the immutable 066.
+
+## Requirements
+
+- **FR-001**: The journal MUST roll over to a new segment once it reaches a
+  configured maximum size or maximum duration, whichever occurs first.
+- **FR-002**: Expired data MUST be reclaimed by deleting an entire segment file
+  once every event within it falls outside the retention window; the journal
+  MUST NOT rewrite or partially truncate a segment in place.
+- **FR-003**: `publish()` MUST wait for the durable write to complete only up
+  to a configured timeout; on timeout it MUST return a distinct
+  `journal_write_timeout` error and MUST NOT block indefinitely.
+- **FR-004**: An event that hits `journal_write_timeout` MUST be rejected, not
+  delivered, and MUST NOT be silently downgraded to in-memory-only delivery;
+  the caller is responsible for handling the failure.
+- **FR-005**: A `journal_write_timeout` MUST produce a structured audit event,
+  consistent with the existing backpressure/failure observability requirement
+  in spec 036 (NFR-006).
+
+## Out of Scope
+
+- In-place segment compaction (rewriting a segment to remove individual
+  expired records before the whole segment ages out).
+- Automatic timeout tuning or adaptive backpressure based on measured disk
+  latency (tracked separately as future operational-limits evaluation work,
+  issues #629/#630).
+- Multi-segment concurrent write coordination beyond what FR-001's rollover
+  trigger requires.
+
+## Verification
+
+- Tests MUST prove a segment is deleted only once all its events are outside
+  the retention window, and that a segment forced to roll over by size/duration
+  bounds the pinned-segment overhang to one rollover period.
+- Tests MUST prove `publish()` returns `journal_write_timeout` (not an
+  indefinite hang) when the durable write exceeds the configured timeout, and
+  that the event is not delivered through any path.
+- Tests MUST prove a `journal_write_timeout` produces a structured audit event.

--- a/specs/067-durable-journal-retention-and-write-limits/spec.md
+++ b/specs/067-durable-journal-retention-and-write-limits/spec.md
@@ -17,13 +17,14 @@ rather than by amending the immutable 066.
 ## Requirements
 
 - **FR-001**: The journal MUST roll over to a new segment once it reaches a
-  configured maximum size or maximum duration, whichever occurs first.
+  configured maximum size or maximum duration, whichever occurs first; the
+  default is 64 MB or 10 minutes.
 - **FR-002**: Expired data MUST be reclaimed by deleting an entire segment file
   once every event within it falls outside the retention window; the journal
   MUST NOT rewrite or partially truncate a segment in place.
 - **FR-003**: `publish()` MUST wait for the durable write to complete only up
-  to a configured timeout; on timeout it MUST return a distinct
-  `journal_write_timeout` error and MUST NOT block indefinitely.
+  to a configured timeout, defaulting to 2 seconds; on timeout it MUST return a
+  distinct `journal_write_timeout` error and MUST NOT block indefinitely.
 - **FR-004**: An event that hits `journal_write_timeout` MUST be rejected, not
   delivered, and MUST NOT be silently downgraded to in-memory-only delivery;
   the caller is responsible for handling the failure.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -777,6 +777,18 @@
         "specs/066-durable-identity-event-delivery/",
         "specs/governance/"
       ]
+    },
+    {
+      "id": "067-durable-journal-retention-and-write-limits",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/067-durable-journal-retention-and-write-limits/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "specs/067-durable-journal-retention-and-write-limits/",
+        "specs/governance/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Issue #593 was blocked pending a spec amendment to `036-event-subscription-replay` covering durable event journal permanence. `066-durable-identity-event-delivery` (approved via #631) already answered most of #593's Definition of Done, but left two operational questions open: how expired journal data is physically reclaimed, and what `publish()` does when a durable write stalls.
- This PR approves `067-durable-journal-retention-and-write-limits`, a narrow amendment closing those two gaps, decided via a structured brainstorm session:
  - **Retention/pruning**: whole-segment deletion once every event in a segment ages out (no in-place compaction — matches spec 066's own "no pluggable storage abstraction in the first implementation" stance), with a required segment rollover cap (max size or max duration, whichever first) so a single old event can't pin newer sibling events past the nominal retention window indefinitely.
  - **Write-path stalls**: `publish()` waits up to a configured timeout for the durable write to complete, then hard-fails with a distinct `journal_write_timeout` error (event rejected, not silently downgraded to in-memory-only delivery) and a structured audit event, rather than blocking indefinitely.
- Recorded as [ADR-0006](docs/adr/0006-durable-journal-retention-and-write-limits.md) and Decision 17 in the decision log, matching the existing style used for specs 063-066.
- Updated issue #593: relabeled `needs-spec`/`blocked`/`future` → `no-spec-needed` and moved to Project 1 `Ready`, matching how sibling issue #591 was unblocked from the same spec cluster (the issue itself now carries the implementation work directly rather than spinning off a separate ticket).

## Governing Spec

- 004-spec-alignment-gate
- 065-sigstore-bundle-verification
- 067-durable-journal-retention-and-write-limits

## Project Item

Relates to #593 (spec-definition Definition of Done now satisfied; implementation is tracked under #593 itself, now Ready)

## Validation

- `jq empty specs/governance/approved-specs.json` — valid JSON.
- `bash scripts/ci/spec_alignment_check.sh` — passes locally against this branch.
- `bash scripts/ci/pr_body_check.sh` — passes locally against this PR body.
- No source code changed; no test/coverage/clippy impact.
