### PR TITLE
feat(runtime): bounded durable write path with revocation and audit (#659 slice 2)

### DIFF
--- a/crates/traverse-runtime/src/events/durable.rs
+++ b/crates/traverse-runtime/src/events/durable.rs
@@ -1,0 +1,581 @@
+//! Durable write path for event publication.
+//!
+//! Governed by spec 067-durable-journal-retention-and-write-limits
+//! (FR-003..FR-005): `publish()` waits for the durable journal write only up
+//! to a configured timeout, a timed-out event is rejected — never silently
+//! downgraded to in-memory-only delivery — and every timeout produces a
+//! structured audit record (spec 036 NFR-006).
+
+use std::sync::mpsc;
+use std::sync::{Arc, Condvar, Mutex, PoisonError};
+use std::time::Duration;
+
+use serde::Serialize;
+
+use super::journal::{DurableEventJournal, JournalError};
+use super::types::{EventBroker, EventError, Subscription, SubscriptionPoll, TraverseEvent};
+
+/// Durable sink the writer thread appends through. [`DurableEventJournal`]
+/// is the production implementation; tests inject slow or failing sinks to
+/// drive the timeout and revocation paths deterministically.
+pub trait JournalSink: Send {
+    /// Durably append an event, returning its cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JournalError`] when the durable write fails.
+    fn append_event(&mut self, event: &TraverseEvent) -> Result<String, JournalError>;
+
+    /// Durably suppress a previously written cursor from replay.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JournalError`] when the durable write fails.
+    fn append_revocation(&mut self, revoked_cursor: &str) -> Result<String, JournalError>;
+}
+
+impl JournalSink for DurableEventJournal {
+    fn append_event(&mut self, event: &TraverseEvent) -> Result<String, JournalError> {
+        self.append(event)
+    }
+
+    fn append_revocation(&mut self, revoked_cursor: &str) -> Result<String, JournalError> {
+        DurableEventJournal::append_revocation(self, revoked_cursor)
+    }
+}
+
+/// Configuration for the durable write path (067 FR-003 default: 2 seconds).
+#[derive(Debug, Clone, Copy)]
+pub struct DurableBrokerConfig {
+    /// Maximum time `publish()` waits for the durable write to complete.
+    pub write_timeout: Duration,
+}
+
+impl Default for DurableBrokerConfig {
+    fn default() -> Self {
+        Self {
+            write_timeout: Duration::from_secs(2),
+        }
+    }
+}
+
+/// Structured audit record for durable write-path failures (067 FR-005,
+/// consistent with spec 036 NFR-006 observability).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct JournalWriteAuditRecord {
+    /// `journal_write_timeout` or `journal_revocation_failed`.
+    pub kind: String,
+    /// Id of the affected event.
+    pub event_id: String,
+    /// Type of the affected event.
+    pub event_type: String,
+    /// Human-readable failure detail.
+    pub detail: String,
+}
+
+/// Receives structured audit records from the durable write path.
+pub trait JournalWriteAuditSink: Send + Sync {
+    /// Record one audit entry.
+    fn record(&self, record: &JournalWriteAuditRecord);
+}
+
+enum AckState {
+    Pending,
+    Done(String),
+    Failed(JournalError),
+    Abandoned,
+}
+
+type Ack = Arc<(Mutex<AckState>, Condvar)>;
+
+enum WriterJob {
+    Write {
+        event: TraverseEvent,
+        ack: Ack,
+    },
+    Revoke {
+        cursor: String,
+        event_id: String,
+        event_type: String,
+    },
+}
+
+/// [`EventBroker`] decorator that makes every published event durable before
+/// it is delivered: the event is journaled with fsync-before-acknowledgement
+/// (066 FR-006) and only then forwarded to the inner broker for live
+/// delivery. A write that exceeds the configured timeout rejects the event
+/// with `journal_write_timeout` (067 FR-003/FR-004); if the abandoned write
+/// completes later, the writer durably revokes it so it can never surface
+/// through replay.
+pub struct DurableBroker<B: EventBroker> {
+    inner: B,
+    jobs: mpsc::Sender<WriterJob>,
+    write_timeout: Duration,
+    audit: Arc<dyn JournalWriteAuditSink>,
+}
+
+impl<B: EventBroker> DurableBroker<B> {
+    /// Wrap `inner` with a durable write path backed by `sink`.
+    pub fn new(
+        inner: B,
+        sink: impl JournalSink + 'static,
+        config: DurableBrokerConfig,
+        audit: Arc<dyn JournalWriteAuditSink>,
+    ) -> Self {
+        let (jobs, queue) = mpsc::channel();
+        let writer_audit = Arc::clone(&audit);
+        drop(std::thread::spawn(move || {
+            run_writer(sink, &queue, writer_audit.as_ref());
+        }));
+        Self {
+            inner,
+            jobs,
+            write_timeout: config.write_timeout,
+            audit,
+        }
+    }
+}
+
+impl<B: EventBroker> EventBroker for DurableBroker<B> {
+    fn publish(&self, event: TraverseEvent) -> Result<(), EventError> {
+        let ack: Ack = Arc::new((Mutex::new(AckState::Pending), Condvar::new()));
+        self.jobs
+            .send(WriterJob::Write {
+                event: event.clone(),
+                ack: Arc::clone(&ack),
+            })
+            .map_err(|_| EventError::JournalWrite("journal writer is unavailable".to_string()))?;
+
+        let (lock, cvar) = &*ack;
+        let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
+        let (mut state, _) = cvar
+            .wait_timeout_while(guard, self.write_timeout, |state| {
+                matches!(state, AckState::Pending)
+            })
+            .unwrap_or_else(PoisonError::into_inner);
+        // Whatever happens next, the writer must treat this job as abandoned
+        // unless we already saw its outcome.
+        let outcome = std::mem::replace(&mut *state, AckState::Abandoned);
+        drop(state);
+
+        match outcome {
+            AckState::Done(cursor) => match self.inner.publish(event) {
+                Ok(()) => Ok(()),
+                Err(error) => {
+                    // Durably written but undeliverable: revoke so replay
+                    // never surfaces an event that was never delivered live.
+                    let revoke = WriterJob::Revoke {
+                        cursor,
+                        event_id: String::new(),
+                        event_type: String::new(),
+                    };
+                    let _ = self.jobs.send(revoke);
+                    Err(error)
+                }
+            },
+            AckState::Failed(error) => Err(EventError::JournalWrite(error.to_string())),
+            AckState::Pending | AckState::Abandoned => {
+                let detail = format!(
+                    "durable write exceeded {}ms; event rejected",
+                    self.write_timeout.as_millis()
+                );
+                self.audit.record(&JournalWriteAuditRecord {
+                    kind: "journal_write_timeout".to_string(),
+                    event_id: event.id.clone(),
+                    event_type: event.event_type.clone(),
+                    detail: detail.clone(),
+                });
+                Err(EventError::JournalWriteTimeout(detail))
+            }
+        }
+    }
+
+    fn subscribe(&self, event_type: &str, from_cursor: &str) -> Result<Subscription, EventError> {
+        self.inner.subscribe(event_type, from_cursor)
+    }
+
+    fn poll(
+        &self,
+        subscription_id: &str,
+        max_events: usize,
+    ) -> Result<SubscriptionPoll, EventError> {
+        self.inner.poll(subscription_id, max_events)
+    }
+
+    fn cancel(&self, subscription_id: &str) -> Result<(), EventError> {
+        self.inner.cancel(subscription_id)
+    }
+}
+
+fn run_writer(
+    mut sink: impl JournalSink,
+    jobs: &mpsc::Receiver<WriterJob>,
+    audit: &dyn JournalWriteAuditSink,
+) {
+    while let Ok(job) = jobs.recv() {
+        match job {
+            WriterJob::Write { event, ack } => {
+                let result = sink.append_event(&event);
+                let (lock, cvar) = &*ack;
+                let mut state = lock.lock().unwrap_or_else(PoisonError::into_inner);
+                if matches!(*state, AckState::Abandoned) {
+                    drop(state);
+                    // The publisher already rejected this event; if the write
+                    // completed anyway, durably suppress it (067 FR-004).
+                    if let Ok(cursor) = result {
+                        revoke(&mut sink, audit, &cursor, &event.id, &event.event_type);
+                    }
+                } else {
+                    *state = match result {
+                        Ok(cursor) => AckState::Done(cursor),
+                        Err(error) => AckState::Failed(error),
+                    };
+                    cvar.notify_one();
+                }
+            }
+            WriterJob::Revoke {
+                cursor,
+                event_id,
+                event_type,
+            } => revoke(&mut sink, audit, &cursor, &event_id, &event_type),
+        }
+    }
+}
+
+fn revoke(
+    sink: &mut impl JournalSink,
+    audit: &dyn JournalWriteAuditSink,
+    cursor: &str,
+    event_id: &str,
+    event_type: &str,
+) {
+    if let Err(error) = sink.append_revocation(cursor) {
+        audit.record(&JournalWriteAuditRecord {
+            kind: "journal_revocation_failed".to_string(),
+            event_id: event_id.to_string(),
+            event_type: event_type.to_string(),
+            detail: error.to_string(),
+        });
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::events::broker::InProcessBroker;
+    use crate::events::catalog::{EventCatalog, EventCatalogEntry};
+    use crate::events::journal::JournalConfig;
+    use crate::events::types::LifecycleStatus;
+    use std::sync::Mutex as StdMutex;
+    use std::sync::mpsc::{Receiver, Sender, channel};
+    use uuid::Uuid;
+
+    const EVENT_TYPE: &str = "dev.traverse.test.durable";
+
+    #[derive(Default)]
+    struct RecordingAudit {
+        records: StdMutex<Vec<JournalWriteAuditRecord>>,
+        notify: StdMutex<Option<Sender<JournalWriteAuditRecord>>>,
+    }
+
+    impl RecordingAudit {
+        fn with_notify(sender: Sender<JournalWriteAuditRecord>) -> Arc<Self> {
+            Arc::new(Self {
+                records: StdMutex::new(Vec::new()),
+                notify: StdMutex::new(Some(sender)),
+            })
+        }
+
+        fn kinds(&self) -> Vec<String> {
+            self.records
+                .lock()
+                .expect("audit lock must not poison")
+                .iter()
+                .map(|record| record.kind.clone())
+                .collect()
+        }
+    }
+
+    impl JournalWriteAuditSink for RecordingAudit {
+        fn record(&self, record: &JournalWriteAuditRecord) {
+            self.records
+                .lock()
+                .expect("audit lock must not poison")
+                .push(record.clone());
+            if let Some(sender) = &*self.notify.lock().expect("notify lock must not poison") {
+                let _ = sender.send(record.clone());
+            }
+        }
+    }
+
+    /// Sink whose `append_event` blocks until the test releases it, then
+    /// reports the outcome the test scripted; revocations are reported back
+    /// over a channel so tests can rendezvous deterministically.
+    struct ScriptedSink {
+        gate: Receiver<Result<String, JournalError>>,
+        revocations: Sender<String>,
+        fail_revocation: bool,
+    }
+
+    impl JournalSink for ScriptedSink {
+        fn append_event(&mut self, _event: &TraverseEvent) -> Result<String, JournalError> {
+            self.gate
+                .recv()
+                .unwrap_or_else(|_| Err(JournalError::Io("gate closed".to_string())))
+        }
+
+        fn append_revocation(&mut self, revoked_cursor: &str) -> Result<String, JournalError> {
+            let _ = self.revocations.send(revoked_cursor.to_string());
+            if self.fail_revocation {
+                return Err(JournalError::Io("revocation rejected".to_string()));
+            }
+            Ok("0".to_string())
+        }
+    }
+
+    fn test_event() -> TraverseEvent {
+        TraverseEvent {
+            id: Uuid::new_v4().to_string(),
+            source: "traverse-runtime/test.capability".to_string(),
+            event_type: EVENT_TYPE.to_string(),
+            datacontenttype: "application/json".to_string(),
+            time: "2026-07-13T00:00:00Z".to_string(),
+            data: serde_json::json!({ "ok": true }),
+            owner: "test.capability".to_string(),
+            version: "1.0.0".to_string(),
+            lifecycle_status: LifecycleStatus::Active,
+        }
+    }
+
+    fn active_catalog() -> Arc<EventCatalog> {
+        let catalog = EventCatalog::new();
+        catalog
+            .register(EventCatalogEntry {
+                event_type: EVENT_TYPE.to_string(),
+                version: "1.0.0".to_string(),
+                owner: "test.capability".to_string(),
+                lifecycle_status: LifecycleStatus::Active,
+                consumer_count: 0,
+            })
+            .expect("catalog entry must register");
+        Arc::new(catalog)
+    }
+
+    fn inner_broker() -> InProcessBroker {
+        InProcessBroker::new(active_catalog()).expect("broker must build")
+    }
+
+    fn test_root(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("traverse-durable-{name}-{}", Uuid::new_v4()))
+    }
+
+    #[test]
+    fn journal_sink_impl_appends_and_revokes_through_the_real_journal() {
+        let root = test_root("sink-impl");
+        let mut journal = DurableEventJournal::open(
+            &root,
+            JournalConfig::default(),
+            Arc::new(crate::events::broker::SystemClock),
+        )
+        .expect("journal must open");
+        let cursor =
+            JournalSink::append_event(&mut journal, &test_event()).expect("append must succeed");
+        JournalSink::append_revocation(&mut journal, &cursor).expect("revocation must succeed");
+        assert!(
+            journal
+                .replay_from("0", 10)
+                .expect("replay must succeed")
+                .is_empty(),
+            "the revoked event must not replay"
+        );
+    }
+
+    #[test]
+    fn durable_publish_journals_then_delivers() {
+        let root = test_root("happy");
+        let journal = DurableEventJournal::open(
+            &root,
+            JournalConfig::default(),
+            Arc::new(crate::events::broker::SystemClock),
+        )
+        .expect("journal must open");
+        let audit = Arc::new(RecordingAudit::default());
+        let broker = DurableBroker::new(
+            inner_broker(),
+            journal,
+            DurableBrokerConfig::default(),
+            audit.clone(),
+        );
+
+        let subscription = broker
+            .subscribe(EVENT_TYPE, "0")
+            .expect("subscribe must succeed");
+        broker.publish(test_event()).expect("publish must succeed");
+
+        let poll = broker
+            .poll(&subscription.subscription_id, 10)
+            .expect("poll must succeed");
+        assert_eq!(poll.events.len(), 1, "live delivery must still work");
+        broker
+            .cancel(&subscription.subscription_id)
+            .expect("cancel must succeed");
+
+        let reader = DurableEventJournal::open(
+            &root,
+            JournalConfig::default(),
+            Arc::new(crate::events::broker::SystemClock),
+        )
+        .expect("journal must reopen");
+        let replayed = reader.replay_from("0", 10).expect("replay must succeed");
+        assert_eq!(replayed.len(), 1, "the event must be durable");
+        assert!(audit.kinds().is_empty(), "no audit records on success");
+    }
+
+    #[test]
+    fn undeliverable_event_is_revoked_after_durable_write() {
+        let (gate_tx, gate_rx) = channel();
+        let (revoked_tx, revoked_rx) = channel();
+        let sink = ScriptedSink {
+            gate: gate_rx,
+            revocations: revoked_tx,
+            fail_revocation: false,
+        };
+        let audit = Arc::new(RecordingAudit::default());
+        let broker =
+            DurableBroker::new(inner_broker(), sink, DurableBrokerConfig::default(), audit);
+
+        let mut unregistered = test_event();
+        unregistered.event_type = "dev.traverse.test.unknown".to_string();
+        gate_tx
+            .send(Ok("41".to_string()))
+            .expect("gate must accept");
+        let err = broker
+            .publish(unregistered)
+            .expect_err("unregistered event type must be rejected by the inner broker");
+        assert!(matches!(err, EventError::UnregisteredEventType(_)), "{err}");
+
+        let revoked = revoked_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("the durably written but undelivered event must be revoked");
+        assert_eq!(revoked, "41");
+    }
+
+    #[test]
+    fn slow_durable_write_times_out_rejects_and_revokes() {
+        let (gate_tx, gate_rx) = channel();
+        let (revoked_tx, revoked_rx) = channel();
+        let (audit_tx, audit_rx) = channel();
+        let sink = ScriptedSink {
+            gate: gate_rx,
+            revocations: revoked_tx,
+            fail_revocation: false,
+        };
+        let audit = RecordingAudit::with_notify(audit_tx);
+        let broker = DurableBroker::new(
+            inner_broker(),
+            sink,
+            DurableBrokerConfig {
+                write_timeout: Duration::from_millis(50),
+            },
+            audit.clone(),
+        );
+
+        let subscription = broker
+            .subscribe(EVENT_TYPE, "0")
+            .expect("subscribe must succeed");
+        let err = broker
+            .publish(test_event())
+            .expect_err("a stalled durable write must time out");
+        assert!(matches!(err, EventError::JournalWriteTimeout(_)), "{err}");
+        assert!(
+            err.to_string().contains("journal_write_timeout"),
+            "the error code must be distinct: {err}"
+        );
+
+        let timeout_audit = audit_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("timeout must produce a structured audit record");
+        assert_eq!(timeout_audit.kind, "journal_write_timeout");
+        assert_eq!(timeout_audit.event_type, EVENT_TYPE);
+
+        let poll = broker
+            .poll(&subscription.subscription_id, 10)
+            .expect("poll must succeed");
+        assert!(
+            poll.events.is_empty(),
+            "a rejected event must not be delivered live"
+        );
+
+        // Release the stalled write; the writer must observe the abandoned
+        // ack and durably revoke the late record.
+        gate_tx.send(Ok("7".to_string())).expect("gate must accept");
+        let revoked = revoked_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("the late write must be revoked");
+        assert_eq!(revoked, "7");
+    }
+
+    #[test]
+    fn failed_durable_write_rejects_the_event() {
+        let (gate_tx, gate_rx) = channel();
+        let (revoked_tx, _revoked_rx) = channel();
+        let sink = ScriptedSink {
+            gate: gate_rx,
+            revocations: revoked_tx,
+            fail_revocation: false,
+        };
+        let audit = Arc::new(RecordingAudit::default());
+        let broker =
+            DurableBroker::new(inner_broker(), sink, DurableBrokerConfig::default(), audit);
+
+        gate_tx
+            .send(Err(JournalError::Io("disk gone".to_string())))
+            .expect("gate must accept");
+        let err = broker
+            .publish(test_event())
+            .expect_err("a failed durable write must reject the event");
+        assert!(matches!(err, EventError::JournalWrite(_)), "{err}");
+        assert!(err.to_string().contains("disk gone"), "{err}");
+    }
+
+    #[test]
+    fn revocation_failures_are_audited() {
+        let (gate_tx, gate_rx) = channel();
+        let (revoked_tx, revoked_rx) = channel();
+        let (audit_tx, audit_rx) = channel();
+        let sink = ScriptedSink {
+            gate: gate_rx,
+            revocations: revoked_tx,
+            fail_revocation: true,
+        };
+        let audit = RecordingAudit::with_notify(audit_tx);
+        let broker = DurableBroker::new(
+            inner_broker(),
+            sink,
+            DurableBrokerConfig {
+                write_timeout: Duration::from_millis(50),
+            },
+            audit.clone(),
+        );
+
+        let err = broker
+            .publish(test_event())
+            .expect_err("a stalled durable write must time out");
+        assert!(matches!(err, EventError::JournalWriteTimeout(_)), "{err}");
+        let timeout_audit = audit_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("timeout audit must arrive");
+        assert_eq!(timeout_audit.kind, "journal_write_timeout");
+
+        gate_tx.send(Ok("9".to_string())).expect("gate must accept");
+        let _ = revoked_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("revocation must be attempted");
+        let failure_audit = audit_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("revocation failure must be audited");
+        assert_eq!(failure_audit.kind, "journal_revocation_failed");
+        assert!(failure_audit.detail.contains("revocation rejected"));
+    }
+}

