### PR TITLE
.NET: add runtime bridge client and conformance

### DIFF
--- a/packages/dotnet/TraverseEmbedder/README.md
+++ b/packages/dotnet/TraverseEmbedder/README.md
@@ -24,5 +24,9 @@ bridge call by default.
 before the next mutation, bounds descriptors, and releases each caller-owned
 input and descriptor allocation exactly once.
 
+`RuntimeTraverseEmbedder` maps the raw boundary into stable public submission,
+event, and compatible-lifecycle result records while preserving runtime-owned
+identifiers, ordering, and statuses.
+
 Request marshalling, event subscriptions, evidence publication, shared
 conformance, and WinUI reference-app integration remain tracked by Traverse #649.

--- a/packages/dotnet/TraverseEmbedder/README.md
+++ b/packages/dotnet/TraverseEmbedder/README.md
@@ -20,5 +20,9 @@ lifecycle export surface without enabling WASI. The host applies a 32 MiB
 runtime-memory ceiling, 10,000,000 fuel, and a 30-second epoch deadline to each
 bridge call by default.
 
+`WasmtimeBridgeClient` serializes UTF-8 JSON calls, copies runtime-owned output
+before the next mutation, bounds descriptors, and releases each caller-owned
+input and descriptor allocation exactly once.
+
 Request marshalling, event subscriptions, evidence publication, shared
 conformance, and WinUI reference-app integration remain tracked by Traverse #649.

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/WasmtimeRuntimeBridgeTests.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/WasmtimeRuntimeBridgeTests.cs
@@ -10,6 +10,7 @@ public sealed class WasmtimeRuntimeBridgeTests
     private const string ImportedFixture = "AGFzbQEAAAABCAJgAABgAAF/AiMBFndhc2lfc25hcHNob3RfcHJldmlldzEIZmRfd3JpdGUAAAMCAQEFAwEAAQcoAgZtZW1vcnkCABt0cmF2ZXJzZV9icmlkZ2VfYWJpX3ZlcnNpb24AAQoIAQYAQfTOAAs=";
     private const string BridgeTenFixture = "AGFzbQEAAAABFgRgAAF/YAF/AX9gAn9/AGADf39/AX8DDAsAAQIDAwEDAwMDAQUEAQEBEAf8AQwGbWVtb3J5AgAbdHJhdmVyc2VfYnJpZGdlX2FiaV92ZXJzaW9uAAAOdHJhdmVyc2VfYWxsb2MAARB0cmF2ZXJzZV9kZWFsbG9jAAINdHJhdmVyc2VfaW5pdAADD3RyYXZlcnNlX3N1Ym1pdAAEE3RyYXZlcnNlX25leHRfZXZlbnQABQ90cmF2ZXJzZV9jYW5jZWwABhl0cmF2ZXJzZV9jb21wYXRpYmxlX3N0YXJ0AAcYdHJhdmVyc2VfY29tcGF0aWJsZV9zdG9wAAgYdHJhdmVyc2VfY29tcGF0aWJsZV9raWxsAAkRdHJhdmVyc2Vfc2h1dGRvd24ACgo5CwYAQZDOAAsFAEHAAAsCAAsEAEEACwQAQQALBABBAAsEAEEACwQAQQALBABBAAsEAEEACwQAQQAL";
     private const string ClientFixture = "AGFzbQEAAAABFgRgAAF/YAF/AX9gAn9/AGADf39/AX8DDQwAAQIDAwMBAwMDAwEFBAEBARAGBgF/AUEACwf8AQwGbWVtb3J5AgAbdHJhdmVyc2VfYnJpZGdlX2FiaV92ZXJzaW9uAAAOdHJhdmVyc2VfYWxsb2MAARB0cmF2ZXJzZV9kZWFsbG9jAAINdHJhdmVyc2VfaW5pdAAED3RyYXZlcnNlX3N1Ym1pdAAFE3RyYXZlcnNlX25leHRfZXZlbnQABg90cmF2ZXJzZV9jYW5jZWwABxl0cmF2ZXJzZV9jb21wYXRpYmxlX3N0YXJ0AAgYdHJhdmVyc2VfY29tcGF0aWJsZV9zdG9wAAkYdHJhdmVyc2VfY29tcGF0aWJsZV9raWxsAAoRdHJhdmVyc2Vfc2h1dGRvd24ACwqXAQwGAEH0zgALBQBBwAALAgALFQAgACABNgIAIABBBGogAjYCAEEACwsAIAJBgARBEhADCwsAIAJBoARBFRADCxsAIwBFBH9BASQAIABBwARBDhADGkEBBUEACwsLACACQaAEQRUQAwsLACACQaAEQRUQAwsLACACQaAEQRUQAwsLACACQaAEQRUQAwsLACAAQeAEQRQQAwsLYgQAQYAECxJ7InN0YXR1cyI6InJlYWR5In0AQaAECxV7InN0YXR1cyI6ImFjY2VwdGVkIn0AQcAECw57InNlcXVlbmNlIjoxfQBB4AQLFHsic3RhdHVzIjoic3RvcHBlZCJ9";
