### PR TITLE
Swift: marshal native bridge requests

### DIFF
--- a/packages/swift/TraverseEmbedder/README.md
+++ b/packages/swift/TraverseEmbedder/README.md
@@ -14,6 +14,9 @@ SHA-256 digest and a 32 MiB default artifact limit before parsing, rejects all
 ambient imports, and validates the memory, function signatures, and ABI version
 required by `runtime-wasm-bridge/1.1.0`, including compatible lifecycle exports.
 It never links WasmKitWASI. JSON
+marshalling is provided by `WasmKitBridgeClient`, which serializes calls,
+copies runtime-owned output before the next mutation, bounds descriptors, and
+releases every caller allocation exactly once.
 marshalling, the serialized event-drain loop, evidence publication, and
 app-reference integration remain tracked by Traverse #647.
 

--- a/packages/swift/TraverseEmbedder/README.md
+++ b/packages/swift/TraverseEmbedder/README.md
@@ -17,8 +17,12 @@ It never links WasmKitWASI. JSON
 marshalling is provided by `WasmKitBridgeClient`, which serializes calls,
 copies runtime-owned output before the next mutation, bounds descriptors, and
 releases every caller allocation exactly once.
-marshalling, the serialized event-drain loop, evidence publication, and
-app-reference integration remain tracked by Traverse #647.
+
+`RuntimeTraverseEmbedder` maps that boundary into stable public Swift
+submission, event, and compatible-lifecycle result types without synthesizing
+runtime identifiers, ordering, or statuses.
+Evidence publication and app-reference integration remain tracked by Traverse
+#647.
 
 Release tooling constructs `TraverseReleaseEvidence` with the semantic package
 version, runtime-WASM digest, conformance version, and supported iOS/macOS host

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/RuntimeTraverseEmbedder.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/RuntimeTraverseEmbedder.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Typed public embedder backed exclusively by runtime-owned bridge results.
+public final class RuntimeTraverseEmbedder: @unchecked Sendable {
+    private let client: WasmKitBridgeClient
+
+    public convenience init(bundle: TraverseBundle) throws {
+        try self.init(client: WasmKitBridgeClient(bridge: WasmKitRuntimeBridge(bundle: bundle)))
+    }
+
+    public init(client: WasmKitBridgeClient) {
+        self.client = client
+    }
+
+    public func initialize(configJSON: Data) throws -> Data {
+        try client.initialize(configJSON: configJSON)
+    }
+
+    public func submit(_ submission: TraverseSubmission) throws -> TraverseSubmissionResult {
+        let request = try encode([
+            "target_id": submission.targetID,
+            "input": try JSONSerialization.jsonObject(with: submission.inputJSON, options: .fragmentsAllowed),
+        ])
+        let result = try object(try client.submit(requestJSON: request))
+        return TraverseSubmissionResult(
+            sessionID: try requiredString("session_id", in: result),
+            status: try requiredString("status", in: result)
+        )
+    }
+
+    public func subscribe() throws -> [TraverseRuntimeEvent] {
+        var events: [TraverseRuntimeEvent] = []
+        while let bytes = try client.nextEvent() {
+            let event = try object(bytes)
+            events.append(TraverseRuntimeEvent(
+                sequence: try requiredInt("sequence", in: event),
+                targetID: try requiredString("target_id", in: event),
+                status: try requiredString("status", in: event),
+                instanceID: optionalString("instance_id", in: event)
+            ))
+        }
+        return events
+    }
+
+    public func cancel(sessionID: String) throws -> Data {
+        try client.cancel(requestJSON: encode(["session_id": sessionID]))
+    }
+
+    public func compatibleStart(capabilityID: String, inputJSON: Data) throws -> TraverseCompatibleResult {
+        let request = try encode([
+            "capability_id": capabilityID,
+            "input": try JSONSerialization.jsonObject(with: inputJSON, options: .fragmentsAllowed),
+        ])
+        return try compatibleResult(client.compatibleStart(requestJSON: request))
+    }
+
+    public func compatibleStop(capabilityID: String, instanceID: String?) throws -> TraverseCompatibleResult {
+        try compatibleResult(client.compatibleStop(requestJSON: encode([
+            "capability_id": capabilityID,
+            "instance_id": (instanceID as Any?) ?? NSNull(),
+        ])))
+    }
+
+    public func compatibleKill(capabilityID: String, instanceID: String?) throws -> TraverseCompatibleResult {
+        try compatibleResult(client.compatibleKill(requestJSON: encode([
+            "capability_id": capabilityID,
+            "instance_id": (instanceID as Any?) ?? NSNull(),
+        ])))
+    }
+
+    public func shutdown() throws -> Data { try client.shutdown() }
+
+    private func compatibleResult(_ bytes: Data) throws -> TraverseCompatibleResult {
+        let result = try object(bytes)
+        return TraverseCompatibleResult(
+            instanceID: optionalString("instance_id", in: result),
+            status: try requiredString("status", in: result)
+        )
+    }
+
+    private func encode(_ value: [String: Any]) throws -> Data {
+        do {
+            return try JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+        } catch {
+            throw TraverseBridgeError(status: -2, message: "bridge_invalid_json")
+        }
+    }
+
+    private func object(_ data: Data) throws -> [String: Any] {
+        guard let value = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw TraverseBridgeError(status: -2, message: "bridge_invalid_json")
+        }
+        return value
+    }
+
+    private func requiredString(_ name: String, in value: [String: Any]) throws -> String {
+        guard let result = value[name] as? String else {
+            throw TraverseBridgeError(status: -2, message: "bridge result is missing \(name)")
+        }
+        return result
+    }
+
+    private func requiredInt(_ name: String, in value: [String: Any]) throws -> Int {
+        guard let result = value[name] as? Int else {
+            throw TraverseBridgeError(status: -2, message: "bridge result is missing \(name)")
+        }
+        return result
+    }
+
+    private func optionalString(_ name: String, in value: [String: Any]) -> String? {
+        value[name] as? String
+    }
+}

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitBridgeClient.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitBridgeClient.swift
@@ -1,0 +1,163 @@
+import Foundation
+import WasmKit
+
+/// Serialized UTF-8 JSON client for the governed runtime-WASM bridge.
+public final class WasmKitBridgeClient: @unchecked Sendable {
+    public static let defaultMaximumOutputBytes = 1024 * 1024
+
+    private let instance: Instance
+    private let memory: Memory
+    private let lock = NSLock()
+    private let maximumOutputBytes: Int
+
+    public init(
+        bridge: WasmKitRuntimeBridge,
+        maximumOutputBytes: Int = WasmKitBridgeClient.defaultMaximumOutputBytes
+    ) throws {
+        guard maximumOutputBytes > 0 else {
+            throw TraverseBridgeError(status: -4, message: "maximum bridge output size must be positive")
+        }
+        guard let memory = bridge.instance.exports[memory: "memory"] else {
+            throw TraverseBridgeError(status: -3, message: "bridge_invalid_descriptor")
+        }
+        self.instance = bridge.instance
+        self.memory = memory
+        self.maximumOutputBytes = maximumOutputBytes
+    }
+
+    public func initialize(configJSON: Data) throws -> Data {
+        try serialized { try invokeWithInput("traverse_init", input: configJSON) }
+    }
+
+    public func submit(requestJSON: Data) throws -> Data {
+        try serialized { try invokeWithInput("traverse_submit", input: requestJSON) }
+    }
+
+    public func cancel(requestJSON: Data) throws -> Data {
+        try serialized { try invokeWithInput("traverse_cancel", input: requestJSON) }
+    }
+
+    public func compatibleStart(requestJSON: Data) throws -> Data {
+        try serialized { try invokeWithInput("traverse_compatible_start", input: requestJSON) }
+    }
+
+    public func compatibleStop(requestJSON: Data) throws -> Data {
+        try serialized { try invokeWithInput("traverse_compatible_stop", input: requestJSON) }
+    }
+
+    public func compatibleKill(requestJSON: Data) throws -> Data {
+        try serialized { try invokeWithInput("traverse_compatible_kill", input: requestJSON) }
+    }
+
+    public func nextEvent() throws -> Data? {
+        try serialized {
+            let descriptor = try allocate(Self.descriptorBytes)
+            defer { try? deallocate(descriptor, length: Self.descriptorBytes) }
+            let status = try callStatus("traverse_next_event", [.i32(descriptor)])
+            if status == 0 { return nil }
+            return try readResult(status: status, descriptor: descriptor)
+        }
+    }
+
+    public func shutdown() throws -> Data {
+        try serialized {
+            let descriptor = try allocate(Self.descriptorBytes)
+            defer { try? deallocate(descriptor, length: Self.descriptorBytes) }
+            let status = try callStatus("traverse_shutdown", [.i32(descriptor)])
+            return try readResult(status: status, descriptor: descriptor)
+        }
+    }
+
+    private func invokeWithInput(_ export: String, input: Data) throws -> Data {
+        let inputPointer = try allocate(input.count)
+        let descriptor = try allocate(Self.descriptorBytes)
+        defer {
+            try? deallocate(descriptor, length: Self.descriptorBytes)
+            try? deallocate(inputPointer, length: input.count)
+        }
+        try write(input, at: inputPointer)
+        let status = try callStatus(export, [
+            .i32(inputPointer), .i32(UInt32(input.count)), .i32(descriptor),
+        ])
+        return try readResult(status: status, descriptor: descriptor)
+    }
+
+    private func allocate(_ length: Int) throws -> UInt32 {
+        guard let function = instance.exports[function: "traverse_alloc"] else {
+            throw TraverseBridgeError(status: -5, message: "bridge allocation export is unavailable")
+        }
+        let result = try function([.i32(UInt32(length))])
+        guard result.count == 1, case .i32(let pointer) = result[0] else {
+            throw TraverseBridgeError(status: -4, message: "bridge allocation failed")
+        }
+        return pointer
+    }
+
+    private func deallocate(_ pointer: UInt32, length: Int) throws {
+        guard let function = instance.exports[function: "traverse_dealloc"] else { return }
+        _ = try function([.i32(pointer), .i32(UInt32(length))])
+    }
+
+    private func callStatus(_ export: String, _ arguments: [Value]) throws -> Int32 {
+        guard let function = instance.exports[function: export] else {
+            throw TraverseBridgeError(status: -5, message: "bridge export \(export) is unavailable")
+        }
+        let result = try function(arguments)
+        guard result.count == 1, case .i32(let rawStatus) = result[0] else {
+            throw TraverseBridgeError(status: -5, message: "bridge export \(export) returned an invalid status")
+        }
+        return Int32(bitPattern: rawStatus)
+    }
+
+    private func readResult(status: Int32, descriptor: UInt32) throws -> Data {
+        let descriptorBytes = try read(at: descriptor, count: Self.descriptorBytes)
+        let pointer = descriptorBytes.prefix(4).withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }.littleEndian
+        let length = descriptorBytes.suffix(4).withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }.littleEndian
+        guard length <= UInt32(maximumOutputBytes) else {
+            throw TraverseBridgeError(status: -3, message: "bridge_invalid_descriptor")
+        }
+        let output = try read(at: pointer, count: Int(length))
+        if status < 0 {
+            throw TraverseBridgeError(
+                status: status,
+                message: String(data: output, encoding: .utf8) ?? "bridge_invalid_json"
+            )
+        }
+        return output
+    }
+
+    private func write(_ data: Data, at pointer: UInt32) throws {
+        guard Int(pointer) <= memory.data.count - data.count else {
+            throw TraverseBridgeError(status: -3, message: "bridge_invalid_descriptor")
+        }
+        _ = memory.withUnsafeMutableBufferPointer(offset: UInt(pointer), count: data.count) { buffer in
+            data.copyBytes(to: buffer.bindMemory(to: UInt8.self))
+        }
+    }
+
+    private func read(at pointer: UInt32, count: Int) throws -> Data {
+        let snapshot = memory.data
+        guard count >= 0, Int(pointer) <= snapshot.count - count else {
+            throw TraverseBridgeError(status: -3, message: "bridge_invalid_descriptor")
+        }
+        return Data(snapshot[Int(pointer)..<Int(pointer) + count])
+    }
+
+    private func serialized<T>(_ body: () throws -> T) rethrows -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body()
+    }
+
+    private static let descriptorBytes = 8
+}
+
+public struct TraverseBridgeError: Error, Equatable, Sendable {
+    public let status: Int32
+    public let message: String
+
+    public init(status: Int32, message: String) {
+        self.status = status
+        self.message = message
+    }
+}

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitRuntimeBridge.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitRuntimeBridge.swift
@@ -25,7 +25,7 @@ public final class WasmKitRuntimeBridge: @unchecked Sendable {
     ]
 
     private let store: Store
