### PR TITLE
ci(runtime): schedule journal operational measurements

### DIFF
--- a/.github/workflows/journal-operational-limits.yml
+++ b/.github/workflows/journal-operational-limits.yml
@@ -1,0 +1,68 @@
+name: Journal operational limits
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 7 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    name: ${{ matrix.os }} / ${{ matrix.profile }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            profile: host-local
+            pressure: false
+          - os: ubuntu-latest
+            profile: fsync-pressure
+            pressure: true
+          - os: macos-latest
+            profile: host-local
+            pressure: false
+          - os: windows-latest
+            profile: host-local
+            pressure: false
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Measure journal limits
+        shell: bash
+        env:
+          TRAVERSE_JOURNAL_BENCH_EVENTS: "1000"
+          TRAVERSE_JOURNAL_BENCH_PAYLOAD_BYTES: "512"
+          TRAVERSE_JOURNAL_BENCH_PROFILE: ${{ matrix.profile }}
+          TRAVERSE_JOURNAL_BENCH_ROOT: ${{ runner.temp }}
+          PRESSURE_ENABLED: ${{ matrix.pressure }}
+        run: |
+          set -euo pipefail
+          evidence="journal-operational-${{ runner.os }}-${{ matrix.profile }}.json"
+          pressure_pid=""
+          if [[ "${PRESSURE_ENABLED}" == "true" ]]; then
+            python scripts/ci/journal_storage_pressure.py "${RUNNER_TEMP}/journal-pressure" &
+            pressure_pid="$!"
+            trap 'kill "${pressure_pid}" 2>/dev/null || true' EXIT
+          fi
+          cargo run --release -p traverse-runtime --example journal_operational_limits > "${evidence}"
+          python scripts/ci/journal_operational_summary.py "${evidence}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload comparable evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: journal-operational-${{ runner.os }}-${{ matrix.profile }}
+          path: journal-operational-${{ runner.os }}-${{ matrix.profile }}.json
+          retention-days: 90

--- a/crates/traverse-runtime/examples/journal_operational_limits.rs
+++ b/crates/traverse-runtime/examples/journal_operational_limits.rs
@@ -20,6 +20,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "TRAVERSE_JOURNAL_BENCH_PAYLOAD_BYTES",
         DEFAULT_PAYLOAD_BYTES,
     )?;