+    private const string TypedClientFixture = "AGFzbQEAAAABFgRgAAF/YAF/AX9gAn9/AGADf39/AX8DDQwAAQIDAwMBAwMDAwEFBAEBARAGBgF/AUEACwf8AQwGbWVtb3J5AgAbdHJhdmVyc2VfYnJpZGdlX2FiaV92ZXJzaW9uAAAOdHJhdmVyc2VfYWxsb2MAARB0cmF2ZXJzZV9kZWFsbG9jAAINdHJhdmVyc2VfaW5pdAAED3RyYXZlcnNlX3N1Ym1pdAAFE3RyYXZlcnNlX25leHRfZXZlbnQABg90cmF2ZXJzZV9jYW5jZWwABxl0cmF2ZXJzZV9jb21wYXRpYmxlX3N0YXJ0AAgYdHJhdmVyc2VfY29tcGF0aWJsZV9zdG9wAAkYdHJhdmVyc2VfY29tcGF0aWJsZV9raWxsAAoRdHJhdmVyc2Vfc2h1dGRvd24ACwqXAQwGAEH0zgALBQBBwAALAgALFQAgACABNgIAIABBBGogAjYCAEEACwsAIAJBgARBEhADCwsAIAJBoARBJxADCxsAIwBFBH9BASQAIABB4ARBNhADGkEBBUEACwsLACACQaAEQScQAwsLACACQaAEQScQAwsLACACQaAEQScQAwsLACACQaAEQScQAwsLACAAQcAFQRQQAwsLnAEEAEGABAsSeyJzdGF0dXMiOiJyZWFkeSJ9AEGgBAsneyJzZXNzaW9uX2lkIjoiczEiLCJzdGF0dXMiOiJhY2NlcHRlZCJ9AEHgBAs2eyJzZXF1ZW5jZSI6MSwidGFyZ2V0X2lkIjoiZGVtbyIsInN0YXR1cyI6ImNvbXBsZXRlZCJ9AEHABQsUeyJzdGF0dXMiOiJzdG9wcGVkIn0=";
 
     [Fact]
     public void VerifiesAndInstantiatesTheGovernedBridge()
@@ -66,6 +67,22 @@ public sealed class WasmtimeRuntimeBridgeTests
         Assert.Equal("{\"sequence\":1}", Text(client.NextEvent()!));
         Assert.Null(client.NextEvent());
         Assert.Equal("{\"status\":\"stopped\"}", Text(client.Shutdown()));
