### PR TITLE
test(http): cover idempotency retention normalization

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -9191,6 +9191,22 @@ mod tests {
     }
 
     #[test]
+    fn idempotency_retention_normalizes_default_floor_and_explicit_values() {
+        assert_eq!(
+            configured_idempotency_retention(None),
+            DEFAULT_IDEMPOTENCY_RETENTION_SECONDS
+        );
+        assert_eq!(
+            configured_idempotency_retention(Some(1)),
+            MIN_IDEMPOTENCY_RETENTION_SECONDS
+        );
+        assert_eq!(
+            configured_idempotency_retention(Some(MIN_IDEMPOTENCY_RETENTION_SECONDS + 1)),
+            MIN_IDEMPOTENCY_RETENTION_SECONDS + 1
+        );
+    }
+
+    #[test]
     fn execution_status_endpoint_returns_running_status() {
         let state = empty_state();
         state


### PR DESCRIPTION
## Summary

- Covers the HTTP API's idempotency-retention normalization helper for default, floor, and explicit configurations.
- Continues the bounded coverage-restoration work for #637.

## Governing Spec

- `033-http-json-api`

## Project Item

- Refs #637

## Definition of Done

- [x] The normalization branches have direct deterministic test coverage.
- [x] The focused CLI test passes locally.

## Validation

```text
cargo test -p traverse-cli --bin traverse-cli idempotency_retention_normalizes_default_floor_and_explicit_values
```
