### PR TITLE
Measure durable journal operational limits

### DIFF
--- a/crates/traverse-runtime/examples/journal_operational_limits.rs
+++ b/crates/traverse-runtime/examples/journal_operational_limits.rs
@@ -1,0 +1,158 @@
+//! Reproducible local workload for issue #629 journal operational limits.
+
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use traverse_runtime::events::{
+    DurableEventJournal, JournalConfig, LifecycleStatus, SystemClock, TraverseEvent,
+};
+
+const DEFAULT_EVENTS: usize = 1_000;
+const DEFAULT_PAYLOAD_BYTES: usize = 512;
+const BENCH_SEGMENT_BYTES: u64 = 16 * 1024;
+const BENCH_RETENTION_BYTES: u64 = 64 * 1024;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let event_count = env_usize("TRAVERSE_JOURNAL_BENCH_EVENTS", DEFAULT_EVENTS)?;
+    let payload_bytes = env_usize(
+        "TRAVERSE_JOURNAL_BENCH_PAYLOAD_BYTES",
+        DEFAULT_PAYLOAD_BYTES,
+    )?;
+    let root = benchmark_root()?;
+    let config = JournalConfig {
+        max_segment_bytes: BENCH_SEGMENT_BYTES,
+        max_segment_age_secs: 600,
+        retention_max_age_secs: None,
+        retention_max_total_bytes: Some(BENCH_RETENTION_BYTES),
+    };
+
+    let mut journal = DurableEventJournal::open(&root, config.clone(), Arc::new(SystemClock))?;
+    let mut append_micros = Vec::with_capacity(event_count);
+    for index in 0..event_count {
+        let event = fixture_event(index, payload_bytes);
+        let started = Instant::now();
+        let _cursor = journal.append(&event)?;
+        append_micros.push(started.elapsed().as_micros());
+    }
+    drop(journal);
+
+    let bytes_before_prune = directory_bytes(&root)?;
+    let segments_before_prune = segment_count(&root)?;
+    let recovery_started = Instant::now();
+    let mut recovered = DurableEventJournal::open(&root, config, Arc::new(SystemClock))?;
+    let recovery_micros = recovery_started.elapsed().as_micros();
+
+    let replay_started = Instant::now();
+    let replayed = recovered.replay_from("0", event_count)?;
+    let replay_micros = replay_started.elapsed().as_micros();
+
+    let prune_started = Instant::now();
+    let deleted = recovered.prune()?;
+    let prune_micros = prune_started.elapsed().as_micros();
+    drop(recovered);
+
+    let bytes_after_prune = directory_bytes(&root)?;
+    let segments_after_prune = segment_count(&root)?;
+    append_micros.sort_unstable();
+    let result = json!({
+        "schema_version": "1.0.0",
+        "workload": {
+            "event_count": event_count,
+            "payload_bytes": payload_bytes,
+            "segment_max_bytes": BENCH_SEGMENT_BYTES,
+            "retention_max_total_bytes": BENCH_RETENTION_BYTES
+        },
+        "append_latency_micros": {
+            "min": percentile(&append_micros, 0),
+            "p50": percentile(&append_micros, 50),
+            "p95": percentile(&append_micros, 95),
+            "p99": percentile(&append_micros, 99),
+            "max": percentile(&append_micros, 100)
+        },
+        "restart_recovery_micros": recovery_micros,
+        "replay": {
+            "event_count": replayed.len(),
+            "elapsed_micros": replay_micros,
+            "events_per_second": throughput(replayed.len(), replay_micros)
+        },
+        "retention_compaction": {
+            "elapsed_micros": prune_micros,
+            "deleted_segments": deleted.len(),
+            "segments_before": segments_before_prune,
+            "segments_after": segments_after_prune,
+            "bytes_before": bytes_before_prune,
+            "bytes_after": bytes_after_prune
+        },
+        "disk": {
+            "bytes_per_event_before_prune": ratio(bytes_before_prune, event_count),
+            "bytes_per_event_after_prune": ratio(bytes_after_prune, event_count)
+        }
+    });
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    fs::remove_dir_all(&root)?;
+    Ok(())
+}
+
+fn fixture_event(index: usize, payload_bytes: usize) -> TraverseEvent {
+    TraverseEvent {
+        id: format!("journal-benchmark-{index:08}"),
+        source: "traverse-runtime/journal-benchmark".to_string(),
+        event_type: "dev.traverse.journal.benchmark".to_string(),
+        datacontenttype: "application/json".to_string(),
+        time: "2026-07-15T00:00:00Z".to_string(),
+        data: json!({"sequence": index, "payload": "x".repeat(payload_bytes)}),
+        owner: "traverse-runtime".to_string(),
+        version: "1.0.0".to_string(),
+        lifecycle_status: LifecycleStatus::Active,
+        subject_id: Some(format!("benchmark-subject-{}", index % 32)),
+        actor_id: None,
+    }
+}
+
+fn env_usize(name: &str, default: usize) -> Result<usize, Box<dyn std::error::Error>> {
+    match std::env::var(name) {
+        Ok(value) => Ok(value.parse::<usize>()?),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(Box::new(error)),
+    }
+}
+
+fn benchmark_root() -> Result<PathBuf, std::time::SystemTimeError> {
+    let nonce = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    Ok(std::env::temp_dir().join(format!("traverse-journal-benchmark-{nonce}")))
+}
+
+fn directory_bytes(root: &Path) -> Result<u64, std::io::Error> {
+    fs::read_dir(root)?.try_fold(0_u64, |total, entry| {
+        let entry = entry?;
+        Ok(total + entry.metadata()?.len())
+    })
+}
+
+fn segment_count(root: &Path) -> Result<usize, std::io::Error> {
+    Ok(fs::read_dir(root)?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().ends_with(".jsonl"))
+        .count())
+}
+
+fn percentile(sorted: &[u128], percentile: usize) -> u128 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let index = (sorted.len() - 1) * percentile / 100;
+    sorted[index]
+}
+
+fn throughput(events: usize, elapsed_micros: u128) -> u128 {
+    if elapsed_micros == 0 {
+        return events as u128;
+    }
+    events as u128 * 1_000_000 / elapsed_micros
+}
+
+fn ratio(bytes: u64, events: usize) -> u64 {
+    bytes / u64::try_from(events.max(1)).unwrap_or(u64::MAX)
+}

