### PR TITLE
docs: draft Spec 068 public embedder packages

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -376,3 +376,32 @@ seconds) rejects the event with a distinct `journal_write_timeout` error and
 audit event, rather than blocking indefinitely or silently degrading to
 in-memory-only delivery. This closes the remaining gap in issue #593's
 Definition of Done left open by Decision 16.
+
+## Decision 18: Deliver Traverse as Consumable Platform Embedder Packages
+
+- **Date**: 2026-07-13
+- **Status**: Accepted
+- **Governing spec**: `068-public-platform-embedder-packages`
+- **Related issues**: `#645`, `#646`, `#647`, `#648`, `#649`, `#650`; App
+  References `#113`–`#117`
+
+### Context
+
+The approved embedder model and #553's implementation establish manifest
+validation, an IDL, and CLI conformance, but do not give a Web, Swift, Android,
+WinUI, or Linux app an SDK it can import to host a bundled Traverse runtime.
+
+### Decision
+
+Traverse will publish versioned, public platform packages that implement the
+complete `embedder-api/1.0.0` lifecycle. They load application-owned runtime
+and capability bundles, preserve runtime-owned workflow/output semantics, pass
+the shared conformance corpus, and emit digest-backed release evidence. The
+five platform slices are tracked separately so each downstream reference app
+can become Ready only when its usable SDK exists.
+
+### Outcome
+
+The decision log is the authoritative design record. Spec 068 and its tickets
+are derived traceability artifacts; they must not reopen this accepted
+direction for a second design review.

