### PR TITLE
docs(adr): decide durable journal evolution from evidence

### DIFF
--- a/docs/adr/0009-retain-durable-journal-after-operational-evaluation.md
+++ b/docs/adr/0009-retain-durable-journal-after-operational-evaluation.md
@@ -1,0 +1,59 @@
+# ADR-0009: Retain the Durable Journal After Operational Evaluation
+
+- Status: Accepted
+- Date: 2026-07-17
+
+## Context
+
+Issue #630 required an evidence-led choice between retaining the initial
+append-only durable journal, migrating to SQLite, or introducing a storage
+provider boundary. The decision must preserve the cursor and replay semantics
+defined by Specs 066 and 067.
+
+The checked-in operational-limit harness was run successfully on 2026-07-16
+for Linux host-local, Linux `fsync-pressure`, macOS host-local, and Windows
+host-local profiles. Its four JSON artifacts are retained with the successful
+[workflow run](https://github.com/traverse-framework/traverse/actions/runs/29504715796).
+
+## Decision
+
+Retain the current append-only segmented journal. Do not migrate to SQLite and
+do not introduce a storage-provider boundary in the current product slice.
+
+The comparable 1,000-event/512-byte-payload runs show host-local append p99 of
+0.524 ms (Linux), 6.160 ms (macOS), and 0.711 ms (Windows); restart recovery
+was 2.732-5.366 ms and replay throughput was 202,306-311,623 events/s. The
+Linux `fsync-pressure` profile raised append p99 to 41.557 ms, but recovery
+remained 3.278 ms and replay remained 274,122 events/s. This is above the
+25 ms investigation threshold, not the two-second durable-write timeout, and
+is one non-production constrained profile rather than evidence of a general
+storage-engine limit.
+
+The current journal therefore meets the measured operational need while
+preserving its existing cursor and replay behavior without a migration. The
+weekly/manual workflow remains the regression signal. Open a focused
+remediation issue if that threshold is exceeded on two consecutive comparable
+runs or reproduces on the affected storage class; reassess SQLite or a
+provider boundary only with that evidence.
+
+## Consequences
+
+- No journal format, cursor, replay, or public API migration is required.
+- No abstraction layer is added before a second backend has a demonstrated
+  operational need.
+- Operators retain the existing size/age retention controls and the 2-second
+  fail-closed write timeout.
+- The `fsync-pressure` p99 is explicitly monitored, not ignored or treated as
+  a merge-blocking benchmark gate.
+
+## Alternatives Considered
+
+- **Migrate to SQLite now**: rejected because the measured recovery and replay
+  results do not demonstrate a limitation that SQLite would solve, while a
+  migration would add format and compatibility risk.
+- **Introduce a provider abstraction now**: rejected because there is only one
+  supported backend and no evidence-driven second backend requirement; the
+  abstraction would add indirection without an exercised implementation.
+- **Treat one pressure-profile threshold breach as a migration trigger**:
+  rejected because the documented workflow requires a repeatable regression
+  signal before changing defaults or architecture.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -454,9 +454,9 @@ the same envelope and subject-filter semantics.
 #591 can resume once Spec 070 lands; #659 then builds durable replay on the
 same identity/filter boundary rather than inventing a second path.
 
-## Decision 21: Defer Durable-Journal Storage Evolution Until Measurement
+## Decision 21: Retain the Durable Journal After Operational Evaluation
 
-- **Date**: 2026-07-14
+- **Date**: 2026-07-17
 - **Status**: Accepted
 - **Governing specs**: `066-durable-identity-event-delivery`,
   `067-durable-journal-retention-and-write-limits`
@@ -464,10 +464,19 @@ same identity/filter boundary rather than inventing a second path.
 
 ### Decision
 
-Keep the initial durable journal while #629 measures append latency, recovery,
-replay, retention compaction, and disk growth under representative workloads.
-Choose retain, SQLite, or a provider abstraction only from that evidence; no
-storage migration or abstraction is preselected.
+Retain the initial append-only journal. The completed #713 matrix measured
+Linux, macOS, Windows, and a Linux `fsync-pressure` profile using the
+checked-in #629 harness. Host-local append p99 remained 0.524-6.160 ms,
+recovery 2.732-5.366 ms, and replay 202k-312k events/s. The pressure profile
+reached 41.557 ms p99, above the 25 ms investigation threshold but far below
+the two-second fail-closed write timeout; it is a single constrained-profile
+signal, so it does not justify a storage migration.
+
+Do not add SQLite or a storage-provider boundary now. Preserve the existing
+cursor and replay semantics, keep the weekly/manual measurement workflow, and
+revisit this decision only after a comparable threshold breach occurs on two
+consecutive runs or reproduces on the affected storage class. ADR-0009 records
+the evidence and alternatives.
 
 ## Decision 22: Keep Application Source Out of the Traverse Runtime Repository
 


### PR DESCRIPTION
## Summary

- record ADR-0009 retaining the append-only durable journal after the completed multi-platform operational evaluation
- compare retention with a SQLite migration and a provider boundary using the checked-in evidence
- preserve current cursor and replay semantics while documenting the fsync-pressure follow-up threshold

Closes #630.

## Governing Spec

- `066-durable-identity-event-delivery`
- `067-durable-journal-retention-and-write-limits`

## Project Item

- Traverse Project 1: #630

## Definition of Done

- [x] Compare retained journal, SQLite, and provider-boundary options against measured workload evidence.
- [x] Record an ADR decision to retain the current journal.
- [x] Preserve cursor compatibility and replay semantics; no migration is introduced.

## Validation

- `git diff --check`
- `bash scripts/ci/repository_checks.sh`
- Reviewed the four JSON artifacts from successful workflow run 29504715796.