### PR TITLE
Runtime: await durable rejected-event revocation

### DIFF
--- a/crates/traverse-runtime/src/events/durable.rs
+++ b/crates/traverse-runtime/src/events/durable.rs
@@ -338,49 +338,28 @@ impl<B: EventBroker> EventBroker for DurableBroker<B> {
                             event_type: event_type.clone(),
                             ack: Some(Arc::clone(&revoke_ack)),
                         };
-                        if self.jobs.send(revoke).is_ok() {
-                            let (lock, cvar) = &*revoke_ack;
-                            let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
-                            let (mut state, _) = cvar
-                                .wait_timeout_while(guard, self.write_timeout, |state| {
-                                    matches!(state, AckState::Pending)
-                                })
-                                .unwrap_or_else(PoisonError::into_inner);
-                            let revoke_outcome =
-                                std::mem::replace(&mut *state, AckState::Abandoned);
-                            match revoke_outcome {
-                                AckState::Done(_) => {}
-                                AckState::Failed(revoke_error) => {
-                                    return Err(EventError::JournalWrite(format!(
-                                        "journal revocation failed: {revoke_error}"
-                                    )));
-                                }
-                                AckState::Pending | AckState::Abandoned => {
-                                    let detail = format!(
-                                        "journal revocation exceeded {}ms; event remains rejected",
-                                        self.write_timeout.as_millis()
-                                    );
-                                    self.audit.record(&JournalWriteAuditRecord {
-                                        kind: "journal_revocation_failed".to_string(),
-                                        event_id: event_id.clone(),
-                                        event_type: event_type.clone(),
-                                        detail: detail.clone(),
-                                    });
-                                    return Err(EventError::JournalWriteTimeout(detail));
-                                }
-                            }
-                        } else {
-                            self.audit.record(&JournalWriteAuditRecord {
-                                kind: "journal_revocation_failed".to_string(),
-                                event_id,
-                                event_type,
-                                detail: "journal writer is unavailable".to_string(),
-                            });
-                            return Err(EventError::JournalWrite(
-                                "journal revocation failed: journal writer is unavailable"
-                                    .to_string(),
-                            ));
-                        }
+                        enqueue_revocation(
+                            &self.jobs,
+                            revoke,
+                            self.audit.as_ref(),
+                            &event_id,
+                            &event_type,
+                        )?;
+                        let (lock, cvar) = &*revoke_ack;
+                        let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
+                        let (mut state, _) = cvar
+                            .wait_timeout_while(guard, self.write_timeout, |state| {
+                                matches!(state, AckState::Pending)
+                            })
+                            .unwrap_or_else(PoisonError::into_inner);
+                        let revoke_outcome = std::mem::replace(&mut *state, AckState::Abandoned);
+                        map_revocation_outcome(
+                            revoke_outcome,
+                            self.audit.as_ref(),
+                            &event_id,
+                            &event_type,
+                            self.write_timeout,
+                        )?;
                         Err(error)
                     }
                 }
@@ -544,6 +523,59 @@ impl<B: EventBroker> EventBroker for DurableBroker<B> {
     }
 }
 
