### PR TITLE
Kotlin: add verified Chicory runtime loader

### DIFF
--- a/packages/kotlin/TraverseEmbedder/.gitignore
+++ b/packages/kotlin/TraverseEmbedder/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+**/build/
+local.properties

--- a/packages/kotlin/TraverseEmbedder/README.md
+++ b/packages/kotlin/TraverseEmbedder/README.md
@@ -10,5 +10,10 @@ digest, conformance version, and supported Android host versions for a release.
 It never launches `traverse-cli serve` or uses server-discovery files in
 production.
 
-Runtime-WASM bridging, runtime event subscriptions, release evidence, and the
-Compose reference-app integration remain tracked by Traverse #648.
+`ChicoryRuntimeBridge` is the production runtime loader. It pins Chicory 1.7.5,
+verifies `runtime/runtime.wasm` against its declared SHA-256 digest and a 32 MiB
+default artifact limit before parsing, rejects ambient imports, and validates
+the complete `runtime-wasm-bridge/1.1.0` memory, function-signature, and ABI
+surface without linking Chicory WASI. Runtime JSON marshalling, serialized
+event draining, release evidence publication, and Compose reference-app
+integration remain tracked by Traverse #648.

--- a/packages/kotlin/TraverseEmbedder/dependency-review.json
+++ b/packages/kotlin/TraverseEmbedder/dependency-review.json
@@ -1,0 +1,18 @@
+{
+  "reviewed_at": "2026-07-16",
+  "engine": "Chicory",
+  "source": "https://github.com/dylibso/chicory",
+  "exact_version": "1.7.5",
+  "license": "Apache-2.0",
+  "compatibility": {
+    "java_release": "11",
+    "android_min_sdk": 28,
+    "traverse_jvm_target": 17
+  },
+  "selection": "1.7.5 is the current stable Maven Central release and includes upstream Android device-test coverage at minSdk 28.",
+  "security_boundary": "Pure JVM interpreter; runtime and wasm artifacts only; no chicory-wasi production dependency; imports rejected; SHA-256 verified before parsing; 32 MiB default artifact limit.",
+  "known_limitations": [
+    "Chicory 1.7.5 does not expose fuel or epoch interruption controls.",
+    "Runtime JSON marshalling, serialized event draining, and deadline enforcement remain follow-up work before package release."
+  ]
+}

