### PR TITLE
test(http): cover invalid simplified workspace execution

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -8990,6 +8990,23 @@ mod tests {
     }
 
     #[test]
+    fn workspace_execute_endpoint_rejects_simplified_request_without_capability_id() {
+        let body = json!({"input": {"value": "demo"}}).to_string().into_bytes();
+        let state = test_state_with("test.api.do-something", "1.0.0");
+        let req = make_http_request("POST", "/v1/workspaces/ws-test/execute", body);
+
+        let mut out = Vec::new();
+        handle_execute_workspace(&mut out, &req, &state, true, "ws-test")
+            .expect("invalid request must write a response");
+
+        assert_eq!(response_status(&out), 400);
+        assert_eq!(
+            parse_response_body(&out)["traverse_code"],
+            "invalid_request"
+        );
+    }
+
+    #[test]
     fn workspace_execute_endpoint_returns_async_accepted_envelope_for_prefer_header() {
         let body = make_runtime_request_body("test.api.do-something");
         let state = test_state_with("test.api.do-something", "1.0.0");


### PR DESCRIPTION
## Summary

- cover rejection of simplified workspace-execution requests without a capability id
- assert the public API returns the stable `invalid_request` error envelope

## Governing Spec

- `033-http-json-api`

## Project Item

Refs #637

## Definition of Done

- [x] Add focused coverage for an uncovered workspace execution validation branch.
- [ ] Continue separate focused passes until the tracked HTTP API coverage gap is closed.

## Validation

- `cargo test -p traverse-cli workspace_execute_endpoint_rejects_simplified_request_without_capability_id`