### PR TITLE
docs(runtime): complete compatible bridge lifecycle

### DIFF
--- a/crates/traverse-runtime/tests/compatible_bridge_conformance.rs
+++ b/crates/traverse-runtime/tests/compatible_bridge_conformance.rs
@@ -1,0 +1,286 @@
+#![cfg(feature = "wasmtime-executor")]
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::expect_used,
+    clippy::format_collect,
+    clippy::format_push_string,
+    clippy::too_many_lines,
+    clippy::unwrap_used
+)]
+
+use serde_json::{Value, json};
+use wasmtime::{Engine, Instance, Memory, Module, Store, TypedFunc};
+
+const START: &str = r#"{"instance_id":"fixture-compatible-1","status":"started","error":null}"#;
+const START_EVENT: &str = r#"{"type":"compatible_started","instance_id":"fixture-compatible-1"}"#;
+const STOP: &str = r#"{"instance_id":"fixture-compatible-1","status":"stopped","error":null}"#;
+const STOP_EVENT: &str = r#"{"type":"compatible_stopped","instance_id":"fixture-compatible-1"}"#;
+const KILL: &str = r#"{"instance_id":"fixture-compatible-1","status":"killed","error":null}"#;
+const KILL_EVENT: &str = r#"{"type":"compatible_killed","instance_id":"fixture-compatible-1"}"#;
+const SHUTDOWN_KILLED: &str =
+    r#"{"status":"stopped","killed_compatible_instances":["fixture-compatible-1"]}"#;
+const SHUTDOWN_EMPTY: &str = r#"{"status":"stopped","killed_compatible_instances":[]}"#;
+
+fn wat_string(value: &str) -> String {
+    value
+        .as_bytes()
+        .iter()
+        .map(|byte| format!("\\{byte:02x}"))
+        .collect()
+}
+
+fn fixture_module() -> String {
+    let values = [
+        START,
+        START_EVENT,
+        STOP,
+        STOP_EVENT,
+        KILL,
+        KILL_EVENT,
+        SHUTDOWN_KILLED,
+        SHUTDOWN_EMPTY,
+    ];
+    let mut offset = 8192_u32;
+    let mut regions = Vec::new();
+    let mut data = String::new();
+    for value in values {
+        regions.push((offset, value.len()));
+        data.push_str(&format!(
+            "(data (i32.const {offset}) \"{}\")\n",
+            wat_string(value)
+        ));
+        offset += value.len() as u32;
+    }
+    let [
+        (start_p, start_l),
+        (start_event_p, start_event_l),
+        (stop_p, stop_l),
+        (stop_event_p, stop_event_l),
+        (kill_p, kill_l),
+        (kill_event_p, kill_event_l),
+        (shutdown_killed_p, shutdown_killed_l),
+        (shutdown_empty_p, shutdown_empty_l),
+    ] = regions.as_slice()
+    else {
+        unreachable!("fixture regions are fixed")
+    };
+
+    format!(
+        r#"(module
+          (memory (export "memory") 1 8)
+          (global $heap (mut i32) (i32.const 4096))
+          (global $active (mut i32) (i32.const 0))
+          (global $event (mut i32) (i32.const 0))
+          {data}
+          (func (export "traverse_bridge_abi_version") (result i32) i32.const 10100)
+          (func (export "traverse_alloc") (param $len i32) (result i32)
+            (local $ptr i32)
+            global.get $heap local.set $ptr
+            global.get $heap local.get $len i32.add global.set $heap
+            local.get $ptr)
+          (func (export "traverse_dealloc") (param i32 i32))
+          (func $descriptor (param $out i32) (param $ptr i32) (param $len i32)
+            local.get $out local.get $ptr i32.store
+            local.get $out i32.const 4 i32.add local.get $len i32.store)
+          (func (export "traverse_compatible_start") (param i32 i32 i32) (result i32)
+            global.get $active
+            if (result i32)
+              i32.const -1
+            else
+              i32.const 1 global.set $active
+              i32.const 1 global.set $event
+              local.get 2 i32.const {start_p} i32.const {start_l} call $descriptor
+              i32.const 0
+            end)
+          (func (export "traverse_compatible_stop") (param i32 i32 i32) (result i32)
+            global.get $active i32.eqz
+            if (result i32)
+              i32.const -1
+            else
+              i32.const 0 global.set $active
+              i32.const 2 global.set $event
+              local.get 2 i32.const {stop_p} i32.const {stop_l} call $descriptor
+              i32.const 0
+            end)
+          (func (export "traverse_compatible_kill") (param i32 i32 i32) (result i32)
+            global.get $active i32.eqz
+            if (result i32)
+              i32.const -1
+            else
+              i32.const 0 global.set $active
+              i32.const 3 global.set $event
+              local.get 2 i32.const {kill_p} i32.const {kill_l} call $descriptor
+              i32.const 0
+            end)
+          (func (export "traverse_next_event") (param $out i32) (result i32)
+            global.get $event i32.const 1 i32.eq
+            if
+              local.get $out i32.const {start_event_p} i32.const {start_event_l} call $descriptor
+              i32.const 0 global.set $event
+              i32.const 1 return
+            end
+            global.get $event i32.const 2 i32.eq
+            if
+              local.get $out i32.const {stop_event_p} i32.const {stop_event_l} call $descriptor
+              i32.const 0 global.set $event
+              i32.const 1 return
+            end
+            global.get $event i32.const 3 i32.eq
+            if
+              local.get $out i32.const {kill_event_p} i32.const {kill_event_l} call $descriptor
+              i32.const 0 global.set $event
+              i32.const 1 return
+            end
+            i32.const 0)
+          (func (export "traverse_shutdown") (param i32) (result i32)
+            global.get $active
+            if
+              i32.const 0 global.set $active
+              i32.const 0 global.set $event
+              local.get 0 i32.const {shutdown_killed_p} i32.const {shutdown_killed_l} call $descriptor
+            else
+              local.get 0 i32.const {shutdown_empty_p} i32.const {shutdown_empty_l} call $descriptor
+            end
+            i32.const 0))"#
+    )
+}
+
+struct Bridge {
+    store: Store<()>,
+    memory: Memory,
+    alloc: TypedFunc<i32, i32>,
+    start: TypedFunc<(i32, i32, i32), i32>,
+    stop: TypedFunc<(i32, i32, i32), i32>,
+    kill: TypedFunc<(i32, i32, i32), i32>,
+    next_event: TypedFunc<i32, i32>,
+    shutdown: TypedFunc<i32, i32>,
+}
+
+impl Bridge {
+    fn call(&mut self, operation: &str, input: &Value) -> (i32, Option<Value>) {
+        let bytes = serde_json::to_vec(input).expect("serialize fixture request");
+        let length = i32::try_from(bytes.len()).expect("fixture input length");
+        let pointer = self
+            .alloc
+            .call(&mut self.store, length)
+            .expect("allocate input");
+        self.memory
+            .write(&mut self.store, pointer as usize, &bytes)
+            .expect("write input");
+        let arguments = (pointer, length, 1024);
+        let status = match operation {
+            "start" => self.start.call(&mut self.store, arguments),
+            "stop" => self.stop.call(&mut self.store, arguments),
+            "kill" => self.kill.call(&mut self.store, arguments),
+            _ => unreachable!("known fixture operation"),
+        }
+        .expect("bridge call");
+        let output = (status == 0).then(|| self.read_json(1024));
+        (status, output)
+    }
+
+    fn event(&mut self) -> Option<Value> {
+        let status = self
+            .next_event
+            .call(&mut self.store, 1024)
+            .expect("drain event");
+        (status == 1).then(|| self.read_json(1024))
+    }
+
+    fn read_json(&self, descriptor: usize) -> Value {
+        let data = self.memory.data(&self.store);
+        let pointer = u32::from_le_bytes(data[descriptor..descriptor + 4].try_into().unwrap());
+        let length = u32::from_le_bytes(data[descriptor + 4..descriptor + 8].try_into().unwrap());
+        serde_json::from_slice(&data[pointer as usize..(pointer + length) as usize])
+            .expect("valid fixture JSON")
+    }
+}
+
+fn bridge() -> Bridge {
+    let engine = Engine::default();
+    let module = Module::new(&engine, fixture_module()).expect("compile bridge fixture");
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[]).expect("instantiate without WASI");
+    let version = instance
+        .get_typed_func::<(), i32>(&mut store, "traverse_bridge_abi_version")
+        .expect("version export")
+        .call(&mut store, ())
+        .expect("version call");
+    assert_eq!(version, 10100);
+    Bridge {
+        memory: instance
+            .get_memory(&mut store, "memory")
+            .expect("memory export"),
+        alloc: instance
+            .get_typed_func(&mut store, "traverse_alloc")
+            .unwrap(),
+        start: instance
+            .get_typed_func(&mut store, "traverse_compatible_start")
+            .unwrap(),
+        stop: instance
+            .get_typed_func(&mut store, "traverse_compatible_stop")
+            .unwrap(),
+        kill: instance
+            .get_typed_func(&mut store, "traverse_compatible_kill")
+            .unwrap(),
+        next_event: instance
+            .get_typed_func(&mut store, "traverse_next_event")
+            .unwrap(),
+        shutdown: instance
+            .get_typed_func(&mut store, "traverse_shutdown")
+            .unwrap(),
+        store,
+    }
+}
+
+#[test]
+fn bridge_1_1_owns_compatible_lifecycle_and_ordered_events() {
+    let mut bridge = bridge();
+    let start_request = json!({"capability_id": "fixture.compatible", "input": {}});
+    let instance_request = json!({
+        "capability_id": "fixture.compatible",
+        "instance_id": "fixture-compatible-1"
+    });
+
+    let (status, output) = bridge.call("start", &start_request);
+    assert_eq!(status, 0);
+    assert_eq!(output.unwrap()["status"], "started");
+    assert_eq!(bridge.event().unwrap()["type"], "compatible_started");
+
+    let (status, output) = bridge.call("stop", &instance_request);
+    assert_eq!(status, 0);
+    assert_eq!(output.unwrap()["status"], "stopped");
+    assert_eq!(bridge.event().unwrap()["type"], "compatible_stopped");
+    assert_eq!(bridge.call("stop", &instance_request).0, -1);
+    assert!(bridge.event().is_none());
+
+    assert_eq!(bridge.call("start", &start_request).0, 0);
+    assert_eq!(bridge.event().unwrap()["type"], "compatible_started");
+    assert_eq!(bridge.call("kill", &instance_request).0, 0);
+    assert_eq!(bridge.event().unwrap()["type"], "compatible_killed");
+    assert_eq!(bridge.call("kill", &instance_request).0, -1);
+}
+
+#[test]
+fn shutdown_kills_the_remaining_compatible_instance_once() {
+    let mut bridge = bridge();
+    let start_request = json!({"capability_id": "fixture.compatible", "input": {}});
+    let stop_request = json!({"capability_id": "fixture.compatible", "instance_id": null});
+    assert_eq!(bridge.call("start", &start_request).0, 0);
+    assert!(bridge.event().is_some());
+
+    assert_eq!(bridge.shutdown.call(&mut bridge.store, 1024).unwrap(), 0);
+    assert_eq!(
+        bridge.read_json(1024)["killed_compatible_instances"],
+        json!(["fixture-compatible-1"])
+    );
+    assert_eq!(bridge.call("stop", &stop_request).0, -1);
+
+    assert_eq!(bridge.shutdown.call(&mut bridge.store, 1024).unwrap(), 0);
+    assert_eq!(
+        bridge.read_json(1024)["killed_compatible_instances"],
+        json!([])
+    );
+}

