### PR TITLE
test(http): cover in-process workflow registration

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -9402,6 +9402,35 @@ mod tests {
     }
 
     #[test]
+    fn in_process_api_rejects_malformed_workflow_registration() {
+        let api = InProcessApi::new(ApiServerConfig {
+            bind_address: "127.0.0.1:0".to_string(),
+            requested_auth_mode: None,
+            allow_unauthenticated: true,
+            allowed_origins: Vec::new(),
+            render_mobile_qr: false,
+            capability_registry: CapabilityRegistry::new(),
+            workflow_registry: WorkflowRegistry::new(),
+            registry_root: test_registry_root(),
+            executor: TestExecutor::ok(json!({})),
+            idempotency_retention_seconds: None,
+            jwt_verification_key_hex: None,
+            read_timeout: None,
+            write_timeout: None,
+            request_deadline: None,
+            max_concurrent_connections: None,
+        });
+
+        let (status, body) = api
+            .register_workflow(b"not-json".to_vec(), true)
+            .expect("registration must render a JSON response");
+
+        assert_eq!(status, 400);
+        assert_eq!(body["status"], 400);
+        assert_eq!(body["traverse_code"], "invalid_request");
+    }
+
+    #[test]
     fn execution_status_endpoint_returns_running_status() {
         let state = empty_state();
         state

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -9467,6 +9467,35 @@ mod tests {
     }
 
     #[test]
+    fn in_process_api_rejects_empty_workspace_id_when_listing_workflows() {
+        let api = InProcessApi::new(ApiServerConfig {
+            bind_address: "127.0.0.1:0".to_string(),
+            requested_auth_mode: None,
+            allow_unauthenticated: true,
+            allowed_origins: Vec::new(),
+            render_mobile_qr: false,
+            capability_registry: CapabilityRegistry::new(),
+            workflow_registry: WorkflowRegistry::new(),
+            registry_root: test_registry_root(),
+            executor: TestExecutor::ok(json!({})),
+            idempotency_retention_seconds: None,
+            jwt_verification_key_hex: None,
+            read_timeout: None,
+            write_timeout: None,
+            request_deadline: None,
+            max_concurrent_connections: None,
+        });
+
+        let (status, body) = api
+            .list_workflows("", true)
+            .expect("listing must render a JSON response");
+
+        assert_eq!(status, 400);
+        assert_eq!(body["status"], 400);
+        assert_eq!(body["traverse_code"], "workspace_id_invalid");
+    }
+
+    #[test]
     fn execution_status_endpoint_returns_running_status() {
         let state = empty_state();
         state

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -9431,6 +9431,42 @@ mod tests {
     }
 
     #[test]
+    fn in_process_api_reports_unresolved_workflow_capability_reference() {
+        let api = InProcessApi::new(ApiServerConfig {
+            bind_address: "127.0.0.1:0".to_string(),
+            requested_auth_mode: None,
+            allow_unauthenticated: true,
+            allowed_origins: Vec::new(),
+            render_mobile_qr: false,
+            capability_registry: CapabilityRegistry::new(),
+            workflow_registry: WorkflowRegistry::new(),
+            registry_root: test_registry_root(),
+            executor: TestExecutor::ok(json!({})),
+            idempotency_retention_seconds: None,
+            jwt_verification_key_hex: None,
+            read_timeout: None,
+            write_timeout: None,
+            request_deadline: None,
+            max_concurrent_connections: None,
+        });
+        let mut body: Value = serde_json::from_slice(&valid_workflow_registration_body(
+            "test.api.unowned-workflow",
+            "1.0.0",
+            "test.api.unowned-capability",
+        ))
+        .expect("test workflow body must be valid JSON");
+        body["workspace_id"] = json!("ws-unowned");
+
+        let (status, response) = api
+            .register_workflow(body.to_string().into_bytes(), true)
+            .expect("registration must render a JSON response");
+
+        assert_eq!(status, 422, "unexpected response: {response}");
+        assert_eq!(response["status"], 422);
+        assert_eq!(response["traverse_code"], "unresolved_capability_reference");
+    }
+
+    #[test]
     fn execution_status_endpoint_returns_running_status() {
         let state = empty_state();
         state


### PR DESCRIPTION
## Summary

- cover the in-process workflow registration wrapper's malformed JSON response path.
- cover its stable unresolved-capability failure response.

## Governing Spec

- `033-http-json-api`

## Project Item

- Refs #637

## Definition of Done

- [x] The in-process registration API returns its stable invalid-request response for malformed workflow payloads.
- [x] The in-process registration API returns the stable unresolved-capability response for a workflow with a missing dependency.

## Validation

```text
cargo fmt --check
cargo test -p traverse-cli --bin traverse-cli in_process_api_rejects_malformed_workflow_registration
```