--- a/packages/kotlin/TraverseEmbedder/settings.gradle.kts
+++ b/packages/kotlin/TraverseEmbedder/settings.gradle.kts
@@ -1,2 +1,20 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 rootProject.name = "TraverseEmbedder"
 include(":traverse-embedder")

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/build.gradle.kts
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/build.gradle.kts
@@ -21,5 +21,8 @@ android {
 }
 
 dependencies {
+    implementation("com.dylibso.chicory:runtime:1.7.5")
+    implementation("com.dylibso.chicory:wasm:1.7.5")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("com.dylibso.chicory:wabt:1.7.5")
 }

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/ChicoryRuntimeBridge.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/ChicoryRuntimeBridge.kt
@@ -1,0 +1,114 @@
+package dev.traverse.embedder
+
+import com.dylibso.chicory.runtime.Instance
+import com.dylibso.chicory.wasm.Parser
+import com.dylibso.chicory.wasm.types.ExternalType
+import com.dylibso.chicory.wasm.types.FunctionType
+import com.dylibso.chicory.wasm.types.ValType
+import java.io.File
+import java.security.MessageDigest
+
+/** Fail-closed Chicory loader for `runtime-wasm-bridge/1.1.0`. */
+class ChicoryRuntimeBridge(
+    bundle: TraverseBundle,
+    maximumArtifactBytes: Int = DEFAULT_MAXIMUM_ARTIFACT_BYTES,
+) {
+    val runtimeFile: File
+    val runtimeWasmDigest: String
+
+    @Suppress("unused")
+    private val instance: Instance
+
+    init {
+        require(maximumArtifactBytes > 0) { "maximum runtime WASM size must be positive" }
+
+        runtimeFile = File(bundle.rootPath, "runtime/runtime.wasm")
+        if (!runtimeFile.isFile) {
+            throw TraverseBundleException("runtime/runtime.wasm is unavailable")
+        }
+        if (runtimeFile.length() > maximumArtifactBytes) {
+            throw TraverseBundleException("runtime/runtime.wasm exceeds the configured size limit")
+        }
+
+        val bytes = runtimeFile.readBytes()
+        runtimeWasmDigest = "sha256:" + MessageDigest.getInstance("SHA-256")
+            .digest(bytes)
+            .joinToString("") { "%02x".format(it) }
+        if (normalizeDigest(bundle.runtimeWasmDigest) != runtimeWasmDigest) {
+            throw TraverseBundleException("bundle_digest_mismatch")
+        }
+
+        val module = try {
+            Parser.parse(bytes)
+        } catch (error: RuntimeException) {
+            throw TraverseBundleException("runtime/runtime.wasm is not a valid core WebAssembly module", error)
+        }
+        if (module.importSection().importCount() != 0) {
+            throw TraverseBundleException("runtime/runtime.wasm requires undeclared ambient imports")
+        }
+
+        val memoryExports = (0 until module.exportSection().exportCount())
+            .map { module.exportSection().getExport(it) }
+            .filter { it.exportType() == ExternalType.MEMORY }
+        if (memoryExports.size != 1 || memoryExports.single().name() != "memory") {
+            throw TraverseBundleException("runtime/runtime.wasm must export exactly one bridge memory")
+        }
+
+        instance = try {
+            Instance.builder(module).build()
+        } catch (error: RuntimeException) {
+            throw TraverseBundleException("runtime/runtime.wasm could not be instantiated", error)
+        }
+        REQUIRED_FUNCTIONS.forEach { (name, expectedType) ->
+            val actualType = try {
+                instance.exportType(name)
+            } catch (error: RuntimeException) {
+                throw TraverseBundleException("runtime/runtime.wasm is missing required export $name", error)
+            }
+            if (actualType != expectedType) {
+                throw TraverseBundleException("runtime/runtime.wasm has an invalid signature for $name")
+            }
+        }
+
+        val version = try {
+            instance.export("traverse_bridge_abi_version").apply()
+        } catch (error: RuntimeException) {
+            throw TraverseBundleException("bridge_version_mismatch", error)
+        }
+        if (version.size != 1 || version[0] != ABI_VERSION.toLong()) {
+            throw TraverseBundleException("bridge_version_mismatch")
+        }
+    }
+
+    companion object {
+        const val ABI_VERSION = 10_100
+        const val DEFAULT_MAXIMUM_ARTIFACT_BYTES = 32 * 1024 * 1024
+
+        private val I32_TO_I32 = FunctionType.of(listOf(ValType.I32), listOf(ValType.I32))
+        private val THREE_I32_TO_I32 = FunctionType.of(
+            listOf(ValType.I32, ValType.I32, ValType.I32),
+            listOf(ValType.I32),
+        )
+        private val REQUIRED_FUNCTIONS = mapOf(
+            "traverse_bridge_abi_version" to FunctionType.returning(ValType.I32),
+            "traverse_alloc" to I32_TO_I32,
+            "traverse_dealloc" to FunctionType.of(listOf(ValType.I32, ValType.I32), emptyList()),
+            "traverse_init" to THREE_I32_TO_I32,
+            "traverse_submit" to THREE_I32_TO_I32,
+            "traverse_next_event" to I32_TO_I32,
+            "traverse_cancel" to THREE_I32_TO_I32,
+            "traverse_shutdown" to I32_TO_I32,
+            "traverse_compatible_start" to THREE_I32_TO_I32,
+            "traverse_compatible_stop" to THREE_I32_TO_I32,
+            "traverse_compatible_kill" to THREE_I32_TO_I32,
+        )
+
+        private fun normalizeDigest(digest: String): String {
+            val normalized = digest.trim().lowercase()
+            return if (normalized.startsWith("sha256:")) normalized else "sha256:$normalized"
+        }
+    }
+}
+
+class TraverseBundleException(message: String, cause: Throwable? = null) :
+    IllegalArgumentException(message, cause)

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryRuntimeBridgeTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryRuntimeBridgeTest.kt
@@ -1,0 +1,80 @@
+package dev.traverse.embedder
+
+import com.dylibso.chicory.wabt.Wat2Wasm
+import java.io.File
+import java.security.MessageDigest
+import java.nio.file.Files
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ChicoryRuntimeBridgeTest {
+    @Test fun verifiesAndInstantiatesTheGovernedBridge() {
+        val wasm = Wat2Wasm.parse(validBridgeWat)
+        val bundle = fixtureBundle(wasm)
+
+        val bridge = ChicoryRuntimeBridge(bundle)
+
+        assertEquals(digest(wasm), bridge.runtimeWasmDigest)
+        assertEquals("runtime.wasm", bridge.runtimeFile.name)
+    }
+
+    @Test fun rejectsTamperingBeforeInstantiation() {
+        val bundle = fixtureBundle(
+            Wat2Wasm.parse(validBridgeWat),
+            "sha256:" + "0".repeat(64),
+        )
+
+        val error = assertThrows(TraverseBundleException::class.java) {
+            ChicoryRuntimeBridge(bundle)
+        }
+        assertEquals("bundle_digest_mismatch", error.message)
+    }
+
+    @Test fun rejectsAmbientImportsAndBridgeTen() {
+        val imported = Wat2Wasm.parse(
+            """
+            (module
+              (import "wasi_snapshot_preview1" "fd_write" (func))
+              (memory (export "memory") 1)
+              (func (export "traverse_bridge_abi_version") (result i32) i32.const 10100))
+            """.trimIndent(),
+        )
+        val importError = assertThrows(TraverseBundleException::class.java) {
+            ChicoryRuntimeBridge(fixtureBundle(imported))
+        }
+        assertEquals("runtime/runtime.wasm requires undeclared ambient imports", importError.message)
+
+        val bridgeTen = Wat2Wasm.parse(validBridgeWat.replace("i32.const 10100", "i32.const 10000"))
+        val versionError = assertThrows(TraverseBundleException::class.java) {
+            ChicoryRuntimeBridge(fixtureBundle(bridgeTen))
+        }
+        assertEquals("bridge_version_mismatch", versionError.message)
+    }
+
+    private fun fixtureBundle(wasm: ByteArray, declaredDigest: String = digest(wasm)): TraverseBundle {
+        val root = Files.createTempDirectory("traverse-kotlin-bridge").toFile()
+        val runtime = File(root, "runtime").apply { mkdirs() }
+        File(runtime, "runtime.wasm").writeBytes(wasm)
+        return TraverseBundle(root.absolutePath, declaredDigest)
+    }
+
+    private fun digest(bytes: ByteArray): String = "sha256:" +
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+    private val validBridgeWat = """
+        (module
+          (memory (export "memory") 1 16)
+          (func (export "traverse_bridge_abi_version") (result i32) i32.const 10100)
+          (func (export "traverse_alloc") (param i32) (result i32) i32.const 64)
+          (func (export "traverse_dealloc") (param i32 i32))
+          (func (export "traverse_init") (param i32 i32 i32) (result i32) i32.const 0)
+          (func (export "traverse_submit") (param i32 i32 i32) (result i32) i32.const 0)
+          (func (export "traverse_next_event") (param i32) (result i32) i32.const 0)
+          (func (export "traverse_cancel") (param i32 i32 i32) (result i32) i32.const 0)
+          (func (export "traverse_shutdown") (param i32) (result i32) i32.const 0)
+          (func (export "traverse_compatible_start") (param i32 i32 i32) (result i32) i32.const 0)
+          (func (export "traverse_compatible_stop") (param i32 i32 i32) (result i32) i32.const 0)
+          (func (export "traverse_compatible_kill") (param i32 i32 i32) (result i32) i32.const 0))
+        """.trimIndent()
+}


