### PR TITLE
feat(swift): ship bounded wasmi embedder bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli-rs"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ed25519-dalek",
  "qrcode",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "semver",
  "serde",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-embedder"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-native-bridge"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "sha2 0.11.0",
  "wat",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "semver",
  "serde",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-swift-host"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -46,20 +46,20 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -69,9 +69,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -93,18 +93,18 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 dependencies = [
  "allocator-api2",
 ]
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cap-fs-ext"
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -222,7 +222,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -266,27 +266,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008f1a8d1da5074ad858f398775a6d1989031892e46927df5ed18d3be1ed8717"
+checksum = "3867f7a56768640a79fc660d2f60298251dc6d65b5d1c907706cd1afff024957"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd76237df1f4e26edb5ad7971d20280ed1e193331fd257f1b4e4dfefd88dda2"
+checksum = "a0661d63dcf8fc4a6538c1ee4d523917c5b27e9fce7a4114cdf9e2b30b4043cf"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380f0bc43e535df6855bbee649efb00bde39c3f33434c47c8e10ac836d21bf47"
+checksum = "a8d535b489159ea63e3c40dfbe8d0e12bfb71f2a14845ef2407353e06c5a697c"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4811e3e4502de04257e90c0a93225b56d9b85e0f9ad10b81446b415511009610"
+checksum = "c3af4f7d421b2354deb01d714266022f38fcdbebc9f5f1ec6d310d3c27286d9e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ffadb34d497f3e76fb3b4baf764c24ba8a51512976a1b77f78bdbf8f4aa687"
+checksum = "09fe4c289e67e0221d1705734a57f95e25c289ed0ead7728743ea21285fc4cf1"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4f6992eb6faf086ddc7deaaa5f279abfe7f5fd5ae5709bd38253450fc7b945"
+checksum = "b3063e5363dc5ee6ee8edd930314582c08eb91c209b9564da1cd667f6424b9b3"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -346,24 +346,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e1b2aad7d055925a4ea9cdbfa9d1d987f9dfc8ad6b708be28f901ac620a298"
+checksum = "c34b9c8dbc9edf37744918e56898d4979ef1e764e8e4bbe8b4d50250838ddfe8"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a355348325e0a63b65c00def3871597b9fcc79d25456397010d16d872b3772"
+checksum = "4eed9dc54204dc99aad19669bca50142659ed583396d9a99a2aef34d7c136ef4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f4847d93ce2c80d2bff929aa1004dfb3ce2cf5d881f6ced54b8d654d967ba3"
+checksum = "9aa2846b239a046217ecf95cfed0e31be4e86843785d07438ad33f456871e888"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba24e5fe5242cc445e7892ef0a51a4351cf716e3a04ac7a3a05820d056c39818"
+checksum = "144f70fa9cd07efb83497c12dc8fb73f360a690cd990c44e8ceebc293d8c13b5"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -385,15 +385,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bc2035de85c4f04ba7bd57eb5bd3a8b775235bf28852dbf87105115cb8919a"
+checksum = "0733ca5b2aaa5f6d5d6a1439e3c44280d34730d4d5c262ca08c6775c8d83f191"
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea6630c16921ab087792750f239d0c0173411e80179ca7c0ce0710ce9e7646a"
+checksum = "75b1290d6193b171172d5fe9a6e42326edf487a79f211fbf1e76f912a4aed035"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.2"
+version = "0.131.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4bbad54fc28cc0da1f9a5d7f7f826ec8cafda3d503b401b2daaaa93c63ef0"
+checksum = "ce0d5c2b4d719566816a0f1c9a9712d35d61e27df0ffd6c72a9afec9048db6c0"
 
 [[package]]
 name = "crc32fast"
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -427,18 +427,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-common"
@@ -483,7 +483,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -539,13 +539,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded-io"
@@ -615,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fd-lock"
@@ -656,12 +656,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -688,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -702,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -712,33 +706,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -787,34 +781,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
+ "r-efi",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
@@ -824,31 +804,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -991,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1006,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1070,29 +1041,30 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "leb128"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -1102,9 +1074,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1114,9 +1086,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -1141,9 +1113,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "mach2"
@@ -1162,9 +1134,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memfd"
@@ -1177,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1202,7 +1174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "memchr",
 ]
@@ -1237,9 +1209,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "postcard"
@@ -1272,29 +1244,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pulley-interpreter"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff0ead8b4616f81b3d3efd41ce41bcf9ea364a5d8df8be8a8a1f98b50104349"
+checksum = "34dff5fd3d9ac4845939fcb4597cd413cb244bc530448ed4766d11b1725e53d0"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1304,13 +1266,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4389e5820b1b39810ac12a27aa665320cab3caa51913a79637c06f284cfe223"
+checksum = "6c60fb1c885bdb1efd7c50e8e973714de558b75a65f20c3e9a41398c652aa44b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1321,18 +1283,12 @@ checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1342,9 +1298,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1403,13 +1359,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "log",
  "rustc-hash",
  "smallvec",
@@ -1417,15 +1373,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -1474,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "semver"
@@ -1490,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1500,22 +1456,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1564,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -1582,18 +1538,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1619,9 +1575,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1636,7 +1603,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1668,7 +1635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -1694,11 +1661,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -1709,18 +1676,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -1735,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "bytes",
  "libc",
@@ -1777,14 +1744,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -1805,7 +1772,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1819,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli-rs"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "ed25519-dalek",
  "qrcode",
@@ -1835,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "semver",
  "serde",
@@ -1844,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-embedder"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",
@@ -1855,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1863,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1874,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-native-bridge"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "sha2 0.11.0",
  "wat",
@@ -1882,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "semver",
  "serde",
