### PR TITLE
test(http): cover in-process workflow lookup

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -9371,6 +9371,37 @@ mod tests {
     }
 
     #[test]
+    fn in_process_api_returns_not_found_for_missing_authorized_workflow() {
+        let registry_root = test_registry_root();
+        persist_local_test_workspace(&registry_root, "ws-authorized");
+        let api = InProcessApi::new(ApiServerConfig {
+            bind_address: "127.0.0.1:0".to_string(),
+            requested_auth_mode: None,
+            allow_unauthenticated: true,
+            allowed_origins: Vec::new(),
+            render_mobile_qr: false,
+            capability_registry: CapabilityRegistry::new(),
+            workflow_registry: WorkflowRegistry::new(),
+            registry_root,
+            executor: TestExecutor::ok(json!({})),
+            idempotency_retention_seconds: None,
+            jwt_verification_key_hex: None,
+            read_timeout: None,
+            write_timeout: None,
+            request_deadline: None,
+            max_concurrent_connections: None,
+        });
+
+        let (status, body) = api
+            .get_workflow("ws-authorized", "missing-workflow", None, true)
+            .expect("lookup must render a JSON response");
+
+        assert_eq!(status, 404);
+        assert_eq!(body["status"], 404);
+        assert_eq!(body["traverse_code"], "workflow_not_found");
+    }
+
+    #[test]
     fn execution_status_endpoint_returns_running_status() {
         let state = empty_state();
         state


### PR DESCRIPTION
## Summary

- Covers authorized `InProcessApi` lookup of a missing workflow and its canonical 404 envelope.
- Continues the bounded HTTP API coverage-restoration work for #637.

## Governing Spec

- `033-http-json-api`

## Project Item

- Refs #637

## Definition of Done

- [x] Public in-process workflow lookup has missing-resource coverage.
- [x] The focused CLI test passes locally.

## Validation

```text
cargo test -p traverse-cli --bin traverse-cli in_process_api_returns_not_found_for_missing_authorized_workflow
```
