### PR TITLE
governance: audit scoped C-ABI boundary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,9 @@ traverse-registry = { path = "crates/traverse-registry", version = "0.8.1" }
 traverse-runtime = { path = "crates/traverse-runtime", version = "0.8.1" }
 
 [workspace.lints.rust]
-# C-ABI exports for the Apple feasibility host are temporarily isolated in
-# `traverse-swift-host`; #771 will decide the permanent governance boundary.
+# C-ABI exports are permitted only in the audited Apple feasibility boundary.
+# `scripts/ci/scoped_unsafe_boundary_check.sh` verifies that no other crate
+# can opt out of this workspace policy.
 unsafe_code = "deny"
 
 [workspace.lints.clippy]

--- a/crates/traverse-swift-host/src/lib.rs
+++ b/crates/traverse-swift-host/src/lib.rs
@@ -3,7 +3,7 @@
 //! The production surface remains deliberately small: Swift configures limits
 //! and invokes only governed runtime operations through a later safe wrapper.
 
-#![allow(unsafe_code)] // Temporary, scoped C-ABI exception tracked by #771.
+#![allow(unsafe_code)] // Audited C-ABI exception; see ADR-0013 and #771.
 
 use wasmi::{Config, Engine, Linker, Module, Store, StoreLimitsBuilder, TrapCode};
 

--- a/docs/adr/0013-scoped-c-abi-boundary.md
+++ b/docs/adr/0013-scoped-c-abi-boundary.md
@@ -26,8 +26,9 @@ only `#[unsafe(no_mangle)]` for the three reviewed C-ABI exports:
 - `traverse_swift_host_fuel_limit_fixture`
 
 `scripts/ci/scoped_unsafe_boundary_check.sh` is part of the required Rust
-checks. It rejects a changed workspace policy, any additional opt-out, unsafe
-syntax outside the boundary, or an expanded export set.
+checks under the spec-alignment gate. It rejects a changed workspace policy,
+any additional opt-out, unsafe syntax outside the boundary, or an expanded
+export set.
 
 The boundary is limited to the feasibility static library. It must not contain
 unsafe blocks, raw-pointer dereferences, FFI imports, mutable globals, manual

--- a/docs/adr/0013-scoped-c-abi-boundary.md
+++ b/docs/adr/0013-scoped-c-abi-boundary.md
@@ -1,0 +1,54 @@
+# ADR-0013: Retain an Audited Scoped C-ABI Boundary
+
+- Status: Accepted
+- Date: 2026-07-19
+- Governing spec: `001-foundation-v0-1`
+- Owner: Traverse maintainers
+- Review by: 2026-10-19
+
+## Context
+
+The Apple `wasmi` feasibility proof in #769 exposes three C-compatible
+functions from `traverse-swift-host` so Swift can load the static library. Rust
+requires the `unsafe(no_mangle)` attribute for those symbols. A workspace-wide
+`unsafe_code = "forbid"` policy cannot accommodate that syntax; weakening the
+policy globally would allow a crate to introduce unsafe code without a
+dedicated review.
+
+## Decision
+
+Retain `unsafe_code = "deny"` at the workspace level and permit exactly one
+crate-level opt-out: `crates/traverse-swift-host/src/lib.rs`. That file may use
+only `#[unsafe(no_mangle)]` for the three reviewed C-ABI exports:
+
+- `traverse_swift_host_abi_version`
+- `traverse_swift_host_memory_limit_fixture`
+- `traverse_swift_host_fuel_limit_fixture`
+
+`scripts/ci/scoped_unsafe_boundary_check.sh` is part of the required Rust
+checks. It rejects a changed workspace policy, any additional opt-out, unsafe
+syntax outside the boundary, or an expanded export set.
+
+The boundary is limited to the feasibility static library. It must not contain
+unsafe blocks, raw-pointer dereferences, FFI imports, mutable globals, manual
+allocation, or production runtime behavior. Any new C-ABI symbol or different
+unsafe operation requires a successor ADR, an explicit owner and expiry, and
+security review before merge.
+
+## Consequences
+
+- The feasibility evidence remains reproducible without silently relaxing
+  safety rules for the rest of the workspace.
+- The Swift production embedder remains blocked on its own certification and
+  engine-selection decisions; this ADR does not certify it.
+- Traverse maintainers must review this exception by 2026-10-19 and remove it
+  when the feasibility host is no longer required.
+
+## Alternatives Considered
+
+- Restore `unsafe_code = "forbid"`: rejected because Rust cannot permit the
+  required C-ABI export attributes below a `forbid` lint.
+- Allow unsafe code workspace-wide: rejected because it loses the auditable,
+  crate-specific boundary required by #771.
+- Move the bridge to a non-Rust shim: deferred; it would add a new toolchain
+  and distribution boundary without improving the current feasibility proof.

