### PR TITLE
fix(registry): preserve connector retry idempotency

### DIFF
--- a/crates/traverse-registry/src/lib.rs
+++ b/crates/traverse-registry/src/lib.rs
@@ -386,7 +386,7 @@ impl CapabilityRegistry {
         };
 
         if let Some(existing) = self.connectors.get(&key) {
-            if existing == &record {
+            if connector_records_match_ignoring_registration_timestamp(existing, &record) {
                 return Ok(existing.clone());
             }
             return Err(single_error(
@@ -802,6 +802,20 @@ impl CapabilityRegistry {
             evidence_ref: evidence_ref.to_string(),
         })
     }
+}
+
+/// `registered_at` is assigned by the registry and is not connector metadata.
+/// A retry that reaches the registry at a later instant must preserve
+/// idempotency instead of appearing to mutate an immutable connector version.
+fn connector_records_match_ignoring_registration_timestamp(
+    existing: &ConnectorRegistryRecord,
+    candidate: &ConnectorRegistryRecord,
+) -> bool {
+    let mut normalized_existing = existing.clone();
+    normalized_existing.registered_at.clear();
+    let mut normalized_candidate = candidate.clone();
+    normalized_candidate.registered_at.clear();
+    normalized_existing == normalized_candidate
 }
 
 struct RegistryRecordInput<'a> {

--- a/crates/traverse-registry/tests/registry.rs
+++ b/crates/traverse-registry/tests/registry.rs
@@ -120,8 +120,17 @@ fn connector_registration_is_idempotent_and_rejects_conflicts() {
         .expect("identical connector registration should be idempotent");
     assert_eq!(first, second);
 
+    let mut retry_with_later_timestamp =
+        connector_registration(RegistryScope::Public, connector.clone());
+    retry_with_later_timestamp.registered_at = "2026-04-20T00:00:00Z".to_string();
+    let retry = registry
+        .register_connector(retry_with_later_timestamp)
+        .expect("retry with a later server timestamp should be idempotent");
+    assert_eq!(first, retry);
+
     let mut conflicting_request = connector_registration(RegistryScope::Public, connector);
-    conflicting_request.registered_at = "2026-04-20T00:00:00Z".to_string();
+    conflicting_request.contract_path =
+        "registry/public/connectors/traverse.env/changed.json".to_string();
     let failure = registry
         .register_connector(conflicting_request)
         .expect_err("different connector metadata should conflict");


### PR DESCRIPTION
## Summary

Ignore the registry-assigned `registered_at` timestamp when deciding whether a connector registration is an idempotent retry.

## Governing Spec

- `039-connector-plugin-architecture` (bug-hardening only; no spec change required)

## Project Item

Closes #653

## Definition of Done

- Later-timestamp retries return the original connector record.
- Genuine metadata changes retain immutable-version conflict behavior.

## Validation

- `cargo test -p traverse-registry`