### PR TITLE
test(http): cover unknown caller auth mode

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -11224,6 +11224,14 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn unknown_auth_mode_is_never_a_trusted_development_caller() {
+        assert!(!is_trusted_dev_caller(
+            IpAddr::from([127, 0, 0, 1]),
+            "production"
+        ));
+    }
+
     // ------------------------------------------------------------------
     // error envelope shape
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Covers rejection of unknown authentication modes by the HTTP API development-caller trust helper.
- Continues the bounded HTTP API coverage-restoration work for #637.

## Governing Spec

- `033-http-json-api`

## Project Item

- Refs #637

## Definition of Done

- [x] The fallback trust branch is directly covered.
- [x] The focused CLI test passes locally.

## Validation

```text
cargo test -p traverse-cli --bin traverse-cli unknown_auth_mode_is_never_a_trusted_development_caller
```
