### PR TITLE
spec: archive 5 stale drafts, retroactively approve 188/190

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -571,3 +571,127 @@ version, but native packages requiring the complete embedder API must reject a
 
 All three native hosts implement one lifecycle contract and can resume without
 inventing platform-specific compatible-capability semantics.
+
+## Decision 25: Archive Stale April-2026 Spec Drafts with No Implementation
+
+- **Date**: 2026-07-18
+- **Status**: Accepted
+- **Related issues**: none — repository/spec-hygiene decision, no implementation ticket
+
+### Context
+
+Five spec directories from April 2026 (`019-local-browser-adapter-transport`,
+`020-downstream-integration-validation`, `021-app-facing-operational-constraints`,
+`022-mcp-wasm-server`, `023-downstream-publication-strategy`) exist on `main`,
+still `Status: Draft`, and were never added to
+`specs/governance/approved-specs.json`. No commit in the repository's history
+references any of their spec IDs. Two of them (`019`, `023`) share a spec
+number with a different, later spec that was approved and implemented instead,
+suggesting these were early exploratory drafts superseded before the real
+scope was specified.
+
+### Decision
+
+Treat "older than ~60 days, zero implementation commits, never approved" as
+sufficient signal on its own — no per-spec review needed. Move all five to
+`Status: Superseded` in their own `spec.md`, with a one-line note pointing to
+whatever superseded it where known (`019` → `019-downstream-consumer-contract`,
+`023` → `023-browser-hosted-mcp-consumer-model`; `020`/`021`/`022` noted as
+superseded with no specific direct successor identified).
+
+### Alternatives Considered
+
+- Review each of the five individually before deciding — more thorough, but
+  the batch signal (age + zero implementation + never approved) was judged
+  strong enough on its own.
+- Leave them untouched — avoids any risk of archiving something still wanted,
+  but leaves the spec directory permanently cluttered with dead drafts.
+
+### Outcome
+
+`specs/` no longer carries unapproved, unreferenced drafts alongside the real
+governing-spec history. The one-line successor notes preserve the "why" for
+anyone who finds the archived draft later.
+
+## Decision 26: Retroactively Approve Specs for Already-Completed Governance/Docs Work
+
+- **Date**: 2026-07-18
+- **Status**: Accepted
+- **Related issues**: `#188`, `#190`
+
+### Context
+
+`188-codex-agent-coordination` and `190-readme-rewrite` were both left
+`Status: Draft` and never added to `approved-specs.json`, but the work they
+describe was independently verified complete: `AGENTS.md` and
+`docs/multi-thread-workflow.md` already implement 188's exact pre-flight/claim
+rules (FR-001 through FR-004), and `README.md` already has every badge and
+section 190 required, including the GitHub repository description and topics
+188 asked for.
+
+### Decision
+
+Add both specs to `specs/governance/approved-specs.json` with `status:
+approved` and `immutable: true`, noting they were approved retroactively after
+independent verification that the implementation already satisfies every
+functional requirement — no code changes needed. `188-codex-agent-coordination`
+governs `AGENTS.md` and `docs/multi-thread-workflow.md`; `190-readme-rewrite`
+governs `README.md`.
+
+### Alternatives Considered
+
+- Archive both as superseded, on the reasoning that formal approval doesn't
+  matter once the goal is met — rejected because the spec content is still an
+  accurate description of the current, real behavior, unlike the five drafts
+  in Decision 25.
+- Leave them unapproved indefinitely — leaves a governance gap where real,
+  load-bearing behavior (agent coordination rules, README requirements) has no
+  approved spec backing it.
+
+### Outcome
+
+The spec-alignment gate can now correctly attribute `AGENTS.md`,
+`docs/multi-thread-workflow.md`, and `README.md` changes to an approved spec
+instead of leaving them ungoverned.
+
+## Decision 27: Raise the Swift Embedder's WasmKit Floor to 0.3.1 for Public Resource Controls
+
+- **Date**: 2026-07-18
+- **Status**: Accepted
+- **Governing spec**: `071-native-runtime-wasm-bridge`
+- **Related issues**: `#740`, `#647`
+
+### Context
+
+`packages/swift/TraverseEmbedder` pins WasmKit 0.2.2, which exposes no public
+fuel/epoch/deadline interruption hooks and no public memory-growth limiter —
+only an `@_spi(Fuzzing) Store.resourceLimiter`, which is not a supported
+production API (documented in the package's own `dependency-review.json`,
+reviewed 2026-07-16). WasmKit 0.3.1 has the public hooks needed, but requires
+Swift tools 6.3, macOS 15, and iOS 18 — newer than the package's current Swift
+6.0 / macOS 14 / iOS 17 floor.
+
+### Decision
+
+Bump `packages/swift/TraverseEmbedder/Package.swift` to WasmKit 0.3.1 and the
+corresponding Swift 6.3 / macOS 15 / iOS 18 minimums. Same engine, same
+integration code, no new dependency-review risk — the tradeoff is a narrower
+supported-device matrix (drops macOS 14 / iOS 17) in exchange for genuine
+production-grade resource controls.
+
+### Alternatives Considered
+
+- Track upstream WasmKit for a 0.2.x-compatible public-hook release, or
+  contribute a backport — keeps the wider device floor, but the timeline isn't
+  in Traverse's control.
+- Swap to a different Swift WASM engine entirely — preserves both the device
+  matrix and gets real safety, but means a full re-integration (bridge, ABI
+  validation, digest verification, tests) against an unproven alternative,
+  for no confirmed benefit over just bumping WasmKit.
+
+### Outcome
+
+Issue `#740` tracks the version bump. `packages/swift/TraverseEmbedder`'s
+`dependency-review.json` `known_limitations` entry should be updated once the
+bump lands, and its resolution unblocks `#647`'s remaining Spec 071
+release-evidence item.