--- a/docs/durable-event-journal-operational-limits.md
+++ b/docs/durable-event-journal-operational-limits.md
@@ -1,0 +1,78 @@
+# Durable Event Journal Operational Limits
+
+This note records the first representative local measurements for the durable
+event journal implemented under Specs 066 and 067. It is evidence for issue
+#629, not a cross-platform service-level guarantee.
+
+## Reproduce
+
+Run the release-mode harness from the repository root:
+
+```bash
+cargo run --release -p traverse-runtime --example journal_operational_limits
+
+TRAVERSE_JOURNAL_BENCH_EVENTS=2500 \
+TRAVERSE_JOURNAL_BENCH_PAYLOAD_BYTES=4096 \
+cargo run --release -p traverse-runtime --example journal_operational_limits
+```
+
+The harness emits stable JSON covering fsync-before-ack append latency,
+restart recovery, replay throughput, whole-segment retention pruning, segment
+counts, and disk growth. Workload size and payload bytes can be overridden by
+environment variables without changing the implementation.
+
+## Measurement environment
+
+- Date: 2026-07-15
+- Host: Darwin arm64, macOS 26.5.2
+- Toolchain: `rustc 1.96.0 (ac68faa20 2026-05-25)`
+- Build: Cargo release profile
+- Storage: host-local filesystem
+- Writer model: one journal writer, matching the initial implementation
+
+Raw results are checked in at
+`docs/evidence/journal-operational-limits-2026-07-15.json`.
+
+## Results
+
+| Workload | Append p50 | Append p95 | Append p99 | Max | Recovery | Replay | Prune |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| 1,000 events, 512-byte payload | 3.975 ms | 4.639 ms | 5.062 ms | 8.108 ms | 5.856 ms | 208,203 events/s | 49 segments in 4.118 ms |
+| 2,500 events, 4,096-byte payload | 3.971 ms | 5.077 ms | 6.205 ms | 10.809 ms | 55.108 ms | 146,404 events/s | 622 segments in 24.932 ms |
+
+The deliberately small 16 KiB benchmark segment forces rollover and stresses
+recovery and pruning. The production default remains 64 MiB or 10 minutes,
+whichever comes first. Disk growth was payload plus approximately 390 bytes
+per event in both measured workloads. Whole-segment size retention reduced the
+workloads to 62,214 bytes and 53,852 bytes respectively, while correctly
+retaining the active segment.
+
+## Recommended defaults and limits
+
+- Keep the Spec 067 defaults: 64 MiB maximum segment size, 10-minute maximum
+  segment age, and a 2-second durable-write timeout. The measured worst append
+  was 10.809 ms, leaving substantial timeout headroom without weakening
+  fsync-before-acknowledgement.
+- Configure size retention explicitly for production workspaces. A starting
+  budget is `peak retained events * (average payload bytes + 400 bytes)`, plus
+  one full active-segment allowance because the active segment is never
+  pruned.
+- Use age retention when the business requirement is time based; combine it
+  with size retention when disk usage must also be bounded.
+- Treat append p99 above 25 ms, recovery above 1 second, or sustained disk
+  growth beyond the configured retention budget as investigation thresholds,
+  not automatic tuning triggers. Re-run this harness on the affected storage
+  class before changing defaults.
+
+## Conclusions
+
+The initial journal meets its current local operational targets for the two
+representative workloads: append latency remains far below the 2-second write
+timeout, restart and replay remain interactive, and whole-segment retention
+reclaims disk without rewriting records. No measured target was violated, so
+no storage-engine migration or provider abstraction is justified by this
+evidence.
+
+One operational risk remains: these measurements cover a single Darwin arm64
+host and local filesystem. Cross-platform and slower-storage regression
+tracking is a separate follow-up so it does not expand the initial evaluation.

