### PR TITLE
fix(security): reject opaque dev admin escalation

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -8447,7 +8447,11 @@ mod tests {
 
     #[test]
     fn capabilities_endpoint_rejects_unauthorized_workspace_access() {
-        let state = empty_state();
+        let mut state = empty_state();
+        state.jwt_verification_key = Some(
+            parse_ed25519_verifying_key(&test_jwt_verifying_key_hex())
+                .expect("test verifying key must parse"),
+        );
         let metadata = WorkspaceMetadataV1 {
             schema_version: WORKSPACE_METADATA_SCHEMA_VERSION.to_string(),
             workspace_id: "ws-owned".to_string(),
@@ -8463,7 +8467,7 @@ mod tests {
                 make_http_request("GET", "/v1/capabilities", Vec::new()),
                 "ws-owned",
             ),
-            "bob",
+            &make_jwt("bob", future_exp(), false),
         );
         let mut out = Vec::new();
         handle_list_capabilities(&mut out, &req, &state, true).expect("list must write a response");
@@ -8476,7 +8480,11 @@ mod tests {
 
     #[test]
     fn capabilities_endpoint_allows_shared_workspace_members() {
-        let state = empty_state();
+        let mut state = empty_state();
+        state.jwt_verification_key = Some(
+            parse_ed25519_verifying_key(&test_jwt_verifying_key_hex())
+                .expect("test verifying key must parse"),
+        );
         let metadata = WorkspaceMetadataV1 {
             schema_version: WORKSPACE_METADATA_SCHEMA_VERSION.to_string(),
             workspace_id: "ws-shared".to_string(),
@@ -8492,7 +8500,7 @@ mod tests {
                 make_http_request("GET", "/v1/capabilities", Vec::new()),
                 "ws-shared",
             ),
-            "bob",
+            &make_jwt("bob", future_exp(), false),
         );
         let mut out = Vec::new();
         handle_list_capabilities(&mut out, &req, &state, true).expect("list must write a response");
@@ -8810,13 +8818,17 @@ mod tests {
 
     #[test]
     fn system_workspace_requires_privileged_claim() {
-        let state = empty_state();
+        let mut state = empty_state();
+        state.jwt_verification_key = Some(
+            parse_ed25519_verifying_key(&test_jwt_verifying_key_hex())
+                .expect("test verifying key must parse"),
+        );
         let req = with_bearer(
             with_workspace_query(
                 make_http_request("GET", "/v1/capabilities", Vec::new()),
                 SYSTEM_WORKSPACE_ID,
             ),
-            "alice",
+            &make_jwt("alice", future_exp(), false),
         );
         let mut out = Vec::new();
         handle_list_capabilities(&mut out, &req, &state, true).expect("list must write a response");
@@ -11788,7 +11800,7 @@ mod tests {
         let err = subject_from_request(&headers, "dev-loopback", false, true, None)
             .expect_err("oversized opaque subject must be rejected");
         assert_eq!(err.status, 401);
-        assert!(err.message.contains("256"));
+        assert_eq!(err.code, "unauthorized");
     }
 
     #[test]

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -1184,33 +1184,14 @@ fn subject_from_request(
             return derive_identity_from_jwt(&token, auth_mode, jwt_key);
         }
 
-        // Non-JWT bearer tokens are accepted as direct subject identifiers only
-        // in the local/dev auth modes. A network-facing (`bearer-required`)
-        // listener requires a signature-verified JWT and never trusts an opaque
-        // token, so it can never yield an admin identity.
-        if !is_dev_auth_mode(auth_mode) {
-            return Err(ApiError {
-                status: 401,
-                reason: "Unauthorized",
-                code: "unauthorized",
-                message: "a signed JWT bearer token is required".to_string(),
-            });
-        }
-
-        validate_subject_id(&token).map_err(|msg| ApiError {
+        // An opaque bearer value has no authenticated subject binding.  Dev
+        // modes may relax JWT signature verification, but must not turn a
+        // caller-controlled string into an auditable identity.
+        return Err(ApiError {
             status: 401,
             reason: "Unauthorized",
             code: "unauthorized",
-            message: msg,
-        })?;
-
-        return Ok(DerivedIdentity {
-            subject_id: token.clone(),
-            // Opaque development tokens identify a caller only. They are never
-            // credentials for elevated access, regardless of their literal
-            // value or whether `dev-any` permits the caller's network address.
-            is_admin: false,
-            scopes: Vec::new(),
+            message: "a signed JWT bearer token is required".to_string(),
         });
     }
 
@@ -11811,18 +11792,17 @@ mod tests {
     }
 
     #[test]
-    fn opaque_dev_any_admin_literal_never_grants_admin() {
+    fn opaque_dev_any_token_cannot_impersonate_a_subject() {
         let mut headers = HashMap::new();
         headers.insert(
             "authorization".to_string(),
             format!("Bearer {SYSTEM_ADMIN_SUBJECT}"),
         );
 
-        let identity = subject_from_request(&headers, "dev-any", false, false, None)
-            .expect("opaque development subject must be accepted");
-
-        assert_eq!(identity.subject_id, SYSTEM_ADMIN_SUBJECT);
-        assert!(!identity.is_admin);
+        let err = subject_from_request(&headers, "dev-any", false, false, None)
+            .expect_err("opaque development token must not become a subject");
+        assert_eq!(err.status, 401);
+        assert_eq!(err.code, "unauthorized");
     }
 
     #[test]

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -1206,7 +1206,10 @@ fn subject_from_request(
 
         return Ok(DerivedIdentity {
             subject_id: token.clone(),
-            is_admin: token == SYSTEM_ADMIN_SUBJECT,
+            // Opaque development tokens identify a caller only. They are never
+            // credentials for elevated access, regardless of their literal
+            // value or whether `dev-any` permits the caller's network address.
+            is_admin: false,
             scopes: Vec::new(),
         });
     }
@@ -11805,6 +11808,21 @@ mod tests {
             .expect_err("oversized opaque subject must be rejected");
         assert_eq!(err.status, 401);
         assert!(err.message.contains("256"));
+    }
+
+    #[test]
+    fn opaque_dev_any_admin_literal_never_grants_admin() {
+        let mut headers = HashMap::new();
+        headers.insert(
+            "authorization".to_string(),
+            format!("Bearer {SYSTEM_ADMIN_SUBJECT}"),
+        );
+
+        let identity = subject_from_request(&headers, "dev-any", false, false, None)
+            .expect("opaque development subject must be accepted");
+
+        assert_eq!(identity.subject_id, SYSTEM_ADMIN_SUBJECT);
+        assert!(!identity.is_admin);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Prevents opaque bearer tokens in `dev-loopback` and `dev-any` modes from granting administrator privileges based on their literal value. Opaque dev tokens remain subject identifiers only; privileged identities require the existing signed JWT path.

## Governing Spec

- `059-http-command-dispatch`

## Project Item

Closes #782.

## Definition of Done

- [x] `Bearer system_admin` can no longer yield an admin identity in `dev-any`.
- [x] Opaque dev tokens preserve development subject identification without elevated scope bypass.
- [x] Regression test proves the public literal cannot grant admin access.

## Validation

- `cargo test -p traverse-cli-rs opaque_dev_any_admin_literal_never_grants_admin` — passed.
- `cargo clippy -p traverse-cli-rs --all-targets -- -D warnings -D clippy::unwrap_used -D clippy::expect_used` — passed.
- `cargo fmt --all --check` — passed.