+    }
+
+    [Fact]
+    public void RuntimeEmbedderMapsRuntimeOwnedResultsIntoPublicTypes()
+    {
+        using var bridge = new WasmtimeRuntimeBridge(FixtureBundle(fixture: TypedClientFixture).Bundle);
+        var runtime = new RuntimeTraverseEmbedder(new WasmtimeBridgeClient(bridge));
+        runtime.Initialize("{}");
+
+        Assert.Equal(
+            new TraverseSubmissionResult("s1", "accepted"),
+            runtime.Submit(new TraverseSubmission("demo", "{}")));
+        Assert.Equal(
+            [new TraverseRuntimeEvent(1, "demo", "completed")],
+            runtime.Subscribe());
+        Assert.Equal("{\"status\":\"stopped\"}", runtime.Shutdown());
     }
 
     private static (TraverseBundle Bundle, byte[] Bytes) FixtureBundle(

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/WasmtimeRuntimeBridgeTests.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/WasmtimeRuntimeBridgeTests.cs
@@ -9,6 +9,7 @@ public sealed class WasmtimeRuntimeBridgeTests
     private const string BridgeFixture = "AGFzbQEAAAABFgRgAAF/YAF/AX9gAn9/AGADf39/AX8DDAsAAQIDAwEDAwMDAQUEAQEBEAf8AQwGbWVtb3J5AgAbdHJhdmVyc2VfYnJpZGdlX2FiaV92ZXJzaW9uAAAOdHJhdmVyc2VfYWxsb2MAARB0cmF2ZXJzZV9kZWFsbG9jAAINdHJhdmVyc2VfaW5pdAADD3RyYXZlcnNlX3N1Ym1pdAAEE3RyYXZlcnNlX25leHRfZXZlbnQABQ90cmF2ZXJzZV9jYW5jZWwABhl0cmF2ZXJzZV9jb21wYXRpYmxlX3N0YXJ0AAcYdHJhdmVyc2VfY29tcGF0aWJsZV9zdG9wAAgYdHJhdmVyc2VfY29tcGF0aWJsZV9raWxsAAkRdHJhdmVyc2Vfc2h1dGRvd24ACgo5CwYAQfTOAAsFAEHAAAsCAAsEAEEACwQAQQALBABBAAsEAEEACwQAQQALBABBAAsEAEEACwQAQQAL";
     private const string ImportedFixture = "AGFzbQEAAAABCAJgAABgAAF/AiMBFndhc2lfc25hcHNob3RfcHJldmlldzEIZmRfd3JpdGUAAAMCAQEFAwEAAQcoAgZtZW1vcnkCABt0cmF2ZXJzZV9icmlkZ2VfYWJpX3ZlcnNpb24AAQoIAQYAQfTOAAs=";
     private const string BridgeTenFixture = "AGFzbQEAAAABFgRgAAF/YAF/AX9gAn9/AGADf39/AX8DDAsAAQIDAwEDAwMDAQUEAQEBEAf8AQwGbWVtb3J5AgAbdHJhdmVyc2VfYnJpZGdlX2FiaV92ZXJzaW9uAAAOdHJhdmVyc2VfYWxsb2MAARB0cmF2ZXJzZV9kZWFsbG9jAAINdHJhdmVyc2VfaW5pdAADD3RyYXZlcnNlX3N1Ym1pdAAEE3RyYXZlcnNlX25leHRfZXZlbnQABQ90cmF2ZXJzZV9jYW5jZWwABhl0cmF2ZXJzZV9jb21wYXRpYmxlX3N0YXJ0AAcYdHJhdmVyc2VfY29tcGF0aWJsZV9zdG9wAAgYdHJhdmVyc2VfY29tcGF0aWJsZV9raWxsAAkRdHJhdmVyc2Vfc2h1dGRvd24ACgo5CwYAQZDOAAsFAEHAAAsCAAsEAEEACwQAQQALBABBAAsEAEEACwQAQQALBABBAAsEAEEACwQAQQAL";
+    private const string ClientFixture = "AGFzbQEAAAABFgRgAAF/YAF/AX9gAn9/AGADf39/AX8DDQwAAQIDAwMBAwMDAwEFBAEBARAGBgF/AUEACwf8AQwGbWVtb3J5AgAbdHJhdmVyc2VfYnJpZGdlX2FiaV92ZXJzaW9uAAAOdHJhdmVyc2VfYWxsb2MAARB0cmF2ZXJzZV9kZWFsbG9jAAINdHJhdmVyc2VfaW5pdAAED3RyYXZlcnNlX3N1Ym1pdAAFE3RyYXZlcnNlX25leHRfZXZlbnQABg90cmF2ZXJzZV9jYW5jZWwABxl0cmF2ZXJzZV9jb21wYXRpYmxlX3N0YXJ0AAgYdHJhdmVyc2VfY29tcGF0aWJsZV9zdG9wAAkYdHJhdmVyc2VfY29tcGF0aWJsZV9raWxsAAoRdHJhdmVyc2Vfc2h1dGRvd24ACwqXAQwGAEH0zgALBQBBwAALAgALFQAgACABNgIAIABBBGogAjYCAEEACwsAIAJBgARBEhADCwsAIAJBoARBFRADCxsAIwBFBH9BASQAIABBwARBDhADGkEBBUEACwsLACACQaAEQRUQAwsLACACQaAEQRUQAwsLACACQaAEQRUQAwsLACACQaAEQRUQAwsLACAAQeAEQRQQAwsLYgQAQYAECxJ7InN0YXR1cyI6InJlYWR5In0AQaAECxV7InN0YXR1cyI6ImFjY2VwdGVkIn0AQcAECw57InNlcXVlbmNlIjoxfQBB4AQLFHsic3RhdHVzIjoic3RvcHBlZCJ9";
 
     [Fact]
     public void VerifiesAndInstantiatesTheGovernedBridge()
@@ -54,6 +55,19 @@ public sealed class WasmtimeRuntimeBridgeTests
         Assert.Equal("bridge_resource_limit", fuelError.Message);
     }
 
