### PR TITLE
fix(security): reject placeholder sigstore evidence

### DIFF
--- a/crates/traverse-cli/src/supply_chain.rs
+++ b/crates/traverse-cli/src/supply_chain.rs
@@ -273,16 +273,10 @@ fn verify_signature(manifest: Option<&ArtifactManifest>) -> CheckEvidence {
             }
         }
         "sigstore" | "Sigstore" => match manifest.sigstore_bundle_ref.as_deref() {
-            Some(bundle_ref) if bundle_ref.starts_with("verified://") => CheckEvidence {
-                status: CheckStatus::Verified,
-                message: "sigstore bundle reference is pre-verified".to_string(),
-                expected: Some("verified:// bundle reference".to_string()),
-                actual: Some(bundle_ref.to_string()),
-            },
             Some(bundle_ref) => CheckEvidence {
                 status: CheckStatus::Invalid,
-                message: "sigstore bundle reference is not verified".to_string(),
-                expected: Some("verified:// bundle reference".to_string()),
+                message: "sigstore bundle references require Rekor/Fulcio verification".to_string(),
+                expected: Some("verified Sigstore bundle evidence".to_string()),
                 actual: Some(bundle_ref.to_string()),
             },
             None => CheckEvidence {
@@ -512,7 +506,7 @@ mod tests {
     }
 
     #[test]
-    fn verifies_manifest_json_input_with_relative_artifact_and_sigstore() {
+    fn rejects_placeholder_sigstore_bundle_in_manifest_json_input() {
         let dir = temp_dir("supply-chain-manifest-json");
         let artifact = dir.join("artifact.bin");
         let manifest = dir.join("manifest.json");
@@ -548,9 +542,9 @@ mod tests {
 
         let report = verify_artifact(&manifest);
 
-        assert_eq!(report.overall_status, OverallStatus::Passed);
+        assert_eq!(report.overall_status, OverallStatus::Failed);
         assert_eq!(report.checksum_status, CheckStatus::Matched);
-        assert_eq!(report.signature_status, CheckStatus::Verified);
+        assert_eq!(report.signature_status, CheckStatus::Invalid);
         assert_eq!(report.provenance_status, CheckStatus::Verified);
     }
 

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -3918,7 +3918,7 @@ mod tests {
     }
 
     #[test]
-    fn governed_artifact_accepts_verified_sigstore_bundle() {
+    fn governed_artifact_rejects_placeholder_sigstore_bundle() {
         let path = temp_artifact_path("sigstore-valid");
         assert!(fs::write(&path, b"sigstore governed bytes").is_ok());
         let signature = ArtifactSignature {
@@ -3938,15 +3938,15 @@ mod tests {
 
         let outcome = runtime.execute(valid_request());
 
-        assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
         assert_eq!(
             outcome
-                .trace
-                .execution
-                .artifact_verification
+                .result
+                .error
                 .as_ref()
-                .and_then(|record| record.scheme),
-            Some(ArtifactVerificationScheme::Sigstore)
+                .and_then(|error| error.details.get("code"))
+                .and_then(serde_json::Value::as_str),
+            Some("sigstore_unreachable")
         );
     }
 

--- a/crates/traverse-runtime/src/security.rs
+++ b/crates/traverse-runtime/src/security.rs
@@ -335,23 +335,9 @@ fn signature_verification_failed(trust_level: ArtifactTrustLevel) -> ArtifactVer
 }
 
 fn verify_sigstore(
-    signature: &ArtifactSignature,
+    _signature: &ArtifactSignature,
     trust_level: ArtifactTrustLevel,
 ) -> Result<ArtifactVerificationRecord, ArtifactVerificationFailure> {
-    if signature
-        .sigstore_bundle_ref
-        .as_deref()
-        .is_some_and(|bundle| bundle.starts_with("verified://"))
-    {
-        return Ok(ArtifactVerificationRecord {
-            status: ArtifactVerificationStatus::Verified,
-            trust_level,
-            scheme: Some(ArtifactVerificationScheme::Sigstore),
-            warning_code: None,
-            error_code: None,
-        });
-    }
-
     let record = rejected_record(
         trust_level,
         Some(ArtifactVerificationScheme::Sigstore),

--- a/scripts/ci/supply_chain_check.sh
+++ b/scripts/ci/supply_chain_check.sh
@@ -113,8 +113,9 @@ cat > "${artifact_one}.manifest.json" <<JSON
   "artifact_path": "${artifact_one}",
   "checksum_algorithm": "sha256",
   "checksum_sha256": "${hash_one}",
-  "signing_scheme": "sigstore",
-  "sigstore_bundle_ref": "verified://local-ci-placeholder",
+  "signing_scheme": "ed25519",
+  "public_key_hex": "0000000000000000000000000000000000000000000000000000000000000000",
+  "signature_hex": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
   "provenance_path": "${provenance_path}"
 }
 JSON


### PR DESCRIPTION
## Summary

- reject all placeholder `verified://` Sigstore references at runtime
- make CLI artifact verification report unverified Sigstore evidence as invalid
- replace the CI placeholder fixture with typed Ed25519 metadata

## Governing Spec

- `030-security-identity-model`
- `031-supply-chain-hardening`

## Project Item

Refs #589. This is a fail-closed hardening slice; it does not close #589 because a real Rekor/Fulcio verifier remains to be implemented.

## Definition of Done

- [x] Reject `verified://` placeholder evidence outside test fixtures.
- [x] Stop supply-chain CI from treating a placeholder as verified evidence.
- [ ] Add production Rekor/Fulcio verification with mock success and unreachable-path coverage.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p traverse-runtime --lib governed_artifact_rejects_placeholder_sigstore_bundle`
- `cargo test -p traverse-cli rejects_placeholder_sigstore_bundle_in_manifest_json_input`