### PR TITLE
Add missing crate descriptions required by crates.io publish

### DIFF
--- a/crates/traverse-contracts/Cargo.toml
+++ b/crates/traverse-contracts/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+description = "Contract definitions and validation for the Traverse capability runtime."
 
 [dependencies]
 semver = "1.0.27"

--- a/crates/traverse-mcp/Cargo.toml
+++ b/crates/traverse-mcp/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+description = "Model Context Protocol server for the Traverse capability runtime."
 
 [[bin]]
 name = "traverse-mcp"

--- a/crates/traverse-registry/Cargo.toml
+++ b/crates/traverse-registry/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+description = "Capability and event registries for the Traverse capability runtime."
 
 [dependencies]
 traverse-contracts = { workspace = true }

--- a/crates/traverse-runtime/Cargo.toml
+++ b/crates/traverse-runtime/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+description = "Core execution engine for the Traverse capability runtime."
 
 [dependencies]
 traverse-contracts = { workspace = true }


### PR DESCRIPTION
## Summary

Fixes the actual publish-blocking defect found while unblocking issue #741 (`CARGO_REGISTRY_TOKEN` pipeline). With the token and account email verification now in place, the real `Publish to crates.io` run failed on `traverse-contracts`:

```
error: failed to publish traverse-contracts v0.8.0 to registry at https://crates.io
Caused by:
  the remote server responded with an error (status 400 Bad Request): missing or empty metadata fields: description.
```

Adds a one-line `description` to the four remaining crates that were missing one (`traverse-contracts`, `traverse-registry`, `traverse-runtime`, `traverse-mcp`). `traverse-expedition-wasm` already had one, and `traverse-cli` was fixed independently in #743 (rebased onto that here — its rename to `traverse-cli-rs` for a crates.io name collision also picked up its own description in the same PR). Descriptions are drawn from each crate's documented role in `CLAUDE.md`'s Project Structure section, not invented.

## Governing Spec

- `048-semver-publishing-pipeline`

## Project Item

#741

## Validation

- [x] `cargo build --workspace` passes
- [x] `cargo publish -p traverse-contracts --dry-run --allow-dirty` — no missing-description warning, packages cleanly
- [x] `cargo publish -p traverse-expedition-wasm --dry-run --allow-dirty` — unaffected, still clean
- [x] `bash scripts/ci/spec_alignment_check.sh` passes locally against this PR body
- [ ] `traverse-registry`/`traverse-runtime`/`traverse-mcp` dry-runs can't be fully verified locally (they resolve `traverse-contracts` as a registry dependency, which doesn't exist on crates.io until it's actually published) — verified instead by the real tag-triggered publish job in dependency order once this merges and a new release is cut
- [ ] Real publish verification: after merge, `docs/release-process.md`'s documented `bump_version.sh` release flow will be run to cut a new tag and confirm all 6 crates publish successfully

Related: #741
