### PR TITLE
feat(swift): reject incompatible embedder bundles

### DIFF
--- a/packages/swift/TraverseEmbedder/README.md
+++ b/packages/swift/TraverseEmbedder/README.md
@@ -9,3 +9,16 @@ the ordered runtime-shaped events recorded by the harness. It never starts
 
 The production runtime-WASM bridge, event subscription stream, package release
 evidence, and app-reference integration are tracked by Traverse #647.
+
+## Bundle compatibility
+
+Applications provide a bundle root URL, the runtime-WASM SHA-256 digest used
+for release traceability, and the bundle's embedder API version. The API version
+defaults to the package's `TraverseEmbedder.apiVersion`. Initialization rejects
+a bundle declaring a different version with `incompatibleBundle`; it does not
+start a sidecar or attempt a network fallback.
+
+The package follows semantic versioning. Additive, backward-compatible API
+changes use minor releases; breaking public API or error-semantic changes use a
+new major version. Call `shutdown()` to clear the active bundle, submission
+sequence, and recorded events before cancellation or replacement.

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/TraverseEmbedder.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/TraverseEmbedder.swift
@@ -8,13 +8,19 @@ public enum TraverseEmbedder {
 public struct TraverseBundle: Sendable, Equatable {
     public let rootURL: URL
     public let runtimeWasmDigest: String
+    public let embedderAPIVersion: String
 
-    public init(rootURL: URL, runtimeWasmDigest: String) throws {
+    public init(
+        rootURL: URL,
+        runtimeWasmDigest: String,
+        embedderAPIVersion: String = TraverseEmbedder.apiVersion
+    ) throws {
         guard !runtimeWasmDigest.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw TraverseEmbedderError.incompatibleBundle("runtime WASM digest is required")
         }
         self.rootURL = rootURL
         self.runtimeWasmDigest = runtimeWasmDigest
+        self.embedderAPIVersion = embedderAPIVersion
     }
 }
 
@@ -72,6 +78,11 @@ public final class InMemoryTraverseEmbedder: @unchecked Sendable {
 
     public func initialize(bundle: TraverseBundle) throws {
         guard self.bundle == nil else { throw TraverseEmbedderError.alreadyInitialized }
+        guard bundle.embedderAPIVersion == TraverseEmbedder.apiVersion else {
+            throw TraverseEmbedderError.incompatibleBundle(
+                "embedder API \(bundle.embedderAPIVersion) is incompatible with \(TraverseEmbedder.apiVersion)"
+            )
+        }
         self.bundle = bundle
     }
 

--- a/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
+++ b/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
@@ -24,3 +24,21 @@ import Testing
         try harness.submit(TraverseSubmission(targetID: "demo.workflow", inputJSON: Data("{}".utf8)))
     }
 }
+
+@Test func incompatibleBundleIsRejectedWithoutInitializing() throws {
+    let harness = InMemoryTraverseEmbedder()
+    let bundle = try TraverseBundle(
+        rootURL: URL(fileURLWithPath: "/tmp/traverse-bundle"),
+        runtimeWasmDigest: "sha256:test",
+        embedderAPIVersion: "2.0.0"
+    )
+
+    #expect(throws: TraverseEmbedderError.incompatibleBundle(
+        "embedder API 2.0.0 is incompatible with 1.0.0"
+    )) {
+        try harness.initialize(bundle: bundle)
+    }
+    #expect(throws: TraverseEmbedderError.notInitialized) {
+        try harness.subscribe()
+    }
+}


### PR DESCRIPTION
## Summary

- add the declared embedder API version to Swift bundle metadata
- reject incompatible bundle/API pairings deterministically during initialization
- document compatibility, shutdown, error, and upgrade behavior

## Governing Spec

- `068-public-platform-embedder-packages`

Implements FR-007 and NFR-001 from version 1.0.0.

## Project Item

Closes part of #647. Project 1 item `PVTI_lADOEbiBt84Bbyp1zgymo7c` remains In Progress for the production runtime bridge, release evidence, shared conformance, and reference-app integration.

## Definition of Done

- [x] Swift bundles declare their embedder API version
- [x] mismatched API versions fail with a stable structured error
- [x] failed compatibility validation leaves the embedder uninitialized
- [x] public documentation states compatibility and upgrade behavior

## Validation

- `swift test` (2 tests passed)
- `git diff --check`