+    [Fact]
+    public void ClientCopiesResultsAndDrainsEventsInOrder()
+    {
+        using var bridge = new WasmtimeRuntimeBridge(FixtureBundle(fixture: ClientFixture).Bundle);
+        var client = new WasmtimeBridgeClient(bridge);
+
+        Assert.Equal("{\"status\":\"ready\"}", Text(client.Initialize("{}"u8)));
+        Assert.Equal("{\"status\":\"accepted\"}", Text(client.Submit("{\"target_id\":\"demo\"}"u8)));
+        Assert.Equal("{\"sequence\":1}", Text(client.NextEvent()!));
+        Assert.Null(client.NextEvent());
+        Assert.Equal("{\"status\":\"stopped\"}", Text(client.Shutdown()));
+    }
+
     private static (TraverseBundle Bundle, byte[] Bytes) FixtureBundle(
         string? declaredDigest = null,
         string fixture = BridgeFixture)
@@ -68,4 +82,6 @@ public sealed class WasmtimeRuntimeBridgeTests
 
     private static string Digest(byte[] bytes) =>
         "sha256:" + Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+
+    private static string Text(byte[] bytes) => System.Text.Encoding.UTF8.GetString(bytes);
 }

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder/RuntimeTraverseEmbedder.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder/RuntimeTraverseEmbedder.cs
@@ -1,0 +1,117 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Traverse.Embedder;
+
+/// <summary>Typed public embedder backed exclusively by runtime-owned bridge results.</summary>
+public sealed class RuntimeTraverseEmbedder
+{
+    private readonly WasmtimeBridgeClient client;
+
+    public RuntimeTraverseEmbedder(TraverseBundle bundle) : this(
+        new WasmtimeBridgeClient(new WasmtimeRuntimeBridge(bundle)))
+    {
+    }
+
+    public RuntimeTraverseEmbedder(WasmtimeBridgeClient client)
+    {
+        this.client = client;
+    }
+
+    public string Initialize(string configJson) => Text(client.Initialize(Encoding.UTF8.GetBytes(configJson)));
+
+    public TraverseSubmissionResult Submit(TraverseSubmission submission)
+    {
+        submission.Validate();
+        var request = new JsonObject
+        {
+            ["target_id"] = submission.TargetId,
+            ["input"] = JsonNode.Parse(submission.InputJson),
+        };
+        using var result = Result(client.Submit(Encoding.UTF8.GetBytes(request.ToJsonString())));
+        return new TraverseSubmissionResult(
+            RequiredString(result.RootElement, "session_id"),
+            RequiredString(result.RootElement, "status"));
+    }
+
+    public IReadOnlyList<TraverseRuntimeEvent> Subscribe()
+    {
+        var events = new List<TraverseRuntimeEvent>();
+        while (client.NextEvent() is { } bytes)
+        {
+            using var result = Result(bytes);
+            var value = result.RootElement;
+            events.Add(new TraverseRuntimeEvent(
+                RequiredInt(value, "sequence"),
+                RequiredString(value, "target_id"),
+                RequiredString(value, "status"),
+                OptionalString(value, "instance_id")));
+        }
+        return events;
+    }
+
+    public string Cancel(string sessionId)
+    {
+        var request = new JsonObject { ["session_id"] = sessionId };
+        return Text(client.Cancel(Encoding.UTF8.GetBytes(request.ToJsonString())));
+    }
+
+    public TraverseCompatibleResult CompatibleStart(string capabilityId, string inputJson)
+    {
+        var request = new JsonObject
+        {
+            ["capability_id"] = capabilityId,
+            ["input"] = JsonNode.Parse(inputJson),
+        };
+        return CompatibleResult(client.CompatibleStart(Encoding.UTF8.GetBytes(request.ToJsonString())));
+    }
+
+    public TraverseCompatibleResult CompatibleStop(string capabilityId, string? instanceId) =>
+        CompatibleResult(client.CompatibleStop(Encoding.UTF8.GetBytes(CompatibleRequest(capabilityId, instanceId))));
+
+    public TraverseCompatibleResult CompatibleKill(string capabilityId, string? instanceId) =>
+        CompatibleResult(client.CompatibleKill(Encoding.UTF8.GetBytes(CompatibleRequest(capabilityId, instanceId))));
+
+    public string Shutdown() => Text(client.Shutdown());
+
+    private static string CompatibleRequest(string capabilityId, string? instanceId) =>
+        new JsonObject { ["capability_id"] = capabilityId, ["instance_id"] = instanceId }.ToJsonString();
+
+    private static TraverseCompatibleResult CompatibleResult(byte[] bytes)
+    {
+        using var result = Result(bytes);
+        return new TraverseCompatibleResult(
+            OptionalString(result.RootElement, "instance_id"),
+            RequiredString(result.RootElement, "status"));
+    }
+
+    private static JsonDocument Result(byte[] bytes)
+    {
+        try
+        {
+            return JsonDocument.Parse(bytes);
+        }
+        catch (JsonException error)
+        {
+            throw new TraverseBridgeException(-2, $"bridge_invalid_json: {error.Message}");
+        }
+    }
+
+    private static string RequiredString(JsonElement value, string name) =>
+        value.TryGetProperty(name, out var property) && property.ValueKind == JsonValueKind.String
+            ? property.GetString()!
+            : throw new TraverseBridgeException(-2, $"bridge result is missing {name}");
+
+    private static string? OptionalString(JsonElement value, string name) =>
+        !value.TryGetProperty(name, out var property) || property.ValueKind == JsonValueKind.Null
+            ? null
+            : property.GetString();
+
+    private static int RequiredInt(JsonElement value, string name) =>
+        value.TryGetProperty(name, out var property) && property.TryGetInt32(out var result)
+            ? result
+            : throw new TraverseBridgeException(-2, $"bridge result is missing {name}");
+
+    private static string Text(byte[] bytes) => Encoding.UTF8.GetString(bytes);
+}

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder/WasmtimeBridgeClient.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder/WasmtimeBridgeClient.cs
@@ -1,0 +1,153 @@
+using System.Buffers.Binary;
+using Wasmtime;
+
+namespace Traverse.Embedder;
+
+/// <summary>Serialized UTF-8 JSON client for the governed runtime-WASM bridge.</summary>
+public sealed class WasmtimeBridgeClient
+{
+    public const int DefaultMaximumOutputBytes = 1024 * 1024;
+    private const int DescriptorBytes = 8;
+
+    private readonly object synchronization = new();
+    private readonly Instance instance;
+    private readonly Memory memory;
+    private readonly Func<int, int> allocate;
+    private readonly Action<int, int> deallocate;
+    private readonly int maximumOutputBytes;
+
+    public WasmtimeBridgeClient(
+        WasmtimeRuntimeBridge bridge,
+        int maximumOutputBytes = DefaultMaximumOutputBytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumOutputBytes);
+        instance = bridge.Instance;
+        memory = instance.GetMemory("memory")
+            ?? throw new TraverseBridgeException(-3, "bridge_invalid_descriptor");
+        allocate = instance.GetFunction<int, int>("traverse_alloc")
+            ?? throw new TraverseBridgeException(-5, "bridge allocation export is unavailable");
+        deallocate = instance.GetAction<int, int>("traverse_dealloc")
+            ?? throw new TraverseBridgeException(-5, "bridge deallocation export is unavailable");
+        this.maximumOutputBytes = maximumOutputBytes;
+    }
+
+    public byte[] Initialize(ReadOnlySpan<byte> configJson)
+    {
+        var input = configJson.ToArray();
+        return Serialized(() => InvokeWithInput("traverse_init", input));
+    }
+
+    public byte[] Submit(ReadOnlySpan<byte> requestJson)
+    {
+        var input = requestJson.ToArray();
+        return Serialized(() => InvokeWithInput("traverse_submit", input));
+    }
+
+    public byte[] Cancel(ReadOnlySpan<byte> requestJson)
+    {
+        var input = requestJson.ToArray();
+        return Serialized(() => InvokeWithInput("traverse_cancel", input));
+    }
+
+    public byte[] CompatibleStart(ReadOnlySpan<byte> requestJson)
+    {
+        var input = requestJson.ToArray();
+        return Serialized(() => InvokeWithInput("traverse_compatible_start", input));
+    }
+
+    public byte[] CompatibleStop(ReadOnlySpan<byte> requestJson)
+    {
+        var input = requestJson.ToArray();
+        return Serialized(() => InvokeWithInput("traverse_compatible_stop", input));
+    }
+
+    public byte[] CompatibleKill(ReadOnlySpan<byte> requestJson)
+    {
+        var input = requestJson.ToArray();
+        return Serialized(() => InvokeWithInput("traverse_compatible_kill", input));
+    }
+
+    public byte[]? NextEvent() => Serialized(() =>
+    {
+        var descriptor = Allocate(DescriptorBytes);
+        try
+        {
+            var function = instance.GetFunction<int, int>("traverse_next_event")
+                ?? throw new TraverseBridgeException(-5, "bridge event export is unavailable");
+            var status = function(descriptor);
+            return status == 0 ? null : ReadResult(status, descriptor);
+        }
+        finally
+        {
+            deallocate(descriptor, DescriptorBytes);
+        }
+    });
+
+    public byte[] Shutdown() => Serialized(() =>
+    {
+        var descriptor = Allocate(DescriptorBytes);
+        try
+        {
+            var function = instance.GetFunction<int, int>("traverse_shutdown")
+                ?? throw new TraverseBridgeException(-5, "bridge shutdown export is unavailable");
+            return ReadResult(function(descriptor), descriptor);
+        }
+        finally
+        {
+            deallocate(descriptor, DescriptorBytes);
+        }
+    });
+
+    private byte[] InvokeWithInput(string export, ReadOnlySpan<byte> input)
+    {
+        var inputPointer = Allocate(input.Length);
+        var descriptor = Allocate(DescriptorBytes);
+        try
+        {
+            input.CopyTo(memory.GetSpan(inputPointer, input.Length));
+            var function = instance.GetFunction<int, int, int, int>(export)
+                ?? throw new TraverseBridgeException(-5, $"bridge export {export} is unavailable");
+            return ReadResult(function(inputPointer, input.Length, descriptor), descriptor);
+        }
+        finally
+        {
+            deallocate(descriptor, DescriptorBytes);
+            deallocate(inputPointer, input.Length);
+        }
+    }
+
+    private int Allocate(int length)
+    {
+        var pointer = allocate(length);
+        if (pointer < 0) throw new TraverseBridgeException(-4, "bridge allocation failed");
+        return pointer;
+    }
+
+    private byte[] ReadResult(int status, int descriptor)
+    {
+        var rawDescriptor = memory.GetSpan(descriptor, DescriptorBytes);
+        var pointer = BinaryPrimitives.ReadInt32LittleEndian(rawDescriptor[..4]);
+        var length = BinaryPrimitives.ReadInt32LittleEndian(rawDescriptor[4..]);
+        if (pointer < 0 || length < 0 || length > maximumOutputBytes)
+        {
+            throw new TraverseBridgeException(-3, "bridge_invalid_descriptor");
+        }
+
+        var output = memory.GetSpan(pointer, length).ToArray();
+        if (status < 0)
+        {
+            throw new TraverseBridgeException(status, System.Text.Encoding.UTF8.GetString(output));
+        }
+        return output;
+    }
+
+    private T Serialized<T>(Func<T> operation)
+    {
+        lock (synchronization) return operation();
+    }
+}
+
+public sealed class TraverseBridgeException(int status, string message) : InvalidOperationException(message)
+{
+    public int Status { get; } = status;
+}

