### PR TITLE
feat(embedder): expose native runtime target output

### DIFF
--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/WasmtimeRuntimeBridgeTests.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/WasmtimeRuntimeBridgeTests.cs
@@ -85,6 +85,15 @@ public sealed class WasmtimeRuntimeBridgeTests
         Assert.Equal("{\"status\":\"stopped\"}", runtime.Shutdown());
     }
 
+    [Fact]
+    public void TestDoubleExposesScriptedTargetOutputPublicly()
+    {
+        var harness = new InMemoryTraverseEmbedder().WithTargetOutput("{\"answer\":42}");
+        harness.Initialize(new TraverseBundle("assets/traverse", "sha256:test"));
+        harness.Submit(new TraverseSubmission("demo.target", "{}"));
+        Assert.Equal(new TraverseRuntimeEvent(1, "demo.target", "accepted", EventType: "capability_result", SessionId: "dotnet-session-1", Output: "{\"answer\":42}"), harness.Subscribe().Single());
+    }
+
     private static (TraverseBundle Bundle, byte[] Bytes) FixtureBundle(
         string? declaredDigest = null,
         string fixture = BridgeFixture)

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder/TraverseEmbedder.cs
@@ -47,7 +47,11 @@ public sealed record TraverseRuntimeEvent(
     int Sequence,
     string TargetId,
     string Status,
-    string? InstanceId = null);
+    string? InstanceId = null,
+    string? EventType = null,
+    string? SessionId = null,
+    string? ErrorData = null,
+    string? Output = null);
 
 public sealed record TraverseCompatibleResult(string? InstanceId, string Status);
 
@@ -62,6 +66,13 @@ public sealed class InMemoryTraverseEmbedder
     private int compatibleSequence;
     private readonly List<TraverseRuntimeEvent> events = [];
     private readonly Dictionary<string, string> compatibleInstances = [];
+    private string? targetOutput;
+
+    public InMemoryTraverseEmbedder WithTargetOutput(string output)
+    {
+        targetOutput = output;
+        return this;
+    }
 
     public void Initialize(TraverseBundle value)
     {
@@ -85,7 +96,9 @@ public sealed class InMemoryTraverseEmbedder
         submission.Validate();
         submissionSequence++;
         var result = new TraverseSubmissionResult($"dotnet-session-{submissionSequence}", "accepted");
-        events.Add(new TraverseRuntimeEvent(submissionSequence, submission.TargetId, result.Status));
+        events.Add(new TraverseRuntimeEvent(submissionSequence, submission.TargetId, result.Status,
+            EventType: targetOutput is null ? null : "capability_result",
+            SessionId: targetOutput is null ? null : result.SessionId, Output: targetOutput));
         return result;
     }
 

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/TraverseEmbedder.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/main/kotlin/dev/traverse/embedder/TraverseEmbedder.kt
@@ -41,6 +41,10 @@ data class TraverseRuntimeEvent(
     val targetId: String,
     val status: String,
     val instanceId: String? = null,
+    val eventType: String? = null,
+    val sessionId: String? = null,
+    val errorData: String? = null,
+    val output: String? = null,
 )
 
 data class TraverseCompatibleResult(val instanceId: String?, val status: String)
