### PR TITLE
docs(runtime): define native runtime-WASM bridge

### DIFF
--- a/crates/traverse-runtime/tests/native_bridge_conformance.rs
+++ b/crates/traverse-runtime/tests/native_bridge_conformance.rs
@@ -1,0 +1,216 @@
+#![cfg(feature = "wasmtime-executor")]
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::expect_used,
+    clippy::format_collect,
+    clippy::format_push_string,
+    clippy::unwrap_used
+)]
+
+use serde_json::{Value, json};
+use wasmtime::{Engine, Instance, Memory, Module, Store, TypedFunc};
+
+const INIT: &str = r#"{"status":"ready","error":null}"#;
+const SUBMIT: &str = r#"{"session_id":"fixture-session","status":"accepted","error":null}"#;
+const STATE: &str =
+    r#"{"type":"state_changed","session_id":"fixture-session","data":{"state":"running"}}"#;
+const INVOKED: &str = r#"{"type":"capability_invoked","session_id":"fixture-session","data":{"capability_id":"fixture.echo"}}"#;
+const RESULT: &str = r#"{"type":"capability_result","session_id":"fixture-session","data":{"output":{"message":"hello"}}}"#;
+const STOPPED: &str = r#"{"status":"stopped"}"#;
+
+fn wat_string(value: &str) -> String {
+    value
+        .as_bytes()
+        .iter()
+        .map(|byte| format!("\\{byte:02x}"))
+        .collect()
+}
+
+fn fixture_module() -> String {
+    let values = [INIT, SUBMIT, STATE, INVOKED, RESULT, STOPPED];
+    let mut offset = 8192_u32;
+    let mut regions = Vec::new();
+    let mut data = String::new();
+    for value in values {
+        regions.push((offset, value.len()));
+        data.push_str(&format!(
+            "(data (i32.const {offset}) \"{}\")\n",
+            wat_string(value)
+        ));
+        offset += value.len() as u32;
+    }
+    let [
+        (init_p, init_l),
+        (submit_p, submit_l),
+        (state_p, state_l),
+        (invoked_p, invoked_l),
+        (result_p, result_l),
+        (stopped_p, stopped_l),
+    ] = regions.as_slice()
+    else {
+        unreachable!("fixture regions are fixed")
+    };
+
+    format!(
+        r#"(module
+          (memory (export "memory") 1 8)
+          (global $heap (mut i32) (i32.const 4096))
+          (global $event (mut i32) (i32.const 0))
+          {data}
+          (func (export "traverse_bridge_abi_version") (result i32) i32.const 10000)
+          (func (export "traverse_alloc") (param $len i32) (result i32)
+            (local $ptr i32)
+            global.get $heap local.set $ptr
+            global.get $heap local.get $len i32.add global.set $heap
+            local.get $ptr)
+          (func (export "traverse_dealloc") (param i32 i32))
+          (func $descriptor (param $out i32) (param $ptr i32) (param $len i32)
+            local.get $out local.get $ptr i32.store
+            local.get $out i32.const 4 i32.add local.get $len i32.store)
+          (func (export "traverse_init") (param i32 i32 i32) (result i32)
+            local.get 2 i32.const {init_p} i32.const {init_l} call $descriptor
+            i32.const 0)
+          (func (export "traverse_submit") (param i32 i32 i32) (result i32)
+            i32.const 0 global.set $event
+            local.get 2 i32.const {submit_p} i32.const {submit_l} call $descriptor
+            i32.const 0)
+          (func (export "traverse_next_event") (param $out i32) (result i32)
+            global.get $event i32.const 0 i32.eq
+            if
+              local.get $out i32.const {state_p} i32.const {state_l} call $descriptor
+              i32.const 1 global.set $event
+              i32.const 1 return
+            end
+            global.get $event i32.const 1 i32.eq
+            if
+              local.get $out i32.const {invoked_p} i32.const {invoked_l} call $descriptor
+              i32.const 2 global.set $event
+              i32.const 1 return
+            end
+            global.get $event i32.const 2 i32.eq
+            if
+              local.get $out i32.const {result_p} i32.const {result_l} call $descriptor
+              i32.const 3 global.set $event
+              i32.const 1 return
+            end
+            i32.const 0)
+          (func (export "traverse_cancel") (param i32 i32 i32) (result i32)
+            i32.const 0)
+          (func (export "traverse_shutdown") (param i32) (result i32)
+            local.get 0 i32.const {stopped_p} i32.const {stopped_l} call $descriptor
+            i32.const 0))"#
+    )
+}
+
+struct Bridge {
+    store: Store<()>,
+    memory: Memory,
+    alloc: TypedFunc<i32, i32>,
+    init: TypedFunc<(i32, i32, i32), i32>,
+    submit: TypedFunc<(i32, i32, i32), i32>,
+    next_event: TypedFunc<i32, i32>,
+    shutdown: TypedFunc<i32, i32>,
+}
+
+impl Bridge {
+    fn call_json(&mut self, function: &str, input: &Value) -> Value {
+        let bytes = serde_json::to_vec(input).expect("serialize fixture request");
+        let pointer = self
+            .alloc
+            .call(&mut self.store, bytes.len() as i32)
+            .expect("allocate request");
+        self.memory
+            .write(&mut self.store, pointer as usize, &bytes)
+            .expect("write request");
+        let status = match function {
+            "init" => self
+                .init
+                .call(&mut self.store, (pointer, bytes.len() as i32, 1024)),
+            "submit" => self
+                .submit
+                .call(&mut self.store, (pointer, bytes.len() as i32, 1024)),
+            _ => unreachable!("known fixture call"),
+        }
+        .expect("bridge call");
+        assert_eq!(status, 0);
+        self.read_json(1024)
+    }
+
+    fn read_json(&self, descriptor: usize) -> Value {
+        let data = self.memory.data(&self.store);
+        let pointer = u32::from_le_bytes(data[descriptor..descriptor + 4].try_into().unwrap());
+        let length = u32::from_le_bytes(data[descriptor + 4..descriptor + 8].try_into().unwrap());
+        serde_json::from_slice(&data[pointer as usize..(pointer + length) as usize])
+            .expect("valid fixture JSON")
+    }
+}
+
+#[test]
+fn core_wasm_bridge_produces_the_cross_platform_lifecycle_transcript() {
+    let engine = Engine::default();
+    let module = Module::new(&engine, fixture_module()).expect("compile bridge fixture");
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).expect("instantiate without WASI");
+    let version = instance
+        .get_typed_func::<(), i32>(&mut store, "traverse_bridge_abi_version")
+        .expect("version export")
+        .call(&mut store, ())
+        .expect("read ABI version");
+    assert_eq!(version, 10000);
+
+    let mut bridge = Bridge {
+        memory: instance
+            .get_memory(&mut store, "memory")
+            .expect("memory export"),
+        alloc: instance
+            .get_typed_func(&mut store, "traverse_alloc")
+            .expect("alloc export"),
+        init: instance
+            .get_typed_func(&mut store, "traverse_init")
+            .expect("init export"),
+        submit: instance
+            .get_typed_func(&mut store, "traverse_submit")
+            .expect("submit export"),
+        next_event: instance
+            .get_typed_func(&mut store, "traverse_next_event")
+            .expect("event export"),
+        shutdown: instance
+            .get_typed_func(&mut store, "traverse_shutdown")
+            .expect("shutdown export"),
+        store,
+    };
+
+    assert_eq!(
+        bridge.call_json("init", &json!({"workspace_id": "fixture"}))["status"],
+        "ready"
+    );
+    assert_eq!(
+        bridge.call_json(
+            "submit",
+            &json!({"target_id": "fixture.echo", "input": {"message": "hello"}})
+        )["status"],
+        "accepted"
+    );
+
+    let mut event_types = Vec::new();
+    loop {
+        let status = bridge
+            .next_event
+            .call(&mut bridge.store, 1024)
+            .expect("drain event");
+        if status == 0 {
+            break;
+        }
+        assert_eq!(status, 1);
+        event_types.push(bridge.read_json(1024)["type"].as_str().unwrap().to_owned());
+    }
+    assert_eq!(
+        event_types,
+        ["state_changed", "capability_invoked", "capability_result"]
+    );
+
+    assert_eq!(bridge.shutdown.call(&mut bridge.store, 1024).unwrap(), 0);
+    assert_eq!(bridge.read_json(1024)["status"], "stopped");
+}