--- a/crates/traverse-runtime/src/events/journal.rs
+++ b/crates/traverse-runtime/src/events/journal.rs
@@ -3,8 +3,8 @@
 //! Governed by spec 066-durable-identity-event-delivery (FR-005..FR-009) and
 //! spec 067-durable-journal-retention-and-write-limits (FR-001, FR-002).
 //!
-//! Storage engine only: broker/sink wiring and the bounded publish write
-//! timeout (067 FR-003..FR-005) build on this in a follow-up slice of #659.
+//! The bounded publish write path that drives this journal lives in
+//! [`super::durable`].
 
 use std::fs;
 use std::io::Write;
@@ -85,12 +85,17 @@ impl std::fmt::Display for JournalError {
 
 impl std::error::Error for JournalError {}
 
-/// One durable record: an acknowledged event with its journal sequence.
+/// One durable record: an acknowledged event with its journal sequence, or a
+/// revocation suppressing a previously written sequence from replay
+/// (067 FR-004: a rejected event must not be delivered through any path).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct JournalRecordV1 {
     seq: u64,
     written_at_secs: u64,
-    event: TraverseEvent,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    event: Option<TraverseEvent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    revokes: Option<u64>,
 }
 
 /// Metadata for one on-disk segment, derived entirely from its contents so
