### PR TITLE
feat(dotnet): model compatible lifecycle results

### DIFF
--- a/packages/dotnet/TraverseEmbedder/README.md
+++ b/packages/dotnet/TraverseEmbedder/README.md
@@ -4,8 +4,9 @@ This public .NET library is the Spec-068 package foundation for
 `embedder-api/1.0.0`. It contains the stable bundle, submission, lifecycle,
 and compatible-capability boundary plus `InMemoryTraverseEmbedder` for
 deterministic conformance tests. Its `Subscribe` operation returns ordered
-runtime-shaped harness events. It never depends on `traverse-cli serve` or
-server-discovery files in production.
+runtime-shaped harness events. Compatible-capability start, stop, and kill
+operations return stable instance identifiers and lifecycle results. It never
+depends on `traverse-cli serve` or server-discovery files in production.
 
 The runtime-WASM bridge, event subscriptions, release evidence, and WinUI
 reference-app integration remain tracked by Traverse #649.

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.cs
@@ -23,7 +23,13 @@ public sealed record TraverseSubmission(string TargetId, string InputJson)
 public sealed record TraverseSubmissionResult(string SessionId, string Status);
 
 /// <summary>Ordered runtime-shaped event exposed by the conformance harness.</summary>
-public sealed record TraverseRuntimeEvent(int Sequence, string TargetId, string Status);
+public sealed record TraverseRuntimeEvent(
+    int Sequence,
+    string TargetId,
+    string Status,
+    string? InstanceId = null);
+
+public sealed record TraverseCompatibleResult(string? InstanceId, string Status);
 
 /// <summary>
 /// Deterministic conformance test double. It never evaluates application
@@ -33,7 +39,9 @@ public sealed class InMemoryTraverseEmbedder
 {
     private TraverseBundle? bundle;
     private int submissionSequence;
+    private int compatibleSequence;
     private readonly List<TraverseRuntimeEvent> events = [];
+    private readonly Dictionary<string, string> compatibleInstances = [];
 
     public void Initialize(TraverseBundle value)
     {
@@ -46,7 +54,9 @@ public sealed class InMemoryTraverseEmbedder
     {
         bundle = null;
         submissionSequence = 0;
+        compatibleSequence = 0;
         events.Clear();
+        compatibleInstances.Clear();
     }
 
     public TraverseSubmissionResult Submit(TraverseSubmission submission)
@@ -66,12 +76,49 @@ public sealed class InMemoryTraverseEmbedder
         return events.Where(@event => @event.Sequence > afterSequence).ToArray();
     }
 
-    public TraverseSubmissionResult CompatibleStart(string capabilityId, string inputJson) =>
-        Submit(new TraverseSubmission(capabilityId, inputJson));
+    public TraverseCompatibleResult CompatibleStart(string capabilityId, string inputJson)
+    {
+        EnsureInitialized();
+        ArgumentException.ThrowIfNullOrWhiteSpace(capabilityId);
+        compatibleSequence++;
+        var instanceId = $"dotnet-compatible-{compatibleSequence}";
+        compatibleInstances[capabilityId] = instanceId;
+        AppendCompatibleEvent(capabilityId, instanceId, "started");
+        return new TraverseCompatibleResult(instanceId, "started");
+    }
 
-    public void CompatibleStop(string capabilityId, string? instanceId) => EnsureInitialized();
+    public TraverseCompatibleResult CompatibleStop(string capabilityId, string? instanceId)
+    {
+        var resolvedInstanceId = CompatibleInstance(capabilityId, instanceId);
+        compatibleInstances.Remove(capabilityId);
+        AppendCompatibleEvent(capabilityId, resolvedInstanceId, "stopped");
+        return new TraverseCompatibleResult(resolvedInstanceId, "stopped");
+    }
 
-    public void CompatibleKill(string capabilityId, string? instanceId) => EnsureInitialized();
+    public TraverseCompatibleResult CompatibleKill(string capabilityId, string? instanceId)
+    {
+        var resolvedInstanceId = CompatibleInstance(capabilityId, instanceId);
+        compatibleInstances.Remove(capabilityId);
+        AppendCompatibleEvent(capabilityId, resolvedInstanceId, "killed");
+        return new TraverseCompatibleResult(resolvedInstanceId, "killed");
+    }
+
+    private string CompatibleInstance(string capabilityId, string? instanceId)
+    {
+        EnsureInitialized();
+        if (!compatibleInstances.TryGetValue(capabilityId, out var activeInstanceId) ||
+            (instanceId is not null && instanceId != activeInstanceId))
+        {
+            throw new InvalidOperationException("compatible instance is not active");
+        }
+        return activeInstanceId;
+    }
+
+    private void AppendCompatibleEvent(string capabilityId, string instanceId, string status)
+    {
+        submissionSequence++;
+        events.Add(new TraverseRuntimeEvent(submissionSequence, capabilityId, status, instanceId));
+    }
 
     private void EnsureInitialized()
     {


### PR DESCRIPTION
## Summary

- model .NET compatible-capability start, stop, and kill results explicitly
- emit deterministic ordered lifecycle events with stable instance identifiers
- reject lifecycle operations for inactive or mismatched instances

## Governing Spec

- `068-public-platform-embedder-packages`

## Project Item

Refs #649

## Definition of Done

- [x] The .NET conformance harness exposes start, stop, and kill result semantics required by `embedder-api/1.0.0`.
- [x] Compatible lifecycle ordering, instance identity, and deterministic rejection are represented by the public source boundary.
- [ ] Production runtime-WASM bridge and WinUI App-References integration remain tracked by #649.

## Validation

- `git diff --check`
- The .NET SDK is unavailable in this workspace; CI must compile the package.