@@ -52,6 +56,9 @@ class InMemoryTraverseEmbedder {
     private var compatibleSequence = 0
     private val events = mutableListOf<TraverseRuntimeEvent>()
     private val compatibleInstances = mutableMapOf<String, String>()
+    private var targetOutput: String? = null
+
+    fun withTargetOutput(output: String): InMemoryTraverseEmbedder = apply { targetOutput = output }
 
     fun initialize(bundle: TraverseBundle) {
         check(this.bundle == null) { "embedder is already initialized" }
@@ -70,7 +77,7 @@ class InMemoryTraverseEmbedder {
         check(bundle != null) { "embedder is not initialized" }
         submissionSequence += 1
         val result = TraverseSubmissionResult("kotlin-session-$submissionSequence", "accepted")
-        events += TraverseRuntimeEvent(submissionSequence, submission.targetId, result.status)
+        events += TraverseRuntimeEvent(submissionSequence, submission.targetId, result.status, eventType = if (targetOutput == null) null else "capability_result", sessionId = if (targetOutput == null) null else result.sessionId, output = targetOutput)
         return result
     }
 

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/TraverseEmbedderTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/TraverseEmbedderTest.kt
@@ -82,4 +82,11 @@ class TraverseEmbedderTest {
             harness.subscribe(),
         )
     }
+
+    @Test fun scriptedTargetOutputIsPublicAndRuntimeOwned() {
+        val harness = InMemoryTraverseEmbedder().withTargetOutput("{\"answer\":42}")
+        harness.initialize(TraverseBundle("assets/traverse", "sha256:test"))
+        harness.submit(TraverseSubmission("demo.target", "{}"))
+        assertEquals(TraverseRuntimeEvent(1, "demo.target", "accepted", eventType = "capability_result", sessionId = "kotlin-session-1", output = "{\"answer\":42}"), harness.subscribe().single())
+    }
 }

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/TraverseEmbedder.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/TraverseEmbedder.swift
@@ -94,12 +94,20 @@ public struct TraverseRuntimeEvent: Sendable, Equatable {
     public let targetID: String
     public let status: String
     public let instanceID: String?
+    public let eventType: String?
+    public let sessionID: String?
+    public let errorData: Data?
+    public let output: Data?
 
-    public init(sequence: Int, targetID: String, status: String, instanceID: String? = nil) {
+    public init(sequence: Int, targetID: String, status: String, instanceID: String? = nil, eventType: String? = nil, sessionID: String? = nil, errorData: Data? = nil, output: Data? = nil) {
         self.sequence = sequence
         self.targetID = targetID
         self.status = status
         self.instanceID = instanceID
+        self.eventType = eventType
+        self.sessionID = sessionID
+        self.errorData = errorData
+        self.output = output
     }
 }
 
@@ -121,8 +129,14 @@ public final class InMemoryTraverseEmbedder: @unchecked Sendable {
     private var compatibleSequence = 0
     private var events: [TraverseRuntimeEvent] = []
     private var compatibleInstances: [String: String] = [:]
+    private var targetOutput: Data?
 
     public init() {}
+
+    public func withTargetOutput(_ output: Data) -> InMemoryTraverseEmbedder {
+        targetOutput = output
+        return self
+    }
 
     public func initialize(bundle: TraverseBundle) throws {
         guard self.bundle == nil else { throw TraverseEmbedderError.alreadyInitialized }
@@ -153,7 +167,10 @@ public final class InMemoryTraverseEmbedder: @unchecked Sendable {
             TraverseRuntimeEvent(
                 sequence: submissionSequence,
                 targetID: submission.targetID,
-                status: result.status
+                status: result.status,
+                eventType: targetOutput == nil ? nil : "capability_result",
+                sessionID: targetOutput == nil ? nil : result.sessionID,
+                output: targetOutput
             )
         )
         return result

--- a/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
+++ b/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
@@ -45,6 +45,16 @@ import WAT
     }
 }
 
+@Test func scriptedTargetOutputIsPublicAndRuntimeOwned() throws {
+    let harness = InMemoryTraverseEmbedder().withTargetOutput(Data("{\"answer\":42}".utf8))
+    try harness.initialize(bundle: TraverseBundle(rootURL: URL(fileURLWithPath: "/tmp/traverse-bundle"), runtimeWasmDigest: "sha256:test"))
+    _ = try harness.submit(TraverseSubmission(targetID: "demo.target", inputJSON: Data("{}".utf8)))
+    let event = try #require(harness.subscribe().first)
+    #expect(event.eventType == "capability_result")
+    #expect(event.sessionID == "swift-session-1")
+    #expect(event.output == Data("{\"answer\":42}".utf8))
+}
+
 @Test func compatibleLifecycleIsDeterministicAndOrdered() throws {
     let harness = InMemoryTraverseEmbedder()
     try harness.initialize(bundle: TraverseBundle(


### PR DESCRIPTION
## Summary

- expose runtime-owned event metadata and terminal output through the public Swift, Kotlin, and .NET embedder APIs
- add deterministic scripted terminal output to each in-memory test double
- cover the public output seam in Swift, Kotlin, and .NET package tests

Closes #751.

## Governing Spec

- `057-embeddable-runtime-host`
- `068-public-platform-embedder-packages`

## Project Item

- [#751](https://github.com/traverse-framework/traverse/issues/751) — Project 1, In Progress

## Definition of Done

- native consumers receive runtime-owned terminal output from public events
- native test doubles script terminal target output without private bridge parsing
- lifecycle compatibility remains additive

## Validation

- `swift test --package-path packages/swift/TraverseEmbedder`
- `dotnet test packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/TraverseEmbedder.Tests.csproj`
- `git diff --check`
- Kotlin test execution is deferred to CI because the repository has no Gradle wrapper and `gradle` is not installed locally.
