### PR TITLE
test(http): cover in-process workspace authorization

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -9313,6 +9313,34 @@ mod tests {
     }
 
     #[test]
+    fn in_process_api_rejects_system_workspace_listing_without_membership_metadata() {
+        let api = InProcessApi::new(ApiServerConfig {
+            bind_address: "127.0.0.1:0".to_string(),
+            requested_auth_mode: None,
+            allow_unauthenticated: true,
+            allowed_origins: Vec::new(),
+            render_mobile_qr: false,
+            capability_registry: CapabilityRegistry::new(),
+            workflow_registry: WorkflowRegistry::new(),
+            registry_root: test_registry_root(),
+            executor: TestExecutor::ok(json!({})),
+            idempotency_retention_seconds: None,
+            jwt_verification_key_hex: None,
+            read_timeout: None,
+            write_timeout: None,
+            request_deadline: None,
+            max_concurrent_connections: None,
+        });
+
+        let (status, body) = api
+            .list_workflows(SYSTEM_WORKSPACE_ID, true)
+            .expect("listing must render a JSON response");
+
+        assert_eq!(status, 403);
+        assert_eq!(body["status"], 403);
+    }
+
+    #[test]
     fn execution_status_endpoint_returns_running_status() {
         let state = empty_state();
         state


### PR DESCRIPTION
## Summary

- Covers `InProcessApi` workflow-listing authorization, preserving fail-closed 403 behavior without workspace membership metadata.
- Continues the bounded HTTP API coverage-restoration work for #637.

## Governing Spec

- `033-http-json-api`

## Project Item

- Refs #637

## Definition of Done

- [x] Public in-process workflow listing has authorization-boundary coverage.
- [x] The focused CLI test passes locally.

## Validation

```text
cargo test -p traverse-cli --bin traverse-cli in_process_api_rejects_system_workspace_listing_without_membership_metadata
```