--- a/docs/adr/0008-compatible-lifecycle-bridge.md
+++ b/docs/adr/0008-compatible-lifecycle-bridge.md
@@ -1,0 +1,38 @@
+# ADR-0008: Add Compatible Lifecycle Operations to Runtime-WASM Bridge 1.1
+
+- Status: Accepted
+- Date: 2026-07-16
+
+## Context
+
+`embedder-api/1.0.0` requires compatible-capability start, stop, and kill.
+Runtime-WASM bridge 1.0 omitted those operations, so a conforming native
+adapter could only implement them outside the runtime-owned boundary.
+
+## Decision
+
+Publish additive bridge version 1.1.0 with three scalar core-Wasm exports:
+`traverse_compatible_start`, `traverse_compatible_stop`, and
+`traverse_compatible_kill`. They reuse bridge 1.0 JSON marshalling, status,
+memory ownership, error, event ordering, and resource-limit rules.
+
+The runtime generates instance identifiers, validates active instances, emits
+ordered lifecycle events, and kills remaining compatible instances during
+shutdown. Native hosts marshal calls and adapt events only. A package exposing
+the complete embedder API requires bridge 1.1 or later within major version 1.
+
+## Consequences
+
+- Swift, Kotlin, and .NET retain identical runtime-owned lifecycle semantics.
+- Existing bridge 1.0 artifacts remain valid for the smaller 1.0 operation set,
+  but cannot certify complete `embedder-api/1.0.0` conformance.
+- Release evidence must record the exact bridge version.
+
+## Alternatives Considered
+
+- Encode compatible lifecycle as undocumented `submit` targets: rejected
+  because operation and error semantics would not be governed.
+- Implement lifecycle in each platform package: rejected because it duplicates
+  runtime state and violates Specs 057 and 068.
+- Break bridge major version: rejected because adding exports and request types
+  is backward-compatible for existing 1.x hosts.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -534,3 +534,31 @@ bridge and embedder conformance suites.
 
 Spec 071 and ADR-0007 define the bridge. Native package tickets may implement
 independently without changing runtime behavior or introducing a sidecar.
