### PR TITLE
Swift: add verified WasmKit runtime loader

### DIFF
--- a/packages/swift/TraverseEmbedder/Package.resolved
+++ b/packages/swift/TraverseEmbedder/Package.resolved
@@ -1,0 +1,69 @@
+{
+  "originHash" : "0bd7e953dbd9000920e63b743fd3dac38352273e9d77e41b2d93d0c57e9be667",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "61e4ca4b81b9e09e2ec863b00c340eb13497dac6",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "wasmkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftwasm/WasmKit.git",
+      "state" : {
+        "revision" : "5c389084423c08136040ab8a41f73d4e76fb7b21",
+        "version" : "0.2.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/packages/swift/TraverseEmbedder/Package.swift
+++ b/packages/swift/TraverseEmbedder/Package.swift
@@ -5,8 +5,23 @@ let package = Package(
     name: "TraverseEmbedder",
     platforms: [.iOS(.v17), .macOS(.v14)],
     products: [.library(name: "TraverseEmbedder", targets: ["TraverseEmbedder"])],
+    dependencies: [
+        .package(url: "https://github.com/swiftwasm/WasmKit.git", exact: "0.2.2"),
+        // WasmKit 0.2.2 declares `from: 1.5.0`; newer swift-system releases
+        // collide with its bundled SystemExtras layer on current Xcode.
+        .package(url: "https://github.com/apple/swift-system.git", exact: "1.5.0"),
+    ],
     targets: [
-        .target(name: "TraverseEmbedder"),
-        .testTarget(name: "TraverseEmbedderTests", dependencies: ["TraverseEmbedder"]),
+        .target(
+            name: "TraverseEmbedder",
+            dependencies: [.product(name: "WasmKit", package: "WasmKit")]
+        ),
+        .testTarget(
+            name: "TraverseEmbedderTests",
+            dependencies: [
+                "TraverseEmbedder",
+                .product(name: "WAT", package: "WasmKit"),
+            ]
+        ),
     ]
 )

--- a/packages/swift/TraverseEmbedder/README.md
+++ b/packages/swift/TraverseEmbedder/README.md
@@ -8,8 +8,13 @@ the ordered runtime-shaped events recorded by the harness. Compatible-capability
 start, stop, and kill operations return stable instance identifiers and lifecycle
 results. It never starts `traverse-cli serve` or uses server-discovery files.
 
-The production runtime-WASM bridge, event subscription stream, evidence
-publication, and app-reference integration are tracked by Traverse #647.
+`WasmKitRuntimeBridge` is the production runtime loader. It resolves only the
+core WasmKit product, verifies `runtime/runtime.wasm` against its declared
+SHA-256 digest and a 32 MiB default artifact limit before parsing, rejects all
+ambient imports, and validates the memory, function signatures, and ABI version
+required by `runtime-wasm-bridge/1.0.0`. It never links WasmKitWASI. JSON
+marshalling, the serialized event-drain loop, evidence publication, and
+app-reference integration remain tracked by Traverse #647.
 
 Release tooling constructs `TraverseReleaseEvidence` with the semantic package
 version, runtime-WASM digest, conformance version, and supported iOS/macOS host
@@ -23,6 +28,11 @@ for release traceability, and the bundle's embedder API version. The API version
 defaults to the package's `TraverseEmbedder.apiVersion`. Initialization rejects
 a bundle declaring a different version with `incompatibleBundle`; it does not
 start a sidecar or attempt a network fallback.
+
+The package pins WasmKit 0.2.2 and swift-system 1.5.0 exactly. The accompanying
+`dependency-review.json` records why this is the newest reviewed combination
+compatible with the package's Swift 6.0 toolchain and discloses the engine's
+remaining resource-control limitations.
 
 The package follows semantic versioning. Additive, backward-compatible API
 changes use minor releases; breaking public API or error-semantic changes use a

--- a/packages/swift/TraverseEmbedder/README.md
+++ b/packages/swift/TraverseEmbedder/README.md
@@ -12,7 +12,8 @@ results. It never starts `traverse-cli serve` or uses server-discovery files.
 core WasmKit product, verifies `runtime/runtime.wasm` against its declared
 SHA-256 digest and a 32 MiB default artifact limit before parsing, rejects all
 ambient imports, and validates the memory, function signatures, and ABI version
-required by `runtime-wasm-bridge/1.0.0`. It never links WasmKitWASI. JSON
+required by `runtime-wasm-bridge/1.1.0`, including compatible lifecycle exports.
+It never links WasmKitWASI. JSON
 marshalling, the serialized event-drain loop, evidence publication, and
 app-reference integration remain tracked by Traverse #647.
 

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitRuntimeBridge.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitRuntimeBridge.swift
@@ -2,12 +2,12 @@ import CryptoKit
 import Foundation
 import WasmKit
 
-/// Production loader for the governed `runtime-wasm-bridge/1.0.0` module.
+/// Production loader for the governed `runtime-wasm-bridge/1.1.0` module.
 ///
 /// The loader verifies the artifact before WasmKit parses or instantiates it,
-/// rejects ambient imports, and validates the complete v1 export surface.
+/// rejects ambient imports, and validates the complete embedder export surface.
 public final class WasmKitRuntimeBridge: @unchecked Sendable {
-    public static let abiVersion = 10_000
+    public static let abiVersion = 10_100
     public static let defaultMaximumArtifactBytes = 32 * 1024 * 1024
 
     private static let requiredFunctions: [(String, [ValueType], [ValueType])] = [
@@ -18,6 +18,9 @@ public final class WasmKitRuntimeBridge: @unchecked Sendable {
         ("traverse_submit", [.i32, .i32, .i32], [.i32]),
         ("traverse_next_event", [.i32], [.i32]),
         ("traverse_cancel", [.i32, .i32, .i32], [.i32]),
+        ("traverse_compatible_start", [.i32, .i32, .i32], [.i32]),
+        ("traverse_compatible_stop", [.i32, .i32, .i32], [.i32]),
+        ("traverse_compatible_kill", [.i32, .i32, .i32], [.i32]),
         ("traverse_shutdown", [.i32], [.i32]),
     ]
 

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitRuntimeBridge.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitRuntimeBridge.swift
@@ -1,0 +1,116 @@
+import CryptoKit
+import Foundation
+import WasmKit
+
+/// Production loader for the governed `runtime-wasm-bridge/1.0.0` module.
+///
+/// The loader verifies the artifact before WasmKit parses or instantiates it,
+/// rejects ambient imports, and validates the complete v1 export surface.
+public final class WasmKitRuntimeBridge: @unchecked Sendable {
+    public static let abiVersion = 10_000
+    public static let defaultMaximumArtifactBytes = 32 * 1024 * 1024
+
+    private static let requiredFunctions: [(String, [ValueType], [ValueType])] = [
+        ("traverse_bridge_abi_version", [], [.i32]),
+        ("traverse_alloc", [.i32], [.i32]),
+        ("traverse_dealloc", [.i32, .i32], []),
+        ("traverse_init", [.i32, .i32, .i32], [.i32]),
+        ("traverse_submit", [.i32, .i32, .i32], [.i32]),
+        ("traverse_next_event", [.i32], [.i32]),
+        ("traverse_cancel", [.i32, .i32, .i32], [.i32]),
+        ("traverse_shutdown", [.i32], [.i32]),
+    ]
+
+    private let store: Store
+    private let instance: Instance
+
+    public let runtimeURL: URL
+    public let runtimeWasmDigest: String
+
+    public init(
+        bundle: TraverseBundle,
+        maximumArtifactBytes: Int = WasmKitRuntimeBridge.defaultMaximumArtifactBytes
+    ) throws {
+        guard bundle.embedderAPIVersion == TraverseEmbedder.apiVersion else {
+            throw TraverseEmbedderError.incompatibleBundle(
+                "embedder API \(bundle.embedderAPIVersion) is incompatible with \(TraverseEmbedder.apiVersion)"
+            )
+        }
+        guard maximumArtifactBytes > 0 else {
+            throw TraverseEmbedderError.incompatibleBundle("maximum runtime WASM size must be positive")
+        }
+
+        let runtimeURL = bundle.rootURL
+            .appendingPathComponent("runtime", isDirectory: true)
+            .appendingPathComponent("runtime.wasm", isDirectory: false)
+        let bytes: Data
+        do {
+            bytes = try Data(contentsOf: runtimeURL, options: [.mappedIfSafe])
+        } catch {
+            throw TraverseEmbedderError.incompatibleBundle("runtime/runtime.wasm is unavailable")
+        }
+        guard bytes.count <= maximumArtifactBytes else {
+            throw TraverseEmbedderError.incompatibleBundle("runtime/runtime.wasm exceeds the configured size limit")
+        }
+
+        let actualDigest = "sha256:" + SHA256.hash(data: bytes).map { String(format: "%02x", $0) }.joined()
+        guard Self.normalizedDigest(bundle.runtimeWasmDigest) == actualDigest else {
+            throw TraverseEmbedderError.incompatibleBundle("bundle_digest_mismatch")
+        }
+
+        let module: Module
+        do {
+            module = try parseWasm(bytes: Array(bytes))
+        } catch {
+            throw TraverseEmbedderError.incompatibleBundle("runtime/runtime.wasm is not a valid core WebAssembly module")
+        }
+        guard module.imports.isEmpty else {
+            throw TraverseEmbedderError.incompatibleBundle("runtime/runtime.wasm requires undeclared ambient imports")
+        }
+
+        let store = Store(engine: Engine())
+        let instance: Instance
+        do {
+            instance = try module.instantiate(store: store)
+        } catch {
+            throw TraverseEmbedderError.incompatibleBundle("runtime/runtime.wasm could not be instantiated")
+        }
+        let memoryExports = instance.exports.filter {
+            if case .memory = $0.value { return true }
+            return false
+        }
+        guard memoryExports.count == 1, instance.exports[memory: "memory"] != nil else {
+            throw TraverseEmbedderError.incompatibleBundle("runtime/runtime.wasm must export exactly one bridge memory")
+        }
+        for (name, parameters, results) in Self.requiredFunctions {
+            guard let function = instance.exports[function: name] else {
+                throw TraverseEmbedderError.incompatibleBundle("runtime/runtime.wasm is missing required export \(name)")
+            }
+            guard function.type.parameters == parameters, function.type.results == results else {
+                throw TraverseEmbedderError.incompatibleBundle("runtime/runtime.wasm has an invalid signature for \(name)")
+            }
+        }
+
+        let versionResults: [Value]
+        do {
+            versionResults = try instance.exports[function: "traverse_bridge_abi_version"]!()
+        } catch {
+            throw TraverseEmbedderError.incompatibleBundle("bridge_version_mismatch")
+        }
+        guard versionResults.count == 1,
+              case .i32(let version) = versionResults[0],
+              version == UInt32(Self.abiVersion) else {
+            throw TraverseEmbedderError.incompatibleBundle("bridge_version_mismatch")
+        }
+
+        self.store = store
+        self.instance = instance
+        self.runtimeURL = runtimeURL
+        self.runtimeWasmDigest = actualDigest
+    }
+
+    private static func normalizedDigest(_ digest: String) -> String {
+        let normalized = digest.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized.hasPrefix("sha256:") ? normalized : "sha256:" + normalized
+    }
+}

--- a/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
+++ b/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
@@ -120,7 +120,7 @@ import WAT
         try WasmKitRuntimeBridge(bundle: importedBundle)
     }
 
-    let wrongVersion = try wat2wasm(validBridgeWAT.replacingOccurrences(of: "i32.const 10000", with: "i32.const 20000"))
+    let wrongVersion = try wat2wasm(validBridgeWAT.replacingOccurrences(of: "i32.const 10100", with: "i32.const 20000"))
     let wrongVersionBundle = try fixtureBundle(wasm: wrongVersion)
     #expect(throws: TraverseEmbedderError.incompatibleBundle("bridge_version_mismatch")) {
         try WasmKitRuntimeBridge(bundle: wrongVersionBundle)
@@ -130,13 +130,16 @@ import WAT
 private let validBridgeWAT = """
     (module
       (memory (export "memory") 1 16)
-      (func (export "traverse_bridge_abi_version") (result i32) i32.const 10000)
+      (func (export "traverse_bridge_abi_version") (result i32) i32.const 10100)
       (func (export "traverse_alloc") (param i32) (result i32) i32.const 64)
       (func (export "traverse_dealloc") (param i32 i32))
       (func (export "traverse_init") (param i32 i32 i32) (result i32) i32.const 0)
       (func (export "traverse_submit") (param i32 i32 i32) (result i32) i32.const 0)
       (func (export "traverse_next_event") (param i32) (result i32) i32.const 0)
       (func (export "traverse_cancel") (param i32 i32 i32) (result i32) i32.const 0)
+      (func (export "traverse_compatible_start") (param i32 i32 i32) (result i32) i32.const 0)
+      (func (export "traverse_compatible_stop") (param i32 i32 i32) (result i32) i32.const 0)
+      (func (export "traverse_compatible_kill") (param i32 i32 i32) (result i32) i32.const 0)
       (func (export "traverse_shutdown") (param i32) (result i32) i32.const 0))
     """
 

--- a/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
+++ b/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
@@ -1,5 +1,7 @@
 import Foundation
+import CryptoKit
 import Testing
+import WAT
 @testable import TraverseEmbedder
 
 @Test func lifecycleAndSubmissionAreDeterministic() throws {
@@ -85,4 +87,70 @@ import Testing
             supportedHostVersions: []
         )
     }
+}
+
+@Test func wasmKitBridgeVerifiesAndInstantiatesTheGovernedABI() throws {
+    let wasm = try wat2wasm(validBridgeWAT)
+    let bundle = try fixtureBundle(wasm: wasm)
+
+    let bridge = try WasmKitRuntimeBridge(bundle: bundle)
+
+    #expect(bridge.runtimeWasmDigest == digest(of: wasm))
+    #expect(bridge.runtimeURL.lastPathComponent == "runtime.wasm")
+}
+
+@Test func wasmKitBridgeRejectsTamperingBeforeInstantiation() throws {
+    let wasm = try wat2wasm(validBridgeWAT)
+    let bundle = try fixtureBundle(wasm: wasm, declaredDigest: "sha256:" + String(repeating: "0", count: 64))
+
+    #expect(throws: TraverseEmbedderError.incompatibleBundle("bundle_digest_mismatch")) {
+        try WasmKitRuntimeBridge(bundle: bundle)
+    }
+}
+
+@Test func wasmKitBridgeRejectsAmbientImportsAndWrongABIMajor() throws {
+    let imported = try wat2wasm("""
+        (module
+          (import "wasi_snapshot_preview1" "fd_write" (func))
+          (memory (export "memory") 1)
+          (func (export "traverse_bridge_abi_version") (result i32) i32.const 10000))
+        """)
+    let importedBundle = try fixtureBundle(wasm: imported)
+    #expect(throws: TraverseEmbedderError.incompatibleBundle("runtime/runtime.wasm requires undeclared ambient imports")) {
+        try WasmKitRuntimeBridge(bundle: importedBundle)
+    }
+
+    let wrongVersion = try wat2wasm(validBridgeWAT.replacingOccurrences(of: "i32.const 10000", with: "i32.const 20000"))
+    let wrongVersionBundle = try fixtureBundle(wasm: wrongVersion)
+    #expect(throws: TraverseEmbedderError.incompatibleBundle("bridge_version_mismatch")) {
+        try WasmKitRuntimeBridge(bundle: wrongVersionBundle)
+    }
+}
+
+private let validBridgeWAT = """
+    (module
+      (memory (export "memory") 1 16)
+      (func (export "traverse_bridge_abi_version") (result i32) i32.const 10000)
+      (func (export "traverse_alloc") (param i32) (result i32) i32.const 64)
+      (func (export "traverse_dealloc") (param i32 i32))
+      (func (export "traverse_init") (param i32 i32 i32) (result i32) i32.const 0)
+      (func (export "traverse_submit") (param i32 i32 i32) (result i32) i32.const 0)
+      (func (export "traverse_next_event") (param i32) (result i32) i32.const 0)
+      (func (export "traverse_cancel") (param i32 i32 i32) (result i32) i32.const 0)
+      (func (export "traverse_shutdown") (param i32) (result i32) i32.const 0))
+    """
+
+private func fixtureBundle(wasm: [UInt8], declaredDigest: String? = nil) throws -> TraverseBundle {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let runtime = root.appendingPathComponent("runtime", isDirectory: true)
+    try FileManager.default.createDirectory(at: runtime, withIntermediateDirectories: true)
+    try Data(wasm).write(to: runtime.appendingPathComponent("runtime.wasm"))
+    return try TraverseBundle(
+        rootURL: root,
+        runtimeWasmDigest: declaredDigest ?? digest(of: wasm)
+    )
+}
+
+private func digest(of bytes: [UInt8]) -> String {
+    "sha256:" + SHA256.hash(data: Data(bytes)).map { String(format: "%02x", $0) }.joined()
 }

