### PR TITLE
docs(spec): require Swift resource controls

### DIFF
--- a/docs/adr/0011-swift-native-resource-controls.md
+++ b/docs/adr/0011-swift-native-resource-controls.md
@@ -1,0 +1,45 @@
+# ADR-0011: Require Supported Swift Resource Controls Before Certification
+
+- Status: Accepted
+- Date: 2026-07-18
+
+## Context
+
+Decision 27 selected WasmKit 0.3.1 on the assumption that it exposed public
+memory and execution-resource controls. Official WasmKit 0.3.1 source shows
+that `Store.resourceLimiter` remains `@_spi(Fuzzing)` and that it exposes no
+supported fuel, epoch, deadline, or interruption API. Raising the Swift and
+Apple platform floors therefore does not satisfy the production requirement in
+Spec 071.
+
+## Decision
+
+Do not certify a Swift package or a cross-platform Native Embedder Baseline
+until its selected runtime profile proves bounded memory growth and
+deterministic interruption through documented public APIs on iOS devices and
+macOS. Unsupported SPI and watchdogs that cannot stop the untrusted execution
+are prohibited.
+
+WasmKit remains an eligible candidate only if a future supported release meets
+these requirements. An alternative engine requires a separate approved
+decision, dependency review, Apple bundle-distribution evidence, and the full
+bridge conformance corpus.
+
+## Consequences
+
+- Decision 27 is superseded: a WasmKit version upgrade alone is not an
+  implementation path for #647.
+- #647 remains blocked until #762 produces a certified profile or confirms an
+  upstream dependency.
+- Kotlin and .NET work may continue, but releases cannot be represented as a
+  cross-platform native baseline while Swift is uncertified.
+
+## Alternatives Considered
+
+- Use WasmKit SPI: rejected because it is unsupported and cannot support a
+  production certification claim.
+- Use an external watchdog around a non-interruptible interpreter: rejected
+  because it can return to the UI while untrusted code continues consuming
+  resources.
+- Switch engines immediately: rejected until a device-level feasibility,
+  security, packaging, and conformance evaluation proves a supported profile.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -736,3 +736,44 @@ Spec 057.
 Spec 073 and ADR-0010 record the release baseline. #750 delivers the real
 artifact and evidence, #751 completes public native event parity, and #647
 resolves the Swift production resource-control prerequisite.
+
+## Decision 29: Require Supported Swift Resource Controls Before Certification
+
+- **Date**: 2026-07-18
+- **Status**: Accepted
+- **Governing spec**: `074-swift-native-resource-control-certification`
+- **Related issues**: `#761`, `#762`, `#647`, `#750`, `#758`
+
+### Context
+
+Decision 27 selected WasmKit 0.3.1 based on a false premise: its official
+source still exposes `Store.resourceLimiter` only through `@_spi(Fuzzing)` and
+does not expose a supported fuel, epoch, deadline, or interruption API.
+Raising the Swift and platform floors alone would leave untrusted execution
+without the required supported resource controls.
+
+### Decision
+
+Do not certify the Swift package or a cross-platform Native Embedder Baseline
+until its runtime profile proves bounded memory growth and deterministic
+execution interruption through supported public APIs on physical iOS and
+macOS. Prohibit SPI and watchdogs that cannot stop untrusted execution.
+Evaluate supported options in #762 before changing engines. A replacement
+engine needs its own approved ADR, security/license review, Apple distribution
+evidence, and full bridge conformance.
+
+### Alternatives Considered
+
+- Upgrade to WasmKit 0.3.1 alone — rejected because it does not expose the
+  required supported controls.
+- Use the existing SPI — rejected because unsupported APIs cannot justify a
+  production certification claim.
+- Adopt an alternative engine immediately — rejected pending device-level
+  feasibility, packaging, security, and conformance evidence.
+
+### Outcome
+
+Decision 27 is superseded. #647 remains blocked on a certified Swift profile;
+#761 records the governing requirements and #762 evaluates the smallest
+supported path. Kotlin and .NET work may continue without calling the release
+cross-platform.