--- a/docs/adr/0013-scoped-c-abi-boundary.md
+++ b/docs/adr/0013-scoped-c-abi-boundary.md
@@ -36,6 +36,8 @@ allocation, or production runtime behavior. Any new C-ABI symbol or different
 unsafe operation requires a successor ADR, an explicit owner and expiry, and
 security review before merge.
 
+This policy does not alter the runtime event boundary or event semantics.
+
 ## Consequences
 
 - The feasibility evidence remains reproducible without silently relaxing

--- a/scripts/ci/rust_checks.sh
+++ b/scripts/ci/rust_checks.sh
@@ -6,6 +6,8 @@ cargo fmt --all --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 
+bash scripts/ci/scoped_unsafe_boundary_check.sh
+
 bash scripts/ci/contractual_enforcement_gate.sh
 
 echo "Rust checks passed."

--- a/scripts/ci/scoped_unsafe_boundary_check.sh
+++ b/scripts/ci/scoped_unsafe_boundary_check.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly approved_boundary="crates/traverse-swift-host/src/lib.rs"
+
+if ! grep -Fqx 'unsafe_code = "deny"' Cargo.toml; then
+  echo "Workspace unsafe-code lint must remain set to deny." >&2
+  exit 1
+fi
+
+opt_outs=()
+while IFS= read -r path; do
+  opt_outs+=("${path}")
+done < <(grep -RIlF --include='*.rs' '#![allow(unsafe_code)]' crates || true)
+if [[ "${#opt_outs[@]}" -ne 1 || "${opt_outs[0]:-}" != "${approved_boundary}" ]]; then
+  echo "Only ${approved_boundary} may opt out of the workspace unsafe-code lint." >&2
+  exit 1
+fi
+
+unsafe_sites=()
+while IFS= read -r site; do
+  unsafe_sites+=("${site}")
+done < <(grep -RIn --include='*.rs' -E '#\[unsafe\(|unsafe[[:space:]]*(\{|fn|impl|trait|extern)' crates || true)
+for site in "${unsafe_sites[@]}"; do
+  if [[ "${site}" != "${approved_boundary}:"* ]] || [[ "${site}" != *'#[unsafe(no_mangle)]'* ]]; then
+    echo "Unsafe syntax is permitted only for no_mangle exports in ${approved_boundary}: ${site}" >&2
+    exit 1
+  fi
+done
+
+if [[ "${#unsafe_sites[@]}" -ne 3 ]]; then
+  echo "The audited Swift host must expose exactly three C-ABI symbols." >&2
+  exit 1
+fi
+
+echo "Scoped unsafe C-ABI boundary check passed."


### PR DESCRIPTION
## Summary

Makes the temporary Swift-host C-ABI exception explicit and auditable. The workspace keeps `unsafe_code = "deny"`; only the three reviewed `#[unsafe(no_mangle)]` exports in `traverse-swift-host` may opt out, and the standard Rust CI gate verifies that boundary.

## Governing Spec

- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `025-wasm-executor-adapter`
- `070-runtime-event-sink-boundary`
- `074-swift-native-resource-control-certification`

## Project Item

Closes #771.

## Definition of Done

- [x] The workspace lint policy supports only the dedicated audited FFI boundary.
- [x] Scope, owner, review date, and prohibited unsafe patterns are recorded in ADR-0013.
- [x] CI rejects unsafe opt-outs, unsafe syntax outside the boundary, and changes to the reviewed export count.

## Validation

- `bash scripts/ci/scoped_unsafe_boundary_check.sh`
- `cargo fmt --all --check`
- `cargo clippy -p traverse-swift-host --all-targets -- -D warnings`
- `cargo test -p traverse-swift-host`
- `bash scripts/ci/rust_checks.sh`