### PR TITLE
Kotlin: bound runtime execution resources

### DIFF
--- a/packages/kotlin/TraverseEmbedder/README.md
+++ b/packages/kotlin/TraverseEmbedder/README.md
@@ -15,14 +15,15 @@ verifies `runtime/runtime.wasm` against its declared SHA-256 digest and a 32 MiB
 default artifact limit before parsing, rejects ambient imports, and validates
 the complete `runtime-wasm-bridge/1.1.0` memory, function-signature, and ABI
 surface without linking Chicory WASI. Runtime JSON marshalling, serialized
-event draining, release evidence publication, and Compose reference-app
-integration remain tracked by Traverse #648.
+event draining, typed mapping, and shared conformance are provided by the
+package; Compose reference-app integration remains tracked by Traverse #648.
 
 `ChicoryBridgeClient` now implements the serialized UTF-8 JSON ABI boundary,
 copies runtime-owned outputs before the next mutation, releases every caller
 allocation exactly once, bounds output descriptors, and exposes ordered
-single-event draining. Typed public result mapping, deadline enforcement,
-shared conformance, and Compose integration remain tracked by #648.
+single-event draining. Each call has a configurable instruction/deadline budget,
+and modules declaring memory above the configured host ceiling fail before
+instantiation. Compose integration remains tracked by #648.
 
 `RuntimeTraverseEmbedder` maps that boundary into stable public Kotlin
 submission, event, and compatible-lifecycle result types while preserving

