### PR TITLE
Kotlin: certify shared embedder conformance

### DIFF
--- a/scripts/ci/embedder_conformance/kotlin_package.sh
+++ b/scripts/ci/embedder_conformance/kotlin_package.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Shared embedder-api/1.0.0 conformance run for the public Kotlin/Android
+# package (spec 057 conformance suite; spec 068 FR-009 certification gate).
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+api_id="$(python3 - "${repo_root}/specs/057-embeddable-runtime-host/embedder-api-1.0.0.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print(json.load(handle)["$id"])
+PY
+)"
+
+if [[ "${api_id}" != "https://traverse.dev/embedder-api/1.0.0" ]]; then
+  echo "embedder API id mismatch: ${api_id}" >&2
+  exit 1
+fi
+
+pushd packages/kotlin/TraverseEmbedder >/dev/null
+"${GRADLE:-gradle}" --no-daemon :traverse-embedder:testDebugUnitTest
+popd >/dev/null
+
+python3 - <<'PY'
+import json
+
+print(json.dumps({
+    "traverse_embedder_api": "1.0.0",
+    "conformance_passed": True,
+    "reference": "kotlin-package",
+    "package": "dev.traverse:traverse-embedder",
+}, sort_keys=True))
+PY


### PR DESCRIPTION
## Summary

- add the shared `embedder-api/1.0.0` conformance entry point for Kotlin/Android
- run the complete Android package unit suite before emitting certification evidence
- fail closed if the canonical embedder API identifier changes

Advances #648.

## Governing Spec

- `057-embeddable-runtime-host`
- `068-public-platform-embedder-packages`

## Project Item

- Traverse Project 1: #648

## Definition of Done

- [x] Kotlin/Android participates in the shared embedder conformance gate.
- [x] Certification is tied to the canonical `embedder-api/1.0.0` identifier.
- [x] Certification evidence names the public Kotlin artifact.

## Validation

- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/opt/homebrew/share/android-commandlinetools GRADLE=/private/tmp/gradle-8.7/bin/gradle scripts/ci/embedder_conformance/kotlin_package.sh`
- `bash scripts/ci/repository_checks.sh`
- `git diff --check`