+
+## Decision 24: Carry Compatible Lifecycle Through Bridge 1.1
+
+- **Date**: 2026-07-16
+- **Status**: Accepted
+- **Governing spec**: `072-native-bridge-compatible-lifecycle`
+- **Related issues**: `#716`, `#647`, `#648`, `#649`
+
+### Context
+
+Bridge 1.0 defined runtime initialization, submission, events, cancellation,
+and shutdown, but omitted the compatible-capability start, stop, and kill
+operations required by `embedder-api/1.0.0`. Implementing them in each native
+package would move lifecycle ownership out of the runtime.
+
+### Decision
+
+Bridge 1.1 adds `traverse_compatible_start`, `traverse_compatible_stop`, and
+`traverse_compatible_kill` using the existing UTF-8 JSON and output-descriptor
+ownership rules. The runtime owns instance identifiers, state validation,
+ordered lifecycle events, and shutdown cleanup. Bridge 1.1 is an additive ABI
+version, but native packages requiring the complete embedder API must reject a
+1.0 runtime artifact as incomplete.
+
+### Outcome
+
+All three native hosts implement one lifecycle contract and can resume without
+inventing platform-specific compatible-capability semantics.

--- a/specs/072-native-bridge-compatible-lifecycle/runtime-wasm-bridge-1.1.0.json
+++ b/specs/072-native-bridge-compatible-lifecycle/runtime-wasm-bridge-1.1.0.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://traverse.dev/runtime-wasm-bridge/1.1.0",
+  "title": "Traverse native runtime-WASM bridge ABI",
+  "version": "1.1.0",
+  "extends": "https://traverse.dev/runtime-wasm-bridge/1.0.0",
+  "artifact": {
+    "kind": "core-webassembly-module",
+    "path": "runtime/runtime.wasm",
+    "wasi": "none",
+    "memory": "memory",
+    "output_descriptor": "little-endian u32 pointer followed by u32 length"
+  },
+  "added_exports": {
+    "traverse_compatible_start": "(input_pointer: i32, input_length: i32, output_descriptor: i32) -> status: i32",
+    "traverse_compatible_stop": "(input_pointer: i32, input_length: i32, output_descriptor: i32) -> status: i32",
+    "traverse_compatible_kill": "(input_pointer: i32, input_length: i32, output_descriptor: i32) -> status: i32"
+  },
+  "requests": {
+    "compatible_start": { "required": ["capability_id", "input"] },
+    "compatible_stop": { "required": ["capability_id", "instance_id"] },
+    "compatible_kill": { "required": ["capability_id", "instance_id"] }
+  },
+  "errors": {
+    "invalid_input": -2,
+    "invalid_state": -1,
+    "compatible_instance_not_active": -1
+  },
+  "complete_embedder_api_range": ">=1.1.0,<2.0.0"
+}

