### PR TITLE
chore: bump version to v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ed25519-dalek 2.2.0",
  "qrcode",
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "semver",
  "serde",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-embedder"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "semver",
  "serde",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "ed25519-dalek 3.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/traverse-framework/traverse"
 rust-version = "1.94"
-version = "0.7.0"
+version = "0.8.0"
 
 [workspace.dependencies]
-traverse-contracts = { path = "crates/traverse-contracts", version = "0.7.0" }
-traverse-registry = { path = "crates/traverse-registry", version = "0.7.0" }
-traverse-runtime = { path = "crates/traverse-runtime", version = "0.7.0" }
+traverse-contracts = { path = "crates/traverse-contracts", version = "0.8.0" }
+traverse-registry = { path = "crates/traverse-registry", version = "0.8.0" }
+traverse-runtime = { path = "crates/traverse-runtime", version = "0.8.0" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/traverse-framework/traverse/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
-[![Version](https://img.shields.io/badge/version-v0.7.0-blue)](https://github.com/traverse-framework/traverse/releases)
+[![Version](https://img.shields.io/badge/version-v0.8.0-blue)](https://github.com/traverse-framework/traverse/releases)
 
 Your business logic runs in the browser, on your server, and in a cloud function.
 They drift. You maintain three versions of the same behavior.
@@ -102,7 +102,7 @@ Scaffolds a governed app bundle. Add your capability contracts, workflows, and W
 
 ### Consumer and release surfaces
 
-- [docs/releases/v0.7.0.md](docs/releases/v0.7.0.md) — current release notes
+- [docs/releases/v0.8.0.md](docs/releases/v0.8.0.md) — current release notes
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) — packaged runtime artifact

--- a/docs/compatibility-policy.md
+++ b/docs/compatibility-policy.md
@@ -14,7 +14,7 @@ The release-facing downstream compatibility statement for the current `youaskm3`
 
 The current Traverse release notes are:
 
-- `docs/releases/v0.7.0.md`
+- `docs/releases/v0.8.0.md`
 
 ## v1 Stability Statement
 

--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,0 +1,52 @@
+# Traverse v0.8.0
+
+Release date: 2026-07-16
+
+Traverse v0.8.0 is the public embedder SDK release. It ships the first two `embedder-api/1.0.0` client SDKs — Rust (Linux GTK/CLI) and Web/TypeScript, both with real bundle execution — and completes the durable event journal so subscriptions survive broker restarts without losing continuity.
+
+Consumers that only need public app validation and registration can remain pinned to `v0.5.0`. Consumers that need provider-neutral governed inference execution can remain pinned to `v0.6.0`. Consumers validating the `traverse-starter` reference app path can remain pinned to `v0.7.0`. Consumers embedding Traverse as a Rust or Web client, or relying on durable event replay across restarts, should move to `v0.8.0`.
+
+## Highlights
+
+- Ships the public `traverse-embedder` Rust SDK (spec 068) for Linux GTK and CLI clients: every `embedder-api/1.0.0` operation (init/shutdown/submit/subscribe and compatible start/stop/kill) against an application-owned bundle, with a deterministic test double and a CI-enforced shared conformance suite.
+- Ships the public Web/TypeScript embedder SDK (spec 068) with real runtime-WASM execution: `BundleEmbedder` loads a bundle, digest-verifies and Traverse-Host-ABI-validates every bundled WASM capability, and executes it directly in the browser's native WebAssembly host through a minimal WASI `preview1` shim — no nested engine, no server sidecar.
+- Completes the durable event journal: a segmented storage engine, a bounded write path with revocation and audit, and journal-backed replay through `subscribe`/`poll` so durable subscriptions resume correctly across a full broker restart (specs 036, 066, 067).
+- Adds the deterministic `doc-approval.recommend` capability and canonical `doc-approval.pipeline` workflow, completing the spec 069 example pipeline.
+- Hardens the runtime: bounds HTTP API connection timeouts with a worker pool (slowloris fix), rejects placeholder Sigstore evidence, classifies governed artifacts via the approved-specs registry instead of path heuristics, and applies the artifact-verification gate to workflow pipeline steps.
+- Fixes idempotency checks across the event and capability registries to compare on registration/validation content instead of wall-clock timestamps.
+- Fixes the release-version pipeline itself: internal crate dependency pins now stay in sync with the workspace version on every `bump_version.sh` run instead of going stale.
+
+## Compatibility Notes
+
+- Traverse remains a `0.x` project. Public surfaces are governed and validated, but compatibility can still move before a `1.0` stability commitment.
+- The v0.5.0 public CLI app registration and durable workspace-state loading surfaces remain available.
+- The v0.6.0 governed model dependency execution surface remains available.
+- The v0.7.0 `traverse-starter` reference app path remains available.
+- Public Swift, Kotlin, and .NET embedder SDKs are in progress and not part of this release.
+- No cross-platform binary package is attached to this release. The release publishes source and release notes.
+
+## Validation
+
+Release preparation must pass these local gates before tagging:
+
+```bash
+cargo test
+cargo clippy --workspace --all-targets -- -D warnings
+bash scripts/ci/repository_checks.sh
+bash scripts/ci/coverage_gate.sh
+git diff --check
+```
+
+The GitHub PR checks must also pass:
+
+- `repository-checks`
+- `coverage-gate`
+- `pr-hygiene`
+- `spec-alignment`
+
+## Traceability
+
+- Release issue: https://github.com/traverse-framework/traverse/issues/727
+- Governing specs: `036-event-subscription-replay`, `048-semver-publishing-pipeline`, `066-durable-identity-event-delivery`, `067-durable-journal-retention-and-write-limits`, `068-public-platform-embedder-packages`, `069-doc-approval-pipeline-canonicalization`
+- Included PRs: #650, #672, #646, #700, #693, #661, #662, #709, #678, #612, #666, #619, #677, #633, #640, #652, #656, #722
+- Included issues: #650, #646, #555, #659, #721

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -21,6 +21,7 @@ required_files=(
   "docs/releases/v0.5.0.md"
   "docs/releases/v0.6.0.md"
   "docs/releases/v0.7.0.md"
+  "docs/releases/v0.8.0.md"
   "docs/troubleshooting.md"
   "docs/adapter-boundaries.md"
   "docs/contract-publication-policy.md"
@@ -353,8 +354,8 @@ grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-source-build-consumer-packaging.md" README.md
 grep -q "docs/v0.3.0-downstream-validation-path.md" README.md
 grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" README.md
-grep -q 'version = "0.7.0"' Cargo.toml
-grep -q "docs/releases/v0.7.0.md" README.md
+grep -q 'version = "0.8.0"' Cargo.toml
+grep -q "docs/releases/v0.8.0.md" README.md
 grep -q "Traverse v0.4.0" docs/releases/v0.4.0.md
 grep -q "044-application-bundle-manifest" docs/releases/v0.4.0.md
 grep -q "045-governed-model-dependency-resolution" docs/releases/v0.4.0.md
@@ -389,6 +390,12 @@ grep -q "App-References" docs/releases/v0.7.0.md
 grep -q "v0.5.0 minimum" docs/releases/v0.7.0.md
 grep -q "bash scripts/ci/traverse_starter_example_smoke.sh" docs/releases/v0.7.0.md
 grep -q "coverage-gate" docs/releases/v0.7.0.md
+grep -q "Traverse v0.8.0" docs/releases/v0.8.0.md
+grep -q "public embedder SDK release" docs/releases/v0.8.0.md
+grep -q "traverse-embedder" docs/releases/v0.8.0.md
+grep -q "journal-backed replay" docs/releases/v0.8.0.md
+grep -q "doc-approval.recommend" docs/releases/v0.8.0.md
+grep -q "coverage-gate" docs/releases/v0.8.0.md
 grep -q "cargo build" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-cli -- serve" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-mcp -- stdio" docs/v0.3.0-source-build-consumer-packaging.md


### PR DESCRIPTION
## Summary
- Bumps the workspace version to 0.8.0 (`scripts/ci/bump_version.sh`, now fixed by #722 to keep internal crate version pins in sync atomically). 122+ unreleased commits have accumulated on main since v0.7.0 (2026-07-03), including the Rust and Web embedder SDKs, the durable event journal, and the doc-approval canonical pipeline.
- Adds `docs/releases/v0.8.0.md` and updates `README.md` / `docs/compatibility-policy.md` to point at it, and updates the pinned version/content checks in `scripts/ci/repository_checks.sh` — this gate hard-pins the current release version and release-notes path (confirmed by inspecting the v0.7.0 release commit), so a version bump alone does not pass CI.
- Tracked by release issue #727.

## Governing Spec
- 048-semver-publishing-pipeline
- 065-sigstore-bundle-verification
- 004-spec-alignment-gate

## Project Item
#727

## Validation
- `cargo build --workspace` passes cleanly at 0.8.0 across every crate
- `cargo clippy --workspace --all-targets -- -D warnings` passes with no warnings
- `bash scripts/ci/repository_checks.sh` passes locally
- `git diff --check` clean
- CI passes on this PR