--- a/specs/074-swift-native-resource-control-certification/checklists/requirements.md
+++ b/specs/074-swift-native-resource-control-certification/checklists/requirements.md
@@ -1,0 +1,25 @@
+# Specification Quality Checklist: Swift Native Resource-Control Certification
+
+**Purpose**: Validate specification completeness before implementation.
+**Created**: 2026-07-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] All mandatory sections are complete.
+- [x] The specification focuses on auditable production-safety outcomes.
+- [x] Protocol and engine names are used only where needed to define the
+  governed compatibility boundary.
+
+## Requirement Completeness
+
+- [x] No `[NEEDS CLARIFICATION]` markers remain.
+- [x] Requirements, acceptance scenarios, and edge cases are testable.
+- [x] Success criteria are measurable.
+- [x] Scope, dependencies, and assumptions are explicit.
+
+## Feature Readiness
+
+- [x] The profile-selection and evidence requirements are independently
+  verifiable.
+- [x] The specification is ready for the #762 evaluation spike.

--- a/specs/074-swift-native-resource-control-certification/spec.md
+++ b/specs/074-swift-native-resource-control-certification/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Swift Native Resource-Control Certification
+
+**Feature Branch**: `codex/issue-761-swift-resource-profile`
+**Created**: 2026-07-18
+**Status**: Approved
+**Version**: 1.0.0
+**Input**: Decision 29, ADR-0011, and Traverse #761.
+
+## Purpose
+
+Define the certification conditions for the Swift/iOS/macOS native embedder to
+join Native Embedder Baseline 1. This successor specification preserves the
+immutable bridge and release-baseline history in Specs 071, 072, and 073 while
+correcting the unsupported assumption that a WasmKit version increase alone
+provides production resource controls.
+
+## User Scenarios & Testing
+
+### User Story 1 - Select a Safe Swift Runtime Profile (Priority: P1)
+
+A downstream Apple application developer can rely on a package release only
+when its selected execution engine enforces documented memory and execution
+limits on supported Apple devices.
+
+**Why this priority**: An unbounded or non-interruptible untrusted module is
+not a production-safe native runtime.
+
+**Independent Test**: Run a memory-growth fixture and a non-terminating
+fixture through the package on iOS device and macOS; both fail predictably
+without allowing continued unbounded execution.
+
+**Acceptance Scenarios**:
+
+1. **Given** a module that requests memory beyond the declared limit, **When**
+   the package instantiates or grows it, **Then** it fails with the stable
+   resource-limit error and does not exceed the configured bound.
+2. **Given** a module that does not terminate within the declared execution
+   budget, **When** the package invokes it, **Then** it is deterministically
+   interrupted and reports the stable timeout or resource-limit error.
+
+### User Story 2 - Audit the Apple Engine Choice (Priority: P2)
+
+A release reviewer can prove that the engine controls used by a Swift package
+are supported public APIs rather than internal or unstable hooks.
+
+**Why this priority**: A version pin does not establish that a host can safely
+enforce its declared limits.
+
+**Independent Test**: Review the package source and evidence record and verify
+the engine version, API support status, device results, and no-SPI policy.
+
+**Acceptance Scenarios**:
+
+1. **Given** release evidence that names an internal or SPI control,
+   **When** certification is reviewed, **Then** the release is rejected.
+2. **Given** complete evidence for a supported profile, **When** it is
+   reviewed, **Then** it identifies the exact engine, public control APIs,
+   Apple host matrix, and conformance results.
+
+### Edge Cases
+
+- An engine has a public memory limiter but no supported way to interrupt a
+  running module.
+- A timeout returns control to the application while the engine continues the
+  untrusted computation in another thread.
+- A candidate runtime works on macOS but has no reproducible physical-iOS
+  device evidence.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: A Swift package MUST NOT certify Native Embedder Baseline 1
+  unless its runtime profile enforces both bounded memory growth and
+  deterministic execution interruption through documented, supported public
+  engine APIs.
+- **FR-002**: Certification MUST prove a module exceeding the configured
+  memory limit fails deterministically without exceeding that limit.
+- **FR-003**: Certification MUST prove a non-terminating module is stopped
+  within the configured execution budget and reports a stable
+  `bridge_timeout` or `bridge_resource_limit` error.
+- **FR-004**: A profile MUST NOT depend on `@_spi`, undocumented APIs, a
+  watchdog that leaves the untrusted execution alive, or an equivalent
+  unsupported escape hatch.
+- **FR-005**: Certification evidence MUST include the exact engine version and
+  license, the public APIs relied upon, configured limits, iOS-device and
+  macOS results, bridge corpus result, and `embedder-api/1.0.0` conformance
+  result.
+- **FR-006**: An engine that satisfies only one required control remains
+  ineligible for production certification. The package MAY remain a
+  development or test harness, but MUST NOT claim a cross-platform baseline.
+- **FR-007**: Replacing the Swift engine requires an approved ADR, renewed
+  license/security review, bundle-distribution evidence, and the complete
+  cross-engine corpus before #647 implementation begins.
+- **FR-008**: WasmKit 0.3.1 is not by itself a certified production profile:
+  its `Store.resourceLimiter` SPI and lack of supported interruption controls
+  do not meet FR-001.
+
+### Key Entities
+
+- **Swift Runtime Profile**: The exact engine, public controls, host matrix,
+  and evidence used by the Apple native embedder.
+- **Resource-Control Evidence**: Reproducible proof of memory and execution
+  bounds on both supported Apple host classes.
+- **Certified Profile**: A Swift runtime profile satisfying every requirement
+  in this specification and the bridge/API contracts it composes.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Every certified profile passes both memory-exhaustion and
+  non-termination fixtures on physical iOS and macOS with a stable error.
+- **SC-002**: Every certified release record identifies 100% of its engine
+  controls as supported public APIs.
+- **SC-003**: No package that lacks either control is described as a
+  cross-platform Native Embedder Baseline release.
+- **SC-004**: A reviewer can reproduce each evidence result from the recorded
+  engine version, host matrix, limits, and fixture commands.
+
+## Assumptions
+
+- Specs 071, 072, and 073 remain immutable sources of bridge and release
+  compatibility history.
+- Kotlin and .NET native profiles can progress independently but do not make a
+  release cross-platform while the Swift profile remains uncertified.
+- #762 evaluates supported options before an engine replacement is proposed.
+
+## Out of Scope
+
+- Choosing or implementing an alternative Swift engine.
+- Relaxing the core-Wasm no-ambient-import boundary in Spec 071.
+- Changing the public `embedder-api/1.0.0` operation set.
+- Releasing #647 before the certification evidence exists.
+
+## Implementation Tickets
+
+- Traverse #761 — this governing specification and ADR.
+- Traverse #762 — supported-engine evaluation spike.
+- Traverse #647 — Apple package implementation after a certified profile.
+- Traverse #750 and #758 — artifact and cross-host certification delivery.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -875,6 +875,19 @@
       ]
     },
     {
+      "id": "074-swift-native-resource-control-certification",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/074-swift-native-resource-control-certification/spec.md",
+      "governs": [
+        "packages/swift/TraverseEmbedder/",
+        "scripts/ci/embedder_conformance/swift_package.sh",
+        "docs/adr/0011-swift-native-resource-controls.md",
+        "specs/074-swift-native-resource-control-certification/"
+      ]
+    },
+    {
       "id": "188-codex-agent-coordination",
       "version": "1.0.0",
       "status": "approved",


### PR DESCRIPTION
## Summary

- supersede the unsupported WasmKit 0.3.1 upgrade premise with a certified
  Swift resource-control profile requirement
- add Spec 074, ADR-0011, and Decision 29 without revising immutable bridge
  and release-baseline specifications
- keep #647 blocked until #762 provides supported public memory and
  interruption controls with Apple-device evidence

Closes #761.

## Governing Spec

- `074-swift-native-resource-control-certification`
- `057-embeddable-runtime-host`
- `070-runtime-event-sink-boundary`
- `073-native-embedder-release-baseline`

## Project Item

- [Issue #761](https://github.com/traverse-framework/traverse/issues/761) — Project 1, In Progress

## Validation

- `bash scripts/ci/repository_checks.sh`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh /private/tmp/issue-761-pr-body.md`
- `git diff --check`