--- a/docs/evidence/journal-operational-limits-2026-07-15.json
+++ b/docs/evidence/journal-operational-limits-2026-07-15.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "1.0.0",
+  "measured_at": "2026-07-15",
+  "environment": {
+    "os": "macOS 26.5.2",
+    "architecture": "arm64",
+    "rustc": "1.96.0 (ac68faa20 2026-05-25)",
+    "profile": "release"
+  },
+  "runs": [
+    {
+      "workload": {
+        "event_count": 1000,
+        "payload_bytes": 512,
+        "segment_max_bytes": 16384,
+        "retention_max_total_bytes": 65536
+      },
+      "append_latency_micros": {
+        "min": 2610,
+        "p50": 3975,
+        "p95": 4639,
+        "p99": 5062,
+        "max": 8108
+      },
+      "restart_recovery_micros": 5856,
+      "replay": {
+        "event_count": 1000,
+        "elapsed_micros": 4803,
+        "events_per_second": 208203
+      },
+      "retention_compaction": {
+        "elapsed_micros": 4118,
+        "deleted_segments": 49,
+        "segments_before": 53,
+        "segments_after": 4,
+        "bytes_before": 901465,
+        "bytes_after": 62214
+      }
+    },
+    {
+      "workload": {
+        "event_count": 2500,
+        "payload_bytes": 4096,
+        "segment_max_bytes": 16384,
+        "retention_max_total_bytes": 65536
+      },
+      "append_latency_micros": {
+        "min": 1556,
+        "p50": 3971,
+        "p95": 5077,
+        "p99": 6205,
+        "max": 10809
+      },
+      "restart_recovery_micros": 55108,
+      "replay": {
+        "event_count": 2500,
+        "elapsed_micros": 17076,
+        "events_per_second": 146404
+      },
+      "retention_compaction": {
+        "elapsed_micros": 24932,
+        "deleted_segments": 622,
+        "segments_before": 625,
+        "segments_after": 3,
+        "bytes_before": 11216999,
+        "bytes_after": 53852
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a reproducible release-mode durable journal operational-limit harness
- publish measured append, recovery, replay, pruning, and disk-growth evidence
- document recommended configuration defaults and investigation thresholds
- track the remaining cross-platform storage risk in #713

## Governing Spec

- `066-durable-identity-event-delivery`
- `067-durable-journal-retention-and-write-limits`
- `070-runtime-event-sink-boundary`

## Project Item

- traverse-framework/traverse#629

## Definition of Done

- [x] benchmark append latency, restart recovery, replay, retention compaction, and disk growth
- [x] publish measured limits and recommended defaults
- [x] create a focused follow-up for the remaining operational risk

## Validation

- `cargo clippy -p traverse-runtime --all-targets -- -D warnings`
- `cargo test -p traverse-runtime` (all passed)
- release benchmark: 1,000 events with 512-byte payload
- release benchmark: 2,500 events with 4,096-byte payload