--- a/docs/adr/0007-native-runtime-wasm-bridge.md
+++ b/docs/adr/0007-native-runtime-wasm-bridge.md
@@ -1,0 +1,63 @@
+# ADR-0007: Host One Canonical Runtime-WASM Bridge in Native Packages
+
+- Status: Accepted
+- Date: 2026-07-15
+
+## Context
+
+Specs 057 and 068 require Swift, Kotlin/Android, and .NET packages to run the
+same runtime-owned semantics without `traverse-cli serve`. The available
+language-native engines do not yet share production-ready WebAssembly
+Component Model support, while all support core WebAssembly modules and linear
+memory. The repository therefore needs a portable ABI and a governed engine
+policy before any native package can be production-complete.
+
+## Decision
+
+Traverse publishes one core WebAssembly orchestrator artifact implementing
+`runtime-wasm-bridge/1.0.0`. Its public exports use scalar WebAssembly values,
+one exported memory, caller-allocated input bytes, and an eight-byte
+little-endian `(pointer, length)` output descriptor. UTF-8 JSON is the v1 wire
+format. The runtime owns all workflow, lifecycle, event, error, cancellation,
+and resource-limit semantics; native adapters only marshal, verify, schedule,
+and expose idiomatic APIs.
+
+The initial host matrix is:
+
+| Package | Engine | License | Selection rationale |
+| --- | --- | --- | --- |
+| Swift/iOS/macOS | WasmKit | MIT (runtime modules) | Swift Package, interpreter-safe on iOS, documented iOS 12+ support |
+| Kotlin/Android | Chicory | Apache-2.0 | JVM-native interpreter with no JNI/native distribution matrix |
+| .NET/WinUI | Wasmtime .NET | Apache-2.0 | Bytecode Alliance package with supported Windows native assets |
+
+Each Traverse package release pins an exact reviewed engine version and records
+its version, license, runtime-WASM digest, supported host versions, and
+conformance result. Automated dependency alerts and upstream security notices
+trigger review; a critical unfixed engine advisory blocks release. Engines
+receive no ambient filesystem, network, clock, environment, or process access.
+Only explicit bridge imports listed by the artifact manifest may be linked.
+
+The bridge uses an engine-neutral pull operation for events. A package may turn
+that ordered stream into a callback, async sequence, Flow, or observable, but
+it cannot reorder, synthesize, or reinterpret events.
+
+## Consequences
+
+- One runtime artifact and conformance corpus govern all native packages.
+- The v1 bridge works on current core-Wasm engines without waiting for uniform
+  Component Model support.
+- JSON and copy-based marshalling trade peak throughput for portability and a
+  reviewable ownership boundary; a future ABI version may add canonical ABI
+  bindings after all supported hosts can certify them.
+- Platform packages carry different engine dependencies, so release evidence
+  and cross-engine fixture execution are mandatory.
+
+## Alternatives Considered
+
+- **WebAssembly Component Model/WIT for v1**: rejected for now because support
+  is incomplete in the selected Swift host and not uniform across all three.
+- **One native C runtime for every platform**: rejected because it adds a large
+  architecture/OS binary matrix and complicates mobile distribution.
+- **Platform-native runtime implementations**: rejected because they duplicate
+  runtime-owned semantics and weaken conformance.
+- **Development sidecar**: rejected by Specs 057 and 068 for production use.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -500,3 +500,37 @@ Those artifacts live under `examples/`, never `apps/`.
 The Reference Apps migration preserves app validation against public Traverse
 surfaces. Traverse follows with removal of the now-obsolete `apps/` directory
 and a repository check that prevents application source from returning.
