### PR TITLE
fix(examples): complete runtime fixture relocation

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -492,8 +492,8 @@ Those artifacts live under `examples/`, never `apps/`.
 | `apps/react-demo/` | Reference Apps | `reference-apps/react-demo/` |
 | `apps/youaskm3-starter-kit/` | Reference Apps | `reference-apps/youaskm3-starter-kit/` |
 | `apps/demo-fixtures/expedition-runtime-session.json` | Traverse fixture | `examples/fixtures/expedition-runtime-session.json` |
-| `apps/meeting-notes/app.manifest.json` | Traverse fixture | `examples/applications/meeting-notes/app.manifest.json` |
-| `apps/traverse-starter/app.manifest.json` | Traverse fixture | `examples/applications/traverse-starter/app.manifest.json` |
+| `apps/meeting-notes/` | Traverse fixture | `examples/applications/meeting-notes/` |
+| `apps/traverse-starter/` | Traverse fixture | `examples/applications/traverse-starter/` |
 
 ### Outcome
 

--- a/examples/applications/meeting-notes/app.manifest.json
+++ b/examples/applications/meeting-notes/app.manifest.json
@@ -18,7 +18,7 @@
     {
       "workflow_id": "meeting-notes.process",
       "workflow_version": "1.0.0",
-      "path": "../../workflows/examples/meeting-notes/process/workflow.json"
+      "path": "../../../workflows/examples/meeting-notes/process/workflow.json"
     }
   ],
   "model_dependencies": [],

--- a/examples/applications/meeting-notes/components/process/component.manifest.json
+++ b/examples/applications/meeting-notes/components/process/component.manifest.json
@@ -1,11 +1,11 @@
 {
-  "component_id": "traverse-starter.process-component",
+  "component_id": "meeting-notes.process-component",
   "version": "1.0.0",
   "schema_version": "1.0.0",
-  "capability_id": "traverse-starter.process",
+  "capability_id": "meeting-notes.process",
   "capability_version": "1.0.0",
-  "contract_path": "../../../../contracts/examples/traverse-starter/capabilities/process/contract.json",
-  "wasm_binary_path": "../../../../examples/traverse-starter/process-agent/artifacts/process-agent.wasm",
+  "contract_path": "../../../../../contracts/examples/meeting-notes/capabilities/process/contract.json",
+  "wasm_binary_path": "../../../../../examples/meeting-notes/process-agent/artifacts/process-agent.wasm",
   "wasm_digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
   "runtime_constraints": {
     "host_api_access": "none",
@@ -22,7 +22,7 @@
     {
       "evidence_type": "checked_in_fixture",
       "status": "passed",
-      "produced_by": "traverse_starter_example_smoke"
+      "produced_by": "meeting_notes_example_smoke"
     }
   ]
 }

--- a/examples/applications/traverse-starter/app.manifest.json
+++ b/examples/applications/traverse-starter/app.manifest.json
@@ -18,7 +18,7 @@
     {
       "workflow_id": "traverse-starter.process",
       "workflow_version": "1.0.0",
-      "path": "../../workflows/examples/traverse-starter/process/workflow.json"
+      "path": "../../../workflows/examples/traverse-starter/process/workflow.json"
     }
   ],
   "model_dependencies": [],

--- a/examples/applications/traverse-starter/components/process/component.manifest.json
+++ b/examples/applications/traverse-starter/components/process/component.manifest.json
@@ -1,11 +1,11 @@
 {
-  "component_id": "meeting-notes.process-component",
+  "component_id": "traverse-starter.process-component",
   "version": "1.0.0",
   "schema_version": "1.0.0",
-  "capability_id": "meeting-notes.process",
+  "capability_id": "traverse-starter.process",
   "capability_version": "1.0.0",
-  "contract_path": "../../../../contracts/examples/meeting-notes/capabilities/process/contract.json",
-  "wasm_binary_path": "../../../../examples/meeting-notes/process-agent/artifacts/process-agent.wasm",
+  "contract_path": "../../../../../contracts/examples/traverse-starter/capabilities/process/contract.json",
+  "wasm_binary_path": "../../../../../examples/traverse-starter/process-agent/artifacts/process-agent.wasm",
   "wasm_digest": "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
   "runtime_constraints": {
     "host_api_access": "none",
@@ -22,7 +22,7 @@
     {
       "evidence_type": "checked_in_fixture",
       "status": "passed",
-      "produced_by": "meeting_notes_example_smoke"
+      "produced_by": "traverse_starter_example_smoke"
     }
   ]
 }

