### PR TITLE
test(mcp): cover canonical bundle load failures

### DIFF
--- a/crates/traverse-mcp/src/stdio_server.rs
+++ b/crates/traverse-mcp/src/stdio_server.rs
@@ -176,7 +176,10 @@ impl McpDiscoveryCatalog {
     ///
     /// Returns `catalog_load_failed` when the expedition registry bundle cannot be loaded.
     pub fn load_canonical() -> Result<Self, StdioServerFailure> {
-        let manifest_path = canonical_expedition_bundle_path();
+        Self::load_from_manifest_path(&canonical_expedition_bundle_path())
+    }
+
+    fn load_from_manifest_path(manifest_path: &Path) -> Result<Self, StdioServerFailure> {
         let bundle = load_registry_bundle(&manifest_path).map_err(|failure| {
             StdioServerFailure::new(
                 "catalog_load_failed",
@@ -209,7 +212,10 @@ impl McpDiscoveryCatalog {
 
 impl CanonicalExecutionContext {
     fn load_canonical() -> Result<Self, StdioServerFailure> {
-        let manifest_path = canonical_expedition_bundle_path();
+        Self::load_from_manifest_path(&canonical_expedition_bundle_path())
+    }
+
+    fn load_from_manifest_path(manifest_path: &Path) -> Result<Self, StdioServerFailure> {
         let bundle = load_registry_bundle(&manifest_path).map_err(|failure| {
             StdioServerFailure::new(
                 "catalog_load_failed",
@@ -1732,6 +1738,28 @@ mod tests {
     #![allow(clippy::expect_used)]
 
     use super::*;
+
+    #[test]
+    fn canonical_bundle_load_failures_are_stable_for_catalog_and_execution() {
+        let missing_manifest = std::env::temp_dir().join(format!(
+            "traverse-mcp-missing-bundle-{}-manifest.json",
+            std::process::id()
+        ));
+
+        for failure in [
+            McpDiscoveryCatalog::load_from_manifest_path(&missing_manifest)
+                .expect_err("missing catalog manifest should fail"),
+            CanonicalExecutionContext::load_from_manifest_path(&missing_manifest)
+                .expect_err("missing execution manifest should fail"),
+        ] {
+            assert_eq!(failure.code, "catalog_load_failed");
+            assert!(
+                failure
+                    .message
+                    .contains("Failed to load expedition registry bundle")
+            );
+        }
+    }
 
     #[test]
     fn emits_deterministic_startup_list_validate_execute_and_shutdown_envelopes() {

--- a/crates/traverse-mcp/src/stdio_server.rs
+++ b/crates/traverse-mcp/src/stdio_server.rs
@@ -180,7 +180,7 @@ impl McpDiscoveryCatalog {
     }
 
     fn load_from_manifest_path(manifest_path: &Path) -> Result<Self, StdioServerFailure> {
-        let bundle = load_registry_bundle(&manifest_path).map_err(|failure| {
+        let bundle = load_registry_bundle(manifest_path).map_err(|failure| {
             StdioServerFailure::new(
                 "catalog_load_failed",
                 format!(
@@ -216,7 +216,7 @@ impl CanonicalExecutionContext {
     }
 
     fn load_from_manifest_path(manifest_path: &Path) -> Result<Self, StdioServerFailure> {
-        let bundle = load_registry_bundle(&manifest_path).map_err(|failure| {
+        let bundle = load_registry_bundle(manifest_path).map_err(|failure| {
             StdioServerFailure::new(
                 "catalog_load_failed",
                 format!(


### PR DESCRIPTION
## Summary

Add a path-injected internal loader seam and regression coverage for canonical MCP bundle-load failures, without mutating shared repository fixtures.

## Governing Spec

- `015-capability-discovery-mcp`
- `042-mcp-library-surface`

## Project Item

Closes #622

## Definition of Done

- Canonical catalog and execution loaders expose stable failures for an unavailable manifest.
- Production loading remains pinned to the canonical expedition bundle path.

## Validation

- `cargo test -p traverse-mcp stdio_server::tests::canonical_bundle_load_failures_are_stable_for_catalog_and_execution`