--- a/docs/project-management.md
+++ b/docs/project-management.md
@@ -116,33 +116,36 @@ The board audit logic lives in [scripts/ci/project_board_audit.sh](../scripts/ci
 
 ---
 
-## External Review Gate for Governing Specs
+## Decision-Log Traceability Gate for Governing Specs
 
-Every new governing spec must go through a time-boxed external review before being marked `approved` in `specs/governance/approved-specs.json`.
+Governing specs are precise, testable artifacts derived from accepted product
+and architecture decisions. They are not a second forum for reconsidering
+decisions already made in the decision log.
 
 ### Policy
 
-- **Reviewers requested**: 3 external reviewers per spec
-- **Review window**: 72 hours from the first review request
-- **Quorum**: if fewer than 3 reviews arrive within the window, the host maintainer reviews the feedback received and makes the call — work proceeds
-- **Format**: asynchronous; no meetings required
-- **Template**: use [`docs/spec-reviewer-guide.md`](spec-reviewer-guide.md) to structure the review request
+- Every new approved spec MUST cite one or more accepted decision-log entries.
+- The decision log records *why* and the approved direction; the spec records
+  the exact requirements, boundaries, acceptance scenarios, and verification.
+- A spec MUST NOT introduce a material new product or architecture decision.
+  Record that decision first, then derive the spec and tickets from it.
+- The author performs a traceability check before approval: each decision is
+  represented in the spec, and each spec requirement is justified by the cited
+  decision or an already-approved governing spec.
 
 ### Process
 
-1. Author completes the spec draft and opens a PR.
-2. Author fills in the reviewer guide template and posts it as a PR comment.
-3. Author tags 3 reviewers and sets a 72-hour deadline in the comment.
-4. Reviewers respond with Yes / Approve with changes / Reject using the checklist in the template.
-5. After the window closes, the host maintainer resolves feedback and merges or revises.
+1. Record or identify the accepted decision in `docs/decision-log.md`.
+2. Create the issue, Project 1 item, and derived spec.
+3. Link the decision, spec, implementation tickets, and downstream blockers.
+4. Run the traceability and repository validation checks.
+5. Mark the spec approved in `specs/governance/approved-specs.json` and merge
+   the codification PR.
 
-### Spec Tickets That Require This Gate
-
-Add a checklist item to each new spec issue:
+### Spec Ticket Checklist
 
 ```
-- [ ] External review requested (3 reviewers, 72h window started YYYY-MM-DD HH:MM UTC)
-- [ ] Review window closed / host maintainer decision recorded
+- [ ] Accepted decision-log entry cited
+- [ ] Spec requirements traced to the decision and existing governing specs
+- [ ] Implementation tickets and downstream blockers linked
 ```
-
-This applies to: #329, #330, #331, #332, #335, #337, #338, #339, and any future spec tickets.

--- a/specs/068-public-platform-embedder-packages/spec.md
+++ b/specs/068-public-platform-embedder-packages/spec.md
@@ -2,11 +2,12 @@
 
 **Feature Branch**: `068-public-platform-embedder-packages`
 **Created**: 2026-07-12
-**Status**: Draft — external review required before approval
-**Version**: 1.0.0-draft
-**Input**: Traverse #645; the App Reference Phase 3 blocker audit. Spec 057
-defines an embedder IDL and conformance shape, but its implementation ticket
-#553 did not produce a package consumable by application clients.
+**Status**: Approved
+**Version**: 1.0.0
+**Input**: Decision 18 in `docs/decision-log.md`, Traverse #645, and the App
+Reference Phase 3 blocker audit. Spec 057 defines an embedder IDL and
+conformance shape, but its implementation ticket #553 did not produce a
+package consumable by application clients.
 
 ## Purpose
 
@@ -33,8 +34,9 @@ Rust/GTK/CLI.
 ## Functional Requirements
 
 - **FR-001**: Each supported platform MUST provide a public, versioned package
-  or crate that implements `embedder-api/1.0.0` operations: `init`,
-  `shutdown`, `submit`, and `subscribe`.
+  or crate that implements every `embedder-api/1.0.0` operation: `init`,
+  `shutdown`, `submit`, `subscribe`, and compatible-capability `start`,
+  `stop`, and `kill`.
 - **FR-002**: A package MUST load an application-owned bundle containing the
   runtime WASM, app manifest, component manifests, and capability artifacts;
   production execution MUST NOT require `traverse-cli serve` or

--- a/specs/068-public-platform-embedder-packages/spec.md
+++ b/specs/068-public-platform-embedder-packages/spec.md
@@ -1,0 +1,112 @@
+# Feature Specification: Public Consumable Platform Embedder Packages
+
+**Feature Branch**: `068-public-platform-embedder-packages`
+**Created**: 2026-07-12
+**Status**: Draft — external review required before approval
+**Version**: 1.0.0-draft
+**Input**: Traverse #645; the App Reference Phase 3 blocker audit. Spec 057
+defines an embedder IDL and conformance shape, but its implementation ticket
+#553 did not produce a package consumable by application clients.
+
+## Purpose
+
+Define what Traverse must ship for a downstream application to embed the
+runtime in production. A consumable embedder package is more than an IDL,
+schema validator, or CLI test fixture: it is a versioned public artifact with
+documented APIs, supported lifecycle semantics, deterministic test seams, and
+release evidence.
+
+This successor specification makes Spec 057 executable for the initial
+platform set: Web/TypeScript, Swift, Kotlin/Android, .NET/WinUI, and
+Rust/GTK/CLI.
+
+## Relationship to Existing Specifications
+
+| Specification | Relationship |
+| --- | --- |
+| 057-embeddable-runtime-host | Defines the platform-neutral operations and thin-embedder boundary; this spec defines public package delivery for those operations. |
+| 058-workflow-pipeline-execution | `submit` must accept the same workflow and capability identifiers. |
+| 052-app-state-machine | State-machine execution remains runtime-owned. |
+| 053-conditional-state-transitions | Conditional routing remains runtime-owned and is surfaced through events only. |
+| 033-http-json-api | Development sidecar only; not a production requirement for a packaged embedder. |
+
+## Functional Requirements
+
+- **FR-001**: Each supported platform MUST provide a public, versioned package
+  or crate that implements `embedder-api/1.0.0` operations: `init`,
+  `shutdown`, `submit`, and `subscribe`.
+- **FR-002**: A package MUST load an application-owned bundle containing the
+  runtime WASM, app manifest, component manifests, and capability artifacts;
+  production execution MUST NOT require `traverse-cli serve` or
+  `.traverse/server.json` discovery.
+- **FR-003**: `submit` MUST accept the workflow/capability identifiers and
+  JSON inputs defined by the bundled manifest and MUST surface runtime errors
+  as structured, versioned events or results.
+- **FR-004**: `subscribe` MUST preserve ordering and payload semantics of the
+  runtime event stream. The package MAY adapt idiomatic callback, async-stream,
+  or observable mechanics, but MUST NOT alter runtime event meaning.
+- **FR-005**: Packages MUST NOT implement business rules, workflow transitions,
+  capability-output derivation, or client-side replicas of conditional routing.
+- **FR-006**: Every package MUST expose a deterministic test double or
+  in-memory harness that implements the same public boundary without replacing
+  production business logic.
+- **FR-007**: Public package documentation MUST state supported platforms,
+  runtime-WASM compatibility, bundle input shape, shutdown/cancellation
+  behavior, error mapping, and upgrade policy.
+- **FR-008**: Package releases MUST use semantic versions and publish release
+  evidence containing package version, embedded runtime-WASM digest, embedder
+  API/conformance version, and supported host versions.
+- **FR-009**: Every package MUST pass the shared embedder conformance corpus
+  for its declared embedder API version before release.
+- **FR-010**: A platform package is complete only when the relevant
+  App-References integration executes a bundled workflow without a sidecar.
+
+## Platform Delivery Matrix
+
+| Platform | Public delivery | Downstream ticket |
+| --- | --- | --- |
+| Web/React | TypeScript package | reference-apps #113 |
+| iOS/macOS | Swift Package | reference-apps #114 |
+| Android Compose | Kotlin/Android artifact | reference-apps #115 |
+| Windows WinUI | .NET package | reference-apps #116 |
+| Linux GTK/CLI | Rust crate | reference-apps #117 |
+
+## Non-Functional Requirements
+
+- **NFR-001 Compatibility**: A package MUST reject an incompatible bundle or
+  runtime version deterministically and explain the mismatch without silently
+  falling back to a sidecar.
+- **NFR-002 Traceability**: The release evidence MUST be sufficient to connect
+  a downstream binary to its package version, runtime digest, and conformance
+  result.
+- **NFR-003 Portability**: Platform adaptation is permitted only at the host
+  boundary; application capability and workflow semantics remain portable.
+- **NFR-004 Security**: Packages MUST not expose secrets in errors, events,
+  test evidence, or bundle metadata.
+
+## Acceptance Scenarios
+
+1. Given a Web/React app bundle, when the app invokes `submit` without a
+   sidecar process, then it receives runtime-owned pipeline output through the
+   public package.
+2. Given an incompatible runtime-WASM/bundle pairing, when `init` is called,
+   then the package returns a stable compatibility error and does not attempt
+   network or sidecar fallback.
+3. Given any two packages implementing `embedder-api/1.0.0`, when they run the
+   shared conformance corpus, then they satisfy the same lifecycle, event, and
+   structured-error expectations.
+
+## Out of Scope
+
+- New business capabilities or UI screens.
+- Replacing the dev sidecar for development tooling.
+- A single cross-language implementation technology or distribution registry.
+- Platform-specific extensions to `embedder-api/1.0.0`.
+
+## Implementation Tickets
+
+- Traverse #646 — Web/TypeScript
+- Traverse #647 — Swift
+- Traverse #648 — Kotlin/Android
+- Traverse #649 — .NET/WinUI
+- Traverse #650 — Rust/GTK/CLI

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -789,6 +789,21 @@
         "specs/067-durable-journal-retention-and-write-limits/",
         "specs/governance/"
       ]
+    },
+    {
+      "id": "068-public-platform-embedder-packages",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/068-public-platform-embedder-packages/spec.md",
+      "governs": [
+        "crates/traverse-embedder/",
+        "packages/",
+        "bindings/",
+        "scripts/ci/embedder_conformance/",
+        "docs/embedder-sdk/",
+        "specs/068-public-platform-embedder-packages/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Records Decision 18, approves its derived Spec 068, and changes governing-spec
approval from redundant external review to decision-log traceability. It closes
the gap between Spec 057's IDL/conformance boundary and the versioned SDK
artifacts required by App Reference clients.

## Governing Spec

- 004-spec-alignment-gate
- 019-downstream-consumer-contract
- 057-embeddable-runtime-host
- 068-public-platform-embedder-packages

## Project Item

Closes #645

## Definition of Done

- [x] Decision 18 records the accepted platform-package direction.
- [x] Spec 068 traces that decision into public-boundary, release, and conformance requirements.
- [x] The approved-spec registry maps the future implementation surface.
- [x] Project 1 tickets #646–#650 and App Reference blockers #113–#117 are linked.

## Validation

- `git diff --check`
- `bash scripts/ci/spec_context_check.sh`
- `jq empty specs/governance/approved-specs.json`
