### PR TITLE
ci: raise traverse-cli coverage floor to 87 percent

### DIFF
--- a/ci/coverage-targets.txt
+++ b/ci/coverage-targets.txt
@@ -8,6 +8,6 @@
 traverse-contracts 100
 traverse-registry 100
 traverse-runtime 100
-traverse-cli 86
+traverse-cli 87
 traverse-embedder 100
 traverse-mcp 98


### PR DESCRIPTION
## Summary

- Raises the checked-in `traverse-cli` line-coverage floor from 86% to 87%.
- Uses the authoritative merged PR #685 CI measurement: 87.21% (15073/17284 lines).

## Governing Spec

- `033-http-json-api`

## Project Item

- Refs #637

## Definition of Done

- [x] The CLI floor reflects coverage achieved by focused HTTP API tests.
- [x] The new floor remains below the authoritative CI measurement.

## Validation

```text
PR #685 coverage-gate: traverse-cli 87.21% (15073/17284 lines)
```