--- a/scripts/ci/embedder_conformance/dotnet_package.sh
+++ b/scripts/ci/embedder_conformance/dotnet_package.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Shared embedder-api/1.0.0 conformance run for the public .NET package
+# (spec 057 conformance suite; spec 068 FR-009 certification gate).
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+api_id="$(python3 - "${repo_root}/specs/057-embeddable-runtime-host/embedder-api-1.0.0.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    print(json.load(handle)["$id"])
+PY
+)"
+
+if [[ "${api_id}" != "https://traverse.dev/embedder-api/1.0.0" ]]; then
+  echo "embedder API id mismatch: ${api_id}" >&2
+  exit 1
+fi
+
+dotnet test packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/TraverseEmbedder.Tests.csproj
+
+python3 - <<'PY'
+import json
+
+print(json.dumps({
+    "traverse_embedder_api": "1.0.0",
+    "conformance_passed": True,
+    "reference": "dotnet-package",
+    "package": "TraverseEmbedder",
+}, sort_keys=True))
+PY


### PR DESCRIPTION
## Summary

- add the public `WasmtimeBridgeClient` for allocation-safe UTF-8 JSON calls to the verified runtime bridge
- map runtime responses into stable public embedder submission, event, and compatible-lifecycle records
- certify the package with the shared .NET embedder conformance check

Closes #649.

## Governing Spec

- 004-spec-alignment-gate
- 028-schema-alignment-gate-v02
- 031-supply-chain-hardening
- 040-contractual-enforcement-gate
- 068-public-platform-embedder-packages
- 071-native-runtime-wasm-bridge

## Project Item

- Traverse Project 1: #649

## Definition of Done

- [x] Public bridge client owns allocation, descriptor, and output-copy boundaries.
- [x] Runtime-owned results map to stable public .NET embedder types.
- [x] Shared conformance is wired into CI.
- [ ] WinUI reference-app integration and release evidence remain downstream work.

## Validation

- `dotnet test packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/TraverseEmbedder.Tests.csproj --no-restore`
- `bash scripts/ci/embedder_conformance/dotnet_package.sh`