-    private let instance: Instance
+    let instance: Instance
 
     public let runtimeURL: URL
     public let runtimeWasmDigest: String

--- a/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
+++ b/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
@@ -127,6 +127,17 @@ import WAT
     }
 }
 
+@Test func wasmKitBridgeClientCopiesResultsAndDrainsEventsInOrder() throws {
+    let wasm = try wat2wasm(clientBridgeWAT)
+    let client = try WasmKitBridgeClient(bridge: WasmKitRuntimeBridge(bundle: fixtureBundle(wasm: wasm)))
+
+    #expect(try client.initialize(configJSON: Data("{}".utf8)) == Data(#"{"status":"ready"}"#.utf8))
+    #expect(try client.submit(requestJSON: Data(#"{"target_id":"demo"}"#.utf8)) == Data(#"{"status":"accepted"}"#.utf8))
+    #expect(try client.nextEvent() == Data(#"{"sequence":1}"#.utf8))
+    #expect(try client.nextEvent() == nil)
+    #expect(try client.shutdown() == Data(#"{"status":"stopped"}"#.utf8))
+}
+
 private let validBridgeWAT = """
     (module
       (memory (export "memory") 1 16)
@@ -142,6 +153,44 @@ private let validBridgeWAT = """
       (func (export "traverse_compatible_kill") (param i32 i32 i32) (result i32) i32.const 0)
       (func (export "traverse_shutdown") (param i32) (result i32) i32.const 0))
     """
+
+private let clientBridgeWAT = #"""
+    (module
+      (memory (export "memory") 1 16)
+      (data (i32.const 512) "{\22status\22:\22ready\22}")
+      (data (i32.const 544) "{\22status\22:\22accepted\22}")
+      (data (i32.const 576) "{\22sequence\22:1}")
+      (data (i32.const 608) "{\22status\22:\22stopped\22}")
+      (global $next (mut i32) (i32.const 0))
+      (func (export "traverse_bridge_abi_version") (result i32) i32.const 10100)
+      (func (export "traverse_alloc") (param i32) (result i32) i32.const 64)
+      (func (export "traverse_dealloc") (param i32 i32))
+      (func $result (param $d i32) (param $p i32) (param $n i32) (result i32)
+        local.get $d local.get $p i32.store
+        local.get $d i32.const 4 i32.add local.get $n i32.store
+        i32.const 0)
+      (func (export "traverse_init") (param i32 i32 i32) (result i32)
+        local.get 2 i32.const 512 i32.const 18 call $result)
+      (func (export "traverse_submit") (param i32 i32 i32) (result i32)
+        local.get 2 i32.const 544 i32.const 21 call $result)
+      (func (export "traverse_next_event") (param i32) (result i32)
+        global.get $next i32.eqz
+        if (result i32)
+          i32.const 1 global.set $next
+          local.get 0 i32.const 576 i32.const 14 call $result drop
+          i32.const 1
+        else i32.const 0 end)
+      (func (export "traverse_cancel") (param i32 i32 i32) (result i32)
+        local.get 2 i32.const 544 i32.const 21 call $result)
+      (func (export "traverse_compatible_start") (param i32 i32 i32) (result i32)
+        local.get 2 i32.const 544 i32.const 21 call $result)
+      (func (export "traverse_compatible_stop") (param i32 i32 i32) (result i32)
+        local.get 2 i32.const 544 i32.const 21 call $result)
+      (func (export "traverse_compatible_kill") (param i32 i32 i32) (result i32)
+        local.get 2 i32.const 544 i32.const 21 call $result)
+      (func (export "traverse_shutdown") (param i32) (result i32)
+        local.get 0 i32.const 608 i32.const 20 call $result))
+    """#
 
 private func fixtureBundle(wasm: [UInt8], declaredDigest: String? = nil) throws -> TraverseBundle {
     let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
+++ b/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
@@ -132,10 +132,22 @@ import WAT
     let client = try WasmKitBridgeClient(bridge: WasmKitRuntimeBridge(bundle: fixtureBundle(wasm: wasm)))
 
     #expect(try client.initialize(configJSON: Data("{}".utf8)) == Data(#"{"status":"ready"}"#.utf8))
-    #expect(try client.submit(requestJSON: Data(#"{"target_id":"demo"}"#.utf8)) == Data(#"{"status":"accepted"}"#.utf8))
-    #expect(try client.nextEvent() == Data(#"{"sequence":1}"#.utf8))
+    #expect(try client.submit(requestJSON: Data(#"{"target_id":"demo"}"#.utf8)) == Data(#"{"session_id":"s1","status":"accepted"}"#.utf8))
+    #expect(try client.nextEvent() == Data(#"{"sequence":1,"target_id":"demo","status":"completed"}"#.utf8))
     #expect(try client.nextEvent() == nil)
     #expect(try client.shutdown() == Data(#"{"status":"stopped"}"#.utf8))
+}
+
+@Test func runtimeEmbedderMapsRuntimeOwnedResultsIntoPublicTypes() throws {
+    let wasm = try wat2wasm(clientBridgeWAT)
+    let client = try WasmKitBridgeClient(bridge: WasmKitRuntimeBridge(bundle: fixtureBundle(wasm: wasm)))
+    let runtime = RuntimeTraverseEmbedder(client: client)
+    _ = try runtime.initialize(configJSON: Data("{}".utf8))
+
+    #expect(try runtime.submit(TraverseSubmission(targetID: "demo", inputJSON: Data("{}".utf8))) ==
+        TraverseSubmissionResult(sessionID: "s1", status: "accepted"))
+    #expect(try runtime.subscribe() == [TraverseRuntimeEvent(sequence: 1, targetID: "demo", status: "completed")])
+    #expect(try runtime.shutdown() == Data(#"{"status":"stopped"}"#.utf8))
 }
 
 private let validBridgeWAT = """
