### PR TITLE
chore: bump version to v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/traverse-framework/traverse"
 rust-version = "1.94"
-version = "0.7.0"
+version = "0.8.0"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
## Summary
- Bump workspace version to 0.8.0 per docs/release-process.md, ahead of tagging v0.8.0 for the crates.io publish pipeline (spec 048).
- No functional changes; version-only bump generated by `scripts/ci/bump_version.sh`.

## Test plan
- [x] CI on main was green immediately prior to this bump
- [ ] CI passes on this PR