+
+## Decision 23: Standardize Native Embedders on One Runtime-WASM Bridge
+
+- **Date**: 2026-07-15
+- **Status**: Accepted
+- **Governing spec**: `071-native-runtime-wasm-bridge`
+- **Related issues**: `#712`, `#647`, `#648`, `#649`
+
+### Context
+
+The Swift, Kotlin/Android, and .NET packages have deterministic API harnesses,
+but no production runtime artifact or shared host boundary. Choosing a native
+library or a platform-specific ABI per package would duplicate runtime
+semantics and make conformance depend on three unrelated implementations.
+
+### Decision
+
+Ship one digest-addressed core WebAssembly orchestrator module implementing
+`runtime-wasm-bridge/1.0.0`. The module owns lifecycle, submission, ordered
+event production, compatibility decisions, cancellation, resource limits, and
+structured errors. Platform packages only verify the bundle, instantiate the
+module, marshal UTF-8 JSON through the governed memory ABI, and adapt event
+delivery to idiomatic callbacks or streams.
+
+Use WasmKit for Swift, Chicory for Kotlin/Android, and the Bytecode Alliance
+Wasmtime .NET package for WinUI. Dependencies are exact-version pinned for a
+release, reviewed for license and security status, and recorded in release
+evidence. A host change is allowed only when the replacement passes the same
+bridge and embedder conformance suites.
+
+### Outcome
+
+Spec 071 and ADR-0007 define the bridge. Native package tickets may implement
+independently without changing runtime behavior or introducing a sidecar.

