### PR TITLE
Kotlin: marshal native bridge requests

### DIFF
--- a/packages/kotlin/TraverseEmbedder/README.md
+++ b/packages/kotlin/TraverseEmbedder/README.md
@@ -23,3 +23,7 @@ copies runtime-owned outputs before the next mutation, releases every caller
 allocation exactly once, bounds output descriptors, and exposes ordered
 single-event draining. Typed public result mapping, deadline enforcement,
 shared conformance, and Compose integration remain tracked by #648.
+
+`RuntimeTraverseEmbedder` maps that boundary into stable public Kotlin
+submission, event, and compatible-lifecycle result types while preserving
+runtime-owned identifiers and statuses.

--- a/packages/kotlin/TraverseEmbedder/README.md
+++ b/packages/kotlin/TraverseEmbedder/README.md
@@ -17,3 +17,9 @@ the complete `runtime-wasm-bridge/1.1.0` memory, function-signature, and ABI
 surface without linking Chicory WASI. Runtime JSON marshalling, serialized
 event draining, release evidence publication, and Compose reference-app
 integration remain tracked by Traverse #648.
+
+`ChicoryBridgeClient` now implements the serialized UTF-8 JSON ABI boundary,
+copies runtime-owned outputs before the next mutation, releases every caller
+allocation exactly once, bounds output descriptors, and exposes ordered
+single-event draining. Typed public result mapping, deadline enforcement,
+shared conformance, and Compose integration remain tracked by #648.

