### PR TITLE
feat(kotlin): model release evidence

### DIFF
--- a/packages/kotlin/TraverseEmbedder/README.md
+++ b/packages/kotlin/TraverseEmbedder/README.md
@@ -5,8 +5,10 @@ It exposes validated bundle and lifecycle types plus an in-memory deterministic
 harness for conformance tests. Its `subscribe(afterSequence)` operation
 returns ordered runtime-shaped harness events. Compatible-capability start,
 stop, and kill operations return stable instance identifiers and lifecycle
-results. It never launches `traverse-cli serve` or uses server-discovery files
-in production.
+results. `TraverseReleaseEvidence` records the package version, runtime-WASM
+digest, conformance version, and supported Android host versions for a release.
+It never launches `traverse-cli serve` or uses server-discovery files in
+production.
 
 Runtime-WASM bridging, runtime event subscriptions, release evidence, and the
 Compose reference-app integration remain tracked by Traverse #648.

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/TraverseEmbedder.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/TraverseEmbedder.kt
@@ -18,6 +18,23 @@ data class TraverseSubmission(val targetId: String, val inputJson: String) {
 
 data class TraverseSubmissionResult(val sessionId: String, val status: String)
 
+/** Traceability evidence published with a TraverseEmbedder package release. */
+data class TraverseReleaseEvidence(
+    val packageVersion: String,
+    val runtimeWasmDigest: String,
+    val conformanceVersion: String,
+    val supportedHostVersions: List<String>,
+) {
+    init {
+        require(packageVersion.isNotBlank()) { "package version is required" }
+        require(runtimeWasmDigest.isNotBlank()) { "runtime WASM digest is required" }
+        require(conformanceVersion.isNotBlank()) { "conformance version is required" }
+        require(supportedHostVersions.isNotEmpty() && supportedHostVersions.all { it.isNotBlank() }) {
+            "supported host versions are required"
+        }
+    }
+}
+
 /** Ordered runtime-shaped event exposed by the deterministic conformance harness. */
 data class TraverseRuntimeEvent(
     val sequence: Int,

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/TraverseEmbedderTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/TraverseEmbedderTest.kt
@@ -5,6 +5,29 @@ import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class TraverseEmbedderTest {
+    @Test fun releaseEvidenceRequiresCompleteVersionedInputs() {
+        assertEquals(
+            TraverseReleaseEvidence(
+                packageVersion = "1.0.0",
+                runtimeWasmDigest = "sha256:test",
+                conformanceVersion = "embedder-api/1.0.0",
+                supportedHostVersions = listOf("Android 26+"),
+            ),
+            TraverseReleaseEvidence(
+                packageVersion = "1.0.0",
+                runtimeWasmDigest = "sha256:test",
+                conformanceVersion = "embedder-api/1.0.0",
+                supportedHostVersions = listOf("Android 26+"),
+            ),
+        )
+        assertThrows(IllegalArgumentException::class.java) {
+            TraverseReleaseEvidence("", "sha256:test", "embedder-api/1.0.0", listOf("Android 26+"))
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            TraverseReleaseEvidence("1.0.0", "sha256:test", "embedder-api/1.0.0", emptyList())
+        }
+    }
+
     @Test fun lifecycleAndSubmissionAreDeterministic() {
         val harness = InMemoryTraverseEmbedder()
         harness.initialize(TraverseBundle("assets/traverse", "sha256:test"))


### PR DESCRIPTION
## Summary

- add the validated Kotlin `TraverseReleaseEvidence` public model.
- document the release-evidence fields required for the Android package.

## Governing Spec

- `068-public-platform-embedder-contract`

## Project Item

- Refs #648

## Definition of Done

- [x] Release evidence records package version, runtime-WASM digest, conformance version, and supported Android host versions.

## Validation

```text
gradle test (not available locally: no Gradle wrapper or Gradle executable)
```