--- a/specs/071-native-runtime-wasm-bridge/conformance/host-profiles.json
+++ b/specs/071-native-runtime-wasm-bridge/conformance/host-profiles.json
@@ -1,0 +1,17 @@
+{
+  "bridge": "runtime-wasm-bridge/1.0.0",
+  "fixture": "native_bridge_conformance",
+  "profiles": [
+    { "id": "swift-wasmkit", "ticket": 647, "engine": "WasmKit" },
+    { "id": "kotlin-chicory", "ticket": 648, "engine": "Chicory" },
+    { "id": "dotnet-wasmtime", "ticket": 649, "engine": "Wasmtime .NET" }
+  ],
+  "required_transcript": [
+    "ready",
+    "accepted",
+    "state_changed",
+    "capability_invoked",
+    "capability_result",
+    "stopped"
+  ]
+}

--- a/specs/071-native-runtime-wasm-bridge/dependency-review.json
+++ b/specs/071-native-runtime-wasm-bridge/dependency-review.json
@@ -1,0 +1,33 @@
+{
+  "reviewed_at": "2026-07-15",
+  "policy": "Exact engine versions are selected and locked by each package implementation PR; major or engine changes require a renewed review and conformance evidence.",
+  "hosts": [
+    {
+      "platform": "Swift/iOS/macOS",
+      "engine": "WasmKit",
+      "source": "https://github.com/swiftwasm/WasmKit",
+      "reviewed_baseline": "0.3.1",
+      "license": "MIT for runtime modules",
+      "supported_hosts": "macOS 10.13+ and iOS 12.0+",
+      "security_boundary": "No WASI linkage; interpreter execution; bounded bridge memory and serialized calls"
+    },
+    {
+      "platform": "Kotlin/Android",
+      "engine": "Chicory",
+      "source": "https://github.com/dylibso/chicory",
+      "reviewed_baseline": "1.x exact version selected by #648",
+      "license": "Apache-2.0",
+      "supported_hosts": "Android/JVM versions declared and tested by #648",
+      "security_boundary": "Pure JVM with no JNI; no WASI linkage; interpreter and bounded bridge memory"
+    },
+    {
+      "platform": ".NET/WinUI",
+      "engine": "Wasmtime .NET",
+      "source": "https://github.com/bytecodealliance/wasmtime-dotnet",
+      "reviewed_baseline": "44.0.0",
+      "license": "Apache-2.0",
+      "supported_hosts": "Windows targets declared and tested by #649",
+      "security_boundary": "No WASI linkage; fuel/epoch interruption and bounded bridge memory"
+    }
+  ]
+}

--- a/specs/071-native-runtime-wasm-bridge/runtime-wasm-bridge-1.0.0.json
+++ b/specs/071-native-runtime-wasm-bridge/runtime-wasm-bridge-1.0.0.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://traverse.dev/runtime-wasm-bridge/1.0.0",
+  "title": "Traverse native runtime-WASM bridge ABI",
+  "version": "1.0.0",
+  "artifact": {
+    "kind": "core-webassembly-module",
+    "path": "runtime/runtime.wasm",
+    "wasi": "none",
+    "memory": "memory",
+    "output_descriptor": "little-endian u32 pointer followed by u32 length"
+  },
+  "exports": {
+    "traverse_bridge_abi_version": "() -> i32; 10000 for 1.0.0",
+    "traverse_alloc": "(length: i32) -> pointer: i32",
+    "traverse_dealloc": "(pointer: i32, length: i32) -> ()",
+    "traverse_init": "(input_pointer: i32, input_length: i32, output_descriptor: i32) -> status: i32",
+    "traverse_submit": "(input_pointer: i32, input_length: i32, output_descriptor: i32) -> status: i32",
+    "traverse_next_event": "(output_descriptor: i32) -> status: i32",
+    "traverse_cancel": "(input_pointer: i32, input_length: i32, output_descriptor: i32) -> status: i32",
+    "traverse_shutdown": "(output_descriptor: i32) -> status: i32"
+  },
+  "status": {
+    "ok": 0,
+    "event": 1,
+    "empty": 0,
+    "invalid_state": -1,
+    "invalid_input": -2,
+    "invalid_descriptor": -3,
+    "resource_limit": -4,
+    "internal_error": -5
+  },
+  "host_error_codes": [
+    "bridge_version_mismatch",
+    "bundle_digest_mismatch",
+    "bridge_invalid_descriptor",
+    "bridge_invalid_json",
+    "bridge_trap",
+    "bridge_timeout",
+    "bridge_resource_limit"
+  ]
+}

