### PR TITLE
fix: recognize crates.io's real already-published error message

### DIFF
--- a/scripts/ci/publish_crates.sh
+++ b/scripts/ci/publish_crates.sh
@@ -99,7 +99,7 @@ publish_one() {
   fi
 
   cat "${output_file}" >&2
-  if grep -Eiq "already uploaded|crate version .* is already uploaded" "${output_file}"; then
+  if grep -Eiq "already uploaded|crate version .* is already uploaded|already exists on crates\.io index" "${output_file}"; then
     echo "${crate} ${workspace_version} is already published; continuing."
     rm -f "${output_file}"
     return 0


### PR DESCRIPTION
## Summary

Second real bug found while running the actual `v0.8.1` publish (issue #741), immediately after #748's sparse-index fix: `publish_one`'s idempotency catch is supposed to treat an already-published crate version as success (`docs/release-process.md` documents reruns as idempotent for exactly this reason), but its regex only matches `"already uploaded"` / `"crate version ... is already uploaded"`. crates.io's actual error text for a real re-publish attempt is:

```
error: crate traverse-contracts@0.8.1 already exists on crates.io index
```

which doesn't match either pattern, so the rerun (needed because `traverse-contracts` already published successfully at 0.8.1 while the other 6 crates were never attempted) hard-failed instead of skipping the done crate and continuing to the rest.

Adds `already exists on crates\.io index` to the idempotency regex.

## Governing Spec

- `048-semver-publishing-pipeline`

## Project Item

#741

## Validation

- [x] `echo 'error: crate traverse-contracts@0.8.1 already exists on crates.io index' | grep -Eiq "already uploaded|crate version .* is already uploaded|already exists on crates\.io index"` — matches
- [x] `bash -n scripts/ci/publish_crates.sh` — syntax OK
- [x] `bash scripts/ci/spec_alignment_check.sh` passes locally against this PR body
