### PR TITLE
fix(cli): make unique_temp_dir collision-proof under concurrent test threads

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -4999,6 +4999,7 @@ mod tests {
     use std::cell::RefCell;
     use std::fs;
     use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
     use traverse_contracts::parse_contract;
     use traverse_registry::{
@@ -6869,11 +6870,13 @@ mod tests {
     }
 
     fn unique_temp_dir() -> PathBuf {
+        static NEXT_TEST_DIR: AtomicU64 = AtomicU64::new(1);
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_nanos();
-        let path = std::env::temp_dir().join(format!("traverse-cli-test-{nanos}"));
+        let sequence = NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!("traverse-cli-test-{nanos}-{sequence}"));
         fs::create_dir_all(&path).expect("temporary directory should create");
         path
     }


### PR DESCRIPTION
## Summary

- While investigating an unrelated flaky test, found a second, confirmed-real flakiness source in `crates/traverse-cli/src/main.rs`: the test helper `unique_temp_dir()` built its path from a nanosecond timestamp alone. Two tests running concurrently in different threads of the same `cargo test` process can occasionally land on the same nanosecond value and collide on the same temp directory.
- Reproduced locally by looping `cargo test -p traverse-cli --bin traverse-cli` ~15 times: two different tests, `tests::inspect_agent_renders_second_governed_wasm_agent_package` and `tests::inspect_agent_renders_hello_world_package`, both wrote their `agent/manifest.json` fixture into the same colliding temp dir, causing one to fail with a spurious `trailing characters` JSON parse error from interleaved/overwritten file contents.
- Fix mirrors the existing pattern already used by `test_registry_root()` in `crates/traverse-cli/src/http_api.rs`: pair the nanosecond timestamp with a local `static AtomicU64` sequence counter via `fetch_add`, guaranteeing uniqueness even when two calls land in the same nanosecond.

## Governing Spec

- 017-ai-agent-packaging

Test-infrastructure fix only (`unique_temp_dir()` test helper used by agent-package-inspection tests), no behavioral or spec change — `no-spec-needed`.

## Project Item

N/A — found incidentally while investigating an unrelated flaky test; no tracked issue.

## Validation

- [x] `cargo build -p traverse-cli --bin traverse-cli --tests` — clean
- [x] 20x stress loop of `cargo test -p traverse-cli --bin traverse-cli -- tests::inspect_agent_renders_second_governed_wasm_agent_package tests::inspect_agent_renders_hello_world_package` — zero collisions (previously reproduced the collision within ~15 runs)
- [x] 20x stress loop of the full `traverse-cli` test binary — all green
- [x] `cargo clippy -p traverse-cli --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)