### PR TITLE
feat(kotlin): model compatible lifecycle results

### DIFF
--- a/packages/kotlin/TraverseEmbedder/README.md
+++ b/packages/kotlin/TraverseEmbedder/README.md
@@ -3,8 +3,10 @@
 This public Android library is the Spec-068 foundation for `embedder-api/1.0.0`.
 It exposes validated bundle and lifecycle types plus an in-memory deterministic
 harness for conformance tests. Its `subscribe(afterSequence)` operation
-returns ordered runtime-shaped harness events. It never launches
-`traverse-cli serve` or uses server-discovery files in production.
+returns ordered runtime-shaped harness events. Compatible-capability start,
+stop, and kill operations return stable instance identifiers and lifecycle
+results. It never launches `traverse-cli serve` or uses server-discovery files
+in production.
 
 Runtime-WASM bridging, runtime event subscriptions, release evidence, and the
 Compose reference-app integration remain tracked by Traverse #648.

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/TraverseEmbedder.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/TraverseEmbedder.kt
@@ -19,13 +19,22 @@ data class TraverseSubmission(val targetId: String, val inputJson: String) {
 data class TraverseSubmissionResult(val sessionId: String, val status: String)
 
 /** Ordered runtime-shaped event exposed by the deterministic conformance harness. */
-data class TraverseRuntimeEvent(val sequence: Int, val targetId: String, val status: String)
+data class TraverseRuntimeEvent(
+    val sequence: Int,
+    val targetId: String,
+    val status: String,
+    val instanceId: String? = null,
+)
+
+data class TraverseCompatibleResult(val instanceId: String?, val status: String)
 
 /** Deterministic test double; it never evaluates application business logic. */
 class InMemoryTraverseEmbedder {
     private var bundle: TraverseBundle? = null
     private var submissionSequence = 0
+    private var compatibleSequence = 0
     private val events = mutableListOf<TraverseRuntimeEvent>()
+    private val compatibleInstances = mutableMapOf<String, String>()
 
     fun initialize(bundle: TraverseBundle) {
         check(this.bundle == null) { "embedder is already initialized" }
@@ -35,7 +44,9 @@ class InMemoryTraverseEmbedder {
     fun shutdown() {
         bundle = null
         submissionSequence = 0
+        compatibleSequence = 0
         events.clear()
+        compatibleInstances.clear()
     }
 
     fun submit(submission: TraverseSubmission): TraverseSubmissionResult {
@@ -52,14 +63,41 @@ class InMemoryTraverseEmbedder {
         return events.filter { it.sequence > afterSequence }
     }
 
-    fun compatibleStart(capabilityId: String, inputJson: String) =
-        submit(TraverseSubmission(capabilityId, inputJson))
-
-    fun compatibleStop(capabilityId: String, instanceId: String?) {
+    fun compatibleStart(capabilityId: String, inputJson: String): TraverseCompatibleResult {
         check(bundle != null) { "embedder is not initialized" }
+        require(capabilityId.isNotBlank()) { "capability_id is required" }
+        compatibleSequence += 1
+        val instanceId = "kotlin-compatible-$compatibleSequence"
+        compatibleInstances[capabilityId] = instanceId
+        appendCompatibleEvent(capabilityId, instanceId, "started")
+        return TraverseCompatibleResult(instanceId, "started")
     }
 
-    fun compatibleKill(capabilityId: String, instanceId: String?) {
+    fun compatibleStop(capabilityId: String, instanceId: String?): TraverseCompatibleResult {
+        val resolvedInstanceId = compatibleInstance(capabilityId, instanceId)
+        compatibleInstances.remove(capabilityId)
+        appendCompatibleEvent(capabilityId, resolvedInstanceId, "stopped")
+        return TraverseCompatibleResult(resolvedInstanceId, "stopped")
+    }
+
+    fun compatibleKill(capabilityId: String, instanceId: String?): TraverseCompatibleResult {
+        val resolvedInstanceId = compatibleInstance(capabilityId, instanceId)
+        compatibleInstances.remove(capabilityId)
+        appendCompatibleEvent(capabilityId, resolvedInstanceId, "killed")
+        return TraverseCompatibleResult(resolvedInstanceId, "killed")
+    }
+
+    private fun compatibleInstance(capabilityId: String, instanceId: String?): String {
         check(bundle != null) { "embedder is not initialized" }
+        val activeInstanceId = compatibleInstances[capabilityId]
+        check(activeInstanceId != null && (instanceId == null || instanceId == activeInstanceId)) {
+            "compatible instance is not active"
+        }
+        return activeInstanceId
+    }
+
+    private fun appendCompatibleEvent(capabilityId: String, instanceId: String, status: String) {
+        submissionSequence += 1
+        events += TraverseRuntimeEvent(submissionSequence, capabilityId, status, instanceId)
     }
 }

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/TraverseEmbedderTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/TraverseEmbedderTest.kt
@@ -1,6 +1,7 @@
 package dev.traverse.embedder
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class TraverseEmbedderTest {
@@ -26,6 +27,36 @@ class TraverseEmbedderTest {
         assertEquals(
             listOf(TraverseRuntimeEvent(2, "demo.capability", "accepted")),
             harness.subscribe(afterSequence = 1),
+        )
+    }
+
+    @Test fun compatibleLifecycleIsDeterministicAndOrdered() {
+        val harness = InMemoryTraverseEmbedder()
+        harness.initialize(TraverseBundle("assets/traverse", "sha256:test"))
+
+        val first = harness.compatibleStart("demo.compatible", "{}")
+        assertEquals(TraverseCompatibleResult("kotlin-compatible-1", "started"), first)
+        assertEquals(
+            TraverseCompatibleResult("kotlin-compatible-1", "stopped"),
+            harness.compatibleStop("demo.compatible", first.instanceId),
+        )
+        assertThrows(IllegalStateException::class.java) {
+            harness.compatibleKill("demo.compatible", first.instanceId)
+        }
+
+        val second = harness.compatibleStart("demo.compatible", "{}")
+        assertEquals(
+            TraverseCompatibleResult("kotlin-compatible-2", "killed"),
+            harness.compatibleKill("demo.compatible", null),
+        )
+        assertEquals(
+            listOf(
+                TraverseRuntimeEvent(1, "demo.compatible", "started", first.instanceId),
+                TraverseRuntimeEvent(2, "demo.compatible", "stopped", first.instanceId),
+                TraverseRuntimeEvent(3, "demo.compatible", "started", second.instanceId),
+                TraverseRuntimeEvent(4, "demo.compatible", "killed", second.instanceId),
+            ),
+            harness.subscribe(),
         )
     }
 }


### PR DESCRIPTION
## Summary

- model Kotlin compatible-capability start, stop, and kill results explicitly
- emit deterministic ordered lifecycle events with stable instance identifiers
- reject lifecycle operations for inactive or mismatched instances

## Governing Spec

- `068-public-platform-embedder-packages`

## Project Item

Refs #648

## Definition of Done

- [x] The Kotlin conformance harness exposes start, stop, and kill result semantics required by `embedder-api/1.0.0`.
- [x] Compatible lifecycle ordering, instance identity, and deterministic rejection have unit coverage.
- [ ] Production runtime-WASM bridge and Compose App-References integration remain tracked by #648.

## Validation

- `git diff --check`
- Gradle/Kotlin tooling is unavailable in this workspace; CI must execute the package tests.
