### PR TITLE
fix(dotnet): reset Wasmtime limits per call

### DIFF
--- a/packages/dotnet/TraverseEmbedder/TraverseEmbedder/WasmtimeBridgeClient.cs
+++ b/packages/dotnet/TraverseEmbedder/TraverseEmbedder/WasmtimeBridgeClient.cs
@@ -10,6 +10,7 @@ public sealed class WasmtimeBridgeClient
     private const int DescriptorBytes = 8;
 
     private readonly object synchronization = new();
+    private readonly WasmtimeRuntimeBridge bridge;
     private readonly Instance instance;
     private readonly Memory memory;
     private readonly Func<int, int> allocate;
@@ -21,6 +22,7 @@ public sealed class WasmtimeBridgeClient
         int maximumOutputBytes = DefaultMaximumOutputBytes)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumOutputBytes);
+        this.bridge = bridge;
         instance = bridge.Instance;
         memory = instance.GetMemory("memory")
             ?? throw new TraverseBridgeException(-3, "bridge_invalid_descriptor");
@@ -143,7 +145,7 @@ public sealed class WasmtimeBridgeClient
 
     private T Serialized<T>(Func<T> operation)
     {
-        lock (synchronization) return operation();
+        lock (synchronization) return bridge.Execute(operation);
     }
 }
 


### PR DESCRIPTION
## Summary

Routes every serialized .NET Wasmtime bridge call through the existing per-call fuel and epoch-deadline wrapper.

## Governing Spec

- `073-native-embedder-release-baseline`
- `074-swift-native-resource-control-certification`

## Project Item

Closes #784.

## Definition of Done

- [x] Fuel and deadline controls are reset for every guest call.
- [x] Existing .NET bridge conformance and resource-limit tests pass.

## Validation

- `dotnet test packages/dotnet/TraverseEmbedder/TraverseEmbedder.Tests/TraverseEmbedder.Tests.csproj`
- `git diff --check`