--- a/packages/kotlin/TraverseEmbedder/dependency-review.json
+++ b/packages/kotlin/TraverseEmbedder/dependency-review.json
@@ -14,5 +14,11 @@
   "known_limitations": [
     "Chicory 1.7.5 does not expose fuel or epoch interruption controls.",
     "Runtime JSON marshalling, serialized event draining, and deadline enforcement remain follow-up work before package release."
-  ]
+  ],
+  "wire_format_dependency": {
+    "package": "org.jetbrains.kotlinx:kotlinx-serialization-json",
+    "version": "1.7.3",
+    "license": "Apache-2.0",
+    "purpose": "Strict typed mapping of runtime-owned UTF-8 JSON results without Android platform JSON stubs"
+  }
 }

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/build.gradle.kts
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/build.gradle.kts
@@ -23,6 +23,7 @@ android {
 dependencies {
     implementation("com.dylibso.chicory:runtime:1.7.5")
     implementation("com.dylibso.chicory:wasm:1.7.5")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     testImplementation("junit:junit:4.13.2")
     testImplementation("com.dylibso.chicory:wabt:1.7.5")
 }

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/ChicoryBridgeClient.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/ChicoryBridgeClient.kt
@@ -1,0 +1,101 @@
+package dev.traverse.embedder
+
+import java.nio.charset.StandardCharsets
+
+/** Serialized UTF-8 JSON client for the governed runtime-WASM bridge. */
+class ChicoryBridgeClient(
+    bridge: ChicoryRuntimeBridge,
+    private val maximumOutputBytes: Int = DEFAULT_MAXIMUM_OUTPUT_BYTES,
+) {
+    private val instance = bridge.instance
+    private val memory = instance.memory()
+    private val allocate = instance.export("traverse_alloc")
+    private val deallocate = instance.export("traverse_dealloc")
+
+    init {
+        require(maximumOutputBytes > 0) { "maximum bridge output size must be positive" }
+    }
+
+    @Synchronized fun initialize(configJson: String): String =
+        invokeWithInput("traverse_init", configJson)
+
+    @Synchronized fun submit(submissionJson: String): String =
+        invokeWithInput("traverse_submit", submissionJson)
+
+    @Synchronized fun cancel(cancellationJson: String): String =
+        invokeWithInput("traverse_cancel", cancellationJson)
+
+    @Synchronized fun compatibleStart(requestJson: String): String =
+        invokeWithInput("traverse_compatible_start", requestJson)
+
+    @Synchronized fun compatibleStop(requestJson: String): String =
+        invokeWithInput("traverse_compatible_stop", requestJson)
+
+    @Synchronized fun compatibleKill(requestJson: String): String =
+        invokeWithInput("traverse_compatible_kill", requestJson)
+
+    @Synchronized fun nextEvent(): String? {
+        val descriptor = allocate(DESCRIPTOR_BYTES)
+        try {
+            val status = instance.export("traverse_next_event").apply(descriptor.toLong()).single().toInt()
+            if (status == STATUS_EMPTY) return null
+            return readResult(status, descriptor)
+        } finally {
+            deallocate.apply(descriptor.toLong(), DESCRIPTOR_BYTES.toLong())
+        }
+    }
+
+    @Synchronized fun shutdown(): String {
+        val descriptor = allocate(DESCRIPTOR_BYTES)
+        try {
+            val status = instance.export("traverse_shutdown").apply(descriptor.toLong()).single().toInt()
+            return readResult(status, descriptor)
+        } finally {
+            deallocate.apply(descriptor.toLong(), DESCRIPTOR_BYTES.toLong())
+        }
+    }
+
+    private fun invokeWithInput(export: String, inputJson: String): String {
+        val input = inputJson.toByteArray(StandardCharsets.UTF_8)
+        val inputPointer = allocate(input.size)
+        val descriptor = allocate(DESCRIPTOR_BYTES)
+        try {
+            memory.write(inputPointer, input)
+            val status = instance.export(export)
+                .apply(inputPointer.toLong(), input.size.toLong(), descriptor.toLong())
+                .single()
+                .toInt()
+            return readResult(status, descriptor)
+        } finally {
+            deallocate.apply(descriptor.toLong(), DESCRIPTOR_BYTES.toLong())
+            deallocate.apply(inputPointer.toLong(), input.size.toLong())
+        }
+    }
+
+    private fun allocate(length: Int): Int {
+        val pointer = allocate.apply(length.toLong()).single().toInt()
+        if (pointer < 0) throw TraverseBridgeException(STATUS_RESOURCE_LIMIT, "bridge allocation failed")
+        return pointer
+    }
+
+    private fun readResult(status: Int, descriptor: Int): String {
+        val pointer = memory.readInt(descriptor)
+        val length = memory.readInt(descriptor + Int.SIZE_BYTES)
+        if (pointer < 0 || length < 0 || length > maximumOutputBytes) {
+            throw TraverseBridgeException(STATUS_INVALID_DESCRIPTOR, "bridge_invalid_descriptor")
+        }
+        val output = memory.readBytes(pointer, length).toString(StandardCharsets.UTF_8)
+        if (status < 0) throw TraverseBridgeException(status, output)
+        return output
+    }
+
+    companion object {
+        const val DEFAULT_MAXIMUM_OUTPUT_BYTES = 1024 * 1024
+        private const val DESCRIPTOR_BYTES = 8
+        private const val STATUS_EMPTY = 0
+        private const val STATUS_INVALID_DESCRIPTOR = -3
+        private const val STATUS_RESOURCE_LIMIT = -4
+    }
+}
+
+class TraverseBridgeException(val status: Int, message: String) : IllegalStateException(message)

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/ChicoryRuntimeBridge.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/ChicoryRuntimeBridge.kt
@@ -16,8 +16,7 @@ class ChicoryRuntimeBridge(
     val runtimeFile: File
     val runtimeWasmDigest: String
 
-    @Suppress("unused")
-    private val instance: Instance
+    internal val instance: Instance
 
     init {
         require(maximumArtifactBytes > 0) { "maximum runtime WASM size must be positive" }

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/RuntimeTraverseEmbedder.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/RuntimeTraverseEmbedder.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
 /** Typed public embedder backed exclusively by runtime-owned bridge results. */
-class RuntimeTraverseEmbedder private constructor(private val client: ChicoryBridgeClient) {
+class RuntimeTraverseEmbedder internal constructor(private val client: ChicoryBridgeClient) {
     constructor(bundle: TraverseBundle) : this(ChicoryBridgeClient(ChicoryRuntimeBridge(bundle)))
 
     fun initialize(configJson: String): String = client.initialize(configJson)
@@ -56,8 +56,11 @@ class RuntimeTraverseEmbedder private constructor(private val client: ChicoryBri
         instanceId: String? = null,
     ): String = buildJsonObject {
         put("capability_id", capabilityId)
-        if (inputJson != null) put("input", Json.parseToJsonElement(inputJson))
-        if (instanceId == null) put("instance_id", JsonNull) else put("instance_id", instanceId)
+        if (inputJson != null) {
+            put("input", Json.parseToJsonElement(inputJson))
+        } else {
+            if (instanceId == null) put("instance_id", JsonNull) else put("instance_id", instanceId)
+        }
     }.toString()
 
     private fun compatibleResult(json: String): TraverseCompatibleResult {

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/RuntimeTraverseEmbedder.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/RuntimeTraverseEmbedder.kt
@@ -1,0 +1,86 @@
+package dev.traverse.embedder
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/** Typed public embedder backed exclusively by runtime-owned bridge results. */
+class RuntimeTraverseEmbedder private constructor(private val client: ChicoryBridgeClient) {
+    constructor(bundle: TraverseBundle) : this(ChicoryBridgeClient(ChicoryRuntimeBridge(bundle)))
+
+    fun initialize(configJson: String): String = client.initialize(configJson)
+
+    fun submit(submission: TraverseSubmission): TraverseSubmissionResult {
+        val result = resultObject(client.submit(buildJsonObject {
+            put("target_id", submission.targetId)
+            put("input", Json.parseToJsonElement(submission.inputJson))
+        }.toString()))
+        return TraverseSubmissionResult(result.requiredString("session_id"), result.requiredString("status"))
+    }
+
+    fun subscribe(): List<TraverseRuntimeEvent> = buildList {
+        while (true) {
+            val value = resultObject(client.nextEvent() ?: break)
+            add(TraverseRuntimeEvent(
+                value.requiredInt("sequence"),
+                value.requiredString("target_id"),
+                value.requiredString("status"),
+                value.optionalString("instance_id"),
+            ))
+        }
+    }
+
+    fun cancel(sessionId: String): String = client.cancel(buildJsonObject {
+        put("session_id", sessionId)
+    }.toString())
+
+    fun compatibleStart(capabilityId: String, inputJson: String): TraverseCompatibleResult =
+        compatibleResult(client.compatibleStart(compatibleRequest(capabilityId, inputJson = inputJson)))
+
+    fun compatibleStop(capabilityId: String, instanceId: String?): TraverseCompatibleResult =
+        compatibleResult(client.compatibleStop(compatibleRequest(capabilityId, instanceId = instanceId)))
+
+    fun compatibleKill(capabilityId: String, instanceId: String?): TraverseCompatibleResult =
+        compatibleResult(client.compatibleKill(compatibleRequest(capabilityId, instanceId = instanceId)))
+
+    fun shutdown(): String = client.shutdown()
+
+    private fun compatibleRequest(
+        capabilityId: String,
+        inputJson: String? = null,
+        instanceId: String? = null,
+    ): String = buildJsonObject {
+        put("capability_id", capabilityId)
+        if (inputJson != null) put("input", Json.parseToJsonElement(inputJson))
+        if (instanceId == null) put("instance_id", JsonNull) else put("instance_id", instanceId)
+    }.toString()
+
+    private fun compatibleResult(json: String): TraverseCompatibleResult {
+        val result = resultObject(json)
+        return TraverseCompatibleResult(result.optionalString("instance_id"), result.requiredString("status"))
+    }
+
+    private fun resultObject(json: String): JsonObject = try {
+        Json.parseToJsonElement(json).jsonObject
+    } catch (error: IllegalArgumentException) {
+        throw TraverseBridgeException(-2, "bridge_invalid_json")
+    }
+
+    private fun JsonObject.requiredString(name: String): String =
+        this[name]?.jsonPrimitive?.content
+            ?: throw TraverseBridgeException(-2, "bridge result is missing $name")
+
+    private fun JsonObject.optionalString(name: String): String? {
+        val value = this[name] ?: return null
+        return if (value is JsonNull) null else value.jsonPrimitive.content
+    }
+
+    private fun JsonObject.requiredInt(name: String): Int =
+        this[name]?.jsonPrimitive?.int
+            ?: throw TraverseBridgeException(-2, "bridge result is missing $name")
+}

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryBridgeClientTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryBridgeClientTest.kt
@@ -1,0 +1,69 @@
+package dev.traverse.embedder
+
+import com.dylibso.chicory.wabt.Wat2Wasm
+import java.io.File
+import java.nio.file.Files
+import java.security.MessageDigest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChicoryBridgeClientTest {
+    @Test fun copiesJsonResultsAndDrainsEventsInOrder() {
+        val client = ChicoryBridgeClient(ChicoryRuntimeBridge(fixtureBundle()))
+
+        assertEquals("{\"status\":\"ready\"}", client.initialize("{}"))
+        assertEquals("{\"status\":\"accepted\"}", client.submit("{\"target_id\":\"demo\"}"))
+        assertEquals("{\"sequence\":1}", client.nextEvent())
+        assertNull(client.nextEvent())
+        assertEquals("{\"status\":\"stopped\"}", client.shutdown())
+    }
+
+    private fun fixtureBundle(): TraverseBundle {
+        val wasm = Wat2Wasm.parse(bridgeWat)
+        val root = Files.createTempDirectory("traverse-kotlin-client").toFile()
+        val runtime = File(root, "runtime").apply { mkdirs() }
+        File(runtime, "runtime.wasm").writeBytes(wasm)
+        val digest = "sha256:" + MessageDigest.getInstance("SHA-256")
+            .digest(wasm).joinToString("") { "%02x".format(it) }
+        return TraverseBundle(root.absolutePath, digest)
+    }
+
+    private val bridgeWat = """
+        (module
+          (memory (export "memory") 1 16)
+          (data (i32.const 512) "{\22status\22:\22ready\22}")
+          (data (i32.const 544) "{\22status\22:\22accepted\22}")
+          (data (i32.const 576) "{\22sequence\22:1}")
+          (data (i32.const 608) "{\22status\22:\22stopped\22}")
+          (global ${'$'}next (mut i32) (i32.const 0))
+          (func (export "traverse_bridge_abi_version") (result i32) i32.const 10100)
+          (func (export "traverse_alloc") (param i32) (result i32) i32.const 64)
+          (func (export "traverse_dealloc") (param i32 i32))
+          (func ${'$'}result (param ${'$'}d i32) (param ${'$'}p i32) (param ${'$'}n i32) (result i32)
+            local.get ${'$'}d local.get ${'$'}p i32.store
+            local.get ${'$'}d i32.const 4 i32.add local.get ${'$'}n i32.store
+            i32.const 0)
+          (func (export "traverse_init") (param i32 i32 i32) (result i32)
+            local.get 2 i32.const 512 i32.const 18 call ${'$'}result)
+          (func (export "traverse_submit") (param i32 i32 i32) (result i32)
+            local.get 2 i32.const 544 i32.const 21 call ${'$'}result)
+          (func (export "traverse_next_event") (param i32) (result i32)
+            global.get ${'$'}next i32.eqz
+            if (result i32)
+              i32.const 1 global.set ${'$'}next
+              local.get 0 i32.const 576 i32.const 14 call ${'$'}result drop
+              i32.const 1
+            else i32.const 0 end)
+          (func (export "traverse_cancel") (param i32 i32 i32) (result i32)
+            local.get 2 i32.const 544 i32.const 21 call ${'$'}result)
+          (func (export "traverse_compatible_start") (param i32 i32 i32) (result i32)
+            local.get 2 i32.const 544 i32.const 21 call ${'$'}result)
+          (func (export "traverse_compatible_stop") (param i32 i32 i32) (result i32)
+            local.get 2 i32.const 544 i32.const 21 call ${'$'}result)
+          (func (export "traverse_compatible_kill") (param i32 i32 i32) (result i32)
+            local.get 2 i32.const 544 i32.const 21 call ${'$'}result)
+          (func (export "traverse_shutdown") (param i32) (result i32)
+            local.get 0 i32.const 608 i32.const 20 call ${'$'}result))
+    """.trimIndent()
+}

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryBridgeClientTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryBridgeClientTest.kt
@@ -13,10 +13,25 @@ class ChicoryBridgeClientTest {
         val client = ChicoryBridgeClient(ChicoryRuntimeBridge(fixtureBundle()))
 
         assertEquals("{\"status\":\"ready\"}", client.initialize("{}"))
-        assertEquals("{\"status\":\"accepted\"}", client.submit("{\"target_id\":\"demo\"}"))
-        assertEquals("{\"sequence\":1}", client.nextEvent())
+        assertEquals("{\"session_id\":\"s1\",\"status\":\"accepted\"}", client.submit("{\"target_id\":\"demo\"}"))
+        assertEquals("{\"sequence\":1,\"target_id\":\"demo\",\"status\":\"completed\"}", client.nextEvent())
         assertNull(client.nextEvent())
         assertEquals("{\"status\":\"stopped\"}", client.shutdown())
+    }
+
+    @Test fun mapsRuntimeOwnedResultsIntoPublicTypes() {
+        val runtime = RuntimeTraverseEmbedder(ChicoryBridgeClient(ChicoryRuntimeBridge(fixtureBundle())))
+        runtime.initialize("{}")
+
+        assertEquals(
+            TraverseSubmissionResult("s1", "accepted"),
+            runtime.submit(TraverseSubmission("demo", "{}")),
+        )
+        assertEquals(
+            listOf(TraverseRuntimeEvent(1, "demo", "completed")),
+            runtime.subscribe(),
+        )
+        assertEquals("{\"status\":\"stopped\"}", runtime.shutdown())
     }
 
     private fun fixtureBundle(): TraverseBundle {
@@ -33,9 +48,9 @@ class ChicoryBridgeClientTest {
         (module
           (memory (export "memory") 1 16)
           (data (i32.const 512) "{\22status\22:\22ready\22}")
-          (data (i32.const 544) "{\22status\22:\22accepted\22}")
-          (data (i32.const 576) "{\22sequence\22:1}")
-          (data (i32.const 608) "{\22status\22:\22stopped\22}")
+          (data (i32.const 544) "{\22session_id\22:\22s1\22,\22status\22:\22accepted\22}")
+          (data (i32.const 608) "{\22sequence\22:1,\22target_id\22:\22demo\22,\22status\22:\22completed\22}")
+          (data (i32.const 704) "{\22status\22:\22stopped\22}")
           (global ${'$'}next (mut i32) (i32.const 0))
           (func (export "traverse_bridge_abi_version") (result i32) i32.const 10100)
           (func (export "traverse_alloc") (param i32) (result i32) i32.const 64)
@@ -47,23 +62,23 @@ class ChicoryBridgeClientTest {
           (func (export "traverse_init") (param i32 i32 i32) (result i32)
             local.get 2 i32.const 512 i32.const 18 call ${'$'}result)
           (func (export "traverse_submit") (param i32 i32 i32) (result i32)
-            local.get 2 i32.const 544 i32.const 21 call ${'$'}result)
+            local.get 2 i32.const 544 i32.const 39 call ${'$'}result)
           (func (export "traverse_next_event") (param i32) (result i32)
             global.get ${'$'}next i32.eqz
             if (result i32)
               i32.const 1 global.set ${'$'}next
-              local.get 0 i32.const 576 i32.const 14 call ${'$'}result drop
+              local.get 0 i32.const 608 i32.const 54 call ${'$'}result drop
               i32.const 1
             else i32.const 0 end)
           (func (export "traverse_cancel") (param i32 i32 i32) (result i32)
-            local.get 2 i32.const 544 i32.const 21 call ${'$'}result)
+            local.get 2 i32.const 544 i32.const 39 call ${'$'}result)
           (func (export "traverse_compatible_start") (param i32 i32 i32) (result i32)
-            local.get 2 i32.const 544 i32.const 21 call ${'$'}result)
+            local.get 2 i32.const 544 i32.const 39 call ${'$'}result)
           (func (export "traverse_compatible_stop") (param i32 i32 i32) (result i32)
-            local.get 2 i32.const 544 i32.const 21 call ${'$'}result)
+            local.get 2 i32.const 544 i32.const 39 call ${'$'}result)
           (func (export "traverse_compatible_kill") (param i32 i32 i32) (result i32)
-            local.get 2 i32.const 544 i32.const 21 call ${'$'}result)
+            local.get 2 i32.const 544 i32.const 39 call ${'$'}result)
           (func (export "traverse_shutdown") (param i32) (result i32)
-            local.get 0 i32.const 608 i32.const 20 call ${'$'}result))
+            local.get 0 i32.const 704 i32.const 20 call ${'$'}result))
     """.trimIndent()
 }


### PR DESCRIPTION
## Summary

- add a serialized UTF-8 JSON client over the merged Chicory bridge loader
- copy runtime-owned output before every subsequent mutation and release caller allocations exactly once
- bound and validate output descriptors and surface stable negative bridge statuses
- expose ordered one-at-a-time event draining plus init, submit, cancel, lifecycle, and shutdown calls
- map submissions, ordered events, and compatible lifecycle results into stable public Kotlin types

Advances #648.

## Governing Spec

- `068-public-platform-embedder-packages`
- `071-native-runtime-wasm-bridge`
- `072-native-bridge-compatible-lifecycle`

## Project Item

- Traverse Project 1: #648

## Definition of Done

- [x] All bridge inputs are caller-owned UTF-8 JSON allocations released exactly once.
- [x] Runtime-owned outputs are copied before another mutating call.
- [x] Descriptors and output sizes fail closed at the host boundary.
- [x] Event draining is serialized and preserves runtime order and empty-queue semantics.
- [x] Init, submit, cancel, compatible lifecycle, and shutdown exports share one marshalling path.
- [x] Runtime-owned identifiers and statuses map into the public typed API without platform semantics.

## Validation

- `:traverse-embedder:testDebugUnitTest --rerun-tasks` (7 tests; 16 tasks executed)
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-issue-648-client-pr-body.md`
- `bash scripts/ci/repository_checks.sh`
- `git diff --check`
