### PR TITLE
fix: keep internal crate version pins in sync with workspace version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ repository = "https://github.com/traverse-framework/traverse"
 rust-version = "1.94"
 version = "0.7.0"
 
+[workspace.dependencies]
+traverse-contracts = { path = "crates/traverse-contracts", version = "0.7.0" }
+traverse-registry = { path = "crates/traverse-registry", version = "0.7.0" }
+traverse-runtime = { path = "crates/traverse-runtime", version = "0.7.0" }
+
 [workspace.lints.rust]
 unsafe_code = "forbid"
 

--- a/crates/traverse-cli/Cargo.toml
+++ b/crates/traverse-cli/Cargo.toml
@@ -14,9 +14,9 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.11"
 zeroize = "1.8"
-traverse-contracts = { path = "../traverse-contracts", version = "0.7.0" }
-traverse-registry = { path = "../traverse-registry", version = "0.7.0" }
-traverse-runtime = { path = "../traverse-runtime", version = "0.7.0" }
+traverse-contracts = { workspace = true }
+traverse-registry = { workspace = true }
+traverse-runtime = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/traverse-embedder/Cargo.toml
+++ b/crates/traverse-embedder/Cargo.toml
@@ -9,8 +9,8 @@ rust-version.workspace = true
 
 [dependencies]
 serde_json = "1.0.145"
-traverse-registry = { path = "../traverse-registry", version = "0.7.0" }
-traverse-runtime = { path = "../traverse-runtime", version = "0.7.0" }
+traverse-registry = { workspace = true }
+traverse-runtime = { workspace = true }
 
 [dev-dependencies]
 sha2 = "0.11"

--- a/crates/traverse-mcp/Cargo.toml
+++ b/crates/traverse-mcp/Cargo.toml
@@ -13,9 +13,9 @@ path = "src/main.rs"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-traverse-contracts = { path = "../traverse-contracts", version = "0.7.0" }
-traverse-registry = { path = "../traverse-registry", version = "0.7.0" }
-traverse-runtime = { path = "../traverse-runtime", version = "0.7.0" }
+traverse-contracts = { workspace = true }
+traverse-registry = { workspace = true }
+traverse-runtime = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/traverse-registry/Cargo.toml
+++ b/crates/traverse-registry/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-traverse-contracts = { path = "../traverse-contracts", version = "0.7.0" }
+traverse-contracts = { workspace = true }
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/crates/traverse-runtime/Cargo.toml
+++ b/crates/traverse-runtime/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-traverse-contracts = { path = "../traverse-contracts", version = "0.7.0" }
-traverse-registry = { path = "../traverse-registry", version = "0.7.0" }
+traverse-contracts = { workspace = true }
+traverse-registry = { workspace = true }
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/scripts/ci/bump_version.sh
+++ b/scripts/ci/bump_version.sh
@@ -38,26 +38,43 @@ trap 'rm -f "${tmp_file}"' EXIT
 awk -v new_version="${new_version}" '
   BEGIN {
     in_workspace_package = 0
-    replacements = 0
+    in_workspace_dependencies = 0
+    package_replacements = 0
+    dependency_replacements = 0
   }
   /^\[workspace\.package\]$/ {
     in_workspace_package = 1
+    in_workspace_dependencies = 0
+    print
+    next
+  }
+  /^\[workspace\.dependencies\]$/ {
+    in_workspace_package = 0
+    in_workspace_dependencies = 1
     print
     next
   }
   /^\[/ {
     in_workspace_package = 0
+    in_workspace_dependencies = 0
   }
   in_workspace_package && $1 == "version" && $2 == "=" {
     print "version = \"" new_version "\""
-    replacements += 1
+    package_replacements += 1
+    next
+  }
+  in_workspace_dependencies && /^traverse-[a-zA-Z0-9_-]+ = \{.*version = "[0-9]+\.[0-9]+\.[0-9]+"/ {
+    line = $0
+    gsub(/version = "[0-9]+\.[0-9]+\.[0-9]+"/, "version = \"" new_version "\"", line)
+    print line
+    dependency_replacements += 1
     next
   }
   {
     print
   }
   END {
-    if (replacements != 1) {
+    if (package_replacements != 1 || dependency_replacements < 1) {
       exit 1
     }
   }


### PR DESCRIPTION
## Summary
- Discovered while cutting the v0.8.0 release: `scripts/ci/bump_version.sh` only rewrites `[workspace.package].version`, but six internal `traverse-*` dependency declarations across `crates/*/Cargo.toml` pinned a literal `version = "0.7.0"` instead of inheriting the workspace version. A bump broke `cargo` resolution workspace-wide (confirmed live on the now-closed #717).
- Moves the three internally-consumed crates (`traverse-contracts`, `traverse-registry`, `traverse-runtime`) into a new `[workspace.dependencies]` block and switches every consumer to `{ workspace = true }`, collapsing the version literal from 6 scattered occurrences down to 3 lines in one place.
- Extends `bump_version.sh`'s awk rewrite to update both `[workspace.package].version` and the `[workspace.dependencies]` internal-crate version literals atomically in the same commit.

## Governing Spec
- 048-semver-publishing-pipeline
- 068-public-platform-embedder-packages

## Project Item
#721

## Validation
- `cargo metadata --no-deps` resolves cleanly with the new `{ workspace = true }` references
- `cargo build --workspace` passes at the current (0.7.0) version
- `cargo clippy --workspace --all-targets -- -D warnings` passes with no warnings
- Ran `bash scripts/ci/bump_version.sh 0.8.0` against a throwaway clone of this branch: all four version literals (workspace + 3 internal pins) updated atomically in one commit, and `cargo build --workspace` then succeeded cleanly at 0.8.0 across every crate
- CI on this PR

Fixes #721