### PR TITLE
chore: bump version to v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,7 +1813,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli-rs"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ed25519-dalek",
  "qrcode",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "semver",
  "serde",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-embedder"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "semver",
  "serde",
@@ -1879,7 +1879,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/traverse-framework/traverse"
 rust-version = "1.94"
-version = "0.8.0"
+version = "0.8.1"
 
 [workspace.dependencies]
-traverse-contracts = { path = "crates/traverse-contracts", version = "0.8.0" }
-traverse-registry = { path = "crates/traverse-registry", version = "0.8.0" }
-traverse-runtime = { path = "crates/traverse-runtime", version = "0.8.0" }
+traverse-contracts = { path = "crates/traverse-contracts", version = "0.8.1" }
+traverse-registry = { path = "crates/traverse-registry", version = "0.8.1" }
+traverse-runtime = { path = "crates/traverse-runtime", version = "0.8.1" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Scaffolds a governed app bundle. Add your capability contracts, workflows, and W
 
 ### Consumer and release surfaces
 
-- [docs/releases/v0.8.0.md](docs/releases/v0.8.0.md) — current release notes
+- [docs/releases/v0.8.1.md](docs/releases/v0.8.1.md) — current release notes
 - [docs/app-consumable-consumer-bundle.md](docs/app-consumable-consumer-bundle.md) — versioned consumer bundle
 - [docs/app-consumable-package-release-pointer.md](docs/app-consumable-package-release-pointer.md) — package release pointer
 - [docs/packaged-traverse-runtime-artifact.md](docs/packaged-traverse-runtime-artifact.md) — packaged runtime artifact

--- a/docs/releases/v0.8.1.md
+++ b/docs/releases/v0.8.1.md
@@ -1,0 +1,39 @@
+# Traverse v0.8.1
+
+Release date: 2026-07-18
+
+Traverse v0.8.1 is a patch release with no functional or spec changes. It fixes the crates.io publish pipeline (spec 048) so the workspace can actually be published: the `v0.8.0` tag's `Publish to crates.io` job never completed a real publish.
+
+## Highlights
+
+- Fixes `CARGO_REGISTRY_TOKEN` being unset in the `Publish to crates.io` job, which had blocked every tagged release from reaching crates.io since the pipeline was introduced.
+- Adds the `description` manifest field to `traverse-contracts`, `traverse-registry`, `traverse-runtime`, and `traverse-mcp`, required by crates.io's publish endpoint (previously only a `cargo publish` warning, now enforced).
+- Renames the `traverse-cli` crate's package identity to `traverse-cli-rs` to resolve a crates.io name collision with an unrelated, already-published crate; the binary invocation stays `traverse-cli`.
+
+## Compatibility Notes
+
+- No runtime, contract, or API behavior changed from `v0.8.0`. This release exists solely to complete `v0.8.0`'s publish to crates.io under a new version number, since the `v0.8.0` git tag cannot be moved after the fact.
+- Traverse remains a `0.x` project.
+
+## Validation
+
+Release preparation must pass these local gates before tagging:
+
+```bash
+cargo build --workspace
+bash scripts/ci/repository_checks.sh
+bash scripts/ci/spec_alignment_check.sh
+```
+
+The GitHub PR checks must also pass:
+
+- `repository-checks`
+- `coverage-gate`
+- `pr-hygiene`
+- `spec-alignment`
+
+## Traceability
+
+- Release issue: https://github.com/traverse-framework/traverse/issues/741
+- Governing spec: `048-semver-publishing-pipeline`
+- Included PRs: #746, #743, #747

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -22,6 +22,7 @@ required_files=(
   "docs/releases/v0.6.0.md"
   "docs/releases/v0.7.0.md"
   "docs/releases/v0.8.0.md"
+  "docs/releases/v0.8.1.md"
   "docs/troubleshooting.md"
   "docs/adapter-boundaries.md"
   "docs/contract-publication-policy.md"
@@ -354,8 +355,8 @@ grep -q "Supply-chain evidence" docs/v0.3.0-public-surface-compatibility.md
 grep -q "docs/v0.3.0-source-build-consumer-packaging.md" README.md
 grep -q "docs/v0.3.0-downstream-validation-path.md" README.md
 grep -q "docs/youaskm3-v0.3.0-integration-readiness.md" README.md
-grep -q 'version = "0.8.0"' Cargo.toml
-grep -q "docs/releases/v0.8.0.md" README.md
+grep -q 'version = "0.8.1"' Cargo.toml
+grep -q "docs/releases/v0.8.1.md" README.md
 grep -q "Traverse v0.4.0" docs/releases/v0.4.0.md
 grep -q "044-application-bundle-manifest" docs/releases/v0.4.0.md
 grep -q "045-governed-model-dependency-resolution" docs/releases/v0.4.0.md
@@ -396,6 +397,12 @@ grep -q "traverse-embedder" docs/releases/v0.8.0.md
 grep -q "journal-backed replay" docs/releases/v0.8.0.md
 grep -q "doc-approval.recommend" docs/releases/v0.8.0.md
 grep -q "coverage-gate" docs/releases/v0.8.0.md
+
+grep -q "Traverse v0.8.1" docs/releases/v0.8.1.md
+grep -q "048-semver-publishing-pipeline" docs/releases/v0.8.1.md
+grep -q "traverse-cli-rs" docs/releases/v0.8.1.md
+grep -q "CARGO_REGISTRY_TOKEN" docs/releases/v0.8.1.md
+grep -q "coverage-gate" docs/releases/v0.8.1.md
 grep -q "cargo build" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-cli-rs -- serve" docs/v0.3.0-source-build-consumer-packaging.md
 grep -q "cargo run -p traverse-mcp -- stdio" docs/v0.3.0-source-build-consumer-packaging.md


### PR DESCRIPTION
## Summary

Bumps the workspace version to 0.8.1 using the documented `scripts/ci/bump_version.sh` release helper, per `docs/release-process.md`. This is a fix-forward release for #741: the v0.8.0 tag's publish job failed on a missing `description` manifest field ([#746](https://github.com/traverse-framework/traverse/pull/746) fixed that on `main`, and #743 separately fixed a `traverse-cli` crates.io name collision), and v0.8.0's tag can't be moved after the fact, so the first real publish attempt goes out at 0.8.1 instead.

`docs/release-process.md` documents `git push origin main` as a release step, but this repo's branch protection now requires all changes through a PR — routing the bump commit through a PR here since a direct push was rejected.

Also discovered `scripts/ci/repository_checks.sh` hardcodes a check that `Cargo.toml`'s workspace version matches the current release-notes file (`docs/releases/v0.8.0.md`) — this has to be updated on every version bump, and nothing in `bump_version.sh` or the docs mentions it. Adds `docs/releases/v0.8.1.md` following the same structure as prior release notes (v0.3.0 through v0.8.0, all still present and individually validated), updates the hardcoded `0.8.0` references in the gate script, and repoints README's release-notes link.

## Governing Spec

- `048-semver-publishing-pipeline`
- `004-spec-alignment-gate`
- `065-sigstore-bundle-verification`
- `190-readme-rewrite`

## Project Item

#741

## Validation

- [x] `bash scripts/ci/bump_version.sh 0.8.1` — refused a dirty tree, touched only `Cargo.toml`, created the bump commit
- [x] `cargo build --workspace` passes at 0.8.1
- [x] `bash scripts/ci/spec_alignment_check.sh` passes locally against this PR body
- [ ] After merge: re-tag `v0.8.1` at the merged commit (squash merge produces a new SHA) and push the tag to trigger the real `Publish to crates.io` job