+    let storage_profile = std::env::var("TRAVERSE_JOURNAL_BENCH_PROFILE")
+        .unwrap_or_else(|_| "host-local".to_string());
     let root = benchmark_root()?;
     let config = JournalConfig {
         max_segment_bytes: BENCH_SEGMENT_BYTES,
@@ -58,6 +60,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     append_micros.sort_unstable();
     let result = json!({
         "schema_version": "1.0.0",
+        "environment": {
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "storage_profile": storage_profile
+        },
         "workload": {
             "event_count": event_count,
             "payload_bytes": payload_bytes,
@@ -121,7 +128,9 @@ fn env_usize(name: &str, default: usize) -> Result<usize, Box<dyn std::error::Er
 
 fn benchmark_root() -> Result<PathBuf, std::time::SystemTimeError> {
     let nonce = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
-    Ok(std::env::temp_dir().join(format!("traverse-journal-benchmark-{nonce}")))
+    let base = std::env::var_os("TRAVERSE_JOURNAL_BENCH_ROOT")
+        .map_or_else(std::env::temp_dir, PathBuf::from);
+    Ok(base.join(format!("traverse-journal-benchmark-{nonce}")))
 }
 
 fn directory_bytes(root: &Path) -> Result<u64, std::io::Error> {

--- a/docs/durable-event-journal-operational-limits.md
+++ b/docs/durable-event-journal-operational-limits.md
@@ -76,3 +76,23 @@ evidence.
 One operational risk remains: these measurements cover a single Darwin arm64
 host and local filesystem. Cross-platform and slower-storage regression
 tracking is a separate follow-up so it does not expand the initial evaluation.
+
+## Cross-platform regression workflow
+
+`.github/workflows/journal-operational-limits.yml` runs weekly and on manual
+dispatch. It executes the same release-mode harness on Linux, macOS, and
+Windows, plus a Linux `fsync-pressure` profile that places a bounded synchronous
+writer beside the journal workload. The pressure profile is a repeatable
+constrained-storage signal, not a claim about a named production disk class.
+
+Each matrix entry uploads a 90-day JSON artifact with the same workload,
+latency, recovery, replay, pruning, and disk-growth fields. The environment
+block records OS, architecture, and storage profile so results remain
+comparable. The workflow summary marks the investigation thresholds above but
+does not convert benchmark variance into a pull-request or unit-test gate.
+
+To collect a targeted run, dispatch **Journal operational limits** from GitHub
+Actions. Download all four artifacts and compare like-for-like profiles. Open a
+focused remediation issue when a threshold is exceeded on two consecutive
+runs or the same regression reproduces locally; attach both JSON artifacts and
+the runner image identifiers.

--- a/scripts/ci/journal_operational_summary.py
+++ b/scripts/ci/journal_operational_summary.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Render non-blocking journal investigation markers for a workflow summary."""
+
+import json
+import pathlib
+import sys
+
+
+evidence_path = pathlib.Path(sys.argv[1])
+data = json.loads(evidence_path.read_text(encoding="utf-8"))
+environment = data["environment"]
+append = data["append_latency_micros"]
+recovery = data["restart_recovery_micros"]
+disk = data["disk"]
+
+markers = []
+if append["p99"] > 25_000:
+    markers.append("append p99 exceeds 25 ms")
+if recovery > 1_000_000:
+    markers.append("restart recovery exceeds 1 second")
+
+status = "investigate" if markers else "within documented thresholds"
+print(
+    f"| {environment['os']}/{environment['arch']} | "
+    f"{environment['storage_profile']} | {append['p50']} | {append['p95']} | "
+    f"{append['p99']} | {recovery} | {data['replay']['events_per_second']} | "
+    f"{disk['bytes_per_event_before_prune']} | {status} |"
+)
+if markers:
+    print("Investigation markers: " + "; ".join(markers))

--- a/scripts/ci/journal_storage_pressure.py
+++ b/scripts/ci/journal_storage_pressure.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Create bounded fsync pressure beside the journal benchmark."""
+
+import os
+import pathlib
+import signal
+import sys
+
+
+running = True
+
+
+def stop(_signal: int, _frame: object) -> None:
+    global running
+    running = False
+
+
+signal.signal(signal.SIGINT, stop)
+signal.signal(signal.SIGTERM, stop)
+
+root = pathlib.Path(sys.argv[1])
+root.mkdir(parents=True, exist_ok=True)
+pressure_file = root / "journal-storage-pressure.bin"
+block = b"p" * (1024 * 1024)
+
+with pressure_file.open("wb", buffering=0) as handle:
+    while running:
+        handle.write(block)
+        handle.flush()
+        os.fsync(handle.fileno())
+        if handle.tell() >= 256 * 1024 * 1024:
+            handle.seek(0)


### PR DESCRIPTION
## Summary

- add a weekly and manually repeatable Linux/macOS/Windows journal measurement matrix
- add an Ubuntu fsync-pressure profile without making benchmark variance a pull-request gate
- enrich comparable JSON evidence with OS, architecture, and storage-profile metadata
- upload 90-day evidence artifacts and render non-blocking investigation markers in the run summary

Advances #713. The issue will close after the first full measurement matrix succeeds and publishes its evidence artifacts.

## Governing Spec

- `004-spec-alignment-gate`
- `062-runtime-target-matrix`
- `066-durable-identity-event-delivery`
- `067-durable-journal-retention-and-write-limits`
- `070-runtime-event-sink-boundary`

## Project Item

- Traverse Project 1: #713

## Definition of Done

- [x] Release harness matrix covers Linux, macOS, and Windows.
- [x] Linux includes a bounded colocated fsync-pressure profile.
- [x] Every entry uploads comparable JSON append, recovery, replay, prune, and disk-growth evidence.
- [x] Workflow is scheduled/manual and does not gate pull requests on benchmark variance.
- [x] Documented thresholds produce visible investigation markers for focused follow-up.

## Validation

- `TRAVERSE_JOURNAL_BENCH_EVENTS=20 TRAVERSE_JOURNAL_BENCH_PAYLOAD_BYTES=64 TRAVERSE_JOURNAL_BENCH_PROFILE=validation cargo run --release -p traverse-runtime --example journal_operational_limits`
- `cargo clippy -p traverse-runtime --example journal_operational_limits -- -D warnings`
- Python pressure/summary scripts parsed successfully.
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-issue-713-pr-body.md`
- `bash scripts/ci/repository_checks.sh`