--- a/specs/071-native-runtime-wasm-bridge/spec.md
+++ b/specs/071-native-runtime-wasm-bridge/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Native Runtime-WASM Bridge
+
+**Feature Branch**: `071-native-runtime-wasm-bridge`  
+**Created**: 2026-07-15  
+**Status**: Approved  
+**Version**: 1.0.0  
+**Input**: Decision 23, ADR-0007, and Traverse #712.
+
+## Purpose
+
+Define the production, cross-engine bridge by which Swift, Kotlin/Android, and
+.NET/WinUI packages host one runtime-owned orchestrator artifact. This is the
+native implementation contract beneath `embedder-api/1.0.0`; it does not add
+public application operations.
+
+## Artifact and Bundle Contract
+
+- **FR-001**: A native bundle MUST contain `runtime/runtime.wasm`,
+  `runtime/runtime-wasm-bridge-1.0.0.json`, the application manifest,
+  component manifests, capability modules, and a digest manifest covering
+  every file.
+- **FR-002**: `runtime.wasm` MUST be a core WebAssembly module implementing
+  `runtime-wasm-bridge/1.0.0` and MUST export exactly one bridge memory plus the
+  required functions in the governed ABI manifest.
+- **FR-003**: Before instantiation, the package MUST verify every declared
+  SHA-256 digest, bridge/API compatibility, artifact size, and required engine
+  features. A failure MUST prevent instantiation and network/sidecar fallback.
+- **FR-004**: Release evidence MUST record package and engine versions,
+  licenses, runtime digest, bridge/API/conformance versions, supported hosts,
+  and the conformance result.
+
+## ABI and Ownership Contract
+
+- **FR-005**: Inputs are caller-owned UTF-8 JSON bytes at `(pointer, length)`.
+  Outputs are runtime-owned UTF-8 JSON referenced by an eight-byte
+  little-endian descriptor `{ pointer: u32, length: u32 }` written at a
+  caller-owned descriptor address.
+- **FR-006**: The module MUST export `traverse_bridge_abi_version`,
+  `traverse_alloc`, `traverse_dealloc`, `traverse_init`, `traverse_submit`,
+  `traverse_next_event`, `traverse_cancel`, and `traverse_shutdown` with the
+  signatures and status codes in the ABI manifest.
+- **FR-007**: The host MUST copy an output before its next mutating bridge call.
+  The runtime may invalidate prior output regions on such a call. Each input
+  allocation MUST be released exactly once by the host.
+- **FR-008**: The v1 module MUST NOT require WASI or ambient host capabilities.
+  Any permitted import MUST be listed in the bundle manifest and linked by an
+  adapter with least privilege.
+
+## Lifecycle, Events, and Errors
+
+- **FR-009**: Calls before successful `init`, duplicate `init`, and calls after
+  `shutdown` MUST return deterministic structured errors without trapping.
+- **FR-010**: `submit` MUST return the same session identifier and acceptance
+  meaning as `embedder-api/1.0.0`; all execution outcomes cross the boundary as
+  runtime-owned events.
+- **FR-011**: `next_event` MUST return one event at a time in runtime order:
+  `1` when an event descriptor is written, `0` when the queue is empty, and a
+  negative stable bridge status for failure. Hosts MUST use a single serialized
+  drain loop per runtime instance.
+- **FR-012**: `cancel` MUST be idempotent. It requests runtime cancellation and
+  does not report completion until the runtime emits its terminal event.
+- **FR-013**: `shutdown` MUST reject new submissions, cancel active work, drain
+  terminal events, release compatible capabilities, and return `stopped`.
+- **FR-014**: Expected failures MUST use JSON `{ "code", "message", "details" }`
+  with a stable machine code and redacted details. WebAssembly traps, invalid
+  descriptors, invalid UTF-8/JSON, and resource exhaustion map to the stable
+  host error codes in the ABI manifest.
+
+## Resource and Compatibility Policy
+
+- **FR-015**: The host MUST configure a bounded memory maximum, fuel or an
+  equivalent instruction budget, epoch/deadline interruption where supported,
+  a maximum event size, and a bounded event-drain queue. Limits and unsupported
+  controls MUST be disclosed in release evidence.
+- **FR-016**: Compatibility is the intersection of exact bridge major version,
+  supported embedder API range, required core-Wasm features, and bundle schema.
+  Minor/patch bridge versions may only add optional behavior; incompatible
+  major versions fail with `bridge_version_mismatch`.
+- **FR-017**: Engine dependencies MUST follow ADR-0007. Exact versions are
+  release-pinned and changes require license/security review plus the full
+  cross-engine conformance suite.
+
+## Acceptance Scenarios
+
+1. The same fixture bundle initializes through each declared host profile,
+   accepts one capability submission, yields ordered `state_changed`,
+   `capability_invoked`, and `capability_result` events, then shuts down.
+2. A modified runtime or capability digest fails before module instantiation.
+3. An incompatible bridge major, malformed descriptor, trap, timeout, or memory
+   limit produces the documented stable error without secrets or sidecar use.
+4. Swift, Kotlin, and .NET adapters pass both this bridge corpus and the
+   `embedder-api/1.0.0` conformance corpus before release.
+
+## Out of Scope
+
+- Public operations beyond `embedder-api/1.0.0`.
+- Platform-owned workflow or capability semantics.
+- A mandatory Component Model dependency for bridge v1.
+- Replacing the development sidecar used by CLI tooling.
+
+## Implementation Tickets
+
+- Traverse #647 — Swift package adapter and WasmKit host.
+- Traverse #648 — Kotlin/Android adapter and Chicory host.
+- Traverse #649 — .NET/WinUI adapter and Wasmtime host.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -831,6 +831,21 @@
         "docs/",
         "specs/070-runtime-event-sink-boundary/"
       ]
