### PR TITLE
test(native): certify generated artifact across hosts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,32 @@ jobs:
       - name: Run web embedder package conformance
         run: bash scripts/ci/embedder_conformance/web_package.sh
 
+  native-artifact-certification:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.94.0
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Certify generated artifact across native packages
+        run: bash scripts/ci/native_artifact_certification.sh
+
   coverage-gate:
     runs-on: ubuntu-latest
 

--- a/crates/traverse-native-bridge/src/main.rs
+++ b/crates/traverse-native-bridge/src/main.rs
@@ -32,9 +32,9 @@ const MODULE: &str = r#"(module
   (func (export "traverse_submit") (param i32 i32 i32) (result i32)
     i32.const 0 global.set $event local.get 2 i32.const 8256 i32.const 67 call $out i32.const 0)
   (func (export "traverse_next_event") (param $d i32) (result i32)
-    global.get $event i32.const 0 i32.eq if local.get $d i32.const 8384 i32.const 83 call $out i32.const 1 global.set $event i32.const 1 return end
-    global.get $event i32.const 1 i32.eq if local.get $d i32.const 8512 i32.const 70 call $out i32.const 2 global.set $event i32.const 1 return end
-    global.get $event i32.const 2 i32.eq if local.get $d i32.const 8640 i32.const 83 call $out i32.const 3 global.set $event i32.const 1 return end i32.const 0)
+    global.get $event i32.const 0 i32.eq if local.get $d i32.const 8384 i32.const 84 call $out i32.const 1 global.set $event i32.const 1 return end
+    global.get $event i32.const 1 i32.eq if local.get $d i32.const 8512 i32.const 72 call $out i32.const 2 global.set $event i32.const 1 return end
+    global.get $event i32.const 2 i32.eq if local.get $d i32.const 8640 i32.const 82 call $out i32.const 3 global.set $event i32.const 1 return end i32.const 0)
   (func (export "traverse_cancel") (param i32 i32 i32) (result i32) i32.const 0)
   (func (export "traverse_shutdown") (param i32) (result i32) local.get 0 i32.const 8768 i32.const 20 call $out i32.const 0)
   (func (export "traverse_compatible_start") (param i32 i32 i32) (result i32) i32.const -1)

--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/WasmtimeRuntimeBridgeTests.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/WasmtimeRuntimeBridgeTests.cs
@@ -13,6 +13,24 @@ public sealed class WasmtimeRuntimeBridgeTests
     private const string TypedClientFixture = "AGFzbQEAAAABFgRgAAF/YAF/AX9gAn9/AGADf39/AX8DDQwAAQIDAwMBAwMDAwEFBAEBARAGBgF/AUEACwf8AQwGbWVtb3J5AgAbdHJhdmVyc2VfYnJpZGdlX2FiaV92ZXJzaW9uAAAOdHJhdmVyc2VfYWxsb2MAARB0cmF2ZXJzZV9kZWFsbG9jAAINdHJhdmVyc2VfaW5pdAAED3RyYXZlcnNlX3N1Ym1pdAAFE3RyYXZlcnNlX25leHRfZXZlbnQABg90cmF2ZXJzZV9jYW5jZWwABxl0cmF2ZXJzZV9jb21wYXRpYmxlX3N0YXJ0AAgYdHJhdmVyc2VfY29tcGF0aWJsZV9zdG9wAAkYdHJhdmVyc2VfY29tcGF0aWJsZV9raWxsAAoRdHJhdmVyc2Vfc2h1dGRvd24ACwqXAQwGAEH0zgALBQBBwAALAgALFQAgACABNgIAIABBBGogAjYCAEEACwsAIAJBgARBEhADCwsAIAJBoARBJxADCxsAIwBFBH9BASQAIABB4ARBNhADGkEBBUEACwsLACACQaAEQScQAwsLACACQaAEQScQAwsLACACQaAEQScQAwsLACACQaAEQScQAwsLACAAQcAFQRQQAwsLnAEEAEGABAsSeyJzdGF0dXMiOiJyZWFkeSJ9AEGgBAsneyJzZXNzaW9uX2lkIjoiczEiLCJzdGF0dXMiOiJhY2NlcHRlZCJ9AEHgBAs2eyJzZXF1ZW5jZSI6MSwidGFyZ2V0X2lkIjoiZGVtbyIsInN0YXR1cyI6ImNvbXBsZXRlZCJ9AEHABQsUeyJzdGF0dXMiOiJzdG9wcGVkIn0=";
 
     [Fact]
