### PR TITLE
test(http): cover server error display

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -7164,6 +7164,18 @@ mod tests {
     };
     use traverse_runtime::{LocalExecutionFailure, LocalExecutionFailureCode};
 
+    #[test]
+    fn serve_error_display_keeps_bind_and_accept_context() {
+        assert_eq!(
+            ServeError::BindFailed("address in use".to_string()).to_string(),
+            "failed to bind HTTP/JSON API server: address in use"
+        );
+        assert_eq!(
+            ServeError::AcceptFailed("socket closed".to_string()).to_string(),
+            "HTTP/JSON API server accept loop failed: socket closed"
+        );
+    }
+
     // ------------------------------------------------------------------
     // Minimal test executor
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- cover stable HTTP server bind and accept-loop error rendering

## Governing Spec

- `033-http-json-api`

## Project Item

Refs #637

## Definition of Done

- [x] Cover an uncovered HTTP API error branch with a stable public assertion.
- [ ] Continue separate focused passes until the tracked HTTP API coverage gap is closed.

## Validation

- `cargo test -p traverse-cli --bin traverse-cli serve_error_display_keeps_bind_and_accept_context`