+    },
+    {
+      "id": "071-native-runtime-wasm-bridge",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/071-native-runtime-wasm-bridge/spec.md",
+      "governs": [
+        "crates/traverse-runtime/tests/native_bridge_conformance.rs",
+        "packages/swift/TraverseEmbedder/",
+        "packages/kotlin/TraverseEmbedder/",
+        "packages/dotnet/TraverseEmbedder/",
+        "docs/adr/0007-native-runtime-wasm-bridge.md",
+        "specs/071-native-runtime-wasm-bridge/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- approve one core-Wasm `runtime-wasm-bridge/1.0.0` contract for Swift, Kotlin/Android, and .NET embedders
- record the ABI, bundle verification, lifecycle, ordered-event, error, resource-limit, dependency, licensing, and security policies
- add an executable no-WASI bridge fixture that proves init, submit, ordered events, and shutdown through the governed ABI
- make #647, #648, and #649 implementation-ready with reviewed WasmKit, Chicory, and Wasmtime .NET host profiles

Closes #712.

## Governing Spec

- `057-embeddable-runtime-host`
- `068-public-platform-embedder-packages`
- `070-runtime-event-sink-boundary`
- `071-native-runtime-wasm-bridge`

## Project Item

- Traverse Project 1: #712

## Validation

- `cargo test -p traverse-runtime --test native_bridge_conformance`
- `cargo clippy -p traverse-runtime --test native_bridge_conformance -- -D warnings`
- `cargo test -p traverse-runtime`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-issue-712-pr-body.md`
- `bash scripts/ci/repository_checks.sh`

## Dependency review

Recorded in `specs/071-native-runtime-wasm-bridge/dependency-review.json`. Native runtime modules use permissive licenses (MIT or Apache-2.0), run without ambient WASI capabilities, and must be exact-version pinned with release evidence and renewed security/license review on change.
