### PR TITLE
fix(security): apply artifact verification gate to workflow pipeline steps

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -6555,11 +6555,15 @@ mod tests {
 
         let registered =
             load_registered_bundle(&bundle_path).expect("starter bundle should register");
+        // Development security mode mirrors the CLI's own execution paths: the
+        // starter bundle ships unsigned local-dev artifacts, which the default
+        // production posture rejects on every workflow step (spec 030 FR-013).
         let runtime = traverse_runtime::Runtime::new(
             registered.capability_registry,
             ExpeditionExampleExecutor,
         )
-        .with_workflow_registry(registered.workflow_registry);
+        .with_workflow_registry(registered.workflow_registry)
+        .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development());
 
         let first_request =
             load_runtime_request(&request_path).expect("pipeline request should load");

--- a/crates/traverse-mcp/src/stdio_server.rs
+++ b/crates/traverse-mcp/src/stdio_server.rs
@@ -1031,9 +1031,17 @@ pub fn run_stdio_server(simulate_startup_failure: bool) -> Result<(), StdioServe
     let event_registry = Box::leak(Box::new(canonical_execution.events));
     let workflow_registry = Box::leak(Box::new(WorkflowRegistry::new()));
 
+    // The stdio server only executes the canonical bundled expedition example,
+    // whose artifacts are unsigned local-dev bundles (SourceKind::Local); the
+    // development security mode allows them with a warning, matching every
+    // other example-executing runtime in this crate and the CLI (spec 030
+    // FR-013 keeps production the default for embedders).
     let runtime = Box::leak(Box::new(
         Runtime::new(canonical_execution.capabilities, ExpeditionExampleExecutor)
-            .with_workflow_registry(canonical_execution.workflows),
+            .with_workflow_registry(canonical_execution.workflows)
+            .with_security_config(
+                traverse_runtime::security::RuntimeSecurityConfig::development(),
+            ),
     ));
     let mcp = Box::leak(Box::new(TraverseMcp::new(
         capability_registry,
@@ -1869,7 +1877,10 @@ mod tests {
         let workflow_registry = Box::leak(Box::new(WorkflowRegistry::new()));
         let runtime = Box::leak(Box::new(
             Runtime::new(execution.capabilities, ExpeditionExampleExecutor)
-                .with_workflow_registry(execution.workflows),
+                .with_workflow_registry(execution.workflows)
+                .with_security_config(
+                    traverse_runtime::security::RuntimeSecurityConfig::development(),
+                ),
         ));
         let mcp = Box::leak(Box::new(TraverseMcp::new(
             capability_registry,

--- a/crates/traverse-mcp/src/stdio_server.rs
+++ b/crates/traverse-mcp/src/stdio_server.rs
@@ -1039,9 +1039,7 @@ pub fn run_stdio_server(simulate_startup_failure: bool) -> Result<(), StdioServe
     let runtime = Box::leak(Box::new(
         Runtime::new(canonical_execution.capabilities, ExpeditionExampleExecutor)
             .with_workflow_registry(canonical_execution.workflows)
-            .with_security_config(
-                traverse_runtime::security::RuntimeSecurityConfig::development(),
-            ),
+            .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development()),
     ));
     let mcp = Box::leak(Box::new(TraverseMcp::new(
         capability_registry,

--- a/crates/traverse-runtime/src/workflows.rs
+++ b/crates/traverse-runtime/src/workflows.rs
@@ -1,3 +1,4 @@
+use crate::security::{RuntimeWarning, verify_artifact};
 use crate::{
     ExecutionFailureReason, ExecutionFailureState, LocalExecutor, Runtime, RuntimeError,
     RuntimeErrorCode, RuntimeExecutionOutcome, execution_failure_outcome, runtime_error,
@@ -196,6 +197,8 @@ pub struct WorkflowExecutionResult {
     pub output: Option<Value>,
     #[serde(default)]
     pub error: Option<RuntimeError>,
+    #[serde(default)]
+    pub warnings: Vec<RuntimeWarning>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -241,6 +244,7 @@ where
                 Vec::new(),
                 Vec::new(),
                 WorkflowEventEvidenceBundle::default(),
+                Vec::new(),
             );
         }
 
@@ -262,6 +266,7 @@ where
                 Vec::new(),
                 Vec::new(),
                 WorkflowEventEvidenceBundle::default(),
+                Vec::new(),
             );
         };
 
@@ -279,6 +284,7 @@ where
                 Vec::new(),
                 Vec::new(),
                 WorkflowEventEvidenceBundle::default(),
+                Vec::new(),
             );
         }
 
@@ -290,7 +296,7 @@ where
 
     pub(crate) fn execute_workflow_capability(
         &self,
-        context: crate::ExecutionContext,
+        mut context: crate::ExecutionContext,
         selected: &ResolvedCapability,
         started_execution: crate::StartedExecution,
     ) -> RuntimeExecutionOutcome {
@@ -328,6 +334,10 @@ where
             input: context.attempt.request.input.clone(),
             governing_spec: WORKFLOW_GOVERNING_SPEC.to_string(),
         });
+        context
+            .attempt
+            .warnings
+            .extend(workflow.result.warnings.iter().cloned());
 
         match workflow.result.status {
             WorkflowTraversalStatus::Completed => {
@@ -380,6 +390,7 @@ where
         let mut emitted = Vec::new();
         let mut event_evidence = WorkflowEventEvidenceBundle::default();
         let mut consumed_event_edges = BTreeSet::new();
+        let mut warnings: Vec<RuntimeWarning> = Vec::new();
         let workflow_execution_id = format!("workflow_exec_{}", request.request_id);
 
         loop {
@@ -401,6 +412,7 @@ where
                     traversed,
                     emitted,
                     event_evidence,
+                    warnings,
                 ));
             };
 
@@ -430,8 +442,69 @@ where
                     traversed,
                     emitted,
                     event_evidence,
+                    warnings,
                 ));
             };
+
+            // Artifact security gate (spec 030-security-identity-model FR-013):
+            // workflow steps apply the same verification as direct capability
+            // execution, so an artifact rejected by `Runtime::execute` cannot
+            // run by being wrapped in a workflow pipeline step (spec 058).
+            let artifact_bytes = match crate::load_artifact_bytes_for_verification(&capability) {
+                Ok(bytes) => bytes,
+                Err(error) => {
+                    let mut failed = visited;
+                    if let Some(last) = failed.last_mut() {
+                        last.status = WorkflowTraversalStepStatus::Failed;
+                    }
+                    return Err(workflow_failure(
+                        request,
+                        WorkflowTraversalFailureReason::StepExecutionFailed,
+                        error,
+                        failed,
+                        traversed,
+                        emitted,
+                        event_evidence,
+                        warnings,
+                    ));
+                }
+            };
+            match verify_artifact(&capability, &artifact_bytes, &self.security) {
+                Ok(record) => {
+                    if let Some(code) = record.warning_code {
+                        warnings.push(RuntimeWarning {
+                            code,
+                            message:
+                                "unsigned local/dev artifact allowed by development security mode"
+                                    .to_string(),
+                        });
+                    }
+                }
+                Err(failure) => {
+                    let mut failed = visited;
+                    if let Some(last) = failed.last_mut() {
+                        last.status = WorkflowTraversalStepStatus::Failed;
+                    }
+                    return Err(workflow_failure(
+                        request,
+                        WorkflowTraversalFailureReason::StepExecutionFailed,
+                        runtime_error(
+                            RuntimeErrorCode::ContractViolation,
+                            "artifact signature verification failed before workflow step execution",
+                            json!({
+                                "code": failure.code(),
+                                "artifact_verification": failure.record(),
+                                "node_id": node.node_id,
+                            }),
+                        ),
+                        failed,
+                        traversed,
+                        emitted,
+                        event_evidence,
+                        warnings,
+                    ));
+                }
+            }
 
             let node_input = node_input(&state, node);
             if let Err(error) = validate_payload_against_contract(
@@ -452,6 +525,7 @@ where
                     traversed,
                     emitted,
                     event_evidence,
+                    warnings,
                 ));
             }
 