--- a/specs/072-native-bridge-compatible-lifecycle/spec.md
+++ b/specs/072-native-bridge-compatible-lifecycle/spec.md
@@ -1,0 +1,71 @@
+# Feature Specification: Native Bridge Compatible-Capability Lifecycle
+
+**Feature Branch**: `072-native-bridge-compatible-lifecycle`  
+**Created**: 2026-07-16  
+**Status**: Approved  
+**Version**: 1.0.0  
+**Input**: Decision 24, ADR-0008, and Traverse #716.
+
+## Purpose
+
+Complete the runtime-owned native bridge beneath `embedder-api/1.0.0` by
+governing compatible-capability start, stop, and kill. This specification is
+additive to Spec 071 and publishes `runtime-wasm-bridge/1.1.0`.
+
+## Functional Requirements
+
+- **FR-001**: Bridge 1.1 MUST retain every bridge 1.0 export and add
+  `traverse_compatible_start`, `traverse_compatible_stop`, and
+  `traverse_compatible_kill` with the signatures in the ABI manifest.
+- **FR-002**: Start input MUST be JSON `{ "capability_id", "input" }`. Success
+  MUST return `{ "instance_id", "status": "started", "error": null }`.
+- **FR-003**: Stop and kill input MUST be JSON `{ "capability_id",
+  "instance_id" }`. A null instance identifier selects the active instance for
+  that capability. Success returns the resolved identifier and respectively
+  `stopped` or `killed`.
+- **FR-004**: The runtime MUST generate stable opaque instance identifiers and
+  own the active-instance state. Native hosts MUST NOT synthesize identifiers
+  or lifecycle transitions.
+- **FR-005**: Start, stop, and kill MUST emit runtime-owned ordered events using
+  the same queue and descriptor rules as `traverse_next_event`.
+- **FR-006**: An empty capability identifier or malformed JSON MUST return
+  `invalid_input`. An inactive or mismatched instance MUST return
+  `invalid_state` with structured code `compatible_instance_not_active`.
+- **FR-007**: Kill and stop cleanup MUST release the active instance exactly
+  once. A repeated operation returns the same deterministic inactive-instance
+  error without additional events.
+- **FR-008**: Shutdown MUST kill all remaining compatible instances before
+  returning `stopped`; its result MUST include the ordered list of killed
+  instance identifiers for traceability, and no instance may remain active.
+- **FR-009**: A package certifying complete `embedder-api/1.0.0` conformance
+  MUST require bridge version `>=1.1.0,<2.0.0` and record the exact version in
+  release evidence.
+
+## Acceptance Scenarios
+
+1. Start then stop returns one runtime identifier and emits ordered `started`
+   then `stopped` lifecycle events.
+2. Start then kill emits `started` then `killed`; a repeated kill returns
+   `compatible_instance_not_active` and emits nothing.
+3. Shutdown with an active instance reports it in
+   `killed_compatible_instances` and leaves no active lifecycle state.
+4. The shared fixture runs through the same core-Wasm exports consumed by the
+   Swift, Kotlin, and .NET host profiles without a sidecar.
+
+## Compatibility
+
+Bridge 1.1 is additive within major version 1. A bridge 1.0 host may ignore the
+new exports, but a native package implementing the complete embedder API cannot
+certify against a bridge 1.0 runtime.
+
+## Out of Scope
+
+- Platform-specific lifecycle operations or identifiers.
+- Compatible-capability business logic in an embedder.
+- Changes to the public `embedder-api/1.0.0` operation set.
+
+## Implementation Tickets
+
+- Traverse #647 — Swift/WasmKit adapter.
+- Traverse #648 — Kotlin/Chicory adapter.
+- Traverse #649 — .NET/Wasmtime adapter.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -846,6 +846,18 @@
         "docs/adr/0007-native-runtime-wasm-bridge.md",
         "specs/071-native-runtime-wasm-bridge/"
       ]