+    public void RealNativeArtifactRunsWithoutASidecar()
+    {
+        var root = Environment.GetEnvironmentVariable("TRAVERSE_NATIVE_ARTIFACT_ROOT");
+        if (string.IsNullOrWhiteSpace(root)) return;
+        var bytes = File.ReadAllBytes(Path.Join(root, "runtime", "runtime.wasm"));
+        using var bridge = new WasmtimeRuntimeBridge(new TraverseBundle(root, Digest(bytes)));
+        var client = new WasmtimeBridgeClient(bridge);
+
+        Assert.Equal("{\"status\":\"ready\",\"error\":null}", Text(client.Initialize("{}"u8)));
+        Assert.Equal("{\"session_id\":\"runtime-session-1\",\"status\":\"accepted\",\"error\":null}", Text(client.Submit("{\"target_id\":\"traverse-starter.pipeline\"}"u8)));
+        Assert.Equal("{\"type\":\"state_changed\",\"session_id\":\"runtime-session-1\",\"data\":{\"state\":\"running\"}}", Text(client.NextEvent()!));
+        Assert.Equal("{\"type\":\"capability_invoked\",\"session_id\":\"runtime-session-1\",\"data\":{}}", Text(client.NextEvent()!));
+        Assert.Equal("{\"type\":\"capability_result\",\"session_id\":\"runtime-session-1\",\"data\":{\"output\":{}}}", Text(client.NextEvent()!));
+        Assert.Null(client.NextEvent());
+        Assert.Equal("{\"status\":\"stopped\"}", Text(client.Shutdown()));
+    }
+
+    [Fact]
     public void VerifiesAndInstantiatesTheGovernedBridge()
     {
         var (bundle, bytes) = FixtureBundle();

--- a/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryBridgeClientTest.kt
+++ b/packages/kotlin/TraverseEmbedder/traverse-embedder/src/test/kotlin/dev/traverse/embedder/ChicoryBridgeClientTest.kt
@@ -10,6 +10,22 @@ import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class ChicoryBridgeClientTest {
+    @Test fun realNativeArtifactRunsWithoutASidecar() {
+        val rootPath = System.getenv("TRAVERSE_NATIVE_ARTIFACT_ROOT") ?: return
+        val runtime = File(rootPath, "runtime/runtime.wasm").readBytes()
+        val digest = "sha256:" + MessageDigest.getInstance("SHA-256")
+            .digest(runtime).joinToString("") { "%02x".format(it) }
+        val client = ChicoryBridgeClient(ChicoryRuntimeBridge(TraverseBundle(rootPath, digest)))
+
+        assertEquals("{\"status\":\"ready\",\"error\":null}", client.initialize("{}"))
+        assertEquals("{\"session_id\":\"runtime-session-1\",\"status\":\"accepted\",\"error\":null}", client.submit("{\"target_id\":\"traverse-starter.pipeline\"}"))
+        assertEquals("{\"type\":\"state_changed\",\"session_id\":\"runtime-session-1\",\"data\":{\"state\":\"running\"}}", client.nextEvent())
+        assertEquals("{\"type\":\"capability_invoked\",\"session_id\":\"runtime-session-1\",\"data\":{}}", client.nextEvent())
+        assertEquals("{\"type\":\"capability_result\",\"session_id\":\"runtime-session-1\",\"data\":{\"output\":{}}}", client.nextEvent())
+        assertNull(client.nextEvent())
+        assertEquals("{\"status\":\"stopped\"}", client.shutdown())
+    }
+
     @Test fun copiesJsonResultsAndDrainsEventsInOrder() {
         val client = ChicoryBridgeClient(ChicoryRuntimeBridge(fixtureBundle()))
 

--- a/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
+++ b/packages/swift/TraverseEmbedder/Tests/TraverseEmbedderTests/TraverseEmbedderTests.swift
@@ -158,6 +158,24 @@ import WAT
     #expect(try client.shutdown() == Data(#"{"status":"stopped"}"#.utf8))
 }
 
+@Test func realNativeArtifactRunsWithoutASidecar() throws {
+    guard let rootPath = ProcessInfo.processInfo.environment["TRAVERSE_NATIVE_ARTIFACT_ROOT"] else { return }
+    let runtimeURL = URL(fileURLWithPath: rootPath).appendingPathComponent("runtime/runtime.wasm")
+    let runtime = try Data(contentsOf: runtimeURL)
+    let client = try WasmiHostBridgeClient(bundle: TraverseBundle(
+        rootURL: URL(fileURLWithPath: rootPath),
+        runtimeWasmDigest: digest(of: Array(runtime))
+    ))
+
+    #expect(try client.initialize(configJSON: Data("{}".utf8)) == Data(#"{"status":"ready","error":null}"#.utf8))
+    #expect(try client.submit(requestJSON: Data(#"{"target_id":"traverse-starter.pipeline"}"#.utf8)) == Data(#"{"session_id":"runtime-session-1","status":"accepted","error":null}"#.utf8))
+    #expect(try client.nextEvent() == Data(#"{"type":"state_changed","session_id":"runtime-session-1","data":{"state":"running"}}"#.utf8))
+    #expect(try client.nextEvent() == Data(#"{"type":"capability_invoked","session_id":"runtime-session-1","data":{}}"#.utf8))
+    #expect(try client.nextEvent() == Data(#"{"type":"capability_result","session_id":"runtime-session-1","data":{"output":{}}}"#.utf8))
+    #expect(try client.nextEvent() == nil)
+    #expect(try client.shutdown() == Data(#"{"status":"stopped"}"#.utf8))
+}
+
 @Test func runtimeEmbedderMapsRuntimeOwnedResultsIntoPublicTypes() throws {
     let wasm = try wat2wasm(clientBridgeWAT)
     let client = try WasmKitBridgeClient(bridge: WasmKitRuntimeBridge(bundle: fixtureBundle(wasm: wasm)))

--- a/scripts/ci/native_artifact_certification.sh
+++ b/scripts/ci/native_artifact_certification.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Runs the generated production bridge through every native package without a
+# CLI, HTTP, or other sidecar.  The package tests consume the one artifact
+# directory supplied through TRAVERSE_NATIVE_ARTIFACT_ROOT.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+artifact_root="$(mktemp -d "${TMPDIR:-/tmp}/traverse-native-artifact.XXXXXX")"
+cleanup() { rm -rf "${artifact_root}"; }
+trap cleanup EXIT
+
+cargo run -q -p traverse-native-bridge -- "${artifact_root}/runtime"
+
+python3 - "${artifact_root}/runtime" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+runtime_dir = pathlib.Path(sys.argv[1])
+wasm = (runtime_dir / "runtime.wasm").read_bytes()
+release = json.loads((runtime_dir / "runtime-release.json").read_text(encoding="utf-8"))
+if release["sha256"] != hashlib.sha256(wasm).hexdigest():
+    raise SystemExit("runtime-release.json digest does not match runtime.wasm")
+if release["bridge_version"] != "1.1.0" or release["bridge_abi_version"] != 10100:
+    raise SystemExit("runtime-release.json bridge identity is incompatible")
+if not release["runtime_version"]:
+    raise SystemExit("runtime-release.json runtime version is required")
+print(json.dumps({"artifact": "runtime.wasm", "release": release, "digest_verified": True}, sort_keys=True))
+PY
+
+export TRAVERSE_NATIVE_ARTIFACT_ROOT="${artifact_root}"
+swift test --package-path "${repo_root}/packages/swift/TraverseEmbedder"
+pushd "${repo_root}/packages/kotlin/TraverseEmbedder" >/dev/null
+"${GRADLE:-gradle}" --no-daemon :traverse-embedder:testDebugUnitTest
+popd >/dev/null
+dotnet test "${repo_root}/packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/TraverseEmbedder.Tests.csproj"
+
+python3 - <<'PY'
+import json
+print(json.dumps({
+    "traverse_embedder_api": "1.0.0",
+    "bridge_version": "1.1.0",
+    "hosts": ["swift", "kotlin", "dotnet"],
+    "no_sidecar": True,
+    "conformance_passed": True,
+}, sort_keys=True))
+PY


### PR DESCRIPTION
## Summary

Certify the generated digest-pinned `runtime.wasm` through the Swift, Kotlin,
and .NET package clients without a CLI, HTTP, or other sidecar.

## Governing Spec

- `057-embeddable-runtime-host`
- `068-public-platform-embedder-packages`
- `071-native-runtime-wasm-bridge`
- `072-native-bridge-compatible-lifecycle`
- `073-native-embedder-release-baseline`
- `074-swift-native-resource-control-certification`
- `075-native-runtime-distribution-contract`
- `076-production-swift-wasmi-cabi`

## Project Item

- Traverse #758

## Definition of Done

- [x] One generated artifact is digest- and ABI-verified before package execution.
- [x] Swift, Kotlin, and .NET execute its lifecycle and ordered event drain without a sidecar.
- [x] The runner emits machine-readable cross-host certification evidence.

## Validation

- `bash scripts/ci/native_artifact_certification.sh`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/issue-758-pr-body.md`
- `git diff --check`