--- a/packages/web/TraverseEmbedder/README.md
+++ b/packages/web/TraverseEmbedder/README.md
@@ -123,6 +123,6 @@ npm test   # builds with tsc, then runs the node:test suite
 `npm test` compiles a set of real WASI capability modules from WebAssembly
 Text format via `wabt` (a devDependency, mirroring the Rust crate's `wat`
 crate test fixtures) and runs `BundleEmbedder` against them — including one
-test that loads and executes the real, checked-in `apps/traverse-starter`
+test that loads and executes the real, checked-in `examples/applications/traverse-starter`
 bundle end to end — so the browser execution engine is exercised for real,
 not mocked.

--- a/scripts/ci/app_ownership_boundary_smoke.sh
+++ b/scripts/ci/app_ownership_boundary_smoke.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="${TRAVERSE_REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+for forbidden_path in \
+  "apps/demo-fixtures" \
+  "apps/meeting-notes" \
+  "apps/traverse-starter"
+do
+  if [[ -d "${repo_root}/${forbidden_path}" ]] &&
+     [[ -n "$(find "${repo_root}/${forbidden_path}" -type f -print -quit)" ]]; then
+    echo "Runtime-owned fixture remains under ${forbidden_path}" >&2
+    exit 1
+  fi
+done
+
+required_paths=(
+  "examples/fixtures/expedition-runtime-session.json"
+  "examples/applications/meeting-notes/app.manifest.json"
+  "examples/applications/meeting-notes/components/process/component.manifest.json"
+  "examples/applications/traverse-starter/app.manifest.json"
+  "examples/applications/traverse-starter/components/process/component.manifest.json"
+)
+
+for required_path in "${required_paths[@]}"; do
+  test -s "${repo_root}/${required_path}"
+done
+
+for app_path in \
+  "apps/android-demo/" \
+  "apps/browser-consumer/" \
+  "apps/macos-demo/" \
+  "apps/react-demo/" \
+  "apps/youaskm3-starter-kit/" \
+  "apps/demo-fixtures/expedition-runtime-session.json" \
+  "apps/meeting-notes/" \
+  "apps/traverse-starter/"
+do
+  grep -Fq "\`${app_path}\`" "${repo_root}/docs/decision-log.md"
+done
+
+for app_id in traverse-starter meeting-notes; do
+  validate_output="$(
+    cd "${repo_root}"
+    cargo run -q -p traverse-cli -- app validate \
+      --manifest "examples/applications/${app_id}/app.manifest.json" --json
+  )"
+  grep -q '"status": "validated"' <<<"${validate_output}"
+  grep -q "\"app_id\": \"${app_id}\"" <<<"${validate_output}"
+done
+
+starter_output="$(
+  cd "${repo_root}"
+  cargo run -q -p traverse-cli -- agent execute \
+    examples/traverse-starter/process-agent/manifest.json \
+    examples/traverse-starter/runtime-requests/process.json
+)"
+grep -q "status: completed" <<<"${starter_output}"
+grep -q "capability_id: traverse-starter.process" <<<"${starter_output}"
+
+meeting_output="$(
+  cd "${repo_root}"
+  cargo run -q -p traverse-cli -- agent execute \
+    examples/meeting-notes/process-agent/manifest.json \
+    examples/meeting-notes/runtime-requests/process.json
+)"
+grep -q "status: completed" <<<"${meeting_output}"
+grep -q "capability_id: meeting-notes.process" <<<"${meeting_output}"
+
+TRAVERSE_REPO_ROOT="${repo_root}" bash "${repo_root}/scripts/ci/runtime_home_smoke.sh"
+
+echo "App ownership boundary smoke test passed."

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -67,7 +67,7 @@ required_files=(
   "contracts/examples/hello-world/capabilities/say-hello/contract.json"
   "workflows/examples/hello-world/say-hello/workflow.json"
   "examples/applications/traverse-starter/app.manifest.json"
-  "apps/traverse-starter/components/process/component.manifest.json"
+  "examples/applications/traverse-starter/components/process/component.manifest.json"
   "examples/traverse-starter/process-agent/manifest.json"
   "examples/traverse-starter/process-agent/build-fixture.sh"
   "examples/traverse-starter/process-agent/src/agent.rs"
@@ -76,6 +76,7 @@ required_files=(
   "contracts/examples/traverse-starter/capabilities/process/contract.json"
   "workflows/examples/traverse-starter/process/workflow.json"
   "scripts/ci/traverse_starter_example_smoke.sh"
+  "scripts/ci/app_ownership_boundary_smoke.sh"
   "docs/exception-process.md"
   "docs/project-management.md"
   "docs/multi-thread-workflow.md"
@@ -329,6 +330,7 @@ grep -q "hello.world.say-hello" examples/hello-world/README.md
 grep -q "traverse-starter.process" contracts/examples/traverse-starter/capabilities/process/contract.json
 grep -q "traverse-starter.process-agent" examples/traverse-starter/process-agent/manifest.json
 grep -q "traverse-starter.process-component" examples/applications/traverse-starter/app.manifest.json
+grep -q "traverse-starter.process-component" examples/applications/traverse-starter/components/process/component.manifest.json
 grep -q "app validate --manifest \"\$app_manifest\" --json" scripts/ci/traverse_starter_example_smoke.sh
 grep -q "/v1/workspaces/local-default/execute" scripts/ci/traverse_starter_example_smoke.sh
 grep -q "starter_status: complete" scripts/ci/traverse_starter_example_smoke.sh
@@ -494,5 +496,8 @@ TRAVERSE_REPO_ROOT="$(pwd)" bash "$(pwd)/scripts/ci/new_capability_scaffold_smok
 
 echo "Running WASI host ABI import whitelist verification..."
 TRAVERSE_REPO_ROOT="$(pwd)" bash "$(pwd)/scripts/ci/wasi_host_abi_imports.sh"
+
+echo "Running app ownership boundary verification..."
+TRAVERSE_REPO_ROOT="$(pwd)" bash "$(pwd)/scripts/ci/app_ownership_boundary_smoke.sh"
 
 echo "Repository checks passed."


### PR DESCRIPTION
## Summary

- complete the runtime-fixture relocation begun by #705 by moving both component manifests
- correct relocated workflow, contract, and WASM paths and update the Web embedder documentation
- add a repository regression guard and focused public-contract validation for the ownership boundary

## Governing Spec

- `004-spec-alignment-gate`
- `044-application-bundle-manifest`
- `052-app-state-machine`
- `053-conditional-state-transitions`
- `054-public-scope-registry-ref`
- `068-public-platform-embedder-packages`
- `070-runtime-event-sink-boundary`

## Project Item

Closes #703

## Definition of Done

- [x] Decision 22 records the application-source/runtime-fixture ownership boundary.
- [x] Every prior `apps/` subtree has an explicit owner and destination.
- [x] Runtime-owned application and component manifests plus shared fixtures live under `examples/`.
- [x] Documentation, scripts, CI, and package references use the relocated paths.
- [x] A repository guard prevents runtime-owned fixtures from returning under `apps/`.
- [x] Focused validation executes both fixture agents and validates both relocated application bundles through the public CLI contract.

## Validation

- `bash scripts/ci/app_ownership_boundary_smoke.sh`
- `bash scripts/ci/repository_checks.sh`
- `git diff --check`
