### PR TITLE
feat(kotlin): scaffold Android embedder package

### DIFF
--- a/packages/kotlin/TraverseEmbedder/README.md
+++ b/packages/kotlin/TraverseEmbedder/README.md
@@ -1,0 +1,9 @@
+# TraverseEmbedder for Kotlin/Android
+
+This public Android library is the Spec-068 foundation for `embedder-api/1.0.0`.
+It exposes validated bundle and lifecycle types plus an in-memory deterministic
+harness for conformance tests. It never launches `traverse-cli serve` or uses
+server-discovery files in production.
+
+Runtime-WASM bridging, runtime event subscriptions, release evidence, and the
+Compose reference-app integration remain tracked by Traverse #648.

--- a/packages/kotlin/TraverseEmbedder/build.gradle.kts
+++ b/packages/kotlin/TraverseEmbedder/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.library") version "8.5.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+}

--- a/packages/kotlin/TraverseEmbedder/settings.gradle.kts
+++ b/packages/kotlin/TraverseEmbedder/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "TraverseEmbedder"
+include(":traverse-embedder")

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/build.gradle.kts
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "dev.traverse.embedder"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 28
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions { jvmTarget = "17" }
+}
+
+dependencies {
+    testImplementation("junit:junit:4.13.2")
+}

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/AndroidManifest.xml
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/TraverseEmbedder.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/TraverseEmbedder.kt
@@ -1,0 +1,52 @@
+package dev.traverse.embedder
+
+/** Public Kotlin/Android surface for Traverse `embedder-api/1.0.0`. */
+object TraverseEmbedder {
+    const val API_VERSION = "1.0.0"
+}
+
+data class TraverseBundle(val rootPath: String, val runtimeWasmDigest: String) {
+    init {
+        require(rootPath.isNotBlank()) { "bundle root path is required" }
+        require(runtimeWasmDigest.isNotBlank()) { "runtime WASM digest is required" }
+    }
+}
+
+data class TraverseSubmission(val targetId: String, val inputJson: String) {
+    init { require(targetId.isNotBlank()) { "target_id is required" } }
+}
+
+data class TraverseSubmissionResult(val sessionId: String, val status: String)
+
+/** Deterministic test double; it never evaluates application business logic. */
+class InMemoryTraverseEmbedder {
+    private var bundle: TraverseBundle? = null
+    private var submissionSequence = 0
+
+    fun initialize(bundle: TraverseBundle) {
+        check(this.bundle == null) { "embedder is already initialized" }
+        this.bundle = bundle
+    }
+
+    fun shutdown() {
+        bundle = null
+        submissionSequence = 0
+    }
+
+    fun submit(submission: TraverseSubmission): TraverseSubmissionResult {
+        check(bundle != null) { "embedder is not initialized" }
+        submissionSequence += 1
+        return TraverseSubmissionResult("kotlin-session-$submissionSequence", "accepted")
+    }
+
+    fun compatibleStart(capabilityId: String, inputJson: String) =
+        submit(TraverseSubmission(capabilityId, inputJson))
+
+    fun compatibleStop(capabilityId: String, instanceId: String?) {
+        check(bundle != null) { "embedder is not initialized" }
+    }
+
+    fun compatibleKill(capabilityId: String, instanceId: String?) {
+        check(bundle != null) { "embedder is not initialized" }
+    }
+}

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/TraverseEmbedderTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/TraverseEmbedderTest.kt
@@ -1,0 +1,16 @@
+package dev.traverse.embedder
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TraverseEmbedderTest {
+    @Test fun lifecycleAndSubmissionAreDeterministic() {
+        val harness = InMemoryTraverseEmbedder()
+        harness.initialize(TraverseBundle("assets/traverse", "sha256:test"))
+
+        assertEquals(
+            TraverseSubmissionResult("kotlin-session-1", "accepted"),
+            harness.submit(TraverseSubmission("demo.workflow", "{}")),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add the versioned public Kotlin/Android library foundation for `embedder-api/1.0.0`
- expose validated bundle/submission types, lifecycle operations, and a deterministic in-memory harness
- document the no-sidecar production boundary

## Governing Spec

- `057-embeddable-runtime-host`
- `068-public-platform-embedder-packages`

## Project Item

Refs #648

## Definition of Done

- [x] Add a public Android library package with the Spec-068 lifecycle surface and deterministic test seam.
- [ ] Wire the production runtime-WASM bridge, event subscription stream, release evidence, and Compose reference-app integration.

## Validation

- `git diff --check`
- Local Gradle/Kotlin toolchain is unavailable in this workspace; Android/CI tooling is the compile gate for this scaffold.