### PR TITLE
fix: confirm_published should check the sparse index, not cargo search

### DIFF
--- a/scripts/ci/publish_crates.sh
+++ b/scripts/ci/publish_crates.sh
@@ -109,15 +109,37 @@ publish_one() {
   return "${rc}"
 }
 
+sparse_index_path() {
+  local crate="$1"
+  local len="${#crate}"
+
+  if [[ "${len}" -eq 1 ]]; then
+    echo "1/${crate}"
+  elif [[ "${len}" -eq 2 ]]; then
+    echo "2/${crate}"
+  elif [[ "${len}" -eq 3 ]]; then
+    echo "3/${crate:0:1}/${crate}"
+  else
+    echo "${crate:0:2}/${crate:2:2}/${crate}"
+  fi
+}
+
 confirm_published() {
   local crate="$1"
+  local path
 
   if [[ "${dry_run}" == "1" ]]; then
     return 0
   fi
 
+  # crates.io's search index (used by `cargo search`) can lag well behind
+  # publish for a brand-new crate name, sometimes past 10 minutes. The
+  # sparse index that cargo itself uses for dependency resolution updates
+  # within seconds of a real publish, so check that directly instead.
+  path="$(sparse_index_path "${crate}")"
+
   for attempt in {1..20}; do
-    if cargo search "${crate}" --limit 5 2>/dev/null | grep -Eq "^${crate} = \"${workspace_version}\""; then
+    if curl -fsS "https://index.crates.io/${path}" 2>/dev/null | grep -Fq "\"vers\":\"${workspace_version}\""; then
       echo "Confirmed ${crate} ${workspace_version} on crates.io."
       return 0
     fi


### PR DESCRIPTION
## Summary

Fixes a real bug found while running the actual `v0.8.1` publish (issue #741): `traverse-contracts` published successfully to crates.io, but `confirm_published`'s 10-minute wait loop timed out anyway, aborting the rest of the pipeline before any of the other 6 crates were attempted.

Root cause: `confirm_published` checks via `cargo search`, which queries crates.io's full-text search index — a separate, eventually-consistent index that can lag real publish by well over 10 minutes for a brand-new crate name (this is exactly our situation: none of these crate names existed before this release). Verified directly: `cargo search traverse-contracts` failed to find it minutes after publish, but the sparse index (`https://index.crates.io/tr/av/traverse-contracts`) — the index cargo itself actually uses for dependency resolution — showed the correct version within seconds of the real publish.

Replaces the `cargo search` check with a direct sparse-index lookup.

## Governing Spec

- `048-semver-publishing-pipeline`

## Project Item

#741

## Validation

- [x] Verified locally: `cargo search traverse-contracts` succeeds (now, well after publish), confirming the old check was simply too slow, not wrong in principle
- [x] Verified the new sparse-index check against the real, already-published `traverse-contracts` v0.8.1: `curl -fsS https://index.crates.io/tr/av/traverse-contracts | grep -F '"vers":"0.8.1"'` matches
- [x] Verified `sparse_index_path` for 1/2/3/4+ character crate names produces the correct crates.io directory scheme
- [x] `bash scripts/ci/spec_alignment_check.sh` passes locally against this PR body