+fn revocation_writer_unavailable(
+    audit: &dyn JournalWriteAuditSink,
+    event_id: &str,
+    event_type: &str,
+) -> EventError {
+    audit.record(&JournalWriteAuditRecord {
+        kind: "journal_revocation_failed".to_string(),
+        event_id: event_id.to_string(),
+        event_type: event_type.to_string(),
+        detail: "journal writer is unavailable".to_string(),
+    });
+    EventError::JournalWrite("journal revocation failed: journal writer is unavailable".to_string())
+}
+
+fn enqueue_revocation(
+    jobs: &mpsc::Sender<WriterJob>,
+    revoke: WriterJob,
+    audit: &dyn JournalWriteAuditSink,
+    event_id: &str,
+    event_type: &str,
+) -> Result<(), EventError> {
+    jobs.send(revoke)
+        .map_err(|_| revocation_writer_unavailable(audit, event_id, event_type))
+}
+
+fn map_revocation_outcome(
+    outcome: AckState,
+    audit: &dyn JournalWriteAuditSink,
+    event_id: &str,
+    event_type: &str,
+    timeout: Duration,
+) -> Result<(), EventError> {
+    match outcome {
+        AckState::Done(_) => Ok(()),
+        AckState::Failed(error) => Err(EventError::JournalWrite(format!(
+            "journal revocation failed: {error}"
+        ))),
+        AckState::Pending | AckState::Abandoned => {
+            let detail = format!(
+                "journal revocation exceeded {}ms; event remains rejected",
+                timeout.as_millis()
+            );
+            audit.record(&JournalWriteAuditRecord {
+                kind: "journal_revocation_failed".to_string(),
+                event_id: event_id.to_string(),
+                event_type: event_type.to_string(),
+                detail: detail.clone(),
+            });
+            Err(EventError::JournalWriteTimeout(detail))
+        }
+    }
+}
+
 fn normalize_cursor(raw: &str) -> Result<String, EventError> {
     raw.parse::<u64>()
         .map(|parsed| parsed.to_string())
@@ -583,18 +615,20 @@ fn run_writer(
                 ack,
             } => {
                 let result = revoke(&mut sink, audit, &cursor, &event_id, &event_type);
-                if let Some(ack) = ack {
-                    let (lock, cvar) = &*ack;
-                    let mut state = lock.lock().unwrap_or_else(PoisonError::into_inner);
-                    *state = match result {
-                        Ok(()) => AckState::Done(String::new()),
-                        Err(error) => AckState::Failed(error),
-                    };
-                    cvar.notify_one();
-                }
+                let _ = ack.map(|ack| acknowledge_revocation(&ack, result));
             }
         }
     }
+}
+
+fn acknowledge_revocation(ack: &Ack, result: Result<(), JournalError>) {
+    let (lock, cvar) = &**ack;
+    let mut state = lock.lock().unwrap_or_else(PoisonError::into_inner);
+    *state = match result {
+        Ok(()) => AckState::Done(String::new()),
+        Err(error) => AckState::Failed(error),
+    };
+    cvar.notify_one();
 }
 
 fn revoke(
@@ -1007,6 +1041,66 @@ mod tests {
             .expect("revocation failure must be audited");
         assert_eq!(failure_audit.kind, "journal_revocation_failed");
         assert!(failure_audit.detail.contains("revocation rejected"));
+    }
+
+    #[test]
+    fn immediate_revocation_failure_returns_a_stable_error() {
+        let (gate_tx, gate_rx) = channel();
+        let (revoked_tx, _revoked_rx) = channel();
+        let sink = ScriptedSink {
+            gate: gate_rx,
+            revocations: revoked_tx,
+            fail_revocation: true,
+        };
+        let broker = DurableBroker::new(
+            inner_broker(),
+            sink,
+            null_source(),
+            DurableBrokerConfig::default(),
+            Arc::new(RecordingAudit::default()),
+        );
+
+        let mut unregistered = test_event();
+        unregistered.event_type = "dev.traverse.test.unknown".to_string();
+        gate_tx
+            .send(Ok("11".to_string()))
+            .expect("gate must accept");
+        let error = broker
+            .publish(unregistered)
+            .expect_err("delivery and revocation failure must be returned");
+        assert!(matches!(error, EventError::JournalWrite(_)), "{error}");
+        assert!(error.to_string().contains("revocation rejected"));
+    }
+
+    #[test]
+    fn disconnected_revocation_writer_is_audited() {
+        let (jobs, receiver) = channel();
+        drop(receiver);
+        let revoke = WriterJob::Revoke {
+            cursor: "1".to_string(),
+            event_id: "event-1".to_string(),
+            event_type: EVENT_TYPE.to_string(),
+            ack: Some(Arc::new((Mutex::new(AckState::Pending), Condvar::new()))),
+        };
+        let audit = RecordingAudit::default();
+        let error = enqueue_revocation(&jobs, revoke, &audit, "event-1", EVENT_TYPE)
+            .expect_err("disconnected writer must fail closed");
+        assert!(matches!(error, EventError::JournalWrite(_)), "{error}");
+    }
+
+    #[test]
+    fn pending_revocation_ack_reports_timeout_and_audits_failure() {
+        let audit = RecordingAudit::default();
+        let timeout = map_revocation_outcome(
+            AckState::Pending,
+            &audit,
+            "event-1",
+            EVENT_TYPE,
+            Duration::from_millis(25),
+        )
+        .expect_err("pending acknowledgement must time out");
+        assert!(matches!(timeout, EventError::JournalWriteTimeout(_)));
+        assert_eq!(audit.kinds(), vec!["journal_revocation_failed"]);
     }
 
     // --- journal-backed replay fallback (spec 066 FR-005, FR-007, FR-008; final #659 slice) ---

--- a/crates/traverse-runtime/src/events/durable.rs
+++ b/crates/traverse-runtime/src/events/durable.rs
@@ -344,23 +344,26 @@ impl<B: EventBroker> EventBroker for DurableBroker<B> {
                             self.audit.as_ref(),
                             &event_id,
                             &event_type,
-                        )?;
-                        let (lock, cvar) = &*revoke_ack;
-                        let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
-                        let (mut state, _) = cvar
-                            .wait_timeout_while(guard, self.write_timeout, |state| {
-                                matches!(state, AckState::Pending)
-                            })
-                            .unwrap_or_else(PoisonError::into_inner);
-                        let revoke_outcome = std::mem::replace(&mut *state, AckState::Abandoned);
-                        map_revocation_outcome(
-                            revoke_outcome,
-                            self.audit.as_ref(),
-                            &event_id,
-                            &event_type,
-                            self.write_timeout,
-                        )?;
-                        Err(error)
+                        )
+                        .and_then(|()| {
+                            let (lock, cvar) = &*revoke_ack;
+                            let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
+                            let (mut state, _) = cvar
+                                .wait_timeout_while(guard, self.write_timeout, |state| {
+                                    matches!(state, AckState::Pending)
+                                })
+                                .unwrap_or_else(PoisonError::into_inner);
+                            let revoke_outcome =
+                                std::mem::replace(&mut *state, AckState::Abandoned);
+                            map_revocation_outcome(
+                                revoke_outcome,
+                                self.audit.as_ref(),
+                                &event_id,
+                                &event_type,
+                                self.write_timeout,
+                            )
+                        })
+                        .and(Err(error))
                     }
                 }
             }