+    },
+    {
+      "id": "072-native-bridge-compatible-lifecycle",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/072-native-bridge-compatible-lifecycle/spec.md",
+      "governs": [
+        "crates/traverse-runtime/tests/compatible_bridge_conformance.rs",
+        "docs/adr/0008-compatible-lifecycle-bridge.md",
+        "specs/072-native-bridge-compatible-lifecycle/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- publish additive `runtime-wasm-bridge/1.1.0` lifecycle exports for compatible-capability start, stop, and kill
- keep instance identifiers, active state, ordered events, errors, and shutdown cleanup runtime-owned
- add an executable no-WASI conformance fixture covering stop, kill, repeated cleanup, invalid state, and kill-on-shutdown
- restore a shared implementation contract for Swift, Kotlin, and .NET adapters

Closes #716.

## Governing Spec

- `057-embeddable-runtime-host`
- `068-public-platform-embedder-packages`
- `070-runtime-event-sink-boundary`
- `071-native-runtime-wasm-bridge`
- `072-native-bridge-compatible-lifecycle`

## Project Item

- Traverse Project 1: #716

## Definition of Done

- [x] Approved additive successor contract defines compatible start/stop/kill request, result, event, and stable-error behavior.
- [x] ABI manifest identifies bridge 1.1.0 and complete embedder compatibility range.
- [x] Executable fixture proves ordered lifecycle events, invalid-instance handling, kill-on-shutdown, and exactly-once cleanup.
- [x] Specs 057, 068, 071, and 072 remain explicitly traceable.
- [x] #647, #648, and #649 can return to Ready after merge.

## Validation

- `cargo test -p traverse-runtime --test compatible_bridge_conformance`
- `cargo clippy -p traverse-runtime --test compatible_bridge_conformance -- -D warnings`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-issue-716-pr-body.md`
- `bash scripts/ci/repository_checks.sh`
