### PR TITLE
feat(runtime): add identity-aware event sink

### DIFF
--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -234,6 +234,15 @@ fn validate_from_cursor(
 }
 
 impl EventBroker for InProcessBroker {
+    fn subscribe_for_subject(
+        &self,
+        event_type: &str,
+        from_cursor: &str,
+        _subject_id: Option<&str>,
+    ) -> Result<Subscription, EventError> {
+        self.subscribe(event_type, from_cursor)
+    }
+
     /// Publish `event` to all registered subscribers.
     ///
     /// # Errors

--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -127,6 +127,61 @@ impl InProcessBroker {
             state: Mutex::new(BrokerState::default()),
         })
     }
+
+    fn subscribe_with_subject(
+        &self,
+        event_type: &str,
+        from_cursor: &str,
+        subject_id: Option<&str>,
+    ) -> Result<Subscription, EventError> {
+        if self.catalog.get(event_type).is_none() {
+            return Err(EventError::UnregisteredEventType(event_type.to_owned()));
+        }
+
+        let from_cursor = parse_cursor(from_cursor)?;
+        let now = self.clock.now();
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
+        prune_expired(&mut state, event_type, self.config.retention_window, now);
+        validate_from_cursor(&state, event_type, from_cursor)?;
+        self.catalog.increment_consumer_count(event_type);
+
+        state.next_subscription = state.next_subscription.saturating_add(1);
+        let subscription_id = format!("sub-{}", state.next_subscription);
+        let mut queue = VecDeque::new();
+        for item in state
+            .buffers
+            .get(event_type)
+            .into_iter()
+            .flat_map(|buffer| buffer.iter())
+        {
+            if (from_cursor == 0 || item.cursor > from_cursor)
+                && subject_id
+                    .is_none_or(|subject| item.event.subject_id.as_deref() == Some(subject))
+            {
+                enqueue_with_drop_oldest(&mut queue, self.config.max_queue_len, item.clone());
+            }
+        }
+
+        state.subscriptions.insert(
+            subscription_id.clone(),
+            SubscriptionState {
+                subscription_id: subscription_id.clone(),
+                event_type: event_type.to_string(),
+                subject_id: subject_id.map(str::to_owned),
+                cursor: from_cursor,
+                queue,
+            },
+        );
+
+        Ok(Subscription {
+            subscription_id,
+            event_type: event_type.to_string(),
+            cursor: cursor_to_string(from_cursor),
+        })
+    }
 }
 
 fn parse_cursor(raw: &str) -> Result<u64, EventError> {
@@ -241,24 +296,7 @@ impl EventBroker for InProcessBroker {
         from_cursor: &str,
         subject_id: Option<&str>,
     ) -> Result<Subscription, EventError> {
-        let subscription = self.subscribe(event_type, from_cursor)?;
-        if let Some(subject_id) = subject_id {
-            let mut state = self
-                .state
-                .lock()
-                .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
-            let state_subscription = state
-                .subscriptions
-                .get_mut(&subscription.subscription_id)
-                .ok_or_else(|| {
-                    EventError::SubscriptionNotFound(subscription.subscription_id.clone())
-                })?;
-            state_subscription.subject_id = Some(subject_id.to_string());
-            state_subscription
-                .queue
-                .retain(|item| item.event.subject_id.as_deref() == Some(subject_id));
-        }
-        Ok(subscription)
+        self.subscribe_with_subject(event_type, from_cursor, subject_id)
     }
 
     /// Publish `event` to all registered subscribers.
@@ -357,55 +395,7 @@ impl EventBroker for InProcessBroker {
     ///
     /// Returns [`EventError::UnregisteredEventType`] if the event type is not catalogued.
     fn subscribe(&self, event_type: &str, from_cursor: &str) -> Result<Subscription, EventError> {
-        if self.catalog.get(event_type).is_none() {
-            return Err(EventError::UnregisteredEventType(event_type.to_owned()));
-        }
-
-        let from_cursor = parse_cursor(from_cursor)?;
-
-        let now = self.clock.now();
-        let mut state = self
-            .state
-            .lock()
-            .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
-
-        prune_expired(&mut state, event_type, self.config.retention_window, now);
-
-        validate_from_cursor(&state, event_type, from_cursor)?;
-
-        self.catalog.increment_consumer_count(event_type);
-
-        state.next_subscription = state.next_subscription.saturating_add(1);
-        let subscription_id = format!("sub-{}", state.next_subscription);
-
-        let mut queue = VecDeque::new();
-        for item in state
-            .buffers
-            .get(event_type)
-            .into_iter()
-            .flat_map(|buffer| buffer.iter())
-        {
-            if from_cursor == 0 || item.cursor > from_cursor {
-                enqueue_with_drop_oldest(&mut queue, self.config.max_queue_len, item.clone());
-            }
-        }
-
-        state.subscriptions.insert(
-            subscription_id.clone(),
-            SubscriptionState {
-                subscription_id: subscription_id.clone(),
-                event_type: event_type.to_string(),
-                subject_id: None,
-                cursor: from_cursor,
-                queue,
-            },
-        );
-
-        Ok(Subscription {
-            subscription_id,
-            event_type: event_type.to_string(),
-            cursor: cursor_to_string(from_cursor),
-        })
+        self.subscribe_with_subject(event_type, from_cursor, None)
     }
 
     /// Poll a subscription for up to `max_events`.

--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -57,6 +57,7 @@ struct BufferedEvent {
 struct SubscriptionState {
     subscription_id: SubscriptionId,
     event_type: String,
+    subject_id: Option<String>,
     cursor: u64,
     queue: VecDeque<BufferedEvent>,
 }
@@ -238,9 +239,26 @@ impl EventBroker for InProcessBroker {
         &self,
         event_type: &str,
         from_cursor: &str,
-        _subject_id: Option<&str>,
+        subject_id: Option<&str>,
     ) -> Result<Subscription, EventError> {
-        self.subscribe(event_type, from_cursor)
+        let subscription = self.subscribe(event_type, from_cursor)?;
+        if let Some(subject_id) = subject_id {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
+            let state_subscription = state
+                .subscriptions
+                .get_mut(&subscription.subscription_id)
+                .ok_or_else(|| {
+                    EventError::SubscriptionNotFound(subscription.subscription_id.clone())
+                })?;
+            state_subscription.subject_id = Some(subject_id.to_string());
+            state_subscription
+                .queue
+                .retain(|item| item.event.subject_id.as_deref() == Some(subject_id));
+        }
+        Ok(subscription)
     }
 
     /// Publish `event` to all registered subscribers.
@@ -318,6 +336,13 @@ impl EventBroker for InProcessBroker {
             if sub.event_type != event.event_type {
                 continue;
             }
+            if sub
+                .subject_id
+                .as_deref()
+                .is_some_and(|subject_id| event.subject_id.as_deref() != Some(subject_id))
+            {
+                continue;
+            }
             enqueue_with_drop_oldest(&mut sub.queue, self.config.max_queue_len, buffered.clone());
         }
 
@@ -370,6 +395,7 @@ impl EventBroker for InProcessBroker {
             SubscriptionState {
                 subscription_id: subscription_id.clone(),
                 event_type: event_type.to_string(),
+                subject_id: None,
                 cursor: from_cursor,
                 queue,
             },

--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -592,6 +592,47 @@ mod tests {
     }
 
     #[test]
+    fn subject_subscription_filters_backlog_and_live_delivery() {
+        let event_type = "dev.traverse.subject-filter";
+        let broker = InProcessBroker::new(make_catalog(event_type, LifecycleStatus::Active))
+            .expect("broker must be created");
+        let mut other = sample_event(event_type, "evt-other");
+        other.subject_id = Some("subject-other".to_string());
+        let mut expected = sample_event(event_type, "evt-match");
+        expected.subject_id = Some("subject-match".to_string());
+        broker.publish(other).expect("backlog publish must succeed");
+        broker
+            .publish(expected.clone())
+            .expect("backlog publish must succeed");
+
+        let subscription = broker
+            .subscribe_for_subject(event_type, "0", Some("subject-match"))
+            .expect("subject subscription must succeed");
+        let backlog = broker
+            .poll(&subscription.subscription_id, 10)
+            .expect("backlog poll must succeed");
+        assert_eq!(backlog.events.len(), 1);
+        assert_eq!(backlog.events[0].event.id, expected.id);
+
+        let mut live_other = sample_event(event_type, "evt-live-other");
+        live_other.subject_id = Some("subject-other".to_string());
+        let mut live_expected = sample_event(event_type, "evt-live-match");
+        live_expected.subject_id = Some("subject-match".to_string());
+        broker
+            .publish(live_other)
+            .expect("non-matching live publish must succeed");
+        broker
+            .publish(live_expected.clone())
+            .expect("matching live publish must succeed");
+
+        let live = broker
+            .poll(&subscription.subscription_id, 10)
+            .expect("live poll must succeed");
+        assert_eq!(live.events.len(), 1);
+        assert_eq!(live.events[0].event.id, live_expected.id);
+    }
+
+    #[test]
     fn publish_rejects_deprecated_and_draft_event_types() {
         let deprecated = InProcessBroker::new(make_catalog(
             "dev.traverse.deprecated",

--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -518,6 +518,8 @@ mod tests {
             owner: "cap.test".to_string(),
             version: "1.0.0".to_string(),
             lifecycle_status: LifecycleStatus::Active,
+            subject_id: None,
+            actor_id: None,
         }
     }
 

--- a/crates/traverse-runtime/src/events/durable.rs
+++ b/crates/traverse-runtime/src/events/durable.rs
@@ -445,6 +445,38 @@ mod tests {
     }
 
     #[test]
+    fn durable_subject_subscription_delegates_to_inner_broker() {
+        let root = test_root("subject-subscription");
+        let journal = DurableEventJournal::open(
+            &root,
+            JournalConfig::default(),
+            Arc::new(crate::events::broker::SystemClock),
+        )
+        .expect("journal must open");
+        let broker = DurableBroker::new(
+            inner_broker(),
+            journal,
+            DurableBrokerConfig::default(),
+            Arc::new(RecordingAudit::default()),
+        );
+        let mut event = test_event();
+        event.subject_id = Some("subject-match".to_string());
+        broker.publish(event).expect("publish must succeed");
+
+        let subscription = broker
+            .subscribe_for_subject(EVENT_TYPE, "0", Some("subject-match"))
+            .expect("subject subscription must succeed");
+        let poll = broker
+            .poll(&subscription.subscription_id, 10)
+            .expect("poll must succeed");
+        assert_eq!(poll.events.len(), 1);
+        assert_eq!(
+            poll.events[0].event.subject_id.as_deref(),
+            Some("subject-match")
+        );
+    }
+
+    #[test]
     fn undeliverable_event_is_revoked_after_durable_write() {
         let (gate_tx, gate_rx) = channel();
         let (revoked_tx, revoked_rx) = channel();

--- a/crates/traverse-runtime/src/events/durable.rs
+++ b/crates/traverse-runtime/src/events/durable.rs
@@ -194,6 +194,16 @@ impl<B: EventBroker> EventBroker for DurableBroker<B> {
         self.inner.subscribe(event_type, from_cursor)
     }
 
+    fn subscribe_for_subject(
+        &self,
+        event_type: &str,
+        from_cursor: &str,
+        subject_id: Option<&str>,
+    ) -> Result<Subscription, EventError> {
+        self.inner
+            .subscribe_for_subject(event_type, from_cursor, subject_id)
+    }
+
     fn poll(
         &self,
         subscription_id: &str,
@@ -345,6 +355,8 @@ mod tests {
             owner: "test.capability".to_string(),
             version: "1.0.0".to_string(),
             lifecycle_status: LifecycleStatus::Active,
+            subject_id: None,
+            actor_id: None,
         }
     }
 

--- a/crates/traverse-runtime/src/events/journal.rs
+++ b/crates/traverse-runtime/src/events/journal.rs
@@ -587,6 +587,8 @@ mod tests {
             owner: "test.capability".to_string(),
             version: "1.0.0".to_string(),
             lifecycle_status: LifecycleStatus::Active,
+            subject_id: None,
+            actor_id: None,
         }
     }
 

--- a/crates/traverse-runtime/src/events/mod.rs
+++ b/crates/traverse-runtime/src/events/mod.rs
@@ -15,6 +15,7 @@ pub use durable::{
 };
 pub use journal::{DurableEventJournal, JournalConfig, JournalError};
 pub use types::{
-    BrokerEvent, EventBroker, EventCursor, EventError, LifecycleStatus, Subscription,
-    SubscriptionId, SubscriptionPoll, TraverseEvent,
+    BrokerEvent, BrokerEventSink, EventBroker, EventCursor, EventError, LifecycleStatus,
+    NoopRuntimeEventSink, RuntimeEventSink, Subscription, SubscriptionId, SubscriptionPoll,
+    TraverseEvent,
 };

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -230,6 +230,8 @@ pub struct SubscriptionPoll {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::expect_used)]
+
     use super::*;
 
     fn sample_event(event_type: &str) -> TraverseEvent {

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -114,6 +114,14 @@ pub trait EventBroker: Send + Sync {
     /// [`EventError::CursorExpired`] if the cursor is outside the retention window.
     fn subscribe(&self, event_type: &str, from_cursor: &str) -> Result<Subscription, EventError>;
 
+    /// Create a subscription optionally limited to one event subject.
+    fn subscribe_for_subject(
+        &self,
+        event_type: &str,
+        from_cursor: &str,
+        subject_id: Option<&str>,
+    ) -> Result<Subscription, EventError>;
+
     /// Poll a subscription for up to `max_events`.
     ///
     /// # Errors

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -116,6 +116,11 @@ pub trait EventBroker: Send + Sync {
     fn subscribe(&self, event_type: &str, from_cursor: &str) -> Result<Subscription, EventError>;
 
     /// Create a subscription optionally limited to one event subject.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::subscribe`] when the event type or
+    /// cursor is invalid.
     fn subscribe_for_subject(
         &self,
         event_type: &str,
@@ -227,6 +232,22 @@ pub struct SubscriptionPoll {
 mod tests {
     use super::*;
 
+    fn sample_event(event_type: &str) -> TraverseEvent {
+        TraverseEvent {
+            id: "f0f83e66-4d87-4dd6-884d-0128d94f730f".to_string(),
+            source: "traverse-runtime".to_string(),
+            event_type: event_type.to_string(),
+            datacontenttype: "application/json".to_string(),
+            time: "2026-07-14T00:00:00Z".to_string(),
+            data: serde_json::json!({"execution_id": "exec_test"}),
+            owner: "traverse-runtime".to_string(),
+            version: "1.0.0".to_string(),
+            lifecycle_status: LifecycleStatus::Active,
+            subject_id: Some("subject_test".to_string()),
+            actor_id: Some("actor_test".to_string()),
+        }
+    }
+
     #[test]
     fn event_error_display_covers_all_variants() {
         let cases: Vec<EventError> = vec![
@@ -247,5 +268,48 @@ mod tests {
             let rendered = err.to_string();
             assert!(!rendered.is_empty());
         }
+    }
+
+    #[test]
+    fn noop_runtime_event_sink_accepts_an_envelope() {
+        assert!(
+            NoopRuntimeEventSink
+                .emit(sample_event("dev.traverse.noop"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn broker_event_sink_forwards_the_original_envelope() {
+        let event_type = "dev.traverse.runtime.execution.completed";
+        let catalog = Arc::new(crate::events::EventCatalog::new());
+        catalog
+            .register(crate::events::EventCatalogEntry {
+                event_type: event_type.to_string(),
+                owner: "traverse-runtime".to_string(),
+                version: "1.0.0".to_string(),
+                lifecycle_status: LifecycleStatus::Active,
+                consumer_count: 0,
+            })
+            .expect("catalog registration must succeed");
+        let broker =
+            Arc::new(crate::events::InProcessBroker::new(catalog).expect("broker must be created"));
+        let sink = BrokerEventSink::new(broker.clone());
+        let event = sample_event(event_type);
+
+        sink.emit(event.clone())
+            .expect("sink delivery must succeed");
+        let subscription = broker
+            .subscribe_for_subject(event_type, "0", Some("subject_test"))
+            .expect("subject subscription must succeed");
+        let delivered = broker
+            .poll(&subscription.subscription_id, 1)
+            .expect("poll must succeed");
+
+        assert_eq!(format!("{sink:?}"), "BrokerEventSink { .. }");
+        assert_eq!(delivered.events.len(), 1);
+        assert_eq!(delivered.events[0].event.subject_id, event.subject_id);
+        assert_eq!(delivered.events[0].event.actor_id, event.actor_id);
+        assert_eq!(delivered.events[0].event.data, event.data);
     }
 }

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -36,6 +36,12 @@ pub struct TraverseEvent {
     pub version: String,
     /// Lifecycle status at the time the event was created.
     pub lifecycle_status: LifecycleStatus,
+    /// Authenticated subject that caused this event, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_id: Option<String>,
+    /// Delegated actor distinct from the subject, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor_id: Option<String>,
 }
 
 /// Errors that can occur during event broker operations.

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -4,6 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 
 /// Lifecycle status of an event type in the catalog.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -139,6 +140,57 @@ pub trait EventBroker: Send + Sync {
     ///
     /// Returns [`EventError::SubscriptionNotFound`] if the subscription id is unknown.
     fn cancel(&self, subscription_id: &str) -> Result<(), EventError>;
+}
+
+/// Narrow runtime boundary for publishing lifecycle envelopes.
+///
+/// The runtime depends on this seam rather than a concrete broker so embedders
+/// can choose an in-memory broker, durable broker, or a no-op delivery policy.
+pub trait RuntimeEventSink: Send + Sync + std::fmt::Debug {
+    /// Deliver one already-materialized runtime lifecycle envelope.
+    ///
+    /// # Errors
+    ///
+    /// Implementations return an error when the configured delivery mechanism
+    /// cannot accept the envelope. Runtime execution remains authoritative and
+    /// reports delivery failures as warnings.
+    fn emit(&self, event: TraverseEvent) -> Result<(), EventError>;
+}
+
+/// Default sink used by existing runtime constructors.
+#[derive(Debug, Default)]
+pub struct NoopRuntimeEventSink;
+
+impl RuntimeEventSink for NoopRuntimeEventSink {
+    fn emit(&self, _event: TraverseEvent) -> Result<(), EventError> {
+        Ok(())
+    }
+}
+
+/// Adapter that routes runtime lifecycle envelopes through an event broker.
+pub struct BrokerEventSink {
+    broker: Arc<dyn EventBroker>,
+}
+
+impl BrokerEventSink {
+    #[must_use]
+    pub fn new(broker: Arc<dyn EventBroker>) -> Self {
+        Self { broker }
+    }
+}
+
+impl std::fmt::Debug for BrokerEventSink {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("BrokerEventSink")
+            .finish_non_exhaustive()
+    }
+}
+
+impl RuntimeEventSink for BrokerEventSink {
+    fn emit(&self, event: TraverseEvent) -> Result<(), EventError> {
+        self.broker.publish(event)
+    }
 }
 
 /// A broker-issued event cursor string.

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -13,6 +13,8 @@ pub mod router;
 pub mod security;
 pub mod trace;
 
+use chrono::Utc;
+use events::{NoopRuntimeEventSink, RuntimeEventSink, TraverseEvent};
 use security::{
     ArtifactVerificationFailure, ArtifactVerificationRecord, RuntimeIdentity,
     RuntimeSecurityConfig, RuntimeWarning, derive_identity_from_jwt, verify_artifact,
@@ -23,6 +25,7 @@ use serde_json::{Map, Value, json};
 use std::fmt;
 use std::fs;
 use std::path::Path;
+use std::sync::Arc;
 use traverse_contracts::{
     ExecutionTarget, HostApiAccess, Lifecycle, NetworkAccess, ViolationRecord,
 };
@@ -33,6 +36,7 @@ use traverse_registry::{
     WorkflowRegistry, WorkspaceAppStateFailure, WorkspaceApplicationRegistration,
     load_workspace_application_registries, resolve_dependencies, resolve_version_range,
 };
+use uuid::Uuid;
 
 const RUNTIME_REQUEST_KIND: &str = "runtime_request";
 const RUNTIME_RESULT_KIND: &str = "runtime_result";
@@ -51,6 +55,7 @@ const STATE_MACHINE_GOVERNING_SPEC: &str = "010-runtime-state-machine";
 const BROWSER_SUBSCRIPTION_GOVERNING_SPEC: &str = "013-browser-runtime-subscription";
 const EXECUTION_PREFIX: &str = "exec_";
 const TRACE_PREFIX: &str = "trace_";
+const RUNTIME_EXECUTION_EVENT_TYPE: &str = "dev.traverse.runtime.execution.completed";
 
 #[derive(Debug, Clone)]
 pub struct Runtime<E> {
@@ -60,6 +65,7 @@ pub struct Runtime<E> {
     executor: E,
     observability: RuntimeObservabilityConfig,
     security: RuntimeSecurityConfig,
+    event_sink: Arc<dyn RuntimeEventSink>,
 }
 
 impl<E> Runtime<E> {
@@ -72,6 +78,7 @@ impl<E> Runtime<E> {
             executor,
             observability: RuntimeObservabilityConfig::default(),
             security: RuntimeSecurityConfig::default(),
+            event_sink: Arc::new(NoopRuntimeEventSink),
         }
     }
 
@@ -124,6 +131,13 @@ impl<E> Runtime<E> {
     #[must_use]
     pub fn with_security_config(mut self, security: RuntimeSecurityConfig) -> Self {
         self.security = security;
+        self
+    }
+
+    /// Configures delivery for runtime-owned lifecycle envelopes.
+    #[must_use]
+    pub fn with_event_sink(mut self, event_sink: Arc<dyn RuntimeEventSink>) -> Self {
+        self.event_sink = event_sink;
         self
     }
 
@@ -772,6 +786,8 @@ pub struct TraceResultRecord {
     pub output: Option<serde_json::Value>,
     #[serde(default)]
     pub error: Option<RuntimeError>,
+    #[serde(default)]
+    pub warnings: Vec<RuntimeWarning>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1101,6 +1117,7 @@ where
     /// Executes one runtime request against the current registry state.
     #[must_use]
     pub fn execute(&self, request: RuntimeRequest) -> RuntimeExecutionOutcome {
+        let identity = request.context.identity.clone();
         let (attempt, mut emitter) = begin_attempt(request, self.observability.clone());
         emitter.push(
             RuntimeState::Discovering,
@@ -1111,37 +1128,72 @@ where
             }),
         );
 
-        if let Some(error) = validate_request(&attempt.request) {
-            return invalid_request_outcome(attempt, emitter, error);
-        }
+        let mut outcome = if let Some(error) = validate_request(&attempt.request) {
+            invalid_request_outcome(attempt, emitter, error)
+        } else {
+            let resolution = self.resolve_candidates(&attempt.request, &mut emitter);
 
-        let resolution = self.resolve_candidates(&attempt.request, &mut emitter);
+            if resolution.eligible.is_empty() {
+                no_eligible_outcome(attempt, emitter, resolution.collection)
+            } else if resolution.eligible.len() > 1 {
+                ambiguous_outcome(attempt, emitter, resolution)
+            } else {
+                let mut eligible = resolution.eligible;
+                let selected = eligible.remove(0);
+                let selection = SelectionRecord {
+                    status: SelectionStatus::Selected,
+                    selected_capability_id: Some(selected.record.id.clone()),
+                    selected_capability_version: Some(selected.record.version.clone()),
+                    failure_reason: None,
+                    remaining_candidates: Vec::new(),
+                };
 
-        if resolution.eligible.is_empty() {
-            return no_eligible_outcome(attempt, emitter, resolution.collection);
-        }
-
-        if resolution.eligible.len() > 1 {
-            return ambiguous_outcome(attempt, emitter, resolution);
-        }
-
-        let mut eligible = resolution.eligible;
-        let selected = eligible.remove(0);
-        let selection = SelectionRecord {
-            status: SelectionStatus::Selected,
-            selected_capability_id: Some(selected.record.id.clone()),
-            selected_capability_version: Some(selected.record.version.clone()),
-            failure_reason: None,
-            remaining_candidates: Vec::new(),
+                self.execute_selected(
+                    attempt,
+                    emitter,
+                    resolution.collection,
+                    selection,
+                    &selected,
+                )
+            }
         };
 
-        self.execute_selected(
-            attempt,
-            emitter,
-            resolution.collection,
-            selection,
-            &selected,
-        )
+        self.emit_execution_lifecycle_event(&mut outcome, identity.as_ref());
+        outcome
+    }
+
+    fn emit_execution_lifecycle_event(
+        &self,
+        outcome: &mut RuntimeExecutionOutcome,
+        identity: Option<&RuntimeIdentity>,
+    ) {
+        let event = TraverseEvent {
+            id: Uuid::new_v4().to_string(),
+            source: "traverse-runtime".to_string(),
+            event_type: RUNTIME_EXECUTION_EVENT_TYPE.to_string(),
+            datacontenttype: "application/json".to_string(),
+            time: Utc::now().to_rfc3339(),
+            data: json!({
+                "execution_id": outcome.result.execution_id,
+                "request_id": outcome.result.request_id,
+                "status": outcome.result.status,
+                "trace_ref": outcome.result.trace_ref,
+            }),
+            owner: "traverse-runtime".to_string(),
+            version: SUPPORTED_SCHEMA_VERSION.to_string(),
+            lifecycle_status: events::LifecycleStatus::Active,
+            subject_id: identity.map(|identity| identity.subject_id.clone()),
+            actor_id: identity.and_then(|identity| identity.actor_id.clone()),
+        };
+
+        if let Err(error) = self.event_sink.emit(event) {
+            let warning = RuntimeWarning {
+                code: "runtime_event_sink_delivery_failed".to_string(),
+                message: error.to_string(),
+            };
+            outcome.result.warnings.push(warning.clone());
+            outcome.trace.result.warnings.push(warning);
+        }
     }
 
     fn collect_candidates(
@@ -1517,6 +1569,7 @@ fn terminal_failure(context: FailureContext) -> RuntimeExecutionOutcome {
         status: RuntimeResultStatus::Error,
         output: None,
         error: Some(context.error.clone()),
+        warnings: context.attempt.warnings.clone(),
     };
     let otel_trace = otel_trace_record(
         &context.attempt,
@@ -2086,6 +2139,7 @@ fn successful_execution_outcome(
         status: RuntimeResultStatus::Completed,
         output: Some(execution_output.clone()),
         error: None,
+        warnings: attempt.warnings.clone(),
     };
     let otel_trace = otel_trace_record(
         &attempt,
@@ -3056,6 +3110,7 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
     use traverse_contracts::{
         BinaryFormat as ContractBinaryFormat, Entrypoint, EntrypointKind, Execution,
         ExecutionConstraints, ExecutionTarget, FilesystemAccess, HostApiAccess, Lifecycle,
@@ -3073,6 +3128,38 @@ mod tests {
 
     const HEX_TABLE: &[u8; 16] = b"0123456789abcdef";
     static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Debug, Default)]
+    struct RecordingEventSink {
+        events: Mutex<Vec<super::events::TraverseEvent>>,
+    }
+
+    impl super::events::RuntimeEventSink for RecordingEventSink {
+        fn emit(
+            &self,
+            event: super::events::TraverseEvent,
+        ) -> Result<(), super::events::EventError> {
+            self.events
+                .lock()
+                .expect("recording sink lock must not be poisoned")
+                .push(event);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingEventSink;
+
+    impl super::events::RuntimeEventSink for FailingEventSink {
+        fn emit(
+            &self,
+            _event: super::events::TraverseEvent,
+        ) -> Result<(), super::events::EventError> {
+            Err(super::events::EventError::JournalWrite(
+                "sink unavailable".to_string(),
+            ))
+        }
+    }
 
     #[test]
     fn missing_binary_metadata_is_rejected_as_artifact_missing() {
@@ -3642,6 +3729,49 @@ mod tests {
             outcome.trace.state_machine_validation.status,
             super::RuntimeStateMachineValidationStatus::Passed
         );
+    }
+
+    #[test]
+    fn runtime_emits_a_token_free_terminal_event_for_invalid_requests() {
+        let sink = Arc::new(RecordingEventSink::default());
+        let mut request = valid_request();
+        request.kind = "unsupported_runtime_request".to_string();
+        request.context.identity = Some(super::security::RuntimeIdentity {
+            subject_id: "subject_123".to_string(),
+            actor_id: Some("actor_456".to_string()),
+            token_reference_hash: "must-not-leak".to_string(),
+        });
+
+        let outcome = Runtime::new(CapabilityRegistry::new(), NoopExecutor)
+            .with_event_sink(sink.clone())
+            .execute(request);
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+        let events = sink
+            .events
+            .lock()
+            .expect("recording sink lock must not be poisoned");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, super::RUNTIME_EXECUTION_EVENT_TYPE);
+        assert_eq!(events[0].subject_id.as_deref(), Some("subject_123"));
+        assert_eq!(events[0].actor_id.as_deref(), Some("actor_456"));
+        let serialized = serde_json::to_string(&events[0]).expect("event must serialize");
+        assert!(!serialized.contains("must-not-leak"));
+    }
+
+    #[test]
+    fn runtime_records_sink_delivery_failures_without_changing_execution_status() {
+        let outcome = Runtime::new(CapabilityRegistry::new(), NoopExecutor)
+            .with_event_sink(Arc::new(FailingEventSink))
+            .execute(valid_request());
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
+        assert_eq!(outcome.result.warnings.len(), 1);
+        assert_eq!(
+            outcome.result.warnings[0].code,
+            "runtime_event_sink_delivery_failed"
+        );
+        assert_eq!(outcome.trace.result.warnings, outcome.result.warnings);
     }
 
     #[test]

--- a/crates/traverse-runtime/tests/event_broker_tests.rs
+++ b/crates/traverse-runtime/tests/event_broker_tests.rs
@@ -29,6 +29,8 @@ fn sample_event(event_type: &str, id: &str, time: &str) -> TraverseEvent {
         owner: "cap.test".to_string(),
         version: "1.0.0".to_string(),
         lifecycle_status: LifecycleStatus::Active,
+        subject_id: None,
+        actor_id: None,
     }
 }
 

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -163,6 +163,8 @@ fn sample_event(event_type: &str) -> TraverseEvent {
         owner: "router.tests".to_string(),
         version: "1.0.0".to_string(),
         lifecycle_status: LifecycleStatus::Active,
+        subject_id: None,
+        actor_id: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the runtime-owned identity-aware event-sink boundary for lifecycle envelopes.

## Governing Spec

- `030-security-identity-model`
- `036-event-subscription-replay`
- `070-runtime-event-sink-boundary`

## Project Item

Closes #591

## Definition of Done

- [x] Runtime materializes token-free subject/actor event envelopes.
- [x] Runtime depends on a narrow injected sink and keeps a compatible no-op default.
- [x] Broker adapter forwards the canonical envelope without recomputing identity.
- [x] Sink errors are reported as traceable warnings without altering execution status.

## Validation

- `cargo test -p traverse-runtime --lib`
- `cargo test -p traverse-runtime --lib events:: --no-fail-fast`
