### PR TITLE
test(http): cover in-process workflow listing

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -9341,6 +9341,36 @@ mod tests {
     }
 
     #[test]
+    fn in_process_api_lists_an_authorized_empty_workspace() {
+        let registry_root = test_registry_root();
+        persist_local_test_workspace(&registry_root, "ws-authorized");
+        let api = InProcessApi::new(ApiServerConfig {
+            bind_address: "127.0.0.1:0".to_string(),
+            requested_auth_mode: None,
+            allow_unauthenticated: true,
+            allowed_origins: Vec::new(),
+            render_mobile_qr: false,
+            capability_registry: CapabilityRegistry::new(),
+            workflow_registry: WorkflowRegistry::new(),
+            registry_root,
+            executor: TestExecutor::ok(json!({})),
+            idempotency_retention_seconds: None,
+            jwt_verification_key_hex: None,
+            read_timeout: None,
+            write_timeout: None,
+            request_deadline: None,
+            max_concurrent_connections: None,
+        });
+
+        let (status, body) = api
+            .list_workflows("ws-authorized", true)
+            .expect("listing must render a JSON response");
+
+        assert_eq!(status, 200);
+        assert_eq!(body, json!([]));
+    }
+
+    #[test]
     fn execution_status_endpoint_returns_running_status() {
         let state = empty_state();
         state


### PR DESCRIPTION
## Summary

- Covers successful `InProcessApi` workflow listing for a workspace with local membership metadata.
- Complements the fail-closed authorization coverage merged in PR #691.

## Governing Spec

- `033-http-json-api`

## Project Item

- Refs #637

## Definition of Done

- [x] Authorized in-process workflow listing renders the expected empty response.
- [x] The focused CLI test passes locally.

## Validation

```text
cargo test -p traverse-cli --bin traverse-cli in_process_api_lists_an_authorized_empty_workspace
```