--- a/packages/swift/TraverseEmbedder/dependency-review.json
+++ b/packages/swift/TraverseEmbedder/dependency-review.json
@@ -1,0 +1,20 @@
+{
+  "reviewed_at": "2026-07-16",
+  "engine": "WasmKit",
+  "source": "https://github.com/swiftwasm/WasmKit",
+  "exact_version": "0.2.2",
+  "license": "MIT for runtime modules",
+  "compatibility": {
+    "swift_tools": "6.0",
+    "macos": "10.13+",
+    "ios": "12.0+",
+    "swift_system": "1.5.0 exact"
+  },
+  "selection": "0.2.2 is the newest reviewed release compatible with the package Swift 6.0 toolchain. The Spec 071 baseline 0.3.1 requires Swift tools 6.3, macOS 15, and iOS 18 and is therefore not host-compatible.",
+  "transitive_resolution": "swift-system 1.5.0 is pinned because WasmKit's open lower bound otherwise resolves 1.7.x, whose Stat API conflicts with WasmKit 0.2.2 SystemExtras on current Xcode.",
+  "security_boundary": "Core Wasm interpreter only; no WasmKitWASI product; imports rejected; SHA-256 verified before parsing; 32 MiB default artifact limit.",
+  "known_limitations": [
+    "WasmKit 0.2.2 does not expose public fuel or epoch controls.",
+    "Runtime memory growth and serialized call enforcement remain follow-up work before package release."
+  ]
+}


### PR DESCRIPTION
## Summary

- pin the reviewed WasmKit dependency graph for the Swift embedder
- verify the runtime artifact digest and size before parsing or instantiation
- reject ambient imports and validate the complete bridge 1.1 ABI, including compatible lifecycle exports
- keep this PR as a bounded loader slice of #647; request marshalling and event draining remain follow-up work

Advances #647.

## Governing Spec

- `068-public-platform-embedder-packages`
- `071-native-runtime-wasm-bridge`
- `072-native-bridge-compatible-lifecycle`

## Project Item

- Traverse Project 1: #647

## Definition of Done

- [x] Swift resolves and locks the reviewed WasmKit dependency graph.
- [x] The loader verifies the governed artifact before WasmKit parses it.
- [x] Ambient imports fail closed and no WasmKitWASI target is linked.
- [x] Bridge 1.1 version, memory, signatures, and compatible lifecycle exports are validated.
- [x] Tampering, imports, and incompatible bridge versions have deterministic tests.

## Validation

- `swift test` (7 tests passed)
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-issue-647-wasmkit-pr-body.md`
- `git diff --check`
