### PR TITLE
feat(dotnet): add ordered conformance subscriptions

### DIFF
--- a/packages/dotnet/TraverseEmbedder/README.md
+++ b/packages/dotnet/TraverseEmbedder/README.md
@@ -3,7 +3,8 @@
 This public .NET library is the Spec-068 package foundation for
 `embedder-api/1.0.0`. It contains the stable bundle, submission, lifecycle,
 and compatible-capability boundary plus `InMemoryTraverseEmbedder` for
-deterministic conformance tests. It never depends on `traverse-cli serve` or
+deterministic conformance tests. Its `Subscribe` operation returns ordered
+runtime-shaped harness events. It never depends on `traverse-cli serve` or
 server-discovery files in production.
 
 The runtime-WASM bridge, event subscriptions, release evidence, and WinUI

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.cs
@@ -22,6 +22,9 @@ public sealed record TraverseSubmission(string TargetId, string InputJson)
 
 public sealed record TraverseSubmissionResult(string SessionId, string Status);
 
+/// <summary>Ordered runtime-shaped event exposed by the conformance harness.</summary>
+public sealed record TraverseRuntimeEvent(int Sequence, string TargetId, string Status);
+
 /// <summary>
 /// Deterministic conformance test double. It never evaluates application
 /// business logic and never starts a Traverse sidecar process.
@@ -30,6 +33,7 @@ public sealed class InMemoryTraverseEmbedder
 {
     private TraverseBundle? bundle;
     private int submissionSequence;
+    private readonly List<TraverseRuntimeEvent> events = [];
 
     public void Initialize(TraverseBundle value)
     {
@@ -42,6 +46,7 @@ public sealed class InMemoryTraverseEmbedder
     {
         bundle = null;
         submissionSequence = 0;
+        events.Clear();
     }
 
     public TraverseSubmissionResult Submit(TraverseSubmission submission)
@@ -49,7 +54,16 @@ public sealed class InMemoryTraverseEmbedder
         if (bundle is null) throw new InvalidOperationException("embedder is not initialized");
         submission.Validate();
         submissionSequence++;
-        return new TraverseSubmissionResult($"dotnet-session-{submissionSequence}", "accepted");
+        var result = new TraverseSubmissionResult($"dotnet-session-{submissionSequence}", "accepted");
+        events.Add(new TraverseRuntimeEvent(submissionSequence, submission.TargetId, result.Status));
+        return result;
+    }
+
+    /// <summary>Returns ordered runtime-shaped events emitted after a sequence cursor.</summary>
+    public IReadOnlyList<TraverseRuntimeEvent> Subscribe(int afterSequence = 0)
+    {
+        EnsureInitialized();
+        return events.Where(@event => @event.Sequence > afterSequence).ToArray();
     }
 
     public TraverseSubmissionResult CompatibleStart(string capabilityId, string inputJson) =>


### PR DESCRIPTION
## Summary

- add an ordered `Subscribe` operation to the public .NET conformance harness
- record runtime-shaped submission events without introducing client business logic

## Governing Spec

- `068-public-platform-embedder-packages`

## Project Item

Refs #649

## Definition of Done

- [x] The deterministic .NET package surface implements the missing subscribe operation.
- [x] The source preserves sequence cursor ordering without a sidecar dependency.
- [ ] Production runtime-WASM bridge and WinUI reference-app integration remain tracked by #649.

## Validation

- Source reviewed locally; no .NET SDK is installed in this workspace.
