### PR TITLE
feat(dotnet): model release evidence

### DIFF
--- a/packages/dotnet/TraverseEmbedder/README.md
+++ b/packages/dotnet/TraverseEmbedder/README.md
@@ -8,5 +8,10 @@ runtime-shaped harness events. Compatible-capability start, stop, and kill
 operations return stable instance identifiers and lifecycle results. It never
 depends on `traverse-cli serve` or server-discovery files in production.
 
-The runtime-WASM bridge, event subscriptions, release evidence, and WinUI
+Release tooling constructs `TraverseReleaseEvidence` with the semantic package
+version, runtime-WASM digest, conformance version, and supported Windows host
+versions. `Validate` rejects incomplete evidence before publication so a
+downstream binary can be traced to its exact package and runtime pairing.
+
+The runtime-WASM bridge, event subscriptions, evidence publication, and WinUI
 reference-app integration remain tracked by Traverse #649.

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.cs
@@ -22,6 +22,26 @@ public sealed record TraverseSubmission(string TargetId, string InputJson)
 
 public sealed record TraverseSubmissionResult(string SessionId, string Status);
 
+/// <summary>Traceability evidence published with a TraverseEmbedder package release.</summary>
+public sealed record TraverseReleaseEvidence(
+    string PackageVersion,
+    string RuntimeWasmDigest,
+    string ConformanceVersion,
+    IReadOnlyList<string> SupportedHostVersions)
+{
+    public void Validate()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(PackageVersion);
+        ArgumentException.ThrowIfNullOrWhiteSpace(RuntimeWasmDigest);
+        ArgumentException.ThrowIfNullOrWhiteSpace(ConformanceVersion);
+        if (SupportedHostVersions is null || SupportedHostVersions.Count == 0 ||
+            SupportedHostVersions.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException("supported host versions are required", nameof(SupportedHostVersions));
+        }
+    }
+}
+
 /// <summary>Ordered runtime-shaped event exposed by the conformance harness.</summary>
 public sealed record TraverseRuntimeEvent(
     int Sequence,


### PR DESCRIPTION
## Summary

- add typed .NET release evidence for package/runtime traceability
- require package version, runtime-WASM digest, conformance version, and host versions
- reject incomplete evidence before publication

## Governing Spec

- `068-public-platform-embedder-packages`

## Project Item

Refs #649

## Definition of Done

- [x] .NET exposes the release-evidence fields required by FR-008.
- [x] Incomplete evidence is rejected at the public package boundary.
- [ ] Evidence publication, production runtime bridge, and WinUI integration remain tracked by #649.

## Validation

- `git diff --check`
- The .NET SDK is unavailable locally; CI compiles the package.