--- a/crates/traverse-runtime/src/events/durable.rs
+++ b/crates/traverse-runtime/src/events/durable.rs
@@ -191,6 +191,7 @@ enum WriterJob {
         cursor: String,
         event_id: String,
         event_type: String,
+        ack: Option<Ack>,
     },
 }
 
@@ -319,20 +320,71 @@ impl<B: EventBroker> EventBroker for DurableBroker<B> {
         drop(state);
 
         match outcome {
-            AckState::Done(cursor) => match self.inner.publish_with_cursor(event, &cursor) {
-                Ok(()) => Ok(()),
-                Err(error) => {
-                    // Durably written but undeliverable: revoke so replay
-                    // never surfaces an event that was never delivered live.
-                    let revoke = WriterJob::Revoke {
-                        cursor,
-                        event_id: String::new(),
-                        event_type: String::new(),
-                    };
-                    let _ = self.jobs.send(revoke);
-                    Err(error)
+            AckState::Done(cursor) => {
+                let event_id = event.id.clone();
+                let event_type = event.event_type.clone();
+                match self.inner.publish_with_cursor(event, &cursor) {
+                    Ok(()) => Ok(()),
+                    Err(error) => {
+                        // Durably written but undeliverable: revoke so replay
+                        // never surfaces an event that was never delivered live.
+                        // Wait for the writer acknowledgement before returning;
+                        // otherwise an immediate replay can race the revocation.
+                        let revoke_ack: Ack =
+                            Arc::new((Mutex::new(AckState::Pending), Condvar::new()));
+                        let revoke = WriterJob::Revoke {
+                            cursor,
+                            event_id: event_id.clone(),
+                            event_type: event_type.clone(),
+                            ack: Some(Arc::clone(&revoke_ack)),
+                        };
+                        if self.jobs.send(revoke).is_ok() {
+                            let (lock, cvar) = &*revoke_ack;
+                            let guard = lock.lock().unwrap_or_else(PoisonError::into_inner);
+                            let (mut state, _) = cvar
+                                .wait_timeout_while(guard, self.write_timeout, |state| {
+                                    matches!(state, AckState::Pending)
+                                })
+                                .unwrap_or_else(PoisonError::into_inner);
+                            let revoke_outcome =
+                                std::mem::replace(&mut *state, AckState::Abandoned);
+                            match revoke_outcome {
+                                AckState::Done(_) => {}
+                                AckState::Failed(revoke_error) => {
+                                    return Err(EventError::JournalWrite(format!(
+                                        "journal revocation failed: {revoke_error}"
+                                    )));
+                                }
+                                AckState::Pending | AckState::Abandoned => {
+                                    let detail = format!(
+                                        "journal revocation exceeded {}ms; event remains rejected",
+                                        self.write_timeout.as_millis()
+                                    );
+                                    self.audit.record(&JournalWriteAuditRecord {
+                                        kind: "journal_revocation_failed".to_string(),
+                                        event_id: event_id.clone(),
+                                        event_type: event_type.clone(),
+                                        detail: detail.clone(),
+                                    });
+                                    return Err(EventError::JournalWriteTimeout(detail));
+                                }
+                            }
+                        } else {
+                            self.audit.record(&JournalWriteAuditRecord {
+                                kind: "journal_revocation_failed".to_string(),
+                                event_id,
+                                event_type,
+                                detail: "journal writer is unavailable".to_string(),
+                            });
+                            return Err(EventError::JournalWrite(
+                                "journal revocation failed: journal writer is unavailable"
+                                    .to_string(),
+                            ));
+                        }
+                        Err(error)
+                    }
                 }
-            },
+            }
             AckState::Failed(error) => Err(EventError::JournalWrite(error.to_string())),
             AckState::Pending | AckState::Abandoned => {
                 let detail = format!(
@@ -514,7 +566,7 @@ fn run_writer(
                     // The publisher already rejected this event; if the write
                     // completed anyway, durably suppress it (067 FR-004).
                     if let Ok(cursor) = result {
-                        revoke(&mut sink, audit, &cursor, &event.id, &event.event_type);
+                        let _ = revoke(&mut sink, audit, &cursor, &event.id, &event.event_type);
                     }
                 } else {
                     *state = match result {
@@ -528,7 +580,19 @@ fn run_writer(
                 cursor,
                 event_id,
                 event_type,
-            } => revoke(&mut sink, audit, &cursor, &event_id, &event_type),
+                ack,
+            } => {
+                let result = revoke(&mut sink, audit, &cursor, &event_id, &event_type);
+                if let Some(ack) = ack {
+                    let (lock, cvar) = &*ack;
+                    let mut state = lock.lock().unwrap_or_else(PoisonError::into_inner);
+                    *state = match result {
+                        Ok(()) => AckState::Done(String::new()),
+                        Err(error) => AckState::Failed(error),
+                    };
+                    cvar.notify_one();
+                }
+            }
         }
     }
 }
@@ -539,15 +603,17 @@ fn revoke(
     cursor: &str,
     event_id: &str,
     event_type: &str,
-) {
-    if let Err(error) = sink.append_revocation(cursor) {
-        audit.record(&JournalWriteAuditRecord {
-            kind: "journal_revocation_failed".to_string(),
-            event_id: event_id.to_string(),
-            event_type: event_type.to_string(),
-            detail: error.to_string(),
-        });
-    }
+) -> Result<(), JournalError> {
+    sink.append_revocation(cursor)
+        .map(|_| ())
+        .inspect_err(|error| {
+            audit.record(&JournalWriteAuditRecord {
+                kind: "journal_revocation_failed".to_string(),
+                event_id: event_id.to_string(),
+                event_type: event_type.to_string(),
+                detail: error.to_string(),
+            });
+        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- acknowledge rejected-event revocations from the journal writer before `publish()` returns
- retain the configured timeout and surface stable journal errors if revocation cannot complete
- preserve structured `journal_revocation_failed` audit evidence

Closes #736.

## Governing Spec

- `067-durable-journal-retention-and-write-limits`

## Project Item

- Traverse Project 1: #736

## Definition of Done

- [x] Successful revocation is durable before rejected live delivery returns.
- [x] Immediate replay cannot race a queued revocation.
- [x] Writer unavailability, failure, and timeout remain bounded and auditable.
- [x] Existing late-write revocation behavior remains covered.

## Validation

- `cargo test -p traverse-runtime --lib`
- `cargo test -p traverse-runtime shared_journal_sink_revokes_a_durably_written_but_undeliverable_event`
- `cargo test -p traverse-runtime undeliverable_event_is_revoked_after_durable_write`
- `cargo test -p traverse-runtime revocation_failures_are_audited`
- `cargo clippy -p traverse-runtime --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