--- a/specs/019-local-browser-adapter-transport/spec.md
+++ b/specs/019-local-browser-adapter-transport/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `019-local-browser-adapter-transport`  
 **Created**: 2026-04-02  
-**Status**: Draft  
+**Status**: Superseded (2026-07-18 — see decision-log.md Decision 25; never approved, no implementation commits reference this spec ID; superseded by `019-downstream-consumer-contract`)  
 **Input**: Issue `#119`, the approved browser runtime subscription contract, the first app-consumable gap analysis, and the need for one concrete local browser transport that does not redefine core runtime semantics.
 
 ## Purpose

--- a/specs/020-downstream-integration-validation/spec.md
+++ b/specs/020-downstream-integration-validation/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `020-downstream-integration-validation`  
 **Created**: 2026-04-03  
-**Status**: Draft  
+**Status**: Superseded (2026-07-18 — see decision-log.md Decision 25; never approved, no implementation commits reference this spec ID; no specific direct successor identified)  
 **Input**: The approved direction for Traverse as the runtime and MCP substrate under downstream apps such as `youaskm3`, plus the agreed decisions that the first proving path must validate browser/runtime consumption, MCP consumption, quickstart usability for humans and agents, and release-readiness evidence together.
 
 ## Purpose

--- a/specs/021-app-facing-operational-constraints/spec.md
+++ b/specs/021-app-facing-operational-constraints/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `021-app-facing-operational-constraints`  
 **Created**: 2026-04-03  
-**Status**: Draft  
+**Status**: Superseded (2026-07-18 — see decision-log.md Decision 25; never approved, no implementation commits reference this spec ID; no specific direct successor identified)  
 **Input**: The agreed decision that v0.1 needs one narrow operational-constraints slice covering first-consumer performance expectations and app-facing security/safety boundaries without attempting a full production operating model.
 
 ## Purpose

--- a/specs/022-mcp-wasm-server/spec.md
+++ b/specs/022-mcp-wasm-server/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `022-mcp-wasm-server`  
 **Created**: 2026-04-06  
-**Status**: Draft  
+**Status**: Superseded (2026-07-18 — see decision-log.md Decision 25; never approved, no implementation commits reference this spec ID; no specific direct successor identified)  
 **Input**: User description: "Specify the first dedicated Traverse MCP WASM server model using the portable MCP runtime lessons from UMA Chapter 13."
 
 ## Purpose