@@ -1893,7 +1860,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -1913,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-swift-host"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",
@@ -1969,7 +1936,7 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1987,28 +1954,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2019,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2029,22 +1978,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -2068,16 +2017,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
@@ -2094,18 +2033,6 @@ checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.253.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -2156,18 +2083,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
@@ -2203,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4eccc0728f061979efa8ff4c962cff7041fead4baadb74973f01b9c47158a4"
+checksum = "d807f646bfecc1dbb4990d8c864beebccbdb3f2cd1b39b2b82957b4e294c6058"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -2256,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e84dbe3208c1336a41546beb75927b3b37e2e4fce06653d214b407136fbe295"
+checksum = "48b945309908f22473ebcd585ac2993948044228491cd96941d367aa81a49c3f"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -2287,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910b8dcadc0888344b2dea5a087c836b58156d4f455c52b6dac0bdc776a9d029"
+checksum = "f14b8b93c2137c88ed84114d9a09cb11cb8bf9394aba4856e48f5304a4f99eec"
 dependencies = [
  "base64",
  "directories-next",
@@ -2307,30 +2222,30 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c223bd503db76df8d74d1fcca39e734d25f7a0c1dcaf1509b67f3855d1b0f803"
+checksum = "7307dec6251a18ffa9df03120d2945ac2476ce150b5b099f39b199e8f81464dc"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.246.2",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab123ad511483a1b918399789d0cc7dea7c5c6476743df73949007b5b225fc74"
+checksum = "7a3d899b0270bcf04852f141bd9538cb162a436e7f56b2c6e0f4e57ecc70743a"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4364d345719bba7fc4c435992ea1cb0c118f1e90a88c6e6f22a7a4fc507700c6"
+checksum = "aedd3947487d0afdd37accb981466fcd60571e898004c8955111f88686581dfc"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -2340,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a3bc28a172037c7864128bb208017a02bba659a59c27acacc048c09e25c1fc"
+checksum = "512fd846630c064bfc42909eeba90a7d26703b6ded09ad4778ff6afcbdc868dd"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2357,7 +2272,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
@@ -2367,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c90a899a47d3da6e384e7b4cad61fdcb27535a395742b32440bdf9980ea83fa"
+checksum = "15629ea71394be5812a52cb8fbc6cd039484ab1dd48fce5e1ef58ae89606289a"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2382,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f364747aa74c686b18925918e5cfd615a73c9613c7a31fc1cd86f42df12fbe"
+checksum = "f5fce5fedc1c952a64cdf3c87e4632af072d2aca0bc2c460d53296fb2654757d"
 dependencies = [
  "cc",
  "object",
@@ -2394,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ba98c1492f530833e0d3cc17dbb0c3c57c9f1bb3b078ae44bb55a233e43eba"
+checksum = "10005b038e662775ac002f233e429447a58892e89918580fa67ce8cdd9192d0a"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2406,9 +2321,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b8f8a89e8f3660646f820c7d8310a67094156bb866e9d56f1b00892e011206"
+checksum = "03f3e0f474281b405a3e9d97239f83f643b572324d292e1ef9dc5e3e0ab04c68"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2419,20 +2334,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a12754f1ffc4a3300d56d324c418b8b32cf029606618da22c7d076213882a3f"
+checksum = "910e5393af4aca456113581a5913b8d499cd2189013e983f8764d06ebc42b2ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b06e4ed07adc579645e5c55c67b3138c49da2e468fad52d3db7b7a098ecc733"
+checksum = "55481651bea5b8336fb200fa49914ccf802f5e7617ba9ab0b4691f16d4f97ff8"
 dependencies = [
  "cranelift-codegen",
  "gimli",
@@ -2447,22 +2362,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f08787948e3c983799d616ef7dd57463253e9ca8bab6607eef8134f12353f70"
+checksum = "d890c3804d0e46000fa901c86ac1a9fdedf684e72dfd64e582b56bb4a78a6746"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap",
- "wit-parser 0.246.2",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2f19834bc6edbc31ac95fdcfd5ddcd7643759265a1d545dec36ac6cc788ca8"
+checksum = "5aa7f927779d92863a1447c1d88192b2242080608cb91ece69c177321488948b"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -2478,7 +2393,7 @@ dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
  "system-interface",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -2490,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e0c6efdbaf90906016be9ed9ff17b7b58f393876287beebe5bd7fa1de54dbb"
+checksum = "d6fd8b702c2aa82bb4907da5ad44120b4385048f6a20731908a6e2485ea7567e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2534,12 +2449,12 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b644ab90da80bbca28973192978ac452cbd876955bb209e6ff2cd1955e43a7"
+checksum = "165512f7870210d0fd45911990b832782b5fb82d40f4ce28cf86b40aaecd453c"
 dependencies = [
  "bitflags",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "wasmtime",
  "wasmtime-environ",
@@ -2548,27 +2463,27 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521f9d558365357274d960340eb9eb4f4d768fafdc79f381fd2e13a85b925ebc"
+checksum = "f7f63d06fdf2e9a133407b318574574f66ea6590ea7a42c4a7554c029824454a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasmtime-environ",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a386e86021363c9f0abd1e189e8f8a729d9b5aab2bb7172a3e40f2ab647a936"
+checksum = "1b976b7285ca32a637e21721021442691a2d7938ab4650cb99472a672e9def6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wiggle-generate",
 ]
 
@@ -2605,9 +2520,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "44.0.2"
+version = "44.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16496e92d2b232f9d195ae74f71a674aabae7b7fa722d39068836723d3b653c"
+checksum = "436a7fa4109b13b0e555d01ec615ab8b928b7834639aca7b2fdc1f55d70a1f0c"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -2615,7 +2530,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
@@ -2643,7 +2558,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2654,7 +2569,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2771,9 +2686,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "winx"
@@ -2783,94 +2698,6 @@ checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser 0.244.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata",
- "wasmparser 0.244.0",
- "wit-parser 0.244.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -2912,9 +2739,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2929,35 +2756,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -2970,7 +2797,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -3010,14 +2837,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,6 +1915,8 @@ dependencies = [
 name = "traverse-swift-host"
 version = "0.8.1"
 dependencies = [
+ "serde_json",
+ "sha2 0.11.0",
  "wasmi",
  "wat",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli-rs"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "ed25519-dalek",
  "qrcode",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "semver",
  "serde",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-embedder"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-native-bridge"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "sha2 0.11.0",
  "wat",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "semver",
  "serde",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-swift-host"
-version = "0.8.2"
+version = "0.8.1"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.104"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -46,20 +46,20 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -69,9 +69,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
@@ -93,18 +93,18 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.3"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
  "allocator-api2",
 ]
 
 [[package]]
 name = "bytes"
-version = "1.12.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cap-fs-ext"
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -222,7 +222,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -266,27 +266,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3867f7a56768640a79fc660d2f60298251dc6d65b5d1c907706cd1afff024957"
+checksum = "008f1a8d1da5074ad858f398775a6d1989031892e46927df5ed18d3be1ed8717"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0661d63dcf8fc4a6538c1ee4d523917c5b27e9fce7a4114cdf9e2b30b4043cf"
+checksum = "9fd76237df1f4e26edb5ad7971d20280ed1e193331fd257f1b4e4dfefd88dda2"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d535b489159ea63e3c40dfbe8d0e12bfb71f2a14845ef2407353e06c5a697c"
+checksum = "380f0bc43e535df6855bbee649efb00bde39c3f33434c47c8e10ac836d21bf47"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3af4f7d421b2354deb01d714266022f38fcdbebc9f5f1ec6d310d3c27286d9e"
+checksum = "4811e3e4502de04257e90c0a93225b56d9b85e0f9ad10b81446b415511009610"
 dependencies = [
  "serde",
  "serde_derive",
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fe4c289e67e0221d1705734a57f95e25c289ed0ead7728743ea21285fc4cf1"
+checksum = "82ffadb34d497f3e76fb3b4baf764c24ba8a51512976a1b77f78bdbf8f4aa687"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3063e5363dc5ee6ee8edd930314582c08eb91c209b9564da1cd667f6424b9b3"
+checksum = "be4f6992eb6faf086ddc7deaaa5f279abfe7f5fd5ae5709bd38253450fc7b945"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -346,24 +346,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34b9c8dbc9edf37744918e56898d4979ef1e764e8e4bbe8b4d50250838ddfe8"
+checksum = "70e1b2aad7d055925a4ea9cdbfa9d1d987f9dfc8ad6b708be28f901ac620a298"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eed9dc54204dc99aad19669bca50142659ed583396d9a99a2aef34d7c136ef4"
+checksum = "89a355348325e0a63b65c00def3871597b9fcc79d25456397010d16d872b3772"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2846b239a046217ecf95cfed0e31be4e86843785d07438ad33f456871e888"
+checksum = "43f4847d93ce2c80d2bff929aa1004dfb3ce2cf5d881f6ced54b8d654d967ba3"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -373,9 +373,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f70fa9cd07efb83497c12dc8fb73f360a690cd990c44e8ceebc293d8c13b5"
+checksum = "ba24e5fe5242cc445e7892ef0a51a4351cf716e3a04ac7a3a05820d056c39818"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -385,15 +385,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0733ca5b2aaa5f6d5d6a1439e3c44280d34730d4d5c262ca08c6775c8d83f191"
+checksum = "89bc2035de85c4f04ba7bd57eb5bd3a8b775235bf28852dbf87105115cb8919a"
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b1290d6193b171172d5fe9a6e42326edf487a79f211fbf1e76f912a4aed035"
+checksum = "5ea6630c16921ab087792750f239d0c0173411e80179ca7c0ce0710ce9e7646a"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.3"
+version = "0.131.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0d5c2b4d719566816a0f1c9a9712d35d61e27df0ffd6c72a9afec9048db6c0"
+checksum = "faa4bbad54fc28cc0da1f9a5d7f7f826ec8cafda3d503b401b2daaaa93c63ef0"
 
 [[package]]
 name = "crc32fast"
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -427,18 +427,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -483,7 +483,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -539,13 +539,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedded-io"
@@ -615,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.5.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fd-lock"
@@ -656,6 +656,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -682,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -696,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -706,33 +712,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -781,20 +787,34 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
@@ -804,22 +824,31 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -962,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -977,7 +1006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1041,30 +1070,29 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.35"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
- "cfg-if",
- "futures-util",
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "leb128"
-version = "0.2.7"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "leb128fmt"
@@ -1074,9 +1102,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -1086,9 +1114,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
  "libc",
 ]
@@ -1113,9 +1141,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mach2"
@@ -1134,9 +1162,9 @@ checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
-version = "2.8.3"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memfd"
@@ -1149,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1174,7 +1202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "crc32fast",
- "hashbrown 0.17.1",
+ "hashbrown 0.17.0",
  "indexmap",
  "memchr",
 ]
@@ -1209,9 +1237,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "postcard"
@@ -1244,19 +1272,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.107"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pulley-interpreter"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34dff5fd3d9ac4845939fcb4597cd413cb244bc530448ed4766d11b1725e53d0"
+checksum = "dff0ead8b4616f81b3d3efd41ce41bcf9ea364a5d8df8be8a8a1f98b50104349"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -1266,13 +1304,13 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c60fb1c885bdb1efd7c50e8e973714de558b75a65f20c3e9a41398c652aa44b"
+checksum = "f4389e5820b1b39810ac12a27aa665320cab3caa51913a79637c06f284cfe223"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -1283,12 +1321,18 @@ checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quote"
-version = "1.0.47"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1298,9 +1342,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1359,13 +1403,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
  "log",
  "rustc-hash",
  "smallvec",
@@ -1373,15 +1417,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.28"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.3"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1430,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -1446,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1456,22 +1500,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn",
 ]
 
 [[package]]
@@ -1520,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "2.0.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signature"
@@ -1538,18 +1582,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1575,20 +1619,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.119"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1603,7 +1636,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -1635,7 +1668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -1661,11 +1694,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1676,18 +1709,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn",
 ]
 
 [[package]]
@@ -1702,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -1744,14 +1777,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.4",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1772,7 +1805,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -1786,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli-rs"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ed25519-dalek",
  "qrcode",
@@ -1802,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "semver",
  "serde",
@@ -1811,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-embedder"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",
@@ -1822,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1830,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1841,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-native-bridge"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "sha2 0.11.0",
  "wat",
@@ -1849,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "semver",
  "serde",