@@ -202,6 +207,30 @@ impl DurableEventJournal {
     /// Returns [`JournalError::Io`] when the durable write fails; the event
     /// is not acknowledged in that case.
     pub fn append(&mut self, event: &TraverseEvent) -> Result<String, JournalError> {
+        self.append_line(Some(event), None)
+    }
+
+    /// Durably record that the event at `revoked_cursor` was rejected and
+    /// must never be delivered through replay (067 FR-004). Used when a
+    /// caller abandoned a write that later completed, or when a durably
+    /// written event could not be delivered.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`JournalError::InvalidCursor`] for unparseable cursors and
+    /// [`JournalError::Io`] when the durable write fails.
+    pub fn append_revocation(&mut self, revoked_cursor: &str) -> Result<String, JournalError> {
+        let revoked = revoked_cursor.parse::<u64>().map_err(|e| {
+            JournalError::InvalidCursor(format!("revoked cursor `{revoked_cursor}`: {e}"))
+        })?;
+        self.append_line(None, Some(revoked))
+    }
+
+    fn append_line(
+        &mut self,
+        event: Option<&TraverseEvent>,
+        revokes: Option<u64>,
+    ) -> Result<String, JournalError> {
         let now_secs = self.now_secs()?;
 
         let needs_rollover = self.active.as_ref().is_some_and(|(meta, _)| {
@@ -217,7 +246,7 @@ impl DurableEventJournal {
             Some(active) => active,
             None => self.open_segment(now_secs)?,
         };
-        let result = append_record(&mut active, self.next_seq, now_secs, event);
+        let result = append_record(&mut active, self.next_seq, now_secs, event, revokes);
         self.active = Some(active);
         let cursor = result?;
         self.next_seq += 1;
@@ -277,7 +306,10 @@ impl DurableEventJournal {
             });
         }
 
-        let mut out = Vec::new();
+        // Revocations always carry a later sequence than the record they
+        // suppress, so the full scan must finish before results are final.
+        let mut revoked = std::collections::HashSet::new();
+        let mut collected: Vec<(u64, TraverseEvent)> = Vec::new();
         let last_index = self.segment_count().saturating_sub(1);
         for (index, meta) in self.segments().enumerate() {
             if meta.last_seq <= after {
@@ -285,15 +317,21 @@ impl DurableEventJournal {
             }
             let allow_torn_tail = index == last_index;
             for record in read_segment_records(&meta.path, allow_torn_tail)? {
-                if record.seq > after {
-                    out.push((record.seq.to_string(), record.event));
-                    if out.len() == max_events {
-                        return Ok(out);
-                    }
+                if let Some(revoked_seq) = record.revokes {
+                    let _ = revoked.insert(revoked_seq);
+                } else if record.seq > after
+                    && let Some(event) = record.event
+                {
+                    collected.push((record.seq, event));
                 }
             }
         }
-        Ok(out)
+        collected.retain(|(seq, _)| !revoked.contains(seq));
+        collected.truncate(max_events);
+        Ok(collected
+            .into_iter()
+            .map(|(seq, event)| (seq.to_string(), event))
+            .collect())
     }
 
     /// The cursor from which the oldest retained event replays; callers that
@@ -399,12 +437,14 @@ fn append_record(
     active: &mut (SegmentMeta, fs::File),
     seq: u64,
     now_secs: u64,
-    event: &TraverseEvent,
+    event: Option<&TraverseEvent>,
+    revokes: Option<u64>,
 ) -> Result<String, JournalError> {
     let record = JournalRecordV1 {
         seq,
         written_at_secs: now_secs,
-        event: event.clone(),
+        event: event.cloned(),
+        revokes,
     };
     let mut line = serde_json::to_vec(&record)
         .map_err(|e| JournalError::Io(format!("serialize journal record: {e}")))?;
@@ -795,7 +835,8 @@ mod tests {
             let mut line = serde_json::to_vec(&JournalRecordV1 {
                 seq,
                 written_at_secs: 1_000,
-                event: test_event("x"),
+                event: Some(test_event("x")),
+                revokes: None,
             })
             .expect("record must serialize");
             line.push(b'\n');
@@ -1053,6 +1094,58 @@ mod tests {
             .prune()
             .expect_err("size pruning an already-missing segment must surface an io error");
         assert!(matches!(err, JournalError::Io(_)), "{err}");
+    }
+
+    #[test]
+    fn revocations_suppress_events_from_replay() {
+        let root = test_root("revocation");
+        let clock = TestClock::at_secs(1_000);
+        let mut journal = open_journal(&root, JournalConfig::default(), clock.clone());
+        journal
+            .append(&test_event("a"))
+            .expect("append must succeed");
+        let second = journal
+            .append(&test_event("b"))
+            .expect("append must succeed");
+        journal
+            .append(&test_event("c"))
+            .expect("append must succeed");
+
+        journal
+            .append_revocation(&second)
+            .expect("revocation must be durable");
+
+        let replayed = journal.replay_from("0", 10).expect("replay must succeed");
+        let markers: Vec<_> = replayed
+            .iter()
+            .map(|(_, event)| event.data["marker"].clone())
+            .collect();
+        assert_eq!(
+            markers,
+            vec![serde_json::json!("a"), serde_json::json!("c")],
+            "the revoked event must not be delivered and the revocation record itself must not appear"
+        );
+
+        let capped = journal.replay_from("0", 2).expect("replay must succeed");
+        assert_eq!(
+            capped.len(),
+            2,
+            "max_events must apply after revocation filtering"
+        );
+
+        let reopened = open_journal(&root, JournalConfig::default(), clock);
+        let recovered = reopened.replay_from("0", 10).expect("replay must succeed");
+        assert_eq!(
+            recovered.len(),
+            2,
+            "revocations must keep suppressing events across restart"
+        );
+
+        let mut invalid = reopened;
+        let err = invalid
+            .append_revocation("not-a-cursor")
+            .expect_err("unparseable revoked cursor must be rejected");
+        assert!(matches!(err, JournalError::InvalidCursor(_)), "{err}");
     }
 
     #[test]

--- a/crates/traverse-runtime/src/events/mod.rs
+++ b/crates/traverse-runtime/src/events/mod.rs
@@ -4,11 +4,15 @@
 
 pub mod broker;
 pub mod catalog;
+pub mod durable;
 pub mod journal;
 pub mod types;
 
 pub use broker::{BrokerClock, BrokerConfig, InProcessBroker, SystemClock};
 pub use catalog::{EventCatalog, EventCatalogEntry};
+pub use durable::{
+    DurableBroker, DurableBrokerConfig, JournalSink, JournalWriteAuditRecord, JournalWriteAuditSink,
+};
 pub use journal::{DurableEventJournal, JournalConfig, JournalError};
 pub use types::{
     BrokerEvent, EventBroker, EventCursor, EventError, LifecycleStatus, Subscription,

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -56,6 +56,11 @@ pub enum EventError {
     SubscriptionNotFound(String),
     /// Broker was configured with an invalid retention window.
     InvalidRetentionWindow(String),
+    /// Durable journal write failed; the event was not acknowledged (066 FR-006).
+    JournalWrite(String),
+    /// Durable journal write exceeded the configured timeout; the event was
+    /// rejected, not delivered (067 FR-003/FR-004).
+    JournalWriteTimeout(String),
 }
 
 impl std::fmt::Display for EventError {
@@ -73,6 +78,8 @@ impl std::fmt::Display for EventError {
             ),
             Self::SubscriptionNotFound(id) => write!(f, "subscription not found: {id}"),
             Self::InvalidRetentionWindow(msg) => write!(f, "invalid retention window: {msg}"),
+            Self::JournalWrite(msg) => write!(f, "journal write failed: {msg}"),
+            Self::JournalWriteTimeout(msg) => write!(f, "journal_write_timeout: {msg}"),
         }
     }
 }
@@ -166,6 +173,8 @@ mod tests {
             },
             EventError::SubscriptionNotFound("sub-1".to_string()),
             EventError::InvalidRetentionWindow("bad".to_string()),
+            EventError::JournalWrite("disk gone".to_string()),
+            EventError::JournalWriteTimeout("exceeded 2000ms".to_string()),
         ];
 
         for err in cases {


### PR DESCRIPTION
## Summary

Second slice of #659: the **bounded durable write path** required by `067-durable-journal-retention-and-write-limits` FR-003..FR-005, building on the journal storage engine from #661.

- **`DurableBroker`** decorates any `EventBroker`: `publish()` first journals the event through a dedicated writer thread (fsync-before-acknowledgement, 066 FR-006), then forwards it to the inner broker for live delivery
- **Bounded wait (FR-003)**: `publish()` waits for the durable write only up to the configured timeout (default 2 s) and returns a distinct `journal_write_timeout` error on expiry — it never blocks indefinitely
- **Rejected means rejected (FR-004)**: the ack handoff is a mutex+condvar state machine, so the publisher's abandonment and the writer's completion cannot race. If an abandoned write completes late, the writer durably appends a **revocation record**; the journal's replay now filters revoked sequences, so a rejected event is not delivered through any path — live or replay, including after restart. An event that journals durably but fails inner delivery (e.g. unregistered type) is revoked the same way
- **Audit (FR-005)**: every timeout and every failed revocation emits a structured `JournalWriteAuditRecord` through an injectable `JournalWriteAuditSink`, consistent with spec 036 NFR-006 observability
- New `EventError::JournalWrite` / `EventError::JournalWriteTimeout` variants; `subscribe`/`poll`/`cancel` delegate to the inner broker (journal-backed replay through subscriptions is the remaining #659 slice, coordinating with #591's identity filtering)

Refs #659.

## Governing Spec

- `066-durable-identity-event-delivery`
- `067-durable-journal-retention-and-write-limits`

## Project Item

Issue #659 — Project 1 item `PVTI_lADOEbiBt84Bbyp1zgyq4R0` (Status: In Progress, label `agent:claude`)

## Validation

- `cargo test -p traverse-runtime` — all green; 6 new `DurableBroker` tests drive the paths deterministically with a scripted sink (channel-gated writes): happy path journals-then-delivers, stalled write times out with `journal_write_timeout` + audit record + late-completion revocation, failed write rejects with `JournalWrite`, undeliverable-after-durable-write is revoked, revocation failure is audited, and the real-journal `JournalSink` impl round-trips append/revoke
- Journal tests extended for revocation records: replay suppression (including across restart), `max_events` after filtering, and unparseable revoked-cursor rejection
- `cargo clippy --workspace --all-targets` — clean; `cargo fmt --check` — clean
- `scripts/ci/coverage_gate.sh` (after `cargo llvm-cov clean`) — **traverse-runtime 100.00% (9979/9979 lines)**; contracts 100%, registry 100%, cli 86.12%, mcp 98.92%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