--- a/specs/023-downstream-publication-strategy/spec.md
+++ b/specs/023-downstream-publication-strategy/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `codex/issue-198-downstream-publication-strategy`  
 **Created**: 2026-04-07  
-**Status**: Draft  
+**Status**: Superseded (2026-07-18 — see decision-log.md Decision 25; never approved, no implementation commits reference this spec ID; superseded by `023-browser-hosted-mcp-consumer-model`)  
 **Input**: User description: "Specify downstream publication strategy for packaged Traverse runtime and MCP artifacts."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/188-codex-agent-coordination/spec.md
+++ b/specs/188-codex-agent-coordination/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `188-codex-agent-coordination`
 **Created**: 2026-04-07
-**Status**: Draft
+**Status**: Approved (retroactively, 2026-07-18 — see decision-log.md Decision 26; implementation independently verified complete in AGENTS.md and docs/multi-thread-workflow.md)
 **Input**: GitHub issue #188
 
 > **Governance note**: Dev tooling only. No runtime capability, no contract changes. Codex is human-triggered via starter prompts — the coordination mechanism lives in instructions and AGENTS.md, not in automated queue scanning.

--- a/specs/190-readme-rewrite/spec.md
+++ b/specs/190-readme-rewrite/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `190-readme-rewrite`
 **Created**: 2026-04-07
-**Status**: Draft
+**Status**: Approved (retroactively, 2026-07-18 — see decision-log.md Decision 26; implementation independently verified complete in README.md)
 **Input**: GitHub issue #190
 
 > **Governance note**: README.md is governed by spec `001-foundation-v0-1`. This spec must be declared in the PR body. No runtime, contract, or CI gate changes.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -858,6 +858,29 @@
         "docs/adr/0008-compatible-lifecycle-bridge.md",
         "specs/072-native-bridge-compatible-lifecycle/"
       ]
+    },
+    {
+      "id": "188-codex-agent-coordination",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/188-codex-agent-coordination/spec.md",
+      "governs": [
+        "AGENTS.md",
+        "docs/multi-thread-workflow.md",
+        "specs/188-codex-agent-coordination/"
+      ]
+    },
+    {
+      "id": "190-readme-rewrite",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/190-readme-rewrite/spec.md",
+      "governs": [
+        "README.md",
+        "specs/190-readme-rewrite/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Ran a `/brainstorm` session to clear the spec-governance backlog: 8 spec directories existed on `main` with real content but were never added to `specs/governance/approved-specs.json`.
- Five April-2026 drafts (`019-local-browser-adapter-transport`, `020-downstream-integration-validation`, `021-app-facing-operational-constraints`, `022-mcp-wasm-server`, `023-downstream-publication-strategy`) marked `Status: Superseded` — zero implementation commits ever referenced them, and two share a number with a different spec that was approved and shipped instead.
- Two specs (`188-codex-agent-coordination`, `190-readme-rewrite`) independently verified as already fully implemented (AGENTS.md/docs/multi-thread-workflow.md and README.md respectively satisfy every functional requirement) — retroactively approved into `approved-specs.json` rather than redoing the work.
- `050-message-passing-worker-isolation` intentionally left untouched — its own text already gates it on v1 shipping and real production workload data, so it isn't a live decision.
- Also resolved issue #740 (Swift WasmKit engine decision) during the same session: raise the platform floor to WasmKit 0.3.1 / Swift 6.3 / macOS 15 / iOS 18 for public resource-control hooks. Decision recorded; issue #740 updated separately (no code change in this PR — that's Swift package work under #647).
- Full context, alternatives considered, and outcome for all four decisions recorded in `docs/decision-log.md` (Decisions 25-27).

## Governing Spec
- 004-spec-alignment-gate
- 065-sigstore-bundle-verification
- 188-codex-agent-coordination
- 190-readme-rewrite

## Project Item
N/A — spec-governance cleanup, not a feature ticket

## Validation
- `jq empty specs/governance/approved-specs.json` — valid JSON, no duplicate ids
- `bash scripts/ci/repository_checks.sh` passes locally
- CI passes on this PR