### PR DESCRIPTION
## Summary

Add the first production Kotlin/Android runtime-WASM adapter slice: an exact Chicory dependency pin and a fail-closed loader for the complete bridge 1.1 surface.

## Governing Spec

- `068-public-platform-embedder-packages`
- `071-native-runtime-wasm-bridge`
- `072-native-bridge-compatible-lifecycle`

## Project Item

- https://github.com/traverse-framework/traverse/issues/648
- https://github.com/orgs/traverse-framework/projects/1/

## Definition of Done

- [x] Pin and review a pure-JVM Chicory engine compatible with Android minSdk 28.
- [x] Verify the runtime artifact digest and size before parsing or instantiation.
- [x] Reject ambient imports and validate the complete bridge 1.1 memory, function-signature, and ABI surface.
- [x] Cover valid loading, tampering, WASI-style imports, and bridge 1.0 rejection with Android unit tests.
- [ ] Implement JSON marshalling, serialized event draining, and resource/deadline enforcement.
- [ ] Pass shared conformance and Compose reference-app integration without a sidecar.

## Validation

- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@17 ANDROID_HOME=/opt/homebrew/share/android-commandlinetools /private/tmp/gradle-8.7/bin/gradle :traverse-embedder:testDebugUnitTest --no-daemon`
- [x] `git diff --check`

## Notes

This is a bounded production slice of #648, not ticket closure. Chicory 1.7.5 does not expose fuel or epoch interruption controls; that limitation and the remaining release work are recorded in dependency evidence.
