### PR TITLE
feat(kotlin): add ordered conformance subscriptions

### DIFF
--- a/packages/kotlin/TraverseEmbedder/README.md
+++ b/packages/kotlin/TraverseEmbedder/README.md
@@ -2,8 +2,9 @@
 
 This public Android library is the Spec-068 foundation for `embedder-api/1.0.0`.
 It exposes validated bundle and lifecycle types plus an in-memory deterministic
-harness for conformance tests. It never launches `traverse-cli serve` or uses
-server-discovery files in production.
+harness for conformance tests. Its `subscribe(afterSequence)` operation
+returns ordered runtime-shaped harness events. It never launches
+`traverse-cli serve` or uses server-discovery files in production.
 
 Runtime-WASM bridging, runtime event subscriptions, release evidence, and the
 Compose reference-app integration remain tracked by Traverse #648.

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/TraverseEmbedder.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/TraverseEmbedder.kt
@@ -18,10 +18,14 @@ data class TraverseSubmission(val targetId: String, val inputJson: String) {
 
 data class TraverseSubmissionResult(val sessionId: String, val status: String)
 
+/** Ordered runtime-shaped event exposed by the deterministic conformance harness. */
+data class TraverseRuntimeEvent(val sequence: Int, val targetId: String, val status: String)
+
 /** Deterministic test double; it never evaluates application business logic. */
 class InMemoryTraverseEmbedder {
     private var bundle: TraverseBundle? = null
     private var submissionSequence = 0
+    private val events = mutableListOf<TraverseRuntimeEvent>()
 
     fun initialize(bundle: TraverseBundle) {
         check(this.bundle == null) { "embedder is already initialized" }
@@ -31,12 +35,21 @@ class InMemoryTraverseEmbedder {
     fun shutdown() {
         bundle = null
         submissionSequence = 0
+        events.clear()
     }
 
     fun submit(submission: TraverseSubmission): TraverseSubmissionResult {
         check(bundle != null) { "embedder is not initialized" }
         submissionSequence += 1
-        return TraverseSubmissionResult("kotlin-session-$submissionSequence", "accepted")
+        val result = TraverseSubmissionResult("kotlin-session-$submissionSequence", "accepted")
+        events += TraverseRuntimeEvent(submissionSequence, submission.targetId, result.status)
+        return result
+    }
+
+    /** Returns ordered runtime-shaped events emitted after the supplied cursor. */
+    fun subscribe(afterSequence: Int = 0): List<TraverseRuntimeEvent> {
+        check(bundle != null) { "embedder is not initialized" }
+        return events.filter { it.sequence > afterSequence }
     }
 
     fun compatibleStart(capabilityId: String, inputJson: String) =

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/TraverseEmbedderTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/TraverseEmbedderTest.kt
@@ -12,5 +12,20 @@ class TraverseEmbedderTest {
             TraverseSubmissionResult("kotlin-session-1", "accepted"),
             harness.submit(TraverseSubmission("demo.workflow", "{}")),
         )
+        assertEquals(
+            TraverseSubmissionResult("kotlin-session-2", "accepted"),
+            harness.submit(TraverseSubmission("demo.capability", "{}")),
+        )
+        assertEquals(
+            listOf(
+                TraverseRuntimeEvent(1, "demo.workflow", "accepted"),
+                TraverseRuntimeEvent(2, "demo.capability", "accepted"),
+            ),
+            harness.subscribe(),
+        )
+        assertEquals(
+            listOf(TraverseRuntimeEvent(2, "demo.capability", "accepted")),
+            harness.subscribe(afterSequence = 1),
+        )
     }
 }


### PR DESCRIPTION
## Summary

- add an ordered `subscribe(afterSequence)` operation to the public Kotlin conformance harness
- record runtime-shaped submission events without introducing client business logic

## Governing Spec

- `068-public-platform-embedder-packages`

## Project Item

Refs #648

## Definition of Done

- [x] The deterministic Kotlin package surface implements the missing subscribe operation.
- [x] Subscription ordering and cursor semantics are covered by unit tests.
- [ ] Production runtime-WASM bridge and Compose reference-app integration remain tracked by #648.

## Validation

- Source and tests reviewed locally; Gradle/Kotlin tooling is unavailable in this workspace.