@@ -1860,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -1880,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-swift-host"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",
@@ -1936,7 +1969,7 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.3",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1954,10 +1987,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.126"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1968,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1978,22 +2029,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2017,6 +2068,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
@@ -2033,6 +2094,18 @@ checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.253.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -2083,6 +2156,18 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
@@ -2118,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d807f646bfecc1dbb4990d8c864beebccbdb3f2cd1b39b2b82957b4e294c6058"
+checksum = "af4eccc0728f061979efa8ff4c962cff7041fead4baadb74973f01b9c47158a4"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -2171,9 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48b945309908f22473ebcd585ac2993948044228491cd96941d367aa81a49c3f"
+checksum = "7e84dbe3208c1336a41546beb75927b3b37e2e4fce06653d214b407136fbe295"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -2202,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14b8b93c2137c88ed84114d9a09cb11cb8bf9394aba4856e48f5304a4f99eec"
+checksum = "910b8dcadc0888344b2dea5a087c836b58156d4f455c52b6dac0bdc776a9d029"
 dependencies = [
  "base64",
  "directories-next",
@@ -2222,30 +2307,30 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7307dec6251a18ffa9df03120d2945ac2476ce150b5b099f39b199e8f81464dc"
+checksum = "c223bd503db76df8d74d1fcca39e734d25f7a0c1dcaf1509b67f3855d1b0f803"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3d899b0270bcf04852f141bd9538cb162a436e7f56b2c6e0f4e57ecc70743a"
+checksum = "ab123ad511483a1b918399789d0cc7dea7c5c6476743df73949007b5b225fc74"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedd3947487d0afdd37accb981466fcd60571e898004c8955111f88686581dfc"
+checksum = "4364d345719bba7fc4c435992ea1cb0c118f1e90a88c6e6f22a7a4fc507700c6"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -2255,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512fd846630c064bfc42909eeba90a7d26703b6ded09ad4778ff6afcbdc868dd"
+checksum = "c5a3bc28a172037c7864128bb208017a02bba659a59c27acacc048c09e25c1fc"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2272,7 +2357,7 @@ dependencies = [
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
@@ -2282,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15629ea71394be5812a52cb8fbc6cd039484ab1dd48fce5e1ef58ae89606289a"
+checksum = "3c90a899a47d3da6e384e7b4cad61fdcb27535a395742b32440bdf9980ea83fa"
 dependencies = [
  "cc",
  "cfg-if",
@@ -2297,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fce5fedc1c952a64cdf3c87e4632af072d2aca0bc2c460d53296fb2654757d"
+checksum = "84f364747aa74c686b18925918e5cfd615a73c9613c7a31fc1cd86f42df12fbe"
 dependencies = [
  "cc",
  "object",
@@ -2309,9 +2394,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10005b038e662775ac002f233e429447a58892e89918580fa67ce8cdd9192d0a"
+checksum = "c3ba98c1492f530833e0d3cc17dbb0c3c57c9f1bb3b078ae44bb55a233e43eba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2321,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f3e0f474281b405a3e9d97239f83f643b572324d292e1ef9dc5e3e0ab04c68"
+checksum = "94b8f8a89e8f3660646f820c7d8310a67094156bb866e9d56f1b00892e011206"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -2334,20 +2419,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "910e5393af4aca456113581a5913b8d499cd2189013e983f8764d06ebc42b2ed"
+checksum = "7a12754f1ffc4a3300d56d324c418b8b32cf029606618da22c7d076213882a3f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55481651bea5b8336fb200fa49914ccf802f5e7617ba9ab0b4691f16d4f97ff8"
+checksum = "4b06e4ed07adc579645e5c55c67b3138c49da2e468fad52d3db7b7a098ecc733"
 dependencies = [
  "cranelift-codegen",
  "gimli",
@@ -2362,22 +2447,22 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d890c3804d0e46000fa901c86ac1a9fdedf684e72dfd64e582b56bb4a78a6746"
+checksum = "0f08787948e3c983799d616ef7dd57463253e9ca8bab6607eef8134f12353f70"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap",
- "wit-parser",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa7f927779d92863a1447c1d88192b2242080608cb91ece69c177321488948b"
+checksum = "1b2f19834bc6edbc31ac95fdcfd5ddcd7643759265a1d545dec36ac6cc788ca8"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -2393,7 +2478,7 @@ dependencies = [
  "io-lifetimes",
  "rustix 1.1.4",
  "system-interface",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -2405,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6fd8b702c2aa82bb4907da5ad44120b4385048f6a20731908a6e2485ea7567e"
+checksum = "c3e0c6efdbaf90906016be9ed9ff17b7b58f393876287beebe5bd7fa1de54dbb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2449,12 +2534,12 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165512f7870210d0fd45911990b832782b5fb82d40f4ce28cf86b40aaecd453c"
+checksum = "17b644ab90da80bbca28973192978ac452cbd876955bb209e6ff2cd1955e43a7"
 dependencies = [
  "bitflags",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
  "wasmtime",
  "wasmtime-environ",
@@ -2463,27 +2548,27 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f63d06fdf2e9a133407b318574574f66ea6590ea7a42c4a7554c029824454a"
+checksum = "521f9d558365357274d960340eb9eb4f4d768fafdc79f381fd2e13a85b925ebc"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "wasmtime-environ",
  "witx",
 ]
 
 [[package]]
 name = "wiggle-macro"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b976b7285ca32a637e21721021442691a2d7938ab4650cb99472a672e9def6c"
+checksum = "8a386e86021363c9f0abd1e189e8f8a729d9b5aab2bb7172a3e40f2ab647a936"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "wiggle-generate",
 ]
 
@@ -2520,9 +2605,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "44.0.3"
+version = "44.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436a7fa4109b13b0e555d01ec615ab8b928b7834639aca7b2fdc1f55d70a1f0c"
+checksum = "f16496e92d2b232f9d195ae74f71a674aabae7b7fa722d39068836723d3b653c"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
@@ -2530,7 +2615,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "wasmparser 0.246.2",
  "wasmtime-environ",
  "wasmtime-internal-core",
@@ -2558,7 +2643,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -2569,7 +2654,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -2686,9 +2771,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "winx"
@@ -2698,6 +2783,94 @@ checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -2739,9 +2912,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2756,35 +2929,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -2797,7 +2970,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
  "synstructure",
 ]
 
@@ -2837,14 +3010,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.23"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/traverse-framework/traverse"
 rust-version = "1.94"
-version = "0.8.2"
+version = "0.8.1"
 
 [workspace.dependencies]
-traverse-contracts = { path = "crates/traverse-contracts", version = "0.8.2" }
-traverse-registry = { path = "crates/traverse-registry", version = "0.8.2" }
-traverse-runtime = { path = "crates/traverse-runtime", version = "0.8.2" }
+traverse-contracts = { path = "crates/traverse-contracts", version = "0.8.1" }
+traverse-registry = { path = "crates/traverse-registry", version = "0.8.1" }
+traverse-runtime = { path = "crates/traverse-runtime", version = "0.8.1" }
 
 [workspace.lints.rust]
 # C-ABI exports are permitted only in the audited Apple feasibility boundary.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/traverse-framework/traverse"
 rust-version = "1.94"
-version = "0.8.1"
+version = "0.8.2"
 
 [workspace.dependencies]
-traverse-contracts = { path = "crates/traverse-contracts", version = "0.8.1" }
-traverse-registry = { path = "crates/traverse-registry", version = "0.8.1" }
-traverse-runtime = { path = "crates/traverse-runtime", version = "0.8.1" }
+traverse-contracts = { path = "crates/traverse-contracts", version = "0.8.2" }
+traverse-registry = { path = "crates/traverse-registry", version = "0.8.2" }
+traverse-runtime = { path = "crates/traverse-runtime", version = "0.8.2" }
 
 [workspace.lints.rust]
 # C-ABI exports are permitted only in the audited Apple feasibility boundary.

--- a/crates/traverse-swift-host/Cargo.toml
+++ b/crates/traverse-swift-host/Cargo.toml
@@ -13,6 +13,8 @@ crate-type = ["staticlib"]
 [dependencies]
 wasmi = { version = "1.1.0", default-features = false }
 wat = "1"
+sha2 = "0.11"
+serde_json = "1.0.145"
 
 [lints]
 workspace = true

--- a/crates/traverse-swift-host/include/traverse_swift_host.h
+++ b/crates/traverse-swift-host/include/traverse_swift_host.h
@@ -2,14 +2,39 @@
 #define TRAVERSE_SWIFT_HOST_H
 
 #include <stdint.h>
+#include <stddef.h>
 
-/// Returns the version of the deliberately narrow Swift-host C boundary.
+/// Returns the version of the production Swift-host C boundary.
 uint32_t traverse_swift_host_abi_version(void);
 
-/// Runs the bounded-memory fixture. Zero means the host stopped growth.
-uint32_t traverse_swift_host_memory_limit_fixture(void);
+typedef struct traverse_swift_host_limits {
+  uint64_t maximum_artifact_bytes;
+  uint64_t maximum_memory_bytes;
+  uint64_t fuel_per_invocation;
+  uint64_t maximum_input_bytes;
+  uint64_t maximum_output_bytes;
+  uint64_t maximum_queued_events;
+} traverse_swift_host_limits;
 
-/// Runs the fuel-budget fixture. Zero means the host stopped execution.
-uint32_t traverse_swift_host_fuel_limit_fixture(void);
+/// Verifies and instantiates a bridge module. `handle_out` receives an opaque
+/// value that must be passed only to this ABI and later destroyed.
+int32_t traverse_swift_host_create(
+  const uint8_t *runtime_bytes, size_t runtime_length,
+  const uint8_t *expected_sha256, size_t expected_sha256_length,
+  const traverse_swift_host_limits *limits, uint64_t *handle_out);
+
+/// Invokes one bridge operation with caller-owned UTF-8 JSON buffers.
+/// On `TRAVERSE_SWIFT_HOST_BUFFER_TOO_SMALL`, `output_length_out` is the exact
+/// required length and the caller may retry once with that capacity.
+int32_t traverse_swift_host_invoke(
+  uint64_t handle, const uint8_t *operation, size_t operation_length,
+  const uint8_t *input, size_t input_length,
+  uint8_t *output, size_t output_capacity, size_t *output_length_out);
+
+/// Invalidates and releases an opaque host handle. Calling it twice is safe.
+int32_t traverse_swift_host_destroy(uint64_t handle);
+
+/// Returns a stable, static UTF-8 description for a status code.
+const char *traverse_swift_host_status_message(int32_t status);
 
 #endif

--- a/crates/traverse-swift-host/src/lib.rs
+++ b/crates/traverse-swift-host/src/lib.rs
@@ -7,6 +7,7 @@
 #![allow(unsafe_code)] // Audited C-ABI exception; see ADR-0015 and Spec 076.
 
 use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
 use wasmi::{
     Config, Engine, Instance, Linker, Memory, Module, Store, StoreLimits, StoreLimitsBuilder,
 };
@@ -122,10 +123,10 @@ fn export_name(operation: &str) -> &'static str {
 
 fn digest(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
-    let hex = digest
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>();
+    let hex = digest.iter().fold(String::new(), |mut hex, byte| {
+        let _ = write!(hex, "{byte:02x}");
+        hex
+    });
     format!("sha256:{hex}")
 }
 
@@ -142,7 +143,7 @@ fn normalised_digest(bytes: &[u8]) -> Result<String, HostError> {
 
 fn require_exports(
     store: &mut Store<StoreLimits>,
-    instance: &Instance,
+    instance: Instance,
 ) -> Result<Memory, HostError> {
     let memory = instance
         .get_memory(&*store, "memory")
@@ -206,7 +207,7 @@ fn create_host(runtime: &[u8], expected_digest: &[u8], limits: Limits) -> Result
     let instance = Linker::new(&engine)
         .instantiate_and_start(&mut store, &module)
         .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?;
-    let memory = require_exports(&mut store, &instance)?;
+    let memory = require_exports(&mut store, instance)?;
     Ok(Host {
         store,
         instance,
@@ -234,6 +235,58 @@ fn output(result: &[u8], buffer: *mut u8, capacity: usize, length_out: *mut usiz
         std::ptr::copy_nonoverlapping(result.as_ptr(), buffer, result.len());
     }
     OK
+}
+
+fn call_export(
+    host: &mut Host,
+    operation: &str,
+    input: &[u8],
+    input_pointer: i32,
+    descriptor: i32,
+) -> Result<i32, HostError> {
+    if operation == "next_event" || operation == "shutdown" {
+        host.instance
+            .get_typed_func::<i32, i32>(&host.store, export_name(operation))
+            .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?
+            .call(&mut host.store, descriptor)
+    } else {
+        host.instance
+            .get_typed_func::<(i32, i32, i32), i32>(&host.store, export_name(operation))
+            .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?
+            .call(
+                &mut host.store,
+                (
+                    input_pointer,
+                    i32::try_from(input.len())
+                        .map_err(|_| HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"))?,
+                    descriptor,
+                ),
+            )
+    }
+    .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))
+}
+
+fn read_descriptor(host: &Host, descriptor: i32) -> Result<(u32, usize), HostError> {
+    let mut descriptor_bytes = [0_u8; 8];
+    host.memory
+        .read(
+            &host.store,
+            usize::try_from(descriptor)
+                .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?,
+            &mut descriptor_bytes,
+        )
+        .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?;
+    let pointer = u32::from_le_bytes(
+        descriptor_bytes[..4]
+            .try_into()
+            .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?,
+    );
+    let length = u32::from_le_bytes(
+        descriptor_bytes[4..]
+            .try_into()
+            .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?,
+    ) as usize;
+    Ok((pointer, length))
 }
 
 fn invoke(host: &mut Host, operation: &str, input: &[u8]) -> Result<Vec<u8>, HostError> {
@@ -285,45 +338,8 @@ fn invoke(host: &mut Host, operation: &str, input: &[u8]) -> Result<Vec<u8>, Hos
             )
             .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?;
     }
-    let status = if operation == "next_event" || operation == "shutdown" {
-        host.instance
-            .get_typed_func::<i32, i32>(&host.store, export_name(operation))
-            .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?
-            .call(&mut host.store, descriptor)
-    } else {
-        host.instance
-            .get_typed_func::<(i32, i32, i32), i32>(&host.store, export_name(operation))
-            .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?
-            .call(
-                &mut host.store,
-                (
-                    input_pointer,
-                    i32::try_from(input.len())
-                        .map_err(|_| HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"))?,
-                    descriptor,
-                ),
-            )
-    }
-    .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?;
-    let mut descriptor_bytes = [0_u8; 8];
-    host.memory
-        .read(
-            &host.store,
-            usize::try_from(descriptor)
-                .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?,
-            &mut descriptor_bytes,
-        )
-        .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?;
-    let pointer = u32::from_le_bytes(
-        descriptor_bytes[..4]
-            .try_into()
-            .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?,
-    );
-    let length = u32::from_le_bytes(
-        descriptor_bytes[4..]
-            .try_into()
-            .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?,
-    ) as usize;
+    let status = call_export(host, operation, input, input_pointer, descriptor)?;
+    let (pointer, length) = read_descriptor(host, descriptor)?;
     if length > host.limits.maximum_output_bytes {
         return Err(HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"));
     }
@@ -351,8 +367,15 @@ pub extern "C" fn traverse_swift_host_abi_version() -> u32 {
 }
 
 /// Creates one verified, bounded host and returns its opaque handle.
+///
+/// # Safety
+///
+/// `runtime` and `expected` must each be valid for reads of their stated
+/// length; `limits` must point to one readable `TraverseSwiftHostLimits`;
+/// `handle_out` must point to one writable `u64`. All four must be non-null,
+/// which this function checks before dereferencing any of them.
 #[unsafe(no_mangle)]
-pub extern "C" fn traverse_swift_host_create(
+pub unsafe extern "C" fn traverse_swift_host_create(
     runtime: *const u8,
     runtime_length: usize,
     expected: *const u8,
@@ -363,7 +386,6 @@ pub extern "C" fn traverse_swift_host_create(
     if runtime.is_null() || expected.is_null() || limits.is_null() || handle_out.is_null() {
         return INVALID_INPUT;
     }
-    // SAFETY: every pointer is checked non-null; callers supply immutable ranges of the stated lengths.
     // SAFETY: every pointer is checked non-null; callers supply immutable ranges of the stated lengths.
     let result = unsafe {
         (*limits).checked().and_then(|value| {
@@ -387,8 +409,19 @@ pub extern "C" fn traverse_swift_host_create(
 }
 
 /// Invokes a governed bridge operation using caller-owned buffers.
+///
+/// # Safety
+///
+/// `handle` must be a live value returned by [`traverse_swift_host_create`]
+/// and not yet passed to [`traverse_swift_host_destroy`]. `operation` and
+/// `input` must each be valid for reads of their stated length.
+/// `output_length_out` must point to one writable `usize`; `output_buffer`
+/// must be valid for writes of `output_capacity` bytes whenever
+/// `output_capacity` is greater than zero. Non-null pointers are checked
+/// before use, but pointer validity and the handle's provenance cannot be
+/// checked by this function and remain the caller's obligation.
 #[unsafe(no_mangle)]
-pub extern "C" fn traverse_swift_host_invoke(
+pub unsafe extern "C" fn traverse_swift_host_invoke(
     handle: u64,
     operation: *const u8,
     operation_length: usize,
@@ -464,6 +497,8 @@ pub extern "C" fn traverse_swift_host_status_message(status: i32) -> *const std:
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::expect_used)]
+
     use super::{
         ABI_VERSION, BUFFER_TOO_SMALL, OK, RESOURCE_LIMIT, TraverseSwiftHostLimits, digest,
         traverse_swift_host_abi_version, traverse_swift_host_create, traverse_swift_host_destroy,
@@ -488,17 +523,19 @@ mod tests {
         let bytes = [0_u8];
         let digest = b"sha256:00";
         let mut handle = 0_u64;
-        assert_eq!(
+        // SAFETY: all pointers below are valid for their stated lengths and
+        // live for the duration of this call.
+        let status = unsafe {
             traverse_swift_host_create(
                 bytes.as_ptr(),
                 bytes.len(),
                 digest.as_ptr(),
                 digest.len(),
-                &limits,
-                &mut handle,
-            ),
-            RESOURCE_LIMIT
-        );
+                &raw const limits,
+                &raw mut handle,
+            )
+        };
+        assert_eq!(status, RESOURCE_LIMIT);
         assert_eq!(handle, 0);
     }
 
@@ -508,22 +545,26 @@ mod tests {
         let expected_digest = digest(&runtime);
         let limits = limits();
         let mut handle = 0_u64;
-        assert_eq!(
+        // SAFETY: all pointers below are valid for their stated lengths and
+        // live for the duration of this call.
+        let create_status = unsafe {
             traverse_swift_host_create(
                 runtime.as_ptr(),
                 runtime.len(),
                 expected_digest.as_ptr(),
                 expected_digest.len(),
-                &limits,
-                &mut handle,
-            ),
-            OK
-        );
+                &raw const limits,
+                &raw mut handle,
+            )
+        };
+        assert_eq!(create_status, OK);
         let operation = b"init";
         let input = b"{}";
         let mut required = 0_usize;
         let mut too_small = [0_u8; 1];
-        assert_eq!(
+        // SAFETY: `handle` is live from the create call above; all other
+        // pointers are valid for their stated lengths.
+        let retry_status = unsafe {
             traverse_swift_host_invoke(
                 handle,
                 operation.as_ptr(),
@@ -532,12 +573,14 @@ mod tests {
                 input.len(),
                 too_small.as_mut_ptr(),
                 too_small.len(),
-                &mut required,
-            ),
-            BUFFER_TOO_SMALL
-        );
+                &raw mut required,
+            )
+        };
+        assert_eq!(retry_status, BUFFER_TOO_SMALL);
         let mut output = vec![0_u8; required];
-        assert_eq!(
+        // SAFETY: `handle` is still live; `output` is sized to the required
+        // length reported by the retry call above.
+        let invoke_status = unsafe {
             traverse_swift_host_invoke(
                 handle,
                 operation.as_ptr(),
@@ -546,10 +589,10 @@ mod tests {
                 input.len(),
                 output.as_mut_ptr(),
                 output.len(),
-                &mut required,
-            ),
-            OK
-        );
+                &raw mut required,
+            )
+        };
+        assert_eq!(invoke_status, OK);
         assert_eq!(&output[..required], br#"{"status":"ready"}"#);
         assert_eq!(traverse_swift_host_destroy(handle), OK);
     }

--- a/crates/traverse-swift-host/src/lib.rs
+++ b/crates/traverse-swift-host/src/lib.rs
@@ -200,6 +200,9 @@ fn create_host(runtime: &[u8], expected_digest: &[u8], limits: Limits) -> Result
         .build();
     let mut store = Store::new(&engine, store_limits);
     store.limiter(|value| value);
+    store
+        .set_fuel(limits.fuel_per_invocation)
+        .map_err(|_| HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"))?;
     let instance = Linker::new(&engine)
         .instantiate_and_start(&mut store, &module)
         .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?;
@@ -462,8 +465,9 @@ pub extern "C" fn traverse_swift_host_status_message(status: i32) -> *const std:
 #[cfg(test)]
 mod tests {
     use super::{
-        ABI_VERSION, RESOURCE_LIMIT, TraverseSwiftHostLimits, traverse_swift_host_abi_version,
-        traverse_swift_host_create,
+        ABI_VERSION, BUFFER_TOO_SMALL, OK, RESOURCE_LIMIT, TraverseSwiftHostLimits, digest,
+        traverse_swift_host_abi_version, traverse_swift_host_create, traverse_swift_host_destroy,
+        traverse_swift_host_invoke,
     };
 
     #[test]
@@ -497,4 +501,88 @@ mod tests {
         );
         assert_eq!(handle, 0);
     }
+
+    #[test]
+    fn creates_and_invokes_with_a_caller_sized_retry_buffer() {
+        let runtime = wat::parse_str(BRIDGE_FIXTURE).expect("fixture must compile");
+        let expected_digest = digest(&runtime);
+        let limits = limits();
+        let mut handle = 0_u64;
+        assert_eq!(
+            traverse_swift_host_create(
+                runtime.as_ptr(),
+                runtime.len(),
+                expected_digest.as_ptr(),
+                expected_digest.len(),
+                &limits,
+                &mut handle,
+            ),
+            OK
+        );
+        let operation = b"init";
+        let input = b"{}";
+        let mut required = 0_usize;
+        let mut too_small = [0_u8; 1];
+        assert_eq!(
+            traverse_swift_host_invoke(
+                handle,
+                operation.as_ptr(),
+                operation.len(),
+                input.as_ptr(),
+                input.len(),
+                too_small.as_mut_ptr(),
+                too_small.len(),
+                &mut required,
+            ),
+            BUFFER_TOO_SMALL
+        );
+        let mut output = vec![0_u8; required];
+        assert_eq!(
+            traverse_swift_host_invoke(
+                handle,
+                operation.as_ptr(),
+                operation.len(),
+                input.as_ptr(),
+                input.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                &mut required,
+            ),
+            OK
+        );
+        assert_eq!(&output[..required], br#"{"status":"ready"}"#);
+        assert_eq!(traverse_swift_host_destroy(handle), OK);
+    }
+
+    fn limits() -> TraverseSwiftHostLimits {
+        TraverseSwiftHostLimits {
+            maximum_artifact_bytes: 1024 * 1024,
+            maximum_memory_bytes: 1024 * 1024,
+            fuel_per_invocation: 10_000,
+            maximum_input_bytes: 1024,
+            maximum_output_bytes: 1024,
+            maximum_queued_events: 8,
+        }
+    }
+
+    const BRIDGE_FIXTURE: &str = r#"
+        (module
+          (memory (export "memory") 1 2)
+          (data (i32.const 128) "{\22status\22:\22ready\22}")
+          (func (export "traverse_bridge_abi_version") (result i32) i32.const 10100)
+          (func (export "traverse_alloc") (param i32) (result i32) i32.const 64)
+          (func (export "traverse_dealloc") (param i32 i32))
+          (func $result (param $descriptor i32) (result i32)
+            local.get $descriptor i32.const 128 i32.store
+            local.get $descriptor i32.const 4 i32.add i32.const 18 i32.store
+            i32.const 0)
+          (func (export "traverse_init") (param i32 i32 i32) (result i32) local.get 2 call $result)
+          (func (export "traverse_submit") (param i32 i32 i32) (result i32) local.get 2 call $result)
+          (func (export "traverse_next_event") (param i32) (result i32) local.get 0 call $result)
+          (func (export "traverse_cancel") (param i32 i32 i32) (result i32) local.get 2 call $result)
+          (func (export "traverse_compatible_start") (param i32 i32 i32) (result i32) local.get 2 call $result)
+          (func (export "traverse_compatible_stop") (param i32 i32 i32) (result i32) local.get 2 call $result)
+          (func (export "traverse_compatible_kill") (param i32 i32 i32) (result i32) local.get 2 call $result)
+          (func (export "traverse_shutdown") (param i32) (result i32) local.get 0 call $result))
+    "#;
 }

--- a/crates/traverse-swift-host/src/lib.rs
+++ b/crates/traverse-swift-host/src/lib.rs
@@ -1,98 +1,500 @@
-//! Minimal C-ABI boundary for the Apple `wasmi` feasibility proof.
+//! Audited five-symbol C ABI for the bounded Apple `wasmi` bridge.
 //!
-//! The production surface remains deliberately small: Swift configures limits
-//! and invokes only governed runtime operations through a later safe wrapper.
+//! All raw-pointer conversion is intentionally confined to this file. The
+//! opaque handle owns a `wasmi` store and cannot grant filesystem, network,
+//! environment, clock, process, or arbitrary-import authority.
 
-#![allow(unsafe_code)] // Audited C-ABI exception; see ADR-0013 and #771.
+#![allow(unsafe_code)] // Audited C-ABI exception; see ADR-0015 and Spec 076.
 
-use wasmi::{Config, Engine, Linker, Module, Store, StoreLimitsBuilder, TrapCode};
+use sha2::{Digest, Sha256};
+use wasmi::{
+    Config, Engine, Instance, Linker, Memory, Module, Store, StoreLimits, StoreLimitsBuilder,
+};
 
-/// Builds the engine-owned memory ceiling used by the feasibility fixture.
-///
-/// This function proves that the engine limit API is available to a static
-/// Apple host without relying on SPI or a watchdog.
-#[must_use]
-pub fn configured_memory_limit(bytes: usize) -> usize {
-    let _limits = StoreLimitsBuilder::new().memory_size(bytes).build();
-    bytes
+const ABI_VERSION: u32 = 2;
+const OK: i32 = 0;
+const INVALID_HANDLE: i32 = -1;
+const INVALID_INPUT: i32 = -2;
+const INVALID_DESCRIPTOR: i32 = -3;
+const RESOURCE_LIMIT: i32 = -4;
+const INTERNAL_ERROR: i32 = -5;
+const BUFFER_TOO_SMALL: i32 = -6;
+const BRIDGE_VERSION: i32 = 10_100;
+const MAX_ERROR_BYTES: usize = 512;
+
+#[repr(C)]
+pub struct TraverseSwiftHostLimits {
+    maximum_artifact_bytes: u64,
+    maximum_memory_bytes: u64,
+    fuel_per_invocation: u64,
+    maximum_input_bytes: u64,
+    maximum_output_bytes: u64,
+    maximum_queued_events: u64,
 }
 
-/// C-compatible build marker for Swift/XCFramework integration checks.
-#[unsafe(no_mangle)]
-pub extern "C" fn traverse_swift_host_abi_version() -> u32 {
-    1
-}
-
-fn memory_fixture() -> Result<(), wasmi::Error> {
-    let engine = Engine::default();
-    let mut store = Store::new(
-        &engine,
-        StoreLimitsBuilder::new()
-            .memory_size(65_536)
-            .trap_on_grow_failure(true)
-            .build(),
-    );
-    store.limiter(|limits| limits);
-    let bytes = wat::parse_str(
-        "(module (memory 1) (func (export \"grow\") (result i32) i32.const 1 memory.grow))",
-    )
-    .map_err(|_| wasmi::Error::new("invalid memory fixture"))?;
-    let module = Module::new(store.engine(), bytes)?;
-    let instance = Linker::new(store.engine()).instantiate_and_start(&mut store, &module)?;
-    let grow = instance.get_typed_func::<(), i32>(&store, "grow")?;
-    match grow.call(&mut store, ()) {
-        Err(error) if error.as_trap_code() == Some(TrapCode::GrowthOperationLimited) => Ok(()),
-        Err(error) => Err(error),
-        Ok(_) => Err(wasmi::Error::new("memory fixture unexpectedly grew")),
+impl TraverseSwiftHostLimits {
+    fn checked(&self) -> Result<Limits, HostError> {
+        let values = [
+            self.maximum_artifact_bytes,
+            self.maximum_memory_bytes,
+            self.fuel_per_invocation,
+            self.maximum_input_bytes,
+            self.maximum_output_bytes,
+            self.maximum_queued_events,
+        ];
+        if values.contains(&0) {
+            return Err(HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"));
+        }
+        Ok(Limits {
+            maximum_artifact_bytes: usize::try_from(self.maximum_artifact_bytes)
+                .map_err(|_| HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"))?,
+            maximum_memory_bytes: usize::try_from(self.maximum_memory_bytes)
+                .map_err(|_| HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"))?,
+            fuel_per_invocation: self.fuel_per_invocation,
+            maximum_input_bytes: usize::try_from(self.maximum_input_bytes)
+                .map_err(|_| HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"))?,
+            maximum_output_bytes: usize::try_from(self.maximum_output_bytes)
+                .map_err(|_| HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"))?,
+        })
     }
 }
 
-fn fuel_fixture() -> Result<(), wasmi::Error> {
+struct Limits {
+    maximum_artifact_bytes: usize,
+    maximum_memory_bytes: usize,
+    fuel_per_invocation: u64,
+    maximum_input_bytes: usize,
+    maximum_output_bytes: usize,
+}
+
+struct Host {
+    store: Store<StoreLimits>,
+    instance: Instance,
+    memory: Memory,
+    limits: Limits,
+}
+
+struct HostError {
+    status: i32,
+    code: &'static str,
+}
+
+impl HostError {
+    const fn new(status: i32, code: &'static str) -> Self {
+        Self { status, code }
+    }
+    fn json(&self) -> Vec<u8> {
+        format!(
+            r#"{{\"code\":\"{}\",\"message\":\"{}\",\"details\":{{}}}}"#,
+            self.code, self.code
+        )
+        .into_bytes()
+    }
+}
+
+fn required_operation(operation: &str) -> bool {
+    matches!(
+        operation,
+        "init"
+            | "submit"
+            | "next_event"
+            | "cancel"
+            | "compatible_start"
+            | "compatible_stop"
+            | "compatible_kill"
+            | "shutdown"
+    )
+}
+
+fn export_name(operation: &str) -> &'static str {
+    match operation {
+        "init" => "traverse_init",
+        "submit" => "traverse_submit",
+        "next_event" => "traverse_next_event",
+        "cancel" => "traverse_cancel",
+        "compatible_start" => "traverse_compatible_start",
+        "compatible_stop" => "traverse_compatible_stop",
+        "compatible_kill" => "traverse_compatible_kill",
+        "shutdown" => "traverse_shutdown",
+        _ => "",
+    }
+}
+
+fn digest(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let hex = digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("sha256:{hex}")
+}
+
+fn normalised_digest(bytes: &[u8]) -> Result<String, HostError> {
+    let value = std::str::from_utf8(bytes)
+        .map_err(|_| HostError::new(INVALID_INPUT, "bundle_digest_mismatch"))?;
+    let value = value.trim().to_ascii_lowercase();
+    Ok(if value.starts_with("sha256:") {
+        value
+    } else {
+        format!("sha256:{value}")
+    })
+}
+
+fn require_exports(
+    store: &mut Store<StoreLimits>,
+    instance: &Instance,
+) -> Result<Memory, HostError> {
+    let memory = instance
+        .get_memory(&*store, "memory")
+        .ok_or_else(|| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?;
+    let version = instance
+        .get_typed_func::<(), i32>(&*store, "traverse_bridge_abi_version")
+        .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?;
+    if version
+        .call(&mut *store, ())
+        .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?
+        != BRIDGE_VERSION
+    {
+        return Err(HostError::new(INVALID_INPUT, "bridge_version_mismatch"));
+    }
+    for name in [
+        "traverse_alloc",
+        "traverse_dealloc",
+        "traverse_init",
+        "traverse_submit",
+        "traverse_next_event",
+        "traverse_cancel",
+        "traverse_compatible_start",
+        "traverse_compatible_stop",
+        "traverse_compatible_kill",
+        "traverse_shutdown",
+    ] {
+        if instance.get_func(&*store, name).is_none() {
+            return Err(HostError::new(
+                INVALID_DESCRIPTOR,
+                "bridge_invalid_descriptor",
+            ));
+        }
+    }
+    Ok(memory)
+}
+
+fn create_host(runtime: &[u8], expected_digest: &[u8], limits: Limits) -> Result<Host, HostError> {
+    if runtime.len() > limits.maximum_artifact_bytes {
+        return Err(HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"));
+    }
+    if normalised_digest(expected_digest)? != digest(runtime) {
+        return Err(HostError::new(INVALID_INPUT, "bundle_digest_mismatch"));
+    }
     let mut config = Config::default();
     config.consume_fuel(true);
     let engine = Engine::new(&config);
-    let mut store = Store::new(&engine, ());
-    store.set_fuel(10)?;
-    let bytes = wat::parse_str("(module (func (export \"loop\") (loop br 0)))")
-        .map_err(|_| wasmi::Error::new("invalid fuel fixture"))?;
-    let module = Module::new(&engine, bytes)?;
-    let instance = Linker::new(&engine).instantiate_and_start(&mut store, &module)?;
-    let run = instance.get_typed_func::<(), ()>(&store, "loop")?;
-    match run.call(&mut store, ()) {
-        Err(error) if error.as_trap_code() == Some(TrapCode::OutOfFuel) => Ok(()),
-        Err(error) => Err(error),
-        Ok(()) => Err(wasmi::Error::new("fuel fixture unexpectedly returned")),
+    let module = Module::new(&engine, runtime)
+        .map_err(|_| HostError::new(INVALID_INPUT, "bridge_invalid_module"))?;
+    if module.imports().next().is_some() {
+        return Err(HostError::new(INVALID_INPUT, "bridge_ambient_import"));
+    }
+    let store_limits = StoreLimitsBuilder::new()
+        .memory_size(limits.maximum_memory_bytes)
+        .trap_on_grow_failure(true)
+        .build();
+    let mut store = Store::new(&engine, store_limits);
+    store.limiter(|value| value);
+    let instance = Linker::new(&engine)
+        .instantiate_and_start(&mut store, &module)
+        .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?;
+    let memory = require_exports(&mut store, &instance)?;
+    Ok(Host {
+        store,
+        instance,
+        memory,
+        limits,
+    })
+}
+
+fn output(result: &[u8], buffer: *mut u8, capacity: usize, length_out: *mut usize) -> i32 {
+    // SAFETY: callers validate `length_out` before this helper; its one write is bounded to that object.
+    unsafe {
+        *length_out = result.len();
+    }
+    if result.len() > capacity {
+        return BUFFER_TOO_SMALL;
+    }
+    if result.is_empty() {
+        return OK;
+    }
+    if buffer.is_null() {
+        return INVALID_DESCRIPTOR;
+    }
+    // SAFETY: the caller promises a writable output region of `capacity`; this copy is limited to `result.len() <= capacity`.
+    unsafe {
+        std::ptr::copy_nonoverlapping(result.as_ptr(), buffer, result.len());
+    }
+    OK
+}
+
+fn invoke(host: &mut Host, operation: &str, input: &[u8]) -> Result<Vec<u8>, HostError> {
+    if !required_operation(operation) {
+        return Err(HostError::new(
+            INVALID_INPUT,
+            "bridge_operation_not_allowed",
+        ));
+    }
+    if input.len() > host.limits.maximum_input_bytes {
+        return Err(HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"));
+    }
+    if !input.is_empty() {
+        serde_json::from_slice::<serde_json::Value>(input)
+            .map_err(|_| HostError::new(INVALID_INPUT, "bridge_invalid_json"))?;
+    }
+    host.store
+        .set_fuel(host.limits.fuel_per_invocation)
+        .map_err(|_| HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"))?;
+    let alloc = host
+        .instance
+        .get_typed_func::<i32, i32>(&host.store, "traverse_alloc")
+        .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?;
+    let dealloc = host
+        .instance
+        .get_typed_func::<(i32, i32), ()>(&host.store, "traverse_dealloc")
+        .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?;
+    let descriptor = alloc
+        .call(&mut host.store, 8)
+        .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?;
+    let input_pointer = if input.is_empty() {
+        0
+    } else {
+        alloc
+            .call(
+                &mut host.store,
+                i32::try_from(input.len())
+                    .map_err(|_| HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"))?,
+            )
+            .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?
+    };
+    if !input.is_empty() {
+        host.memory
+            .write(
+                &mut host.store,
+                usize::try_from(input_pointer)
+                    .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?,
+                input,
+            )
+            .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?;
+    }
+    let status = if operation == "next_event" || operation == "shutdown" {
+        host.instance
+            .get_typed_func::<i32, i32>(&host.store, export_name(operation))
+            .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?
+            .call(&mut host.store, descriptor)
+    } else {
+        host.instance
+            .get_typed_func::<(i32, i32, i32), i32>(&host.store, export_name(operation))
+            .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?
+            .call(
+                &mut host.store,
+                (
+                    input_pointer,
+                    i32::try_from(input.len())
+                        .map_err(|_| HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"))?,
+                    descriptor,
+                ),
+            )
+    }
+    .map_err(|_| HostError::new(INTERNAL_ERROR, "bridge_trap"))?;
+    let mut descriptor_bytes = [0_u8; 8];
+    host.memory
+        .read(
+            &host.store,
+            usize::try_from(descriptor)
+                .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?,
+            &mut descriptor_bytes,
+        )
+        .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?;
+    let pointer = u32::from_le_bytes(
+        descriptor_bytes[..4]
+            .try_into()
+            .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?,
+    );
+    let length = u32::from_le_bytes(
+        descriptor_bytes[4..]
+            .try_into()
+            .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?,
+    ) as usize;
+    if length > host.limits.maximum_output_bytes {
+        return Err(HostError::new(RESOURCE_LIMIT, "bridge_resource_limit"));
+    }
+    let mut result = vec![0; length];
+    host.memory
+        .read(&host.store, pointer as usize, &mut result)
+        .map_err(|_| HostError::new(INVALID_DESCRIPTOR, "bridge_invalid_descriptor"))?;
+    let _ = dealloc.call(&mut host.store, (descriptor, 8));
+    if input_pointer != 0 {
+        let _ = dealloc.call(
+            &mut host.store,
+            (input_pointer, i32::try_from(input.len()).unwrap_or(0)),
+        );
+    }
+    if status < 0 {
+        return Err(HostError::new(status, "bridge_runtime_error"));
+    }
+    Ok(result)
+}
+
+/// C-compatible ABI marker.
+#[unsafe(no_mangle)]
+pub extern "C" fn traverse_swift_host_abi_version() -> u32 {
+    ABI_VERSION
+}
+
+/// Creates one verified, bounded host and returns its opaque handle.
+#[unsafe(no_mangle)]
+pub extern "C" fn traverse_swift_host_create(
+    runtime: *const u8,
+    runtime_length: usize,
+    expected: *const u8,
+    expected_length: usize,
+    limits: *const TraverseSwiftHostLimits,
+    handle_out: *mut u64,
+) -> i32 {
+    if runtime.is_null() || expected.is_null() || limits.is_null() || handle_out.is_null() {
+        return INVALID_INPUT;
+    }
+    // SAFETY: every pointer is checked non-null; callers supply immutable ranges of the stated lengths.
+    // SAFETY: every pointer is checked non-null; callers supply immutable ranges of the stated lengths.
+    let result = unsafe {
+        (*limits).checked().and_then(|value| {
+            create_host(
+                std::slice::from_raw_parts(runtime, runtime_length),
+                std::slice::from_raw_parts(expected, expected_length),
+                value,
+            )
+        })
+    };
+    match result {
+        Ok(host) => {
+            let raw = Box::into_raw(Box::new(host)) as u64; // SAFETY: validated non-null output pointer writes one u64.
+            unsafe {
+                *handle_out = raw;
+            }
+            OK
+        }
+        Err(error) => error.status,
     }
 }
 
-/// Runs the bounded-memory fixture through the static-library boundary.
+/// Invokes a governed bridge operation using caller-owned buffers.
 #[unsafe(no_mangle)]
-pub extern "C" fn traverse_swift_host_memory_limit_fixture() -> u32 {
-    u32::from(memory_fixture().is_err())
+pub extern "C" fn traverse_swift_host_invoke(
+    handle: u64,
+    operation: *const u8,
+    operation_length: usize,
+    input: *const u8,
+    input_length: usize,
+    output_buffer: *mut u8,
+    output_capacity: usize,
+    output_length_out: *mut usize,
+) -> i32 {
+    if handle == 0 || operation.is_null() || input.is_null() || output_length_out.is_null() {
+        return INVALID_INPUT;
+    }
+    // SAFETY: C caller supplies valid ranges; the opaque handle came from `create` and is used only synchronously by the Swift serialization wrapper.
+    let result = unsafe {
+        (|| -> Result<Vec<u8>, HostError> {
+            let host = &mut *(handle as *mut Host);
+            let operation =
+                std::str::from_utf8(std::slice::from_raw_parts(operation, operation_length))
+                    .map_err(|_| HostError::new(INVALID_INPUT, "bridge_invalid_json"))?;
+            invoke(
+                host,
+                operation,
+                std::slice::from_raw_parts(input, input_length),
+            )
+        })()
+    };
+    match result {
+        Ok(value) => output(&value, output_buffer, output_capacity, output_length_out),
+        Err(error) => {
+            let details = error.json();
+            let write_status = output(
+                &details[..details.len().min(MAX_ERROR_BYTES)],
+                output_buffer,
+                output_capacity,
+                output_length_out,
+            );
+            if write_status == BUFFER_TOO_SMALL {
+                BUFFER_TOO_SMALL
+            } else {
+                error.status
+            }
+        }
+    }
 }
 
-/// Runs the fuel-budget fixture through the static-library boundary.
+/// Destroys a host handle; null is an idempotent success.
 #[unsafe(no_mangle)]
-pub extern "C" fn traverse_swift_host_fuel_limit_fixture() -> u32 {
-    u32::from(fuel_fixture().is_err())
+pub extern "C" fn traverse_swift_host_destroy(handle: u64) -> i32 {
+    if handle == 0 {
+        return OK;
+    } // SAFETY: `create` allocates this exact opaque Host pointer; callers must destroy at most once.
+    unsafe {
+        drop(Box::from_raw(handle as *mut Host));
+    }
+    OK
+}
+
+/// Maps a status to a bounded static UTF-8 message.
+#[unsafe(no_mangle)]
+pub extern "C" fn traverse_swift_host_status_message(status: i32) -> *const std::ffi::c_char {
+    let value = match status {
+        OK => "ok\0",
+        INVALID_HANDLE => "invalid_handle\0",
+        INVALID_INPUT => "invalid_input\0",
+        INVALID_DESCRIPTOR => "invalid_descriptor\0",
+        RESOURCE_LIMIT => "resource_limit\0",
+        INTERNAL_ERROR => "internal_error\0",
+        BUFFER_TOO_SMALL => "buffer_too_small\0",
+        _ => "unknown_status\0",
+    };
+    value.as_ptr().cast()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{configured_memory_limit, fuel_fixture, memory_fixture};
+    use super::{
+        ABI_VERSION, RESOURCE_LIMIT, TraverseSwiftHostLimits, traverse_swift_host_abi_version,
+        traverse_swift_host_create,
+    };
 
     #[test]
-    fn exposes_the_configured_memory_limit() {
-        assert_eq!(configured_memory_limit(65_536), 65_536);
+    fn exposes_a_versioned_production_boundary() {
+        assert_eq!(traverse_swift_host_abi_version(), ABI_VERSION);
     }
 
     #[test]
-    fn memory_growth_traps_at_the_configured_limit() {
-        assert!(memory_fixture().is_ok());
-    }
-
-    #[test]
-    fn fuel_exhaustion_stops_a_non_terminating_module() {
-        assert!(fuel_fixture().is_ok());
+    fn rejects_unbounded_limits_before_module_instantiation() {
+        let limits = TraverseSwiftHostLimits {
+            maximum_artifact_bytes: 0,
+            maximum_memory_bytes: 1,
+            fuel_per_invocation: 1,
+            maximum_input_bytes: 1,
+            maximum_output_bytes: 1,
+            maximum_queued_events: 1,
+        };
+        let bytes = [0_u8];
+        let digest = b"sha256:00";
+        let mut handle = 0_u64;
+        assert_eq!(
+            traverse_swift_host_create(
+                bytes.as_ptr(),
+                bytes.len(),
+                digest.as_ptr(),
+                digest.len(),
+                &limits,
+                &mut handle,
+            ),
+            RESOURCE_LIMIT
+        );
+        assert_eq!(handle, 0);
     }
 }

--- a/docs/blog-native-ios-runtime-foundation-hands-on.md
+++ b/docs/blog-native-ios-runtime-foundation-hands-on.md
@@ -117,9 +117,8 @@ import TraverseSwiftHost
 @main
 struct TraverseSwiftHostProofApp: App {
     init() {
-        precondition(traverse_swift_host_abi_version() == 1)
-        precondition(traverse_swift_host_memory_limit_fixture() == 0)
-        precondition(traverse_swift_host_fuel_limit_fixture() == 0)
+        precondition(traverse_swift_host_abi_version() == 2)
+        precondition(String(cString: traverse_swift_host_status_message(0)) == "ok")
     }
 
     var body: some Scene {

--- a/docs/swift-host-device-test.md
+++ b/docs/swift-host-device-test.md
@@ -1,4 +1,4 @@
-# iPhone Test Guide: Traverse Swift Host Feasibility
+# iPhone Test Guide: Traverse Swift Host Boundary
 
 Use this guide after building the branch's XCFramework on a Mac with Xcode and
 an Apple signing identity. It records the final physical-device evidence for
@@ -32,9 +32,8 @@ import TraverseSwiftHost
 @main
 struct TraverseSwiftHostProofApp: App {
     init() {
-        precondition(traverse_swift_host_abi_version() == 1)
-        precondition(traverse_swift_host_memory_limit_fixture() == 0)
-        precondition(traverse_swift_host_fuel_limit_fixture() == 0)
+        precondition(traverse_swift_host_abi_version() == 2)
+        precondition(String(cString: traverse_swift_host_status_message(0)) == "ok")
     }
 
     var body: some Scene { WindowGroup { Text("Traverse Swift host proof passed") } }

--- a/examples/swift-wasmi-proof/main.swift
+++ b/examples/swift-wasmi-proof/main.swift
@@ -1,13 +1,10 @@
 import TraverseSwiftHost
 
 let version = traverse_swift_host_abi_version()
-guard version == 1 else {
+guard version == 2 else {
     fatalError("unexpected Traverse Swift host ABI version: \(version)")
 }
-guard traverse_swift_host_memory_limit_fixture() == 0 else {
-    fatalError("memory fixture did not stop at the configured limit")
+guard String(cString: traverse_swift_host_status_message(0)) == "ok" else {
+    fatalError("production status mapping is unavailable")
 }
-guard traverse_swift_host_fuel_limit_fixture() == 0 else {
-    fatalError("fuel fixture did not stop execution")
-}
-print("Traverse Swift host ABI \(version) is available")
+print("Traverse Swift host production ABI \(version) is available")

--- a/packages/swift/TraverseEmbedder/Package.swift
+++ b/packages/swift/TraverseEmbedder/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .binaryTarget(
             name: "TraverseSwiftHost",
             url: "https://github.com/traverse-framework/traverse/releases/download/v0.8.2/TraverseSwiftHost.xcframework.zip",
-            checksum: "904ed575c25604818695f285ffac9d5d7c4ffb9b2b818bcff9cd196815c2bf01"
+            checksum: "cf9c0461ef777cafb7bedb73f7402dba27f4d956b43dc8157ce56e1006071e48"
         ),
         .target(
             name: "TraverseEmbedder",

--- a/packages/swift/TraverseEmbedder/Package.swift
+++ b/packages/swift/TraverseEmbedder/Package.swift
@@ -12,9 +12,17 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-system.git", exact: "1.5.0"),
     ],
     targets: [
+        .binaryTarget(
+            name: "TraverseSwiftHost",
+            url: "https://github.com/traverse-framework/traverse/releases/download/v0.8.2/TraverseSwiftHost.xcframework.zip",
+            checksum: "904ed575c25604818695f285ffac9d5d7c4ffb9b2b818bcff9cd196815c2bf01"
+        ),
         .target(
             name: "TraverseEmbedder",
-            dependencies: [.product(name: "WasmKit", package: "WasmKit")]
+            dependencies: [
+                "TraverseSwiftHost",
+                .product(name: "WasmKit", package: "WasmKit"),
+            ]
         ),
         .testTarget(
             name: "TraverseEmbedderTests",

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/RuntimeTraverseEmbedder.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/RuntimeTraverseEmbedder.swift
@@ -2,13 +2,13 @@ import Foundation
 
 /// Typed public embedder backed exclusively by runtime-owned bridge results.
 public final class RuntimeTraverseEmbedder: @unchecked Sendable {
-    private let client: WasmKitBridgeClient
+    private let client: any TraverseBridgeClient
 
     public convenience init(bundle: TraverseBundle) throws {
-        try self.init(client: WasmKitBridgeClient(bridge: WasmKitRuntimeBridge(bundle: bundle)))
+        try self.init(client: WasmiHostBridgeClient(bundle: bundle))
     }
 
-    public init(client: WasmKitBridgeClient) {
+    public init(client: any TraverseBridgeClient) {
         self.client = client
     }
 

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitBridgeClient.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitBridgeClient.swift
@@ -2,7 +2,8 @@ import Foundation
 import WasmKit
 
 /// Serialized UTF-8 JSON client for the governed runtime-WASM bridge.
-public final class WasmKitBridgeClient: @unchecked Sendable {
+@available(*, deprecated, message: "Use WasmiHostBridgeClient; WasmKit is retained only for source compatibility.")
+public final class WasmKitBridgeClient: @unchecked Sendable, TraverseBridgeClient {
     public static let defaultMaximumOutputBytes = 1024 * 1024
 
     private let instance: Instance
@@ -160,4 +161,15 @@ public struct TraverseBridgeError: Error, Equatable, Sendable {
         self.status = status
         self.message = message
     }
+}
+
+protocol TraverseBridgeClient: Sendable {
+    func initialize(configJSON: Data) throws -> Data
+    func submit(requestJSON: Data) throws -> Data
+    func cancel(requestJSON: Data) throws -> Data
+    func compatibleStart(requestJSON: Data) throws -> Data
+    func compatibleStop(requestJSON: Data) throws -> Data
+    func compatibleKill(requestJSON: Data) throws -> Data
+    func nextEvent() throws -> Data?
+    func shutdown() throws -> Data
 }

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitBridgeClient.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitBridgeClient.swift
@@ -163,7 +163,7 @@ public struct TraverseBridgeError: Error, Equatable, Sendable {
     }
 }
 
-protocol TraverseBridgeClient: Sendable {
+public protocol TraverseBridgeClient: Sendable {
     func initialize(configJSON: Data) throws -> Data
     func submit(requestJSON: Data) throws -> Data
     func cancel(requestJSON: Data) throws -> Data

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitRuntimeBridge.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmKitRuntimeBridge.swift
@@ -6,6 +6,7 @@ import WasmKit
 ///
 /// The loader verifies the artifact before WasmKit parses or instantiates it,
 /// rejects ambient imports, and validates the complete embedder export surface.
+@available(*, deprecated, message: "Use WasmiHostBridgeClient; WasmKit is retained only for source compatibility.")
 public final class WasmKitRuntimeBridge: @unchecked Sendable {
     public static let abiVersion = 10_100
     public static let defaultMaximumArtifactBytes = 32 * 1024 * 1024

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmiHostBridgeClient.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmiHostBridgeClient.swift
@@ -37,7 +37,11 @@ public final class WasmiHostBridgeClient: @unchecked Sendable, TraverseBridgeCli
     private let lock = NSLock()
     private let limits: TraverseHostLimits
 
-    public init(bundle: TraverseBundle, limits: TraverseHostLimits = try TraverseHostLimits()) throws {
+    public convenience init(bundle: TraverseBundle) throws {
+        try self.init(bundle: bundle, limits: TraverseHostLimits())
+    }
+
+    public init(bundle: TraverseBundle, limits: TraverseHostLimits) throws {
         guard bundle.embedderAPIVersion == TraverseEmbedder.apiVersion else {
             throw TraverseEmbedderError.incompatibleBundle("embedder API \(bundle.embedderAPIVersion) is incompatible with \(TraverseEmbedder.apiVersion)")
         }
@@ -95,7 +99,10 @@ public final class WasmiHostBridgeClient: @unchecked Sendable, TraverseBridgeCli
         try lock.withLock {
             guard handle != 0 else { throw TraverseBridgeError(status: -1, message: "invalid_handle") }
             var required = 0
-            var output = Data()
+            guard let outputCapacity = Int(exactly: limits.maximumOutputBytes) else {
+                throw TraverseBridgeError(status: -4, message: "bridge_resource_limit")
+            }
+            var output = Data(repeating: 0, count: outputCapacity)
             let status = call(operation: operation, input: input, output: &output, required: &required)
             if status == -6 {
                 output = Data(repeating: 0, count: required)
@@ -112,6 +119,7 @@ public final class WasmiHostBridgeClient: @unchecked Sendable, TraverseBridgeCli
 
     private func call(operation: String, input: Data, output: inout Data, required: inout Int) -> Int32 {
         let operationData = Data(operation.utf8)
+        let outputCapacity = output.count
         return operationData.withUnsafeBytes { operationBuffer in
             input.withUnsafeBytes { inputBuffer in
                 output.withUnsafeMutableBytes { outputBuffer in
@@ -122,7 +130,7 @@ public final class WasmiHostBridgeClient: @unchecked Sendable, TraverseBridgeCli
                         inputBuffer.bindMemory(to: UInt8.self).baseAddress,
                         input.count,
                         outputBuffer.bindMemory(to: UInt8.self).baseAddress,
-                        output.count,
+                        outputCapacity,
                         &required
                     )
                 }

--- a/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmiHostBridgeClient.swift
+++ b/packages/swift/TraverseEmbedder/Sources/TraverseEmbedder/WasmiHostBridgeClient.swift
@@ -1,0 +1,136 @@
+import Foundation
+import TraverseSwiftHost
+
+/// Explicit limits for the production `wasmi` host boundary.
+public struct TraverseHostLimits: Sendable, Equatable {
+    public let maximumArtifactBytes: UInt64
+    public let maximumMemoryBytes: UInt64
+    public let fuelPerInvocation: UInt64
+    public let maximumInputBytes: UInt64
+    public let maximumOutputBytes: UInt64
+    public let maximumQueuedEvents: UInt64
+
+    public init(
+        maximumArtifactBytes: UInt64 = 32 * 1024 * 1024,
+        maximumMemoryBytes: UInt64 = 64 * 1024 * 1024,
+        fuelPerInvocation: UInt64 = 1_000_000,
+        maximumInputBytes: UInt64 = 1024 * 1024,
+        maximumOutputBytes: UInt64 = 1024 * 1024,
+        maximumQueuedEvents: UInt64 = 1024
+    ) throws {
+        let values = [maximumArtifactBytes, maximumMemoryBytes, fuelPerInvocation, maximumInputBytes, maximumOutputBytes, maximumQueuedEvents]
+        guard !values.contains(0) else {
+            throw TraverseBridgeError(status: -4, message: "bridge_resource_limit")
+        }
+        self.maximumArtifactBytes = maximumArtifactBytes
+        self.maximumMemoryBytes = maximumMemoryBytes
+        self.fuelPerInvocation = fuelPerInvocation
+        self.maximumInputBytes = maximumInputBytes
+        self.maximumOutputBytes = maximumOutputBytes
+        self.maximumQueuedEvents = maximumQueuedEvents
+    }
+}
+
+/// Serialized engine-neutral client for the production `TraverseSwiftHost` ABI.
+public final class WasmiHostBridgeClient: @unchecked Sendable, TraverseBridgeClient {
+    private var handle: UInt64 = 0
+    private let lock = NSLock()
+    private let limits: TraverseHostLimits
+
+    public init(bundle: TraverseBundle, limits: TraverseHostLimits = try TraverseHostLimits()) throws {
+        guard bundle.embedderAPIVersion == TraverseEmbedder.apiVersion else {
+            throw TraverseEmbedderError.incompatibleBundle("embedder API \(bundle.embedderAPIVersion) is incompatible with \(TraverseEmbedder.apiVersion)")
+        }
+        let runtimeURL = bundle.rootURL.appendingPathComponent("runtime").appendingPathComponent("runtime.wasm")
+        let runtime: Data
+        do {
+            runtime = try Data(contentsOf: runtimeURL, options: [.mappedIfSafe])
+        } catch {
+            throw TraverseEmbedderError.incompatibleBundle("runtime/runtime.wasm is unavailable")
+        }
+        self.limits = limits
+        var nativeLimits = traverse_swift_host_limits(
+            maximum_artifact_bytes: limits.maximumArtifactBytes,
+            maximum_memory_bytes: limits.maximumMemoryBytes,
+            fuel_per_invocation: limits.fuelPerInvocation,
+            maximum_input_bytes: limits.maximumInputBytes,
+            maximum_output_bytes: limits.maximumOutputBytes,
+            maximum_queued_events: limits.maximumQueuedEvents
+        )
+        var nativeHandle: UInt64 = 0
+        let expectedDigest = Data(bundle.runtimeWasmDigest.utf8)
+        let status = runtime.withUnsafeBytes { runtimeBuffer in
+            expectedDigest.withUnsafeBytes { digestBuffer in
+                traverse_swift_host_create(
+                    runtimeBuffer.bindMemory(to: UInt8.self).baseAddress,
+                    runtime.count,
+                    digestBuffer.bindMemory(to: UInt8.self).baseAddress,
+                    expectedDigest.count,
+                    &nativeLimits,
+                    &nativeHandle
+                )
+            }
+        }
+        guard status == 0 else { throw Self.error(status) }
+        handle = nativeHandle
+    }
+
+    deinit {
+        if handle != 0 { _ = traverse_swift_host_destroy(handle) }
+    }
+
+    public func initialize(configJSON: Data) throws -> Data { try invoke("init", input: configJSON) }
+    public func submit(requestJSON: Data) throws -> Data { try invoke("submit", input: requestJSON) }
+    public func cancel(requestJSON: Data) throws -> Data { try invoke("cancel", input: requestJSON) }
+    public func compatibleStart(requestJSON: Data) throws -> Data { try invoke("compatible_start", input: requestJSON) }
+    public func compatibleStop(requestJSON: Data) throws -> Data { try invoke("compatible_stop", input: requestJSON) }
+    public func compatibleKill(requestJSON: Data) throws -> Data { try invoke("compatible_kill", input: requestJSON) }
+    public func nextEvent() throws -> Data? {
+        let result = try invoke("next_event", input: Data("{}".utf8))
+        return result.isEmpty ? nil : result
+    }
+    public func shutdown() throws -> Data { try invoke("shutdown", input: Data("{}".utf8)) }
+
+    private func invoke(_ operation: String, input: Data) throws -> Data {
+        try lock.withLock {
+            guard handle != 0 else { throw TraverseBridgeError(status: -1, message: "invalid_handle") }
+            var required = 0
+            var output = Data()
+            let status = call(operation: operation, input: input, output: &output, required: &required)
+            if status == -6 {
+                output = Data(repeating: 0, count: required)
+                let retry = call(operation: operation, input: input, output: &output, required: &required)
+                guard retry >= 0 else { throw Self.error(retry) }
+                output.count = required
+                return output
+            }
+            guard status >= 0 else { throw Self.error(status) }
+            output.count = required
+            return output
+        }
+    }
+
+    private func call(operation: String, input: Data, output: inout Data, required: inout Int) -> Int32 {
+        let operationData = Data(operation.utf8)
+        return operationData.withUnsafeBytes { operationBuffer in
+            input.withUnsafeBytes { inputBuffer in
+                output.withUnsafeMutableBytes { outputBuffer in
+                    traverse_swift_host_invoke(
+                        handle,
+                        operationBuffer.bindMemory(to: UInt8.self).baseAddress,
+                        operationData.count,
+                        inputBuffer.bindMemory(to: UInt8.self).baseAddress,
+                        input.count,
+                        outputBuffer.bindMemory(to: UInt8.self).baseAddress,
+                        output.count,
+                        &required
+                    )
+                }
+            }
+        }
+    }
+
+    private static func error(_ status: Int32) -> TraverseBridgeError {
+        TraverseBridgeError(status: status, message: String(cString: traverse_swift_host_status_message(status)))
+    }
+}

--- a/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
+++ b/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
@@ -148,6 +148,16 @@ import WAT
     #expect(try client.shutdown() == Data(#"{"status":"stopped"}"#.utf8))
 }
 
+@Test func wasmiHostBridgeClientUsesThePackagedProductionBoundary() throws {
+    let wasm = try wat2wasm(clientBridgeWAT)
+    let client = try WasmiHostBridgeClient(bundle: fixtureBundle(wasm: wasm))
+
+    #expect(try client.initialize(configJSON: Data("{}".utf8)) == Data(#"{"status":"ready"}"#.utf8))
+    #expect(try client.submit(requestJSON: Data(#"{"target_id":"demo"}"#.utf8)) == Data(#"{"session_id":"s1","status":"accepted"}"#.utf8))
+    #expect(try client.nextEvent() == Data(#"{"sequence":1,"target_id":"demo","status":"completed"}"#.utf8))
+    #expect(try client.shutdown() == Data(#"{"status":"stopped"}"#.utf8))
+}
+
 @Test func runtimeEmbedderMapsRuntimeOwnedResultsIntoPublicTypes() throws {
     let wasm = try wat2wasm(clientBridgeWAT)
     let client = try WasmKitBridgeClient(bridge: WasmKitRuntimeBridge(bundle: fixtureBundle(wasm: wasm)))

--- a/scripts/build_swift_host_xcframework.sh
+++ b/scripts/build_swift_host_xcframework.sh
@@ -10,13 +10,13 @@ header_dir="${repo_root}/crates/traverse-swift-host/include"
 for target in aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-darwin; do
   RUSTC="${rustc_path}" rustup run "${toolchain}" cargo build \
     --manifest-path "${repo_root}/Cargo.toml" \
-    -p traverse-swift-host --target "${target}"
+    -p traverse-swift-host --release --target "${target}"
 done
 
 mkdir -p "${output_dir}"
 rm -rf "${output_dir}/TraverseSwiftHost.xcframework"
 xcodebuild -create-xcframework \
-  -library "${repo_root}/target/aarch64-apple-ios/debug/libtraverse_swift_host.a" -headers "${header_dir}" \
-  -library "${repo_root}/target/aarch64-apple-ios-sim/debug/libtraverse_swift_host.a" -headers "${header_dir}" \
-  -library "${repo_root}/target/aarch64-apple-darwin/debug/libtraverse_swift_host.a" -headers "${header_dir}" \
+  -library "${repo_root}/target/aarch64-apple-ios/release/libtraverse_swift_host.a" -headers "${header_dir}" \
+  -library "${repo_root}/target/aarch64-apple-ios-sim/release/libtraverse_swift_host.a" -headers "${header_dir}" \
+  -library "${repo_root}/target/aarch64-apple-darwin/release/libtraverse_swift_host.a" -headers "${header_dir}" \
   -output "${output_dir}/TraverseSwiftHost.xcframework"

--- a/scripts/ci/scoped_unsafe_boundary_check.sh
+++ b/scripts/ci/scoped_unsafe_boundary_check.sh
@@ -18,19 +18,30 @@ if [[ "${#opt_outs[@]}" -ne 1 || "${opt_outs[0]:-}" != "${approved_boundary}" ]]
   exit 1
 fi
 
-unsafe_sites=()
-while IFS= read -r site; do
-  unsafe_sites+=("${site}")
-done < <(grep -RIn --include='*.rs' -E '#\[unsafe\(|unsafe[[:space:]]*(\{|fn|impl|trait|extern)' crates || true)
-for site in "${unsafe_sites[@]}"; do
-  if [[ "${site}" != "${approved_boundary}:"* ]] || [[ "${site}" != *'#[unsafe(no_mangle)]'* ]]; then
-    echo "Unsafe syntax is permitted only for no_mangle exports in ${approved_boundary}: ${site}" >&2
+unsafe_files=()
+while IFS= read -r path; do
+  unsafe_files+=("${path}")
+done < <(grep -RIl --include='*.rs' -E '#\[unsafe\(|unsafe[[:space:]]*(\{|fn|impl|trait|extern)' crates || true)
+if [[ "${#unsafe_files[@]}" -ne 1 || "${unsafe_files[0]:-}" != "${approved_boundary}" ]]; then
+  echo "Unsafe syntax is permitted only in ${approved_boundary}." >&2
+  exit 1
+fi
+
+exports=(
+  traverse_swift_host_abi_version
+  traverse_swift_host_create
+  traverse_swift_host_invoke
+  traverse_swift_host_destroy
+  traverse_swift_host_status_message
+)
+for symbol in "${exports[@]}"; do
+  if [[ "$(grep -Fc "fn ${symbol}" "${approved_boundary}")" -ne 1 ]]; then
+    echo "Missing or duplicate audited C-ABI symbol: ${symbol}" >&2
     exit 1
   fi
 done
-
-if [[ "${#unsafe_sites[@]}" -ne 3 ]]; then
-  echo "The audited Swift host must expose exactly three C-ABI symbols." >&2
+if [[ "$(grep -Fc '#[unsafe(no_mangle)]' "${approved_boundary}")" -ne 5 ]]; then
+  echo "The audited Swift host must expose exactly five production C-ABI symbols." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Ships the public Swift embedder production path through the bounded wasmi C ABI and a versioned SwiftPM XCFramework binary target.

## Governing Spec

- `004-spec-alignment-gate`
- `008-expedition-example-domain`
- `025-wasm-executor-adapter`
- `065-sigstore-bundle-verification`
- `068-public-platform-embedder-packages`
- `071-native-runtime-wasm-bridge`
- `072-native-bridge-compatible-lifecycle`
- `074-swift-native-resource-control-certification`
- `076-production-swift-wasmi-cabi`

## Project Item

- https://github.com/orgs/traverse-framework/projects/1/views/3?pane=issue&itemId=215507199&issue=traverse-framework%7Ctraverse%7C647

## Definition of Done

- SwiftPM consumes the arm64 Apple TraverseSwiftHost XCFramework release asset.
- RuntimeTraverseEmbedder defaults to the engine-neutral wasmi bridge.
- The C ABI verifies digests, limits, imports, ABI exports, and bounded caller buffers.
- WasmKit compatibility wrappers are deprecated and no longer selected by the production initializer.

## Validation

- `swift test --package-path packages/swift/TraverseEmbedder`
- `cargo test -p traverse-swift-host`
- `bash scripts/ci/scoped_unsafe_boundary_check.sh`
- `git diff --check`

Closes #647