### PR TITLE
feat(dotnet): scaffold public embedder package

### DIFF
--- a/packages/dotnet/TraverseEmbedder/README.md
+++ b/packages/dotnet/TraverseEmbedder/README.md
@@ -1,0 +1,10 @@
+# TraverseEmbedder for .NET/WinUI
+
+This public .NET library is the Spec-068 package foundation for
+`embedder-api/1.0.0`. It contains the stable bundle, submission, lifecycle,
+and compatible-capability boundary plus `InMemoryTraverseEmbedder` for
+deterministic conformance tests. It never depends on `traverse-cli serve` or
+server-discovery files in production.
+
+The runtime-WASM bridge, event subscriptions, release evidence, and WinUI
+reference-app integration remain tracked by Traverse #649.

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.cs
@@ -1,0 +1,66 @@
+namespace Traverse.Embedder;
+
+/// <summary>Public .NET surface for Traverse embedder-api/1.0.0.</summary>
+public static class TraverseEmbedder
+{
+    public const string ApiVersion = "1.0.0";
+}
+
+public sealed record TraverseBundle(string RootPath, string RuntimeWasmDigest)
+{
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(RootPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(RuntimeWasmDigest);
+    }
+}
+
+public sealed record TraverseSubmission(string TargetId, string InputJson)
+{
+    public void Validate() => ArgumentException.ThrowIfNullOrWhiteSpace(TargetId);
+}
+
+public sealed record TraverseSubmissionResult(string SessionId, string Status);
+
+/// <summary>
+/// Deterministic conformance test double. It never evaluates application
+/// business logic and never starts a Traverse sidecar process.
+/// </summary>
+public sealed class InMemoryTraverseEmbedder
+{
+    private TraverseBundle? bundle;
+    private int submissionSequence;
+
+    public void Initialize(TraverseBundle value)
+    {
+        if (bundle is not null) throw new InvalidOperationException("embedder is already initialized");
+        value.Validate();
+        bundle = value;
+    }
+
+    public void Shutdown()
+    {
+        bundle = null;
+        submissionSequence = 0;
+    }
+
+    public TraverseSubmissionResult Submit(TraverseSubmission submission)
+    {
+        if (bundle is null) throw new InvalidOperationException("embedder is not initialized");
+        submission.Validate();
+        submissionSequence++;
+        return new TraverseSubmissionResult($"dotnet-session-{submissionSequence}", "accepted");
+    }
+
+    public TraverseSubmissionResult CompatibleStart(string capabilityId, string inputJson) =>
+        Submit(new TraverseSubmission(capabilityId, inputJson));
+
+    public void CompatibleStop(string capabilityId, string? instanceId) => EnsureInitialized();
+
+    public void CompatibleKill(string capabilityId, string? instanceId) => EnsureInitialized();
+
+    private void EnsureInitialized()
+    {
+        if (bundle is null) throw new InvalidOperationException("embedder is not initialized");
+    }
+}

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.csproj
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PackageId>TraverseEmbedder</PackageId>
+    <Version>0.1.0</Version>
+    <Description>Traverse embedder-api/1.0.0 public .NET boundary.</Description>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

- add the versioned public .NET library foundation for `embedder-api/1.0.0`
- expose validated bundle/submission types, lifecycle operations, and a deterministic in-memory harness
- document the no-sidecar production boundary

## Governing Spec

- `057-embeddable-runtime-host`
- `068-public-platform-embedder-packages`

## Project Item

Refs #649

## Definition of Done

- [x] Add a public .NET package with the Spec-068 lifecycle surface and deterministic test seam.
- [ ] Wire the production runtime-WASM bridge, event subscription stream, release evidence, and WinUI reference-app integration.

## Validation

- `git diff --check`
- Local .NET SDK is unavailable in this workspace; CI is the compile gate for this scaffold.