@@ -158,9 +170,9 @@ private let clientBridgeWAT = #"""
     (module
       (memory (export "memory") 1 16)
       (data (i32.const 512) "{\22status\22:\22ready\22}")
-      (data (i32.const 544) "{\22status\22:\22accepted\22}")
-      (data (i32.const 576) "{\22sequence\22:1}")
-      (data (i32.const 608) "{\22status\22:\22stopped\22}")
+      (data (i32.const 544) "{\22session_id\22:\22s1\22,\22status\22:\22accepted\22}")
+      (data (i32.const 608) "{\22sequence\22:1,\22target_id\22:\22demo\22,\22status\22:\22completed\22}")
+      (data (i32.const 704) "{\22status\22:\22stopped\22}")
       (global $next (mut i32) (i32.const 0))
       (func (export "traverse_bridge_abi_version") (result i32) i32.const 10100)
       (func (export "traverse_alloc") (param i32) (result i32) i32.const 64)
@@ -172,24 +184,24 @@ private let clientBridgeWAT = #"""
       (func (export "traverse_init") (param i32 i32 i32) (result i32)
         local.get 2 i32.const 512 i32.const 18 call $result)
       (func (export "traverse_submit") (param i32 i32 i32) (result i32)
-        local.get 2 i32.const 544 i32.const 21 call $result)
+        local.get 2 i32.const 544 i32.const 39 call $result)
       (func (export "traverse_next_event") (param i32) (result i32)
         global.get $next i32.eqz
         if (result i32)
           i32.const 1 global.set $next
-          local.get 0 i32.const 576 i32.const 14 call $result drop
+          local.get 0 i32.const 608 i32.const 54 call $result drop
           i32.const 1
         else i32.const 0 end)
       (func (export "traverse_cancel") (param i32 i32 i32) (result i32)
-        local.get 2 i32.const 544 i32.const 21 call $result)
+        local.get 2 i32.const 544 i32.const 39 call $result)
       (func (export "traverse_compatible_start") (param i32 i32 i32) (result i32)
-        local.get 2 i32.const 544 i32.const 21 call $result)
+        local.get 2 i32.const 544 i32.const 39 call $result)
       (func (export "traverse_compatible_stop") (param i32 i32 i32) (result i32)
-        local.get 2 i32.const 544 i32.const 21 call $result)
+        local.get 2 i32.const 544 i32.const 39 call $result)
       (func (export "traverse_compatible_kill") (param i32 i32 i32) (result i32)
-        local.get 2 i32.const 544 i32.const 21 call $result)
+        local.get 2 i32.const 544 i32.const 39 call $result)
       (func (export "traverse_shutdown") (param i32) (result i32)
-        local.get 0 i32.const 608 i32.const 20 call $result))
+        local.get 0 i32.const 704 i32.const 20 call $result))
     """#
 
 private func fixtureBundle(wasm: [UInt8], declaredDigest: String? = nil) throws -> TraverseBundle {

--- a/scripts/ci/embedder_conformance/swift_package.sh
+++ b/scripts/ci/embedder_conformance/swift_package.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Shared embedder-api/1.0.0 conformance run for the public Swift package
+# (spec 057 conformance suite; spec 068 FR-009 certification gate).
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+api_id="$(python3 - "${repo_root}/specs/057-embeddable-runtime-host/embedder-api-1.0.0.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print(json.load(handle)["$id"])
+PY
+)"
+
+if [[ "${api_id}" != "https://traverse.dev/embedder-api/1.0.0" ]]; then
+  echo "embedder API id mismatch: ${api_id}" >&2
+  exit 1
+fi
+
+swift test --package-path packages/swift/TraverseEmbedder
+
+python3 - <<'PY'
+import json
+
+print(json.dumps({
+    "traverse_embedder_api": "1.0.0",
+    "conformance_passed": True,
+    "reference": "swift-package",
+    "package": "TraverseEmbedder",
+}, sort_keys=True))
+PY


### PR DESCRIPTION
## Summary

- add a serialized Swift client over the merged WasmKit bridge loader
- copy runtime-owned UTF-8 JSON output before each subsequent mutation
- release caller-owned input and descriptor allocations exactly once
- bound descriptors and expose init, submit, cancel, lifecycle, event-drain, and shutdown calls
- map submissions and ordered events into stable public Swift result types without synthesizing runtime semantics
- add the Swift package to the shared `embedder-api/1.0.0` conformance gate

Advances #647.

## Governing Spec

- `068-public-platform-embedder-packages`
- `057-embeddable-runtime-host`
- `071-native-runtime-wasm-bridge`
- `072-native-bridge-compatible-lifecycle`

## Project Item

- Traverse Project 1: #647

## Definition of Done

- [x] Bridge calls are serialized per runtime instance.
- [x] Caller allocations are released exactly once.
- [x] Runtime-owned outputs are copied before another mutating call.
- [x] Descriptor bounds and negative stable statuses fail closed.
- [x] Executable fixture covers init, submit, ordered event draining, empty queue, and shutdown.
- [x] Runtime-owned identifiers, order, and statuses map into public Swift types.
- [x] The complete Swift package suite emits shared conformance certification evidence.

## Validation

- `swift test --filter wasmKitBridgeClientCopiesResultsAndDrainsEventsInOrder`
- `swift test --filter runtimeEmbedderMapsRuntimeOwnedResultsIntoPublicTypes`
- `scripts/ci/embedder_conformance/swift_package.sh`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/traverse-issue-647-client-pr-body.md`
- `bash scripts/ci/repository_checks.sh`
- `git diff --check`