--- a/packages/kotlin/TraverseEmbedder/dependency-review.json
+++ b/packages/kotlin/TraverseEmbedder/dependency-review.json
@@ -12,8 +12,8 @@
   "selection": "1.7.5 is the current stable Maven Central release and includes upstream Android device-test coverage at minSdk 28.",
   "security_boundary": "Pure JVM interpreter; runtime and wasm artifacts only; no chicory-wasi production dependency; imports rejected; SHA-256 verified before parsing; 32 MiB default artifact limit.",
   "known_limitations": [
-    "Chicory 1.7.5 does not expose fuel or epoch interruption controls.",
-    "Runtime JSON marshalling, serialized event draining, and deadline enforcement remain follow-up work before package release."
+    "Chicory 1.7.5 does not expose fuel or epoch interruption controls; Traverse uses its interpreter execution listener for per-call instruction and monotonic-deadline budgets.",
+    "The listener is an interpreter boundary and must be re-reviewed if the package adopts Chicory compiled execution."
   ],
   "wire_format_dependency": {
     "package": "org.jetbrains.kotlinx:kotlinx-serialization-json",

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/ChicoryBridgeClient.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/ChicoryBridgeClient.kt
@@ -8,6 +8,7 @@ class ChicoryBridgeClient(
     private val maximumOutputBytes: Int = DEFAULT_MAXIMUM_OUTPUT_BYTES,
 ) {
     private val instance = bridge.instance
+    private val executionBudget = bridge.executionBudget
     private val memory = instance.memory()
     private val allocate = instance.export("traverse_alloc")
     private val deallocate = instance.export("traverse_dealloc")
@@ -16,42 +17,47 @@ class ChicoryBridgeClient(
         require(maximumOutputBytes > 0) { "maximum bridge output size must be positive" }
     }
 
-    @Synchronized fun initialize(configJson: String): String =
+    @Synchronized fun initialize(configJson: String): String = executionBudget.run {
         invokeWithInput("traverse_init", configJson)
+    }
 
-    @Synchronized fun submit(submissionJson: String): String =
+    @Synchronized fun submit(submissionJson: String): String = executionBudget.run {
         invokeWithInput("traverse_submit", submissionJson)
+    }
 
-    @Synchronized fun cancel(cancellationJson: String): String =
+    @Synchronized fun cancel(cancellationJson: String): String = executionBudget.run {
         invokeWithInput("traverse_cancel", cancellationJson)
+    }
 
-    @Synchronized fun compatibleStart(requestJson: String): String =
+    @Synchronized fun compatibleStart(requestJson: String): String = executionBudget.run {
         invokeWithInput("traverse_compatible_start", requestJson)
+    }
 
-    @Synchronized fun compatibleStop(requestJson: String): String =
+    @Synchronized fun compatibleStop(requestJson: String): String = executionBudget.run {
         invokeWithInput("traverse_compatible_stop", requestJson)
+    }
 
-    @Synchronized fun compatibleKill(requestJson: String): String =
+    @Synchronized fun compatibleKill(requestJson: String): String = executionBudget.run {
         invokeWithInput("traverse_compatible_kill", requestJson)
+    }
 
-    @Synchronized fun nextEvent(): String? {
+    @Synchronized fun nextEvent(): String? = executionBudget.run {
         val descriptor = allocate(DESCRIPTOR_BYTES)
         try {
             val status = instance.export("traverse_next_event").apply(descriptor.toLong()).single().toInt()
-            if (status == STATUS_EMPTY) return null
-            return readResult(status, descriptor)
+            if (status == STATUS_EMPTY) null else readResult(status, descriptor)
         } finally {
-            deallocate.apply(descriptor.toLong(), DESCRIPTOR_BYTES.toLong())
+            executionBudget.cleanup { deallocate.apply(descriptor.toLong(), DESCRIPTOR_BYTES.toLong()) }
         }
     }
 
-    @Synchronized fun shutdown(): String {
+    @Synchronized fun shutdown(): String = executionBudget.run {
         val descriptor = allocate(DESCRIPTOR_BYTES)
         try {
             val status = instance.export("traverse_shutdown").apply(descriptor.toLong()).single().toInt()
-            return readResult(status, descriptor)
+            readResult(status, descriptor)
         } finally {
-            deallocate.apply(descriptor.toLong(), DESCRIPTOR_BYTES.toLong())
+            executionBudget.cleanup { deallocate.apply(descriptor.toLong(), DESCRIPTOR_BYTES.toLong()) }
         }
     }
 
@@ -67,8 +73,10 @@ class ChicoryBridgeClient(
                 .toInt()
             return readResult(status, descriptor)
         } finally {
-            deallocate.apply(descriptor.toLong(), DESCRIPTOR_BYTES.toLong())
-            deallocate.apply(inputPointer.toLong(), input.size.toLong())
+            executionBudget.cleanup {
+                deallocate.apply(descriptor.toLong(), DESCRIPTOR_BYTES.toLong())
+                deallocate.apply(inputPointer.toLong(), input.size.toLong())
+            }
         }
     }
 

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/ChicoryRuntimeBridge.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/ChicoryRuntimeBridge.kt
@@ -1,6 +1,7 @@
 package dev.traverse.embedder
 
 import com.dylibso.chicory.runtime.Instance
+import com.dylibso.chicory.runtime.ExecutionListener
 import com.dylibso.chicory.wasm.Parser
 import com.dylibso.chicory.wasm.types.ExternalType
 import com.dylibso.chicory.wasm.types.FunctionType
@@ -12,14 +13,22 @@ import java.security.MessageDigest
 class ChicoryRuntimeBridge(
     bundle: TraverseBundle,
     maximumArtifactBytes: Int = DEFAULT_MAXIMUM_ARTIFACT_BYTES,
+    maximumMemoryPages: Int = DEFAULT_MAXIMUM_MEMORY_PAGES,
+    maximumInstructionsPerCall: Long = DEFAULT_MAXIMUM_INSTRUCTIONS_PER_CALL,
+    maximumCallDurationMillis: Long = DEFAULT_MAXIMUM_CALL_DURATION_MILLIS,
 ) {
     val runtimeFile: File
     val runtimeWasmDigest: String
 
     internal val instance: Instance
+    internal val executionBudget = ChicoryExecutionBudget(
+        maximumInstructionsPerCall,
+        maximumCallDurationMillis,
+    )
 
     init {
         require(maximumArtifactBytes > 0) { "maximum runtime WASM size must be positive" }
+        require(maximumMemoryPages > 0) { "maximum runtime memory pages must be positive" }
 
         runtimeFile = File(bundle.rootPath, "runtime/runtime.wasm")
         if (!runtimeFile.isFile) {
@@ -52,9 +61,17 @@ class ChicoryRuntimeBridge(
         if (memoryExports.size != 1 || memoryExports.single().name() != "memory") {
             throw TraverseBundleException("runtime/runtime.wasm must export exactly one bridge memory")
         }
+        val memory = module.memorySection().orElseThrow {
+            TraverseBundleException("runtime/runtime.wasm must declare bridge memory")
+        }.getMemory(0)
+        if (memory.limits().maximumPages() > maximumMemoryPages) {
+            throw TraverseBundleException("runtime/runtime.wasm exceeds the configured memory limit")
+        }
 
         instance = try {
-            Instance.builder(module).build()
+            Instance.builder(module)
+                .withUnsafeExecutionListener(executionBudget.listener)
+                .build()
         } catch (error: RuntimeException) {
             throw TraverseBundleException("runtime/runtime.wasm could not be instantiated", error)
         }
@@ -70,7 +87,7 @@ class ChicoryRuntimeBridge(
         }
 
         val version = try {
-            instance.export("traverse_bridge_abi_version").apply()
+            executionBudget.run { instance.export("traverse_bridge_abi_version").apply() }
         } catch (error: RuntimeException) {
             throw TraverseBundleException("bridge_version_mismatch", error)
         }
@@ -82,6 +99,9 @@ class ChicoryRuntimeBridge(
     companion object {
         const val ABI_VERSION = 10_100
         const val DEFAULT_MAXIMUM_ARTIFACT_BYTES = 32 * 1024 * 1024
+        const val DEFAULT_MAXIMUM_MEMORY_PAGES = 512
+        const val DEFAULT_MAXIMUM_INSTRUCTIONS_PER_CALL = 10_000_000L
+        const val DEFAULT_MAXIMUM_CALL_DURATION_MILLIS = 30_000L
 
         private val I32_TO_I32 = FunctionType.of(listOf(ValType.I32), listOf(ValType.I32))
         private val THREE_I32_TO_I32 = FunctionType.of(
@@ -105,6 +125,55 @@ class ChicoryRuntimeBridge(
         private fun normalizeDigest(digest: String): String {
             val normalized = digest.trim().lowercase()
             return if (normalized.startsWith("sha256:")) normalized else "sha256:$normalized"
+        }
+    }
+}
+
+internal class ChicoryExecutionBudget(
+    private val maximumInstructions: Long,
+    maximumDurationMillis: Long,
+) {
+    private val maximumDurationNanos: Long
+    private var active = false
+    private var instructions = 0L
+    private var deadlineNanos = 0L
+
+    init {
+        require(maximumInstructions > 0) { "maximum instructions per call must be positive" }
+        require(maximumDurationMillis > 0 && maximumDurationMillis <= Long.MAX_VALUE / 1_000_000L) {
+            "maximum call duration must be positive and representable"
+        }
+        maximumDurationNanos = maximumDurationMillis * 1_000_000L
+    }
+
+    val listener = ExecutionListener { _, _ ->
+        if (active) {
+            instructions += 1
+            if (instructions > maximumInstructions || System.nanoTime() - deadlineNanos >= 0) {
+                throw TraverseBridgeException(-4, "bridge_resource_limit")
+            }
+        }
+    }
+
+    fun <T> run(block: () -> T): T {
+        check(!active) { "bridge execution budget is already active" }
+        instructions = 0
+        deadlineNanos = System.nanoTime() + maximumDurationNanos
+        active = true
+        return try {
+            block()
+        } finally {
+            active = false
+        }
+    }
+
+    fun <T> cleanup(block: () -> T): T {
+        val wasActive = active
+        active = false
+        return try {
+            block()
+        } finally {
+            active = wasActive
         }
     }
 }

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryBridgeClientTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryBridgeClientTest.kt
@@ -6,6 +6,7 @@ import java.nio.file.Files
 import java.security.MessageDigest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class ChicoryBridgeClientTest {
@@ -34,8 +35,23 @@ class ChicoryBridgeClientTest {
         assertEquals("{\"status\":\"stopped\"}", runtime.shutdown())
     }
 
-    private fun fixtureBundle(): TraverseBundle {
-        val wasm = Wat2Wasm.parse(bridgeWat)
+    @Test fun interruptsCallsThatExceedTheInstructionBudget() {
+        val wasm = Wat2Wasm.parse(
+            bridgeWat.replace(
+                "local.get 2 i32.const 512 i32.const 18 call ${'$'}result",
+                "(loop ${'$'}forever br ${'$'}forever) i32.const 0",
+            ),
+        )
+        val client = ChicoryBridgeClient(
+            ChicoryRuntimeBridge(fixtureBundle(wasm), maximumInstructionsPerCall = 100),
+        )
+
+        val error = assertThrows(TraverseBridgeException::class.java) { client.initialize("{}") }
+        assertEquals(-4, error.status)
+        assertEquals("bridge_resource_limit", error.message)
+    }
+
+    private fun fixtureBundle(wasm: ByteArray = Wat2Wasm.parse(bridgeWat)): TraverseBundle {
         val root = Files.createTempDirectory("traverse-kotlin-client").toFile()
         val runtime = File(root, "runtime").apply { mkdirs() }
         File(runtime, "runtime.wasm").writeBytes(wasm)

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryRuntimeBridgeTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryRuntimeBridgeTest.kt
@@ -52,6 +52,14 @@ class ChicoryRuntimeBridgeTest {
         assertEquals("bridge_version_mismatch", versionError.message)
     }
 
+    @Test fun rejectsRuntimeMemoryAboveTheHostLimit() {
+        val error = assertThrows(TraverseBundleException::class.java) {
+            ChicoryRuntimeBridge(fixtureBundle(Wat2Wasm.parse(validBridgeWat)), maximumMemoryPages = 8)
+        }
+
+        assertEquals("runtime/runtime.wasm exceeds the configured memory limit", error.message)
+    }
+
     private fun fixtureBundle(wasm: ByteArray, declaredDigest: String = digest(wasm)): TraverseBundle {
         val root = Files.createTempDirectory("traverse-kotlin-bridge").toFile()
         val runtime = File(root, "runtime").apply { mkdirs() }


### PR DESCRIPTION
## Summary

- reject runtime modules whose declared memory maximum exceeds the configured Android host ceiling
- enforce configurable per-call instruction and monotonic-deadline budgets through Chicory's interpreter listener
- preserve allocation cleanup after an interrupted call and document the reviewed interpreter boundary

Advances #648.

## Governing Spec

- `068-public-platform-embedder-packages`
- `071-native-runtime-wasm-bridge`

## Project Item

- Traverse Project 1: #648

## Definition of Done

- [x] Runtime memory is bounded before instantiation.
- [x] Every serialized bridge call receives a fresh instruction and deadline budget.
- [x] Budget exhaustion maps to stable `bridge_resource_limit` status `-4`.
- [x] Cleanup calls remain available after budget interruption.
- [x] Tests reject oversized memory and terminate an infinite runtime loop.

## Validation

- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/opt/homebrew/share/android-commandlinetools /private/tmp/gradle-8.7/bin/gradle --no-daemon :traverse-embedder:testDebugUnitTest`
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/opt/homebrew/share/android-commandlinetools GRADLE=/private/tmp/gradle-8.7/bin/gradle scripts/ci/embedder_conformance/kotlin_package.sh`
- `bash scripts/ci/repository_checks.sh`
- `git diff --check`
