### PR TITLE
feat(swift): model release evidence

### DIFF
--- a/packages/swift/TraverseEmbedder/README.md
+++ b/packages/swift/TraverseEmbedder/README.md
@@ -8,8 +8,13 @@ the ordered runtime-shaped events recorded by the harness. Compatible-capability
 start, stop, and kill operations return stable instance identifiers and lifecycle
 results. It never starts `traverse-cli serve` or uses server-discovery files.
 
-The production runtime-WASM bridge, event subscription stream, package release
-evidence, and app-reference integration are tracked by Traverse #647.
+The production runtime-WASM bridge, event subscription stream, evidence
+publication, and app-reference integration are tracked by Traverse #647.
+
+Release tooling constructs `TraverseReleaseEvidence` with the semantic package
+version, runtime-WASM digest, conformance version, and supported iOS/macOS host
+versions. The initializer rejects incomplete evidence before publication so a
+downstream binary can be traced to the exact package and runtime pairing.
 
 ## Bundle compatibility
 

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/TraverseEmbedder.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/TraverseEmbedder.swift
@@ -26,9 +26,43 @@ public struct TraverseBundle: Sendable, Equatable {
 
 public enum TraverseEmbedderError: Error, Equatable, Sendable {
     case incompatibleBundle(String)
+    case invalidReleaseEvidence(String)
     case notInitialized
     case alreadyInitialized
     case unsupportedOperation(String)
+}
+
+/// Traceability evidence published with a TraverseEmbedder package release.
+public struct TraverseReleaseEvidence: Sendable, Equatable {
+    public let packageVersion: String
+    public let runtimeWasmDigest: String
+    public let conformanceVersion: String
+    public let supportedHostVersions: [String]
+
+    public init(
+        packageVersion: String,
+        runtimeWasmDigest: String,
+        conformanceVersion: String = TraverseEmbedder.apiVersion,
+        supportedHostVersions: [String]
+    ) throws {
+        guard !packageVersion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw TraverseEmbedderError.invalidReleaseEvidence("package version is required")
+        }
+        guard !runtimeWasmDigest.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw TraverseEmbedderError.invalidReleaseEvidence("runtime WASM digest is required")
+        }
+        guard !conformanceVersion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw TraverseEmbedderError.invalidReleaseEvidence("conformance version is required")
+        }
+        guard !supportedHostVersions.isEmpty,
+              supportedHostVersions.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+            throw TraverseEmbedderError.invalidReleaseEvidence("supported host versions are required")
+        }
+        self.packageVersion = packageVersion
+        self.runtimeWasmDigest = runtimeWasmDigest
+        self.conformanceVersion = conformanceVersion
+        self.supportedHostVersions = supportedHostVersions
+    }
 }
 
 public struct TraverseSubmission: Sendable, Equatable {

--- a/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
+++ b/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
@@ -66,3 +66,23 @@ import Testing
         TraverseRuntimeEvent(sequence: 4, targetID: "demo.compatible", status: "killed", instanceID: second.instanceID),
     ])
 }
+
+@Test func releaseEvidenceIsCompleteAndDeterministic() throws {
+    #expect(try TraverseReleaseEvidence(
+        packageVersion: "0.1.0",
+        runtimeWasmDigest: "sha256:test",
+        supportedHostVersions: ["iOS 17+", "macOS 14+"]
+    ) == TraverseReleaseEvidence(
+        packageVersion: "0.1.0",
+        runtimeWasmDigest: "sha256:test",
+        conformanceVersion: "1.0.0",
+        supportedHostVersions: ["iOS 17+", "macOS 14+"]
+    ))
+    #expect(throws: TraverseEmbedderError.invalidReleaseEvidence("supported host versions are required")) {
+        try TraverseReleaseEvidence(
+            packageVersion: "0.1.0",
+            runtimeWasmDigest: "sha256:test",
+            supportedHostVersions: []
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add typed Swift release evidence for package/runtime traceability
- require package version, runtime-WASM digest, conformance version, and host versions
- reject incomplete evidence deterministically before publication

## Governing Spec

- `068-public-platform-embedder-packages`

## Project Item

Refs #647

## Definition of Done

- [x] Swift exposes the release-evidence fields required by FR-008.
- [x] Incomplete evidence is rejected with a stable public error.
- [x] Evidence construction and defaults are covered by package tests.
- [ ] Evidence publication, production runtime bridge, and App-References integration remain tracked by #647.

## Validation

- `swift test` (4 tests passed)
- `git diff --check`