@@ -474,6 +548,7 @@ where
                         traversed,
                         emitted,
                         event_evidence,
+                        warnings,
                     ));
                 }
             };
@@ -496,6 +571,7 @@ where
                     traversed,
                     emitted,
                     event_evidence,
+                    warnings,
                 ));
             }
 
@@ -531,6 +607,7 @@ where
                     traversed,
                     emitted,
                     event_evidence,
+                    warnings,
                 ));
             }
             if let Some(edge) = direct.into_iter().next() {
@@ -590,6 +667,7 @@ where
                     traversed,
                     emitted,
                     event_evidence,
+                    warnings,
                 ));
             }
             if let Some(edge) = matched_event_edges.into_iter().next() {
@@ -616,6 +694,7 @@ where
                         traversed,
                         emitted,
                         event_evidence,
+                        warnings,
                     ));
                 }
 
@@ -650,6 +729,7 @@ where
                         status: WorkflowTraversalStatus::Completed,
                         output: Some(final_output),
                         error: None,
+                        warnings,
                     },
                     evidence,
                 });
@@ -676,6 +756,7 @@ where
                 traversed,
                 emitted,
                 event_evidence,
+                warnings,
             ));
         }
     }
@@ -982,6 +1063,7 @@ fn edge_record(edge: &WorkflowEdge) -> WorkflowTraversalEdgeRecord {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn workflow_failure(
     request: &WorkflowExecutionRequest,
     failure_reason: WorkflowTraversalFailureReason,
@@ -990,6 +1072,7 @@ fn workflow_failure(
     traversed_edges: Vec<WorkflowTraversalEdgeRecord>,
     emitted_events: Vec<EventReference>,
     event_evidence: WorkflowEventEvidenceBundle,
+    warnings: Vec<RuntimeWarning>,
 ) -> WorkflowExecutionOutcome {
     let evidence = WorkflowTraversalEvidence {
         kind: WORKFLOW_EVIDENCE_KIND.to_string(),
@@ -1022,6 +1105,7 @@ fn workflow_failure(
             status: WorkflowTraversalStatus::Error,
             output: None,
             error: Some(error),
+            warnings,
         },
         evidence,
     }
@@ -1030,6 +1114,7 @@ fn workflow_failure(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::security::RuntimeSecurityConfig;
     use crate::{
         CandidateCollectionRecord, LocalExecutionFailure, LocalExecutionFailureCode,
         RuntimeContext, RuntimeIntent, RuntimeLookup, RuntimeLookupScope, RuntimeRequest,
@@ -1044,7 +1129,8 @@ mod tests {
         ServiceType, SideEffect, SideEffectKind, ValidationEvidence,
     };
     use traverse_registry::{
-        ArtifactDigests, BinaryFormat, BinaryReference, CapabilityArtifactRecord,
+        ArtifactDigests, ArtifactSignature, ArtifactSignatureScheme, BinaryFormat, BinaryReference,
+        CapabilityArtifactRecord,
         CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
         CompositionPattern, ImplementationKind, RegistryProvenance, RegistryScope, SourceKind,
         SourceReference, WorkflowDefinition, WorkflowEdge, WorkflowEdgeTrigger, WorkflowNode,
@@ -1160,10 +1246,12 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn executes_workflow_deterministically_and_supports_workflow_backed_capabilities() {
         let workflow_registry = workflow_registry_fixture();
         let runtime = Runtime::new(capability_registry_fixture(), WorkflowExecutor)
-            .with_workflow_registry(workflow_registry);
+            .with_workflow_registry(workflow_registry)
+            .with_security_config(RuntimeSecurityConfig::development());
 
         let workflow = runtime.execute_workflow(valid_workflow_request());
         assert_eq!(workflow.result.status, WorkflowTraversalStatus::Completed);
@@ -1230,7 +1318,8 @@ mod tests {
         );
 
         let runtime = Runtime::new(composed_registry, WorkflowExecutor)
-            .with_workflow_registry(workflow_registry_fixture());
+            .with_workflow_registry(workflow_registry_fixture())
+            .with_security_config(RuntimeSecurityConfig::development());
         let result = runtime.execute(RuntimeRequest {
             kind: "runtime_request".to_string(),
             schema_version: "1.0.0".to_string(),
@@ -1264,6 +1353,13 @@ mod tests {
                 json!({"comment_text": "hello", "draft_id": "draft-1", "comment_id": "comment-1"})
             )
         );
+        assert!(
+            result
+                .result
+                .warnings
+                .iter()
+                .any(|warning| warning.code == "unsigned_local_dev_artifact")
+        );
     }
 
     #[test]
@@ -1282,7 +1378,8 @@ mod tests {
 
         let workflow_registry = workflow_registry_fixture();
         let runtime = Runtime::new(capability_registry_fixture(), MissingEventWorkflowExecutor)
-            .with_workflow_registry(workflow_registry);
+            .with_workflow_registry(workflow_registry)
+            .with_security_config(RuntimeSecurityConfig::development());
         let missing_event = runtime.execute_workflow(valid_workflow_request());
         assert_eq!(
             missing_event.evidence.result.failure_reason,
@@ -1290,7 +1387,8 @@ mod tests {
         );
 
         let runtime = Runtime::new(capability_registry_fixture(), FailingWorkflowExecutor)
-            .with_workflow_registry(workflow_registry_fixture());
+            .with_workflow_registry(workflow_registry_fixture())
+            .with_security_config(RuntimeSecurityConfig::development());
         let failed = runtime.execute_workflow(valid_workflow_request());
         assert_eq!(
             failed.evidence.result.failure_reason,
@@ -1448,7 +1546,8 @@ mod tests {
     #[allow(clippy::too_many_lines)]
     fn workflow_runtime_covers_additional_failure_and_helper_branches() {
         let runtime = Runtime::new(capability_registry_fixture(), WorkflowExecutor)
-            .with_workflow_registry(workflow_registry_fixture());
+            .with_workflow_registry(workflow_registry_fixture())
+            .with_security_config(RuntimeSecurityConfig::development());
 
         let invalid_input = runtime.execute_workflow(WorkflowExecutionRequest {
             input: json!({}),
@@ -1494,7 +1593,8 @@ mod tests {
 
         let strict_runtime =
             Runtime::new(strict_input_capability_registry_fixture(), WorkflowExecutor)
-                .with_workflow_registry(workflow_registry_fixture());
+                .with_workflow_registry(workflow_registry_fixture())
+                .with_security_config(RuntimeSecurityConfig::development());
         let input_mismatch = strict_runtime.traverse_workflow(
             &valid_workflow_request(),
             &resolved_workflow(WorkflowDefinition {
@@ -1528,7 +1628,8 @@ mod tests {
 
         let bad_output_runtime =
             Runtime::new(capability_registry_fixture(), BadOutputWorkflowExecutor)
-                .with_workflow_registry(workflow_registry_fixture());
+                .with_workflow_registry(workflow_registry_fixture())
+                .with_security_config(RuntimeSecurityConfig::development());
         let bad_output = bad_output_runtime.execute_workflow(valid_workflow_request());
         assert_eq!(
             bad_output.evidence.result.failure_reason,
@@ -1789,7 +1890,8 @@ mod tests {
             None,
         );
         let failing_runtime = Runtime::new(capability_registry_fixture(), FailingWorkflowExecutor)
-            .with_workflow_registry(workflow_registry_fixture());
+            .with_workflow_registry(workflow_registry_fixture())
+            .with_security_config(RuntimeSecurityConfig::development());
         let outcome = failing_runtime.execute_workflow_capability(
             crate::ExecutionContext {
                 attempt,
@@ -1833,7 +1935,9 @@ mod tests {
         let registry = pipeline_capability_registry();
         let mut workflows = WorkflowRegistry::new();
         register_workflow_ok(&mut workflows, &registry, pipeline_workflow_registration());
-        let runtime = Runtime::new(registry, PipelineExecutor).with_workflow_registry(workflows);
+        let runtime = Runtime::new(registry, PipelineExecutor)
+            .with_workflow_registry(workflows)
+            .with_security_config(RuntimeSecurityConfig::development());
 
         let first = runtime.execute_workflow(pipeline_workflow_request());
         let second = runtime.execute_workflow(pipeline_workflow_request());
@@ -1879,8 +1983,9 @@ mod tests {
         let registry = pipeline_capability_registry();
         let mut workflows = WorkflowRegistry::new();
         register_workflow_ok(&mut workflows, &registry, pipeline_workflow_registration());
-        let runtime =
-            Runtime::new(registry, FailingPipelineExecutor).with_workflow_registry(workflows);
+        let runtime = Runtime::new(registry, FailingPipelineExecutor)
+            .with_workflow_registry(workflows)
+            .with_security_config(RuntimeSecurityConfig::development());
 
         let outcome = runtime.execute_workflow(pipeline_workflow_request());
 
@@ -1894,6 +1999,98 @@ mod tests {
         assert_eq!(steps[0].status, WorkflowTraversalStepStatus::Completed);
         assert_eq!(steps[1].node_id, "process_note");
         assert_eq!(steps[1].status, WorkflowTraversalStepStatus::Failed);
+    }
+
+    #[test]
+    fn workflow_step_rejects_unsigned_artifact_under_default_security_config() {
+        // No explicit security config: the default (Production) posture must
+        // reject the unsigned artifact before the workflow step executes,
+        // exactly like direct capability execution (spec 030 FR-013).
+        let runtime = Runtime::new(capability_registry_fixture(), WorkflowExecutor)
+            .with_workflow_registry(workflow_registry_fixture());
+
+        let outcome = runtime.execute_workflow(valid_workflow_request());
+
+        assert_eq!(outcome.result.status, WorkflowTraversalStatus::Error);
+        assert_eq!(
+            outcome.evidence.result.failure_reason,
+            Some(WorkflowTraversalFailureReason::StepExecutionFailed)
+        );
+        let error = outcome.result.error;
+        assert_eq!(
+            error.as_ref().map(|error| error.code),
+            Some(RuntimeErrorCode::ContractViolation)
+        );
+        assert_eq!(
+            error
+                .as_ref()
+                .and_then(|error| error.details.get("code"))
+                .and_then(Value::as_str),
+            Some("missing_signature")
+        );
+        assert_eq!(
+            error
+                .as_ref()
+                .and_then(|error| error.details.get("node_id"))
+                .and_then(Value::as_str),
+            Some("create_draft")
+        );
+        let steps = &outcome.evidence.visited_nodes;
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].node_id, "create_draft");
+        assert_eq!(steps[0].status, WorkflowTraversalStepStatus::Failed);
+        assert!(outcome.result.warnings.is_empty());
+    }
+
+    #[test]
+    fn workflow_step_unsigned_artifact_warns_and_executes_in_development_mode() {
+        let runtime = Runtime::new(capability_registry_fixture(), WorkflowExecutor)
+            .with_workflow_registry(workflow_registry_fixture())
+            .with_security_config(RuntimeSecurityConfig::development());
+
+        let outcome = runtime.execute_workflow(valid_workflow_request());
+
+        assert_eq!(outcome.result.status, WorkflowTraversalStatus::Completed);
+        assert_eq!(outcome.result.warnings.len(), 3);
+        assert!(
+            outcome
+                .result
+                .warnings
+                .iter()
+                .all(|warning| warning.code == "unsigned_local_dev_artifact")
+        );
+    }
+
+    #[test]
+    fn workflow_step_fails_when_signed_artifact_bytes_cannot_be_loaded() {
+        let runtime = Runtime::new(
+            signed_missing_binary_capability_registry_fixture(),
+            WorkflowExecutor,
+        )
+        .with_workflow_registry(workflow_registry_fixture());
+
+        let outcome = runtime.execute_workflow(valid_workflow_request());
+
+        assert_eq!(outcome.result.status, WorkflowTraversalStatus::Error);
+        assert_eq!(
+            outcome.evidence.result.failure_reason,
+            Some(WorkflowTraversalFailureReason::StepExecutionFailed)
+        );
+        let error = outcome.result.error;
+        assert_eq!(
+            error.as_ref().map(|error| error.code),
+            Some(RuntimeErrorCode::ArtifactMissing)
+        );
+        assert_eq!(
+            error
+                .as_ref()
+                .and_then(|error| error.details.get("code"))
+                .and_then(Value::as_str),
+            Some("artifact_load_failed")
+        );
+        let steps = &outcome.evidence.visited_nodes;
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].status, WorkflowTraversalStepStatus::Failed);
     }
 
     fn pipeline_capability_registry() -> CapabilityRegistry {
@@ -1913,7 +2110,7 @@ mod tests {
                         json!({"type": "object", "additionalProperties": true}),
                         json!({"type": "object", "additionalProperties": true}),
                     ),
-                    contract_path: format!("contracts/{id}.json"),
+                    contract_path: format!("registry/{id}.json"),
                     artifact: CapabilityArtifactRecord {
                         artifact_ref: format!("artifact-{id}"),
                         implementation_kind: ImplementationKind::Executable,
@@ -2128,11 +2325,26 @@ mod tests {
     }
 
     fn capability_registry_fixture() -> CapabilityRegistry {
-        build_capability_registry(false)
+        build_capability_registry(false, None)
     }
 
-    #[allow(clippy::too_many_lines)]
-    fn build_capability_registry(strict_inputs: bool) -> CapabilityRegistry {
+    fn signed_missing_binary_capability_registry_fixture() -> CapabilityRegistry {
+        build_capability_registry(
+            false,
+            Some(ArtifactSignature {
+                scheme: ArtifactSignatureScheme::Ed25519,
+                public_key_hex: Some("00".repeat(32)),
+                signature_hex: Some("00".repeat(64)),
+                sigstore_bundle_ref: None,
+            }),
+        )
+    }
+
+    #[allow(clippy::too_many_lines, clippy::needless_pass_by_value)]
+    fn build_capability_registry(
+        strict_inputs: bool,
+        signature: Option<ArtifactSignature>,
+    ) -> CapabilityRegistry {
         let mut registry = CapabilityRegistry::new();
         for (id, emits, output, required_key) in [
             (
@@ -2203,7 +2415,7 @@ mod tests {
                         }),
                         output,
                     ),
-                    contract_path: format!("contracts/{id}.json"),
+                    contract_path: format!("registry/{id}.json"),
                     artifact: CapabilityArtifactRecord {
                         artifact_ref: format!("artifact-{id}"),
                         implementation_kind: ImplementationKind::Executable,
@@ -2214,7 +2426,7 @@ mod tests {
                         binary: Some(BinaryReference {
                             format: BinaryFormat::Wasm,
                             location: format!("{id}.wasm"),
-                            signature: None,
+                            signature: signature.clone(),
                         }),
                         workflow_ref: None,
                         digests: ArtifactDigests {
@@ -2244,7 +2456,7 @@ mod tests {
     }
 
     fn strict_input_capability_registry_fixture() -> CapabilityRegistry {
-        build_capability_registry(true)
+        build_capability_registry(true, None)
     }
 
     fn workflow_registry_fixture() -> WorkflowRegistry {

--- a/crates/traverse-runtime/src/workflows.rs
+++ b/crates/traverse-runtime/src/workflows.rs
@@ -1130,12 +1130,11 @@ mod tests {
     };
     use traverse_registry::{
         ArtifactDigests, ArtifactSignature, ArtifactSignatureScheme, BinaryFormat, BinaryReference,
-        CapabilityArtifactRecord,
-        CapabilityRegistration, CapabilityRegistry, ComposabilityMetadata, CompositionKind,
-        CompositionPattern, ImplementationKind, RegistryProvenance, RegistryScope, SourceKind,
-        SourceReference, WorkflowDefinition, WorkflowEdge, WorkflowEdgeTrigger, WorkflowNode,
-        WorkflowNodeInput, WorkflowNodeOutput, WorkflowRegistration, WorkflowRegistry,
-        WorkflowRegistryRecord, workflow_artifact_record,
+        CapabilityArtifactRecord, CapabilityRegistration, CapabilityRegistry,
+        ComposabilityMetadata, CompositionKind, CompositionPattern, ImplementationKind,
+        RegistryProvenance, RegistryScope, SourceKind, SourceReference, WorkflowDefinition,
+        WorkflowEdge, WorkflowEdgeTrigger, WorkflowNode, WorkflowNodeInput, WorkflowNodeOutput,
+        WorkflowRegistration, WorkflowRegistry, WorkflowRegistryRecord, workflow_artifact_record,
     };
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #675.

`Runtime::execute_workflow` executed each workflow node's capability directly via `self.executor.execute(...)`, without the `verify_artifact` security gate that `Runtime::execute` applies before direct capability execution. Under the default production security posture (spec 030-security-identity-model FR-013) an unsigned artifact was rejected on direct execution but executed successfully when wrapped as a workflow pipeline step (spec 058) — the signature/checksum enforcement could be bypassed by composing a workflow around the capability. Found while building the Rust embedder SDK (#650).

### Changes

- **`crates/traverse-runtime/src/workflows.rs`**: workflow traversal now loads and verifies each step's artifact (`load_artifact_bytes_for_verification` + `verify_artifact`) before executing the node, with the same stable error codes as the direct path (`missing_signature`, `checksum_mismatch`, `signature_verification_failed`, `sigstore_unreachable`, `artifact_load_failed`). Verification failures surface as deterministic workflow errors: `StepExecutionFailed` failure reason, `node_id` in the error details, and the failed step marked in the traversal trace (spec 058 FR-005). The development-mode `unsigned_local_dev_artifact` warning is carried on a new `WorkflowExecutionResult.warnings` field (`#[serde(default)]`, additive) and propagated into the outer `RuntimeResult.warnings` for workflow-backed capabilities.
- **`crates/traverse-mcp/src/stdio_server.rs`**: the stdio server runtime (which only executes the canonical bundled expedition example — unsigned `SourceKind::Local` artifacts) now opts into the development security mode explicitly, matching every other example-executing runtime in the crate and the CLI. Previously its workflow executions only succeeded under the default production posture *because of* this bypass.
- **`crates/traverse-cli/src/main.rs`**: the starter-bundle pipeline test opts into development mode for the same reason (the CLI's own execution paths already do).

### Tests

New regression tests in `workflows.rs`:

- `workflow_step_rejects_unsigned_artifact_under_default_security_config` — production posture rejects an unsigned step with `contract_violation` / `missing_signature`, failed step id in error details and trace.
- `workflow_step_unsigned_artifact_warns_and_executes_in_development_mode` — dev mode completes with one `unsigned_local_dev_artifact` warning per executed step.
- `workflow_step_fails_when_signed_artifact_bytes_cannot_be_loaded` — unreadable signed artifact fails deterministically with `artifact_missing` / `artifact_load_failed`.
- Warnings-propagation assertion added to the workflow-backed capability test.

Existing workflow test fixtures move from governed `contracts/…` contract paths to non-governed `registry/…` paths (LocalDev trust, mirroring `lib.rs`'s `public_registration`) and step-executing tests opt into development mode — the same posture the direct-execution tests already use.

## Governing Spec

- 030-security-identity-model
- 058-workflow-pipeline-execution
- 007-workflow-registry-traversal
- 006-runtime-request-execution
- 042-mcp-library-surface

## Project Item

- Org Project 1 item for issue #675 (status: In Progress → Done on merge)

## Validation

- `cargo test --workspace` — all green
- `cargo clippy --workspace --all-targets` — no warnings
- `bash scripts/ci/coverage_gate.sh` — traverse-contracts 100.00%, traverse-registry 100.00%, **traverse-runtime 100.00% (10125/10125)**, traverse-cli 87.08% (≥86), traverse-mcp 98.92% (≥98)
- `bash scripts/ci/spec_alignment_check.sh <pr-body>` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
