### PR TITLE
feat(embedder): add embedded trace companion API

### DIFF
--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -86,18 +86,19 @@ mod test_double;
 pub use test_double::EmbedderTestDouble;
 
 use serde_json::{Value, json};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use traverse_registry::{
     ApplicationRegistrationFailure, ApplicationRegistrationRequest, ApplicationRegistry,
     CapabilityRegistry, ComponentExecutionMode, EventRegistry, RegistryScope, WorkflowRegistry,
     load_application_bundle_manifest,
 };
 use traverse_runtime::{
-    ArtifactRouter, PlacementTarget, Runtime, RuntimeContext, RuntimeError, RuntimeErrorCode,
-    RuntimeIntent, RuntimeLookup, RuntimeLookupScope, RuntimeRequest, RuntimeResultStatus,
-    WorkflowExecutionRequest, WorkflowLookupScope, WorkflowTraversalStatus,
-    WorkflowTraversalStepStatus,
+    ArtifactRouter, ExecutionFailureReason, PlacementTarget, Runtime, RuntimeContext, RuntimeError,
+    RuntimeErrorCode, RuntimeExecutionOutcome, RuntimeIntent, RuntimeLookup, RuntimeLookupScope,
+    RuntimeRequest, RuntimeResultStatus, WorkflowExecutionOutcome, WorkflowExecutionRequest,
+    WorkflowLookupScope, WorkflowTraversalStatus, WorkflowTraversalStepStatus,
 };
 
 /// Implemented embedder API version (spec 057 IDL `$id` suffix).
@@ -106,11 +107,178 @@ pub const EMBEDDER_API_VERSION: &str = "1.0.0";
 /// Conformance suite revision this package certifies against (spec 057).
 pub const EMBEDDER_CONFORMANCE_VERSION: &str = "1.0.0";
 
+/// Implemented companion Trace API version (spec 517).
+pub const EMBEDDED_TRACE_API_VERSION: &str = "1.0.0";
+
+/// Maximum number of public trace records retained by one embedded session.
+pub const EMBEDDED_TRACE_RETENTION_LIMIT: usize = 100;
+
+/// Largest page the public embedded Trace API returns in one call.
+pub const EMBEDDED_TRACE_MAX_PAGE_SIZE: usize = 100;
+
 /// Application bundle manifest `schema_version` values this package accepts.
 pub const SUPPORTED_BUNDLE_SCHEMA_VERSIONS: &[&str] = &["1.0.0"];
 
 const EVENT_SCHEMA_VERSION: &str = "1.0.0";
 const DEFAULT_WORKSPACE_ID: &str = "local-default";
+static NEXT_EMBEDDED_TRACE_SESSION: AtomicU64 = AtomicU64::new(1);
+
+/// Stable machine-readable public Trace API failure codes (spec 517 FR-010).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddedTraceApiErrorCode {
+    /// The cursor is malformed, stale, or belongs to another embedder session.
+    InvalidCursor,
+    /// The requested trace is no longer retained by this session.
+    TraceNotFound,
+    /// The embedder has been stopped and cannot serve local diagnostics.
+    TraceApiUnavailable,
+    /// The caller requested a companion API version this package does not support.
+    IncompatibleVersion,
+}
+
+impl EmbeddedTraceApiErrorCode {
+    /// Returns the stable wire representation of this code.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidCursor => "invalid_cursor",
+            Self::TraceNotFound => "trace_not_found",
+            Self::TraceApiUnavailable => "trace_api_unavailable",
+            Self::IncompatibleVersion => "incompatible_version",
+        }
+    }
+}
+
+/// A public Trace API failure with a stable code and deliberately generic text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedTraceApiError {
+    /// Machine-readable failure classification.
+    pub code: EmbeddedTraceApiErrorCode,
+    /// Safe explanatory text. It never contains runtime error details.
+    pub message: &'static str,
+}
+
+impl EmbeddedTraceApiError {
+    fn new(code: EmbeddedTraceApiErrorCode) -> Self {
+        let message = match code {
+            EmbeddedTraceApiErrorCode::InvalidCursor => {
+                "the trace cursor is invalid for this embedded session"
+            }
+            EmbeddedTraceApiErrorCode::TraceNotFound => {
+                "the requested trace is not retained by this embedded session"
+            }
+            EmbeddedTraceApiErrorCode::TraceApiUnavailable => {
+                "the embedded Trace API is unavailable because the host is stopped"
+            }
+            EmbeddedTraceApiErrorCode::IncompatibleVersion => {
+                "the requested embedded Trace API version is not supported"
+            }
+        };
+        Self { code, message }
+    }
+}
+
+/// The safe terminal outcome exposed by the public embedded Trace API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EmbeddedTraceOutcome {
+    /// Runtime execution completed successfully.
+    Completed,
+    /// Runtime execution produced a stable failure classification.
+    Error,
+}
+
+/// One public phase code in a safe trace projection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedTracePhase {
+    /// Stable phase classification; no phase payload or telemetry is exposed.
+    pub code: String,
+}
+
+/// Safe selected-target evidence for a public trace detail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedTraceSelectedTarget {
+    /// Runtime-selected capability or workflow identity.
+    pub target_id: String,
+    /// Selected target version when runtime evidence has one.
+    pub target_version: Option<String>,
+}
+
+/// Safe placement evidence for a public trace detail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedTracePlacement {
+    /// Placement selected by the runtime, rendered as a stable code.
+    pub target: String,
+}
+
+/// Safe list-oriented record for one completed local execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedTraceSummary {
+    /// Opaque public identifier scoped to this embedded session.
+    pub trace_id: String,
+    /// Runtime execution identifier, or a derived workflow execution identifier.
+    pub execution_id: String,
+    /// Submitted bundled target identity.
+    pub target_id: String,
+    /// Deterministic session-local completion time in UTC representation.
+    pub completed_at: String,
+    /// Monotonic completion evidence used for deterministic ordering.
+    pub completion_sequence: u64,
+    /// Safe terminal outcome.
+    pub outcome: EmbeddedTraceOutcome,
+}
+
+/// Safe public diagnostic detail for one retained local trace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedTraceDetail {
+    /// The corresponding list summary.
+    pub summary: EmbeddedTraceSummary,
+    /// Safe runtime or workflow phase classifications.
+    pub phases: Vec<EmbeddedTracePhase>,
+    /// Selected target evidence when runtime evidence reached selection.
+    pub selected_target: Option<EmbeddedTraceSelectedTarget>,
+    /// Selected placement evidence when available.
+    pub placement: Option<EmbeddedTracePlacement>,
+    /// Stable runtime or traversal failure classification, never error text.
+    pub failure_code: Option<String>,
+    /// Whether runtime state-machine evidence has no recorded violations.
+    pub state_machine_valid: Option<bool>,
+}
+
+/// A bounded, cursor-paged public Trace API response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmbeddedTracePage {
+    /// Newest-first public trace summaries.
+    pub summaries: Vec<EmbeddedTraceSummary>,
+    /// Opaque cursor for the following page, if retained results remain.
+    pub next_cursor: Option<String>,
+    /// Fixed process-local retention capacity advertised to consumers.
+    pub retention_limit: usize,
+}
+
+/// The additive `embedded-trace-api/1.0.0` companion surface (spec 517).
+///
+/// This trait intentionally does not alter [`TraverseEmbedderApi`]. A host
+/// that implements it provides `trace.list` and `trace.get` over a bounded,
+/// process-local safe projection; callers must request the advertised version.
+pub trait EmbeddedTraceApi {
+    /// Returns the companion API version advertised by this host.
+    fn embedded_trace_api_version(&self) -> &'static str;
+
+    /// `trace.list`: returns a deterministic page of safe local summaries.
+    fn trace_list(
+        &self,
+        requested_version: &str,
+        page_size: usize,
+        cursor: Option<&str>,
+    ) -> Result<EmbeddedTracePage, EmbeddedTraceApiError>;
+
+    /// `trace.get`: returns one safe retained local trace detail.
+    fn trace_get(
+        &self,
+        requested_version: &str,
+        trace_id: &str,
+    ) -> Result<EmbeddedTraceDetail, EmbeddedTraceApiError>;
+}
 
 /// Runtime artifact verification posture for the embedded runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -348,6 +516,23 @@ struct CompatibleInstance {
     state: InstanceState,
 }
 
+struct EmbeddedTraceRecordInput {
+    execution_id: String,
+    target_id: String,
+    outcome: EmbeddedTraceOutcome,
+    phases: Vec<EmbeddedTracePhase>,
+    selected_target: Option<EmbeddedTraceSelectedTarget>,
+    placement: Option<EmbeddedTracePlacement>,
+    failure_code: Option<String>,
+    state_machine_valid: Option<bool>,
+}
+
+fn logical_completion_time(sequence: u64) -> String {
+    let minute = (sequence / 60) % 60;
+    let second = sequence % 60;
+    format!("1970-01-01T00:{minute:02}:{second:02}Z")
+}
+
 /// Shared deterministic embedder state: identity, counters, subscribers,
 /// event history, and the compatible-capability lifecycle table. Both the
 /// production embedder and the test double delegate here so their public
@@ -365,6 +550,9 @@ pub(crate) struct EmbedderCore {
     next_session: u64,
     next_request: u64,
     next_instance: u64,
+    trace_session: u64,
+    next_trace: u64,
+    traces: VecDeque<EmbeddedTraceDetail>,
     stopped: bool,
 }
 
@@ -389,6 +577,9 @@ impl EmbedderCore {
             next_session: 0,
             next_request: 0,
             next_instance: 0,
+            trace_session: NEXT_EMBEDDED_TRACE_SESSION.fetch_add(1, Ordering::Relaxed),
+            next_trace: 0,
+            traces: VecDeque::new(),
             stopped: false,
         }
     }
@@ -406,6 +597,126 @@ impl EmbedderCore {
     fn next_instance_id(&mut self) -> String {
         self.next_instance += 1;
         format!("inst-{:08}", self.next_instance)
+    }
+
+    fn record_trace(&mut self, input: EmbeddedTraceRecordInput) {
+        self.next_trace += 1;
+        let sequence = self.next_trace;
+        let summary = EmbeddedTraceSummary {
+            trace_id: format!("embedded-trace-{:08}-{:08}", self.trace_session, sequence),
+            execution_id: input.execution_id,
+            target_id: input.target_id,
+            completed_at: logical_completion_time(sequence),
+            completion_sequence: sequence,
+            outcome: input.outcome,
+        };
+        self.traces.push_back(EmbeddedTraceDetail {
+            summary,
+            phases: input.phases,
+            selected_target: input.selected_target,
+            placement: input.placement,
+            failure_code: input.failure_code,
+            state_machine_valid: input.state_machine_valid,
+        });
+        if self.traces.len() > EMBEDDED_TRACE_RETENTION_LIMIT {
+            let _ = self.traces.pop_front();
+        }
+    }
+
+    fn trace_list(
+        &self,
+        requested_version: &str,
+        page_size: usize,
+        cursor: Option<&str>,
+    ) -> Result<EmbeddedTracePage, EmbeddedTraceApiError> {
+        self.ensure_trace_api_available(requested_version)?;
+        let traces = self.newest_traces();
+        let start = match cursor {
+            None => 0,
+            Some(cursor) => self.cursor_start(cursor, &traces)?,
+        };
+        let page_size = page_size.clamp(1, EMBEDDED_TRACE_MAX_PAGE_SIZE);
+        let end = start.saturating_add(page_size).min(traces.len());
+        let summaries = traces[start..end]
+            .iter()
+            .map(|detail| detail.summary.clone())
+            .collect::<Vec<_>>();
+        let next_cursor =
+            (end < traces.len()).then(|| self.cursor_for(&traces[end - 1].summary.trace_id));
+        Ok(EmbeddedTracePage {
+            summaries,
+            next_cursor,
+            retention_limit: EMBEDDED_TRACE_RETENTION_LIMIT,
+        })
+    }
+
+    fn trace_get(
+        &self,
+        requested_version: &str,
+        trace_id: &str,
+    ) -> Result<EmbeddedTraceDetail, EmbeddedTraceApiError> {
+        self.ensure_trace_api_available(requested_version)?;
+        self.traces
+            .iter()
+            .find(|detail| detail.summary.trace_id == trace_id)
+            .cloned()
+            .ok_or_else(|| EmbeddedTraceApiError::new(EmbeddedTraceApiErrorCode::TraceNotFound))
+    }
+
+    fn ensure_trace_api_available(
+        &self,
+        requested_version: &str,
+    ) -> Result<(), EmbeddedTraceApiError> {
+        if self.stopped {
+            return Err(EmbeddedTraceApiError::new(
+                EmbeddedTraceApiErrorCode::TraceApiUnavailable,
+            ));
+        }
+        if requested_version != EMBEDDED_TRACE_API_VERSION {
+            return Err(EmbeddedTraceApiError::new(
+                EmbeddedTraceApiErrorCode::IncompatibleVersion,
+            ));
+        }
+        Ok(())
+    }
+
+    fn newest_traces(&self) -> Vec<&EmbeddedTraceDetail> {
+        let mut traces = self.traces.iter().collect::<Vec<_>>();
+        traces.sort_by(|left, right| {
+            right
+                .summary
+                .completion_sequence
+                .cmp(&left.summary.completion_sequence)
+                .then_with(|| left.summary.trace_id.cmp(&right.summary.trace_id))
+        });
+        traces
+    }
+
+    fn cursor_for(&self, trace_id: &str) -> String {
+        format!("embedded-trace-cursor:{}:{trace_id}", self.trace_session)
+    }
+
+    fn cursor_start(
+        &self,
+        cursor: &str,
+        traces: &[&EmbeddedTraceDetail],
+    ) -> Result<usize, EmbeddedTraceApiError> {
+        let Some((prefix, trace_id)) = cursor.rsplit_once(':') else {
+            return Err(EmbeddedTraceApiError::new(
+                EmbeddedTraceApiErrorCode::InvalidCursor,
+            ));
+        };
+        let expected_prefix = format!("embedded-trace-cursor:{}", self.trace_session);
+        if prefix != expected_prefix {
+            return Err(EmbeddedTraceApiError::new(
+                EmbeddedTraceApiErrorCode::InvalidCursor,
+            ));
+        }
+        traces
+            .iter()
+            .position(|detail| detail.summary.trace_id == trace_id)
+            .map(|position| position + 1)
+            .ok_or_else(|| EmbeddedTraceApiError::new(EmbeddedTraceApiErrorCode::InvalidCursor))
     }
 
     fn emit(&mut self, event_type: &str, session_id: Option<&str>, data: Value) {
@@ -636,6 +947,7 @@ impl EmbedderCore {
             self.set_instance_state(&id, InstanceState::Killed);
         }
         self.stopped = true;
+        self.traces.clear();
         ShutdownOutcome { killed_instances }
     }
 
@@ -648,6 +960,9 @@ impl EmbedderCore {
                 "version": env!("CARGO_PKG_VERSION"),
             },
             "embedder_api_version": EMBEDDER_API_VERSION,
+            "companion_apis": {
+                "embedded-trace-api": EMBEDDED_TRACE_API_VERSION,
+            },
             "conformance_version": EMBEDDER_CONFORMANCE_VERSION,
             "runtime": {
                 "implementation": runtime_implementation,
@@ -844,6 +1159,9 @@ impl BundleEmbedder {
             governing_spec: "007-workflow-registry-traversal".to_string(),
         });
 
+        self.core
+            .record_trace(workflow_trace_input(&outcome, target_id, &workflow_version));
+
         for step in &outcome.evidence.visited_nodes {
             self.core.emit(
                 "capability_invoked",
@@ -926,6 +1244,9 @@ impl BundleEmbedder {
             governing_spec: "006-runtime-request-execution".to_string(),
         });
 
+        self.core
+            .record_trace(runtime_trace_input(&outcome, target_id));
+
         let execution_id = outcome.result.execution_id.clone();
         self.core.emit(
             "capability_invoked",
@@ -967,6 +1288,29 @@ impl BundleEmbedder {
             status: SubmitStatus::Accepted,
             error: None,
         }
+    }
+}
+
+impl EmbeddedTraceApi for BundleEmbedder {
+    fn embedded_trace_api_version(&self) -> &'static str {
+        EMBEDDED_TRACE_API_VERSION
+    }
+
+    fn trace_list(
+        &self,
+        requested_version: &str,
+        page_size: usize,
+        cursor: Option<&str>,
+    ) -> Result<EmbeddedTracePage, EmbeddedTraceApiError> {
+        self.core.trace_list(requested_version, page_size, cursor)
+    }
+
+    fn trace_get(
+        &self,
+        requested_version: &str,
+        trace_id: &str,
+    ) -> Result<EmbeddedTraceDetail, EmbeddedTraceApiError> {
+        self.core.trace_get(requested_version, trace_id)
     }
 }
 
@@ -1031,6 +1375,136 @@ impl TraverseEmbedderApi for BundleEmbedder {
     fn release_evidence(&self) -> Value {
         self.core
             .evidence("traverse-runtime", self.wasm_component_evidence.clone())
+    }
+}
+
+fn runtime_trace_input(
+    outcome: &RuntimeExecutionOutcome,
+    target_id: &str,
+) -> EmbeddedTraceRecordInput {
+    let phases = outcome
+        .trace
+        .state_progression
+        .transitions
+        .iter()
+        .map(|transition| EmbeddedTracePhase {
+            code: runtime_state_code(transition.to_state).to_string(),
+        })
+        .collect();
+    let selected_target =
+        outcome
+            .trace
+            .selection
+            .selected_capability_id
+            .as_ref()
+            .map(|target_id| EmbeddedTraceSelectedTarget {
+                target_id: target_id.clone(),
+                target_version: outcome.trace.selection.selected_capability_version.clone(),
+            });
+    let placement = outcome
+        .trace
+        .execution
+        .placement
+        .selected_target
+        .map(|target| EmbeddedTracePlacement {
+            target: placement_target_code(target).to_string(),
+        });
+    let failure_code = outcome
+        .result
+        .error
+        .as_ref()
+        .map(|error| runtime_error_code_str(error.code).to_string())
+        .or_else(|| {
+            outcome
+                .trace
+                .execution
+                .failure_reason
+                .map(|reason| execution_failure_code(reason).to_string())
+        });
+    EmbeddedTraceRecordInput {
+        execution_id: outcome.result.execution_id.clone(),
+        target_id: target_id.to_string(),
+        outcome: match outcome.result.status {
+            RuntimeResultStatus::Completed => EmbeddedTraceOutcome::Completed,
+            RuntimeResultStatus::Error => EmbeddedTraceOutcome::Error,
+        },
+        phases,
+        selected_target,
+        placement,
+        failure_code,
+        state_machine_valid: Some(outcome.trace.state_machine_validation.violations.is_empty()),
+    }
+}
+
+fn workflow_trace_input(
+    outcome: &WorkflowExecutionOutcome,
+    target_id: &str,
+    workflow_version: &str,
+) -> EmbeddedTraceRecordInput {
+    let phases = outcome
+        .evidence
+        .visited_nodes
+        .iter()
+        .map(|step| EmbeddedTracePhase {
+            code: format!("workflow_{}", workflow_step_status_str(step.status)),
+        })
+        .collect();
+    EmbeddedTraceRecordInput {
+        execution_id: format!("workflow-{}", outcome.result.request_id),
+        target_id: target_id.to_string(),
+        outcome: match outcome.result.status {
+            WorkflowTraversalStatus::Completed => EmbeddedTraceOutcome::Completed,
+            WorkflowTraversalStatus::Error => EmbeddedTraceOutcome::Error,
+        },
+        phases,
+        selected_target: Some(EmbeddedTraceSelectedTarget {
+            target_id: target_id.to_string(),
+            target_version: Some(workflow_version.to_string()),
+        }),
+        placement: None,
+        failure_code: outcome
+            .result
+            .error
+            .as_ref()
+            .map(|error| runtime_error_code_str(error.code).to_string()),
+        state_machine_valid: None,
+    }
+}
+
+fn runtime_state_code(state: traverse_runtime::RuntimeState) -> &'static str {
+    match state {
+        traverse_runtime::RuntimeState::Idle => "idle",
+        traverse_runtime::RuntimeState::LoadingRegistry => "loading_registry",
+        traverse_runtime::RuntimeState::Ready => "ready",
+        traverse_runtime::RuntimeState::Discovering => "discovering",
+        traverse_runtime::RuntimeState::EvaluatingConstraints => "evaluating_constraints",
+        traverse_runtime::RuntimeState::Selecting => "selecting",
+        traverse_runtime::RuntimeState::Executing => "executing",
+        traverse_runtime::RuntimeState::EmittingEvents => "emitting_events",
+        traverse_runtime::RuntimeState::Completed => "completed",
+        traverse_runtime::RuntimeState::Error => "error",
+    }
+}
+
+fn placement_target_code(target: PlacementTarget) -> &'static str {
+    match target {
+        PlacementTarget::Local => "local",
+        PlacementTarget::Browser => "browser",
+        PlacementTarget::Edge => "edge",
+        PlacementTarget::Cloud => "cloud",
+        PlacementTarget::Worker => "worker",
+        PlacementTarget::Device => "device",
+    }
+}
+
+fn execution_failure_code(reason: ExecutionFailureReason) -> &'static str {
+    match reason {
+        ExecutionFailureReason::ContractInputInvalid => "contract_input_invalid",
+        ExecutionFailureReason::ArtifactMissing => "artifact_missing",
+        ExecutionFailureReason::ArtifactNotRunnable => "artifact_not_runnable",
+        ExecutionFailureReason::PlacementUnsupported => "placement_unsupported",
+        ExecutionFailureReason::ExecutionFailed => "execution_failed",
+        ExecutionFailureReason::ContractOutputInvalid => "contract_output_invalid",
     }
 }
 
@@ -1260,5 +1734,118 @@ mod tests {
         );
         core.set_instance_state("inst-missing", InstanceState::Killed);
         assert!(core.history.is_empty());
+    }
+
+    #[test]
+    fn embedded_trace_api_pages_safe_test_double_records() -> Result<(), String> {
+        let secret_input = "input-secret-never-public";
+        let secret_output = "output-secret-never-public";
+        let secret_error = "error-secret-never-public";
+        let mut embedder = EmbedderTestDouble::new("workspace", "app", "1.0.0", "web")
+            .with_target_output("demo.success", json!({ "secret": secret_output }))
+            .with_target_error("demo.failure", "execution_failed", secret_error);
+
+        let accepted = embedder.submit("demo.success", &json!({ "secret": secret_input }));
+        assert_eq!(accepted.status, SubmitStatus::Accepted);
+        let accepted = embedder.submit("demo.failure", &json!({ "secret": secret_input }));
+        assert_eq!(accepted.status, SubmitStatus::Accepted);
+
+        let first_page = embedder
+            .trace_list(EMBEDDED_TRACE_API_VERSION, 1, None)
+            .map_err(|error| error.message.to_string())?;
+        assert_eq!(first_page.retention_limit, EMBEDDED_TRACE_RETENTION_LIMIT);
+        assert_eq!(first_page.summaries.len(), 1);
+        assert_eq!(first_page.summaries[0].target_id, "demo.failure");
+        assert_eq!(first_page.summaries[0].outcome, EmbeddedTraceOutcome::Error);
+        let cursor = first_page
+            .next_cursor
+            .ok_or("the first page should have a continuation cursor")?;
+        let failure = embedder
+            .trace_get(
+                EMBEDDED_TRACE_API_VERSION,
+                &first_page.summaries[0].trace_id,
+            )
+            .map_err(|error| error.message.to_string())?;
+        assert_eq!(failure.failure_code.as_deref(), Some("execution_failed"));
+        assert_eq!(failure.phases[0].code, "error");
+        let safe_debug = format!("{failure:?}");
+        assert!(!safe_debug.contains(secret_input));
+        assert!(!safe_debug.contains(secret_output));
+        assert!(!safe_debug.contains(secret_error));
+
+        let second_page = embedder
+            .trace_list(EMBEDDED_TRACE_API_VERSION, 1, Some(&cursor))
+            .map_err(|error| error.message.to_string())?;
+        assert_eq!(second_page.summaries.len(), 1);
+        assert_eq!(second_page.summaries[0].target_id, "demo.success");
+        assert!(second_page.next_cursor.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn embedded_trace_api_rejects_stale_versions_cursors_and_stopped_hosts() -> Result<(), String> {
+        let mut embedder = EmbedderTestDouble::new("workspace", "app", "1.0.0", "web")
+            .with_target_output("demo.success", json!({ "value": "safe" }));
+        let _ = embedder.submit("demo.success", &json!({}));
+
+        let version_error = embedder
+            .trace_list("2.0.0", 10, None)
+            .err()
+            .ok_or("an incompatible version should fail")?;
+        assert_eq!(
+            version_error.code,
+            EmbeddedTraceApiErrorCode::IncompatibleVersion
+        );
+        let cursor_error = embedder
+            .trace_list(EMBEDDED_TRACE_API_VERSION, 10, Some("not-a-cursor"))
+            .err()
+            .ok_or("a malformed cursor should fail")?;
+        assert_eq!(cursor_error.code, EmbeddedTraceApiErrorCode::InvalidCursor);
+
+        let _ = embedder.shutdown();
+        let stopped_error = embedder
+            .trace_list(EMBEDDED_TRACE_API_VERSION, 10, None)
+            .err()
+            .ok_or("a stopped host should be unavailable")?;
+        assert_eq!(
+            stopped_error.code,
+            EmbeddedTraceApiErrorCode::TraceApiUnavailable
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn embedded_trace_api_evicts_oldest_records_deterministically() -> Result<(), String> {
+        let mut embedder = EmbedderTestDouble::new("workspace", "app", "1.0.0", "web")
+            .with_target_output("demo.success", json!({ "value": "safe" }));
+        let mut first_trace_id = None;
+        for index in 0..=EMBEDDED_TRACE_RETENTION_LIMIT {
+            let _ = embedder.submit("demo.success", &json!({ "index": index }));
+            if index == 0 {
+                first_trace_id = embedder
+                    .trace_list(EMBEDDED_TRACE_API_VERSION, 1, None)
+                    .map_err(|error| error.message.to_string())?
+                    .summaries
+                    .first()
+                    .map(|summary| summary.trace_id.clone());
+            }
+        }
+        let first_trace_id =
+            first_trace_id.ok_or("the first trace should be retained initially")?;
+        let retained = embedder
+            .trace_list(
+                EMBEDDED_TRACE_API_VERSION,
+                EMBEDDED_TRACE_RETENTION_LIMIT,
+                None,
+            )
+            .map_err(|error| error.message.to_string())?;
+        assert_eq!(retained.summaries.len(), EMBEDDED_TRACE_RETENTION_LIMIT);
+        assert_eq!(retained.summaries[0].completion_sequence, 101);
+        let evicted = embedder
+            .trace_get(EMBEDDED_TRACE_API_VERSION, &first_trace_id)
+            .err()
+            .ok_or("the oldest record should have been evicted")?;
+        assert_eq!(evicted.code, EmbeddedTraceApiErrorCode::TraceNotFound);
+        Ok(())
     }
 }

--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -1744,6 +1744,10 @@ mod tests {
         let mut embedder = EmbedderTestDouble::new("workspace", "app", "1.0.0", "web")
             .with_target_output("demo.success", json!({ "secret": secret_output }))
             .with_target_error("demo.failure", "execution_failed", secret_error);
+        assert_eq!(
+            embedder.embedded_trace_api_version(),
+            EMBEDDED_TRACE_API_VERSION
+        );
 
         let accepted = embedder.submit("demo.success", &json!({ "secret": secret_input }));
         assert_eq!(accepted.status, SubmitStatus::Accepted);
@@ -1787,6 +1791,12 @@ mod tests {
         let mut embedder = EmbedderTestDouble::new("workspace", "app", "1.0.0", "web")
             .with_target_output("demo.success", json!({ "value": "safe" }));
         let _ = embedder.submit("demo.success", &json!({}));
+        let _ = embedder.submit("demo.success", &json!({}));
+        let cursor = embedder
+            .trace_list(EMBEDDED_TRACE_API_VERSION, 1, None)
+            .map_err(|error| error.message.to_string())?
+            .next_cursor
+            .ok_or("two retained traces should produce a cursor")?;
 
         let version_error = embedder
             .trace_list("2.0.0", 10, None)
@@ -1801,6 +1811,18 @@ mod tests {
             .err()
             .ok_or("a malformed cursor should fail")?;
         assert_eq!(cursor_error.code, EmbeddedTraceApiErrorCode::InvalidCursor);
+
+        let mut other_session = EmbedderTestDouble::new("workspace", "app", "1.0.0", "web")
+            .with_target_output("demo.success", json!({ "value": "safe" }));
+        let _ = other_session.submit("demo.success", &json!({}));
+        let foreign_cursor_error = other_session
+            .trace_list(EMBEDDED_TRACE_API_VERSION, 10, Some(&cursor))
+            .err()
+            .ok_or("a cursor from another session should fail")?;
+        assert_eq!(
+            foreign_cursor_error.code,
+            EmbeddedTraceApiErrorCode::InvalidCursor
+        );
 
         let _ = embedder.shutdown();
         let stopped_error = embedder
@@ -1847,5 +1869,88 @@ mod tests {
             .ok_or("the oldest record should have been evicted")?;
         assert_eq!(evicted.code, EmbeddedTraceApiErrorCode::TraceNotFound);
         Ok(())
+    }
+
+    #[test]
+    fn embedded_trace_error_codes_render_stably() {
+        let codes = [
+            (EmbeddedTraceApiErrorCode::InvalidCursor, "invalid_cursor"),
+            (EmbeddedTraceApiErrorCode::TraceNotFound, "trace_not_found"),
+            (
+                EmbeddedTraceApiErrorCode::TraceApiUnavailable,
+                "trace_api_unavailable",
+            ),
+            (
+                EmbeddedTraceApiErrorCode::IncompatibleVersion,
+                "incompatible_version",
+            ),
+        ];
+        for (code, expected) in codes {
+            assert_eq!(code.as_str(), expected);
+        }
+    }
+
+    #[test]
+    fn trace_projection_codes_cover_public_runtime_enums() {
+        let states = [
+            (traverse_runtime::RuntimeState::Idle, "idle"),
+            (
+                traverse_runtime::RuntimeState::LoadingRegistry,
+                "loading_registry",
+            ),
+            (traverse_runtime::RuntimeState::Ready, "ready"),
+            (traverse_runtime::RuntimeState::Discovering, "discovering"),
+            (
+                traverse_runtime::RuntimeState::EvaluatingConstraints,
+                "evaluating_constraints",
+            ),
+            (traverse_runtime::RuntimeState::Selecting, "selecting"),
+            (traverse_runtime::RuntimeState::Executing, "executing"),
+            (
+                traverse_runtime::RuntimeState::EmittingEvents,
+                "emitting_events",
+            ),
+            (traverse_runtime::RuntimeState::Completed, "completed"),
+            (traverse_runtime::RuntimeState::Error, "error"),
+        ];
+        for (state, expected) in states {
+            assert_eq!(runtime_state_code(state), expected);
+        }
+
+        let placements = [
+            (PlacementTarget::Local, "local"),
+            (PlacementTarget::Browser, "browser"),
+            (PlacementTarget::Edge, "edge"),
+            (PlacementTarget::Cloud, "cloud"),
+            (PlacementTarget::Worker, "worker"),
+            (PlacementTarget::Device, "device"),
+        ];
+        for (target, expected) in placements {
+            assert_eq!(placement_target_code(target), expected);
+        }
+
+        let failures = [
+            (
+                ExecutionFailureReason::ContractInputInvalid,
+                "contract_input_invalid",
+            ),
+            (ExecutionFailureReason::ArtifactMissing, "artifact_missing"),
+            (
+                ExecutionFailureReason::ArtifactNotRunnable,
+                "artifact_not_runnable",
+            ),
+            (
+                ExecutionFailureReason::PlacementUnsupported,
+                "placement_unsupported",
+            ),
+            (ExecutionFailureReason::ExecutionFailed, "execution_failed"),
+            (
+                ExecutionFailureReason::ContractOutputInvalid,
+                "contract_output_invalid",
+            ),
+        ];
+        for (reason, expected) in failures {
+            assert_eq!(execution_failure_code(reason), expected);
+        }
     }
 }

--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -265,6 +265,12 @@ pub trait EmbeddedTraceApi {
     fn embedded_trace_api_version(&self) -> &'static str;
 
     /// `trace.list`: returns a deterministic page of safe local summaries.
+    ///
+    /// # Errors
+    ///
+    /// Returns a stable API error when the requested version is unsupported,
+    /// the page size is invalid, or the opaque cursor is malformed or belongs
+    /// to another host session.
     fn trace_list(
         &self,
         requested_version: &str,
@@ -273,6 +279,11 @@ pub trait EmbeddedTraceApi {
     ) -> Result<EmbeddedTracePage, EmbeddedTraceApiError>;
 
     /// `trace.get`: returns one safe retained local trace detail.
+    ///
+    /// # Errors
+    ///
+    /// Returns a stable API error when the requested version is unsupported,
+    /// the trace identifier is malformed, or the retained trace is absent.
     fn trace_get(
         &self,
         requested_version: &str,

--- a/crates/traverse-embedder/src/test_double.rs
+++ b/crates/traverse-embedder/src/test_double.rs
@@ -2,9 +2,11 @@
 //! (spec 068 FR-006).
 
 use crate::{
-    CompatibleLifecycleOutcome, CompatibleStartOutcome, EmbedderCore, EmbedderError,
-    EmbedderErrorCode, EventCallback, InstanceState, ShutdownOutcome, SubmitOutcome, SubmitStatus,
-    TraverseEmbedderApi,
+    CompatibleLifecycleOutcome, CompatibleStartOutcome, EMBEDDED_TRACE_API_VERSION,
+    EmbeddedTraceApi, EmbeddedTraceApiError, EmbeddedTraceDetail, EmbeddedTraceOutcome,
+    EmbeddedTracePage, EmbeddedTracePhase, EmbeddedTraceRecordInput, EmbeddedTraceSelectedTarget,
+    EmbedderCore, EmbedderError, EmbedderErrorCode, EventCallback, InstanceState, ShutdownOutcome,
+    SubmitOutcome, SubmitStatus, TraverseEmbedderApi,
 };
 use serde_json::{Value, json};
 use std::collections::BTreeMap;
@@ -108,6 +110,39 @@ impl TraverseEmbedderApi for EmbedderTestDouble {
         let session_id = self.core.next_session_id();
         let request_id = self.core.next_request_id();
         let execution_id = format!("exec_{request_id}");
+        let trace_input = match &result {
+            ScriptedResult::Output(_) => EmbeddedTraceRecordInput {
+                execution_id: execution_id.clone(),
+                target_id: target_id.to_string(),
+                outcome: EmbeddedTraceOutcome::Completed,
+                phases: vec![EmbeddedTracePhase {
+                    code: "completed".to_string(),
+                }],
+                selected_target: Some(EmbeddedTraceSelectedTarget {
+                    target_id: target_id.to_string(),
+                    target_version: Some("1.0.0".to_string()),
+                }),
+                placement: None,
+                failure_code: None,
+                state_machine_valid: Some(true),
+            },
+            ScriptedResult::Error { code, .. } => EmbeddedTraceRecordInput {
+                execution_id: execution_id.clone(),
+                target_id: target_id.to_string(),
+                outcome: EmbeddedTraceOutcome::Error,
+                phases: vec![EmbeddedTracePhase {
+                    code: "error".to_string(),
+                }],
+                selected_target: Some(EmbeddedTraceSelectedTarget {
+                    target_id: target_id.to_string(),
+                    target_version: Some("1.0.0".to_string()),
+                }),
+                placement: None,
+                failure_code: Some(code.clone()),
+                state_machine_valid: Some(true),
+            },
+        };
+        self.core.record_trace(trace_input);
         self.core.emit(
             "capability_invoked",
             Some(&session_id),
@@ -182,5 +217,28 @@ impl TraverseEmbedderApi for EmbedderTestDouble {
 
     fn release_evidence(&self) -> Value {
         self.core.evidence("test-double", json!([]))
+    }
+}
+
+impl EmbeddedTraceApi for EmbedderTestDouble {
+    fn embedded_trace_api_version(&self) -> &'static str {
+        EMBEDDED_TRACE_API_VERSION
+    }
+
+    fn trace_list(
+        &self,
+        requested_version: &str,
+        page_size: usize,
+        cursor: Option<&str>,
+    ) -> Result<EmbeddedTracePage, EmbeddedTraceApiError> {
+        self.core.trace_list(requested_version, page_size, cursor)
+    }
+
+    fn trace_get(
+        &self,
+        requested_version: &str,
+        trace_id: &str,
+    ) -> Result<EmbeddedTraceDetail, EmbeddedTraceApiError> {
+        self.core.trace_get(requested_version, trace_id)
     }
 }

--- a/crates/traverse-embedder/tests/conformance.rs
+++ b/crates/traverse-embedder/tests/conformance.rs
@@ -10,8 +10,9 @@ use common::{
 };
 use serde_json::{Value, json};
 use traverse_embedder::{
-    BundleEmbedder, CompatibleLifecycleStatus, EmbedderConfig, EmbedderErrorCode, SecurityPosture,
-    SubmitStatus, TraverseEmbedderApi,
+    BundleEmbedder, CompatibleLifecycleStatus, EMBEDDED_TRACE_API_VERSION, EmbeddedTraceApi,
+    EmbeddedTraceOutcome, EmbedderConfig, EmbedderErrorCode, SecurityPosture, SubmitStatus,
+    TraverseEmbedderApi,
 };
 
 fn development_embedder(fixture: &BundleFixture, platform: &str) -> BundleEmbedder {
@@ -59,6 +60,53 @@ fn wasm_capability_submit_scenario_emits_capability_result() {
     let expected: Value =
         serde_json::from_str(PROCESS_OUTPUT).expect("expected output should parse");
     assert_eq!(events[1]["data"]["output"], expected);
+}
+
+#[test]
+fn embedded_trace_companion_projects_production_capability_and_workflow_evidence() {
+    let fixture = BundleFixture::new("embedded-trace-production");
+    let mut embedder = development_embedder(&fixture, "linux");
+    assert_eq!(
+        embedder.embedded_trace_api_version(),
+        EMBEDDED_TRACE_API_VERSION
+    );
+
+    let _ = embedder.submit(PROCESS_CAPABILITY_ID, &json!({ "secret": "input-secret" }));
+    let _ = embedder.submit(PIPELINE_WORKFLOW_ID, &json!({ "note": "workflow-secret" }));
+
+    let page = embedder
+        .trace_list(EMBEDDED_TRACE_API_VERSION, 10, None)
+        .expect("production trace list should succeed");
+    assert_eq!(page.summaries.len(), 2);
+    assert_eq!(page.summaries[0].target_id, PIPELINE_WORKFLOW_ID);
+    assert_eq!(page.summaries[0].outcome, EmbeddedTraceOutcome::Completed);
+    let capability = page
+        .summaries
+        .iter()
+        .find(|summary| summary.target_id == PROCESS_CAPABILITY_ID)
+        .expect("capability submission should have a retained trace");
+    let detail = embedder
+        .trace_get(EMBEDDED_TRACE_API_VERSION, &capability.trace_id)
+        .expect("production trace detail should succeed");
+    assert_eq!(detail.summary.execution_id, capability.execution_id);
+    assert_eq!(
+        detail
+            .selected_target
+            .as_ref()
+            .map(|target| target.target_id.as_str()),
+        Some(PROCESS_CAPABILITY_ID)
+    );
+    assert_eq!(
+        detail
+            .placement
+            .as_ref()
+            .map(|placement| placement.target.as_str()),
+        Some("local")
+    );
+    assert!(detail.state_machine_valid.is_some());
+    let public_detail = format!("{detail:?}");
+    assert!(!public_detail.contains("input-secret"));
+    assert!(!public_detail.contains("workflow-secret"));
 }
 
 #[test]

--- a/packages/web/TraverseEmbedder/src/bundleEmbedder.ts
+++ b/packages/web/TraverseEmbedder/src/bundleEmbedder.ts
@@ -33,10 +33,14 @@ import type { BundleLoader } from "./bundleLoader.js";
 import { findUnauthorizedImport } from "./hostAbi.js";
 import { WasiExit, WasiPipes, createWasiPreview1Imports } from "./wasi.js";
 import type { WasiMemoryRef } from "./wasi.js";
-import { embedderError, runtimeStoppedError } from "./types.js";
+import { EMBEDDED_TRACE_API_VERSION, embedderError, runtimeStoppedError } from "./types.js";
 import type {
   CompatibleLifecycleOutcome,
   CompatibleStartOutcome,
+  EmbeddedTraceApi,
+  EmbeddedTraceApiError,
+  EmbeddedTraceDetail,
+  EmbeddedTracePage,
   EventCallback,
   JsonValue,
   ShutdownOutcome,
@@ -178,7 +182,7 @@ function projectWorkflowOutput(
   return projected;
 }
 
-export class BundleEmbedder implements TraverseEmbedderApi {
+export class BundleEmbedder implements TraverseEmbedderApi, EmbeddedTraceApi {
   private readonly core: EmbedderCore;
   private readonly wasmTargets: ReadonlyMap<string, WasmTarget>;
   private readonly workflowTargets: ReadonlyMap<string, WorkflowTarget>;
@@ -441,6 +445,16 @@ export class BundleEmbedder implements TraverseEmbedderApi {
       capability_version: target.capabilityVersion,
     });
     const result = executeWasmModule(target, input);
+    this.core.recordTrace({
+      executionId,
+      targetId,
+      outcome: result.ok ? "completed" : "error",
+      phases: [{ code: result.ok ? "completed" : "error" }],
+      selectedTarget: { targetId, targetVersion: target.capabilityVersion },
+      placement: { target: "browser" },
+      failureCode: result.ok ? null : result.code,
+      stateMachineValid: null,
+    });
     if (result.ok) {
       this.core.emit("capability_result", sessionId, {
         execution_id: executionId,
@@ -525,6 +539,17 @@ export class BundleEmbedder implements TraverseEmbedderApi {
       currentNodeId = workflow.nextByFrom.get(node.nodeId);
     }
 
+    this.core.recordTrace({
+      executionId: `workflow-${requestId}`,
+      targetId,
+      outcome: failure === null ? "completed" : "error",
+      phases: steps.map((step) => ({ code: `workflow_${step.status}` })),
+      selectedTarget: { targetId, targetVersion: workflow.version },
+      placement: { target: "browser" },
+      failureCode: failure?.code ?? null,
+      stateMachineValid: null,
+    });
+
     for (const step of steps) {
       this.core.emit("capability_invoked", sessionId, {
         request_id: requestId,
@@ -559,6 +584,25 @@ export class BundleEmbedder implements TraverseEmbedderApi {
 
   subscribe(callback: EventCallback): void {
     this.core.subscribe(callback);
+  }
+
+  embeddedTraceApiVersion(): string {
+    return EMBEDDED_TRACE_API_VERSION;
+  }
+
+  traceList(
+    requestedVersion: string,
+    pageSize: number,
+    cursor: string | null = null,
+  ): EmbeddedTracePage | EmbeddedTraceApiError {
+    return this.core.traceList(requestedVersion, pageSize, cursor);
+  }
+
+  traceGet(
+    requestedVersion: string,
+    traceId: string,
+  ): EmbeddedTraceDetail | EmbeddedTraceApiError {
+    return this.core.traceGet(requestedVersion, traceId);
   }
 
   startCompatible(capabilityId: string, input: JsonValue): CompatibleStartOutcome {

--- a/packages/web/TraverseEmbedder/src/core.ts
+++ b/packages/web/TraverseEmbedder/src/core.ts
@@ -8,6 +8,9 @@
 import {
   EMBEDDER_API_VERSION,
   EMBEDDER_CONFORMANCE_VERSION,
+  EMBEDDED_TRACE_API_VERSION,
+  EMBEDDED_TRACE_MAX_PAGE_SIZE,
+  EMBEDDED_TRACE_RETENTION_LIMIT,
   EVENT_SCHEMA_VERSION,
   PACKAGE_NAME,
   PACKAGE_VERSION,
@@ -20,6 +23,14 @@ import {
 import type {
   CompatibleLifecycleOutcome,
   CompatibleStartOutcome,
+  EmbeddedTraceApiError,
+  EmbeddedTraceApiErrorCode,
+  EmbeddedTraceDetail,
+  EmbeddedTraceOutcome,
+  EmbeddedTracePage,
+  EmbeddedTracePhase,
+  EmbeddedTracePlacement,
+  EmbeddedTraceSelectedTarget,
   EmbedderError,
   EmbedderEvent,
   EventCallback,
@@ -27,11 +38,43 @@ import type {
   SubmitOutcome,
 } from "./types.js";
 
+let nextEmbeddedTraceSession = 1;
+
 type InstanceState = "started" | "stopped" | "killed";
 
 interface CompatibleInstance {
   readonly capabilityId: string;
   state: InstanceState;
+}
+
+export interface EmbeddedTraceRecordInput {
+  readonly executionId: string;
+  readonly targetId: string;
+  readonly outcome: EmbeddedTraceOutcome;
+  readonly phases: readonly EmbeddedTracePhase[];
+  readonly selectedTarget: EmbeddedTraceSelectedTarget | null;
+  readonly placement: EmbeddedTracePlacement | null;
+  readonly failureCode: string | null;
+  readonly stateMachineValid: boolean | null;
+}
+
+function logicalCompletionTime(sequence: number): string {
+  const minute = Math.floor(sequence / 60) % 60;
+  const second = sequence % 60;
+  return `1970-01-01T00:${String(minute).padStart(2, "0")}:${String(second).padStart(2, "0")}Z`;
+}
+
+function traceError(code: EmbeddedTraceApiErrorCode): EmbeddedTraceApiError {
+  switch (code) {
+    case "invalid_cursor":
+      return { code, message: "the trace cursor is invalid for this embedded session" };
+    case "trace_not_found":
+      return { code, message: "the requested trace is not retained by this embedded session" };
+    case "trace_api_unavailable":
+      return { code, message: "the embedded Trace API is unavailable because the host is stopped" };
+    case "incompatible_version":
+      return { code, message: "the requested embedded Trace API version is not supported" };
+  }
 }
 
 export class EmbedderCore {
@@ -47,6 +90,9 @@ export class EmbedderCore {
   private nextSession = 0;
   private nextRequest = 0;
   private nextInstance = 0;
+  private readonly traceSession = nextEmbeddedTraceSession++;
+  private nextTrace = 0;
+  private readonly traces: EmbeddedTraceDetail[] = [];
   stopped = false;
 
   constructor(
@@ -71,6 +117,100 @@ export class EmbedderCore {
   nextRequestId(): string {
     this.nextRequest += 1;
     return paddedId("req", this.nextRequest);
+  }
+
+  recordTrace(input: EmbeddedTraceRecordInput): void {
+    this.nextTrace += 1;
+    const completionSequence = this.nextTrace;
+    this.traces.push({
+      summary: {
+        traceId: `embedded-trace-${String(this.traceSession).padStart(8, "0")}-${String(completionSequence).padStart(8, "0")}`,
+        executionId: input.executionId,
+        targetId: input.targetId,
+        completedAt: logicalCompletionTime(completionSequence),
+        completionSequence,
+        outcome: input.outcome,
+      },
+      phases: [...input.phases],
+      selectedTarget: input.selectedTarget,
+      placement: input.placement,
+      failureCode: input.failureCode,
+      stateMachineValid: input.stateMachineValid,
+    });
+    if (this.traces.length > EMBEDDED_TRACE_RETENTION_LIMIT) {
+      this.traces.shift();
+    }
+  }
+
+  traceList(
+    requestedVersion: string,
+    pageSize: number,
+    cursor: string | null = null,
+  ): EmbeddedTracePage | EmbeddedTraceApiError {
+    const availability = this.traceApiAvailability(requestedVersion);
+    if (availability !== null) {
+      return availability;
+    }
+    const traces = this.newestTraces();
+    const start = cursor === null ? 0 : this.cursorStart(cursor, traces);
+    if (typeof start !== "number") {
+      return start;
+    }
+    const boundedPageSize = Number.isFinite(pageSize)
+      ? Math.max(1, Math.min(EMBEDDED_TRACE_MAX_PAGE_SIZE, Math.floor(pageSize)))
+      : 1;
+    const end = Math.min(start + boundedPageSize, traces.length);
+    const lastSummary = end < traces.length ? traces[end - 1]?.summary : undefined;
+    return {
+      summaries: traces.slice(start, end).map((detail) => detail.summary),
+      nextCursor: lastSummary === undefined ? null : this.cursorFor(lastSummary.traceId),
+      retentionLimit: EMBEDDED_TRACE_RETENTION_LIMIT,
+    };
+  }
+
+  traceGet(
+    requestedVersion: string,
+    traceId: string,
+  ): EmbeddedTraceDetail | EmbeddedTraceApiError {
+    const availability = this.traceApiAvailability(requestedVersion);
+    if (availability !== null) {
+      return availability;
+    }
+    return this.traces.find((detail) => detail.summary.traceId === traceId) ?? traceError("trace_not_found");
+  }
+
+  private traceApiAvailability(requestedVersion: string): EmbeddedTraceApiError | null {
+    if (this.stopped) {
+      return traceError("trace_api_unavailable");
+    }
+    if (requestedVersion !== EMBEDDED_TRACE_API_VERSION) {
+      return traceError("incompatible_version");
+    }
+    return null;
+  }
+
+  private newestTraces(): EmbeddedTraceDetail[] {
+    return [...this.traces].sort(
+      (left, right) =>
+        right.summary.completionSequence - left.summary.completionSequence ||
+        left.summary.traceId.localeCompare(right.summary.traceId),
+    );
+  }
+
+  private cursorFor(traceId: string): string {
+    return `embedded-trace-cursor:${this.traceSession}:${traceId}`;
+  }
+
+  private cursorStart(
+    cursor: string,
+    traces: readonly EmbeddedTraceDetail[],
+  ): number | EmbeddedTraceApiError {
+    const separator = cursor.lastIndexOf(":");
+    if (separator < 0 || cursor.slice(0, separator) !== `embedded-trace-cursor:${this.traceSession}`) {
+      return traceError("invalid_cursor");
+    }
+    const position = traces.findIndex((detail) => detail.summary.traceId === cursor.slice(separator + 1));
+    return position < 0 ? traceError("invalid_cursor") : position + 1;
   }
 
   private nextInstanceId(): string {
@@ -245,6 +385,7 @@ export class EmbedderCore {
       this.setInstanceState(id, "killed");
     }
     this.stopped = true;
+    this.traces.length = 0;
     return { killedInstances: running.length };
   }
 
@@ -254,6 +395,7 @@ export class EmbedderCore {
       schema_version: EVENT_SCHEMA_VERSION,
       package: { name: PACKAGE_NAME, version: PACKAGE_VERSION },
       embedder_api_version: EMBEDDER_API_VERSION,
+      companion_apis: { "embedded-trace-api": EMBEDDED_TRACE_API_VERSION },
       conformance_version: EMBEDDER_CONFORMANCE_VERSION,
       runtime: { implementation: runtimeImplementation },
       supported_bundle_schema_versions: [...SUPPORTED_BUNDLE_SCHEMA_VERSIONS],

--- a/packages/web/TraverseEmbedder/src/index.ts
+++ b/packages/web/TraverseEmbedder/src/index.ts
@@ -22,6 +22,9 @@
 export {
   EMBEDDER_API_VERSION,
   EMBEDDER_CONFORMANCE_VERSION,
+  EMBEDDED_TRACE_API_VERSION,
+  EMBEDDED_TRACE_MAX_PAGE_SIZE,
+  EMBEDDED_TRACE_RETENTION_LIMIT,
   SUPPORTED_BUNDLE_SCHEMA_VERSIONS,
 } from "./types.js";
 export type {
@@ -29,6 +32,16 @@ export type {
   CompatibleStartOutcome,
   EmbedderError,
   EmbedderErrorCode,
+  EmbeddedTraceApi,
+  EmbeddedTraceApiError,
+  EmbeddedTraceApiErrorCode,
+  EmbeddedTraceDetail,
+  EmbeddedTraceOutcome,
+  EmbeddedTracePage,
+  EmbeddedTracePhase,
+  EmbeddedTracePlacement,
+  EmbeddedTraceSelectedTarget,
+  EmbeddedTraceSummary,
   EmbedderEvent,
   EventCallback,
   JsonValue,

--- a/packages/web/TraverseEmbedder/src/testDouble.ts
+++ b/packages/web/TraverseEmbedder/src/testDouble.ts
@@ -6,10 +6,14 @@
  * no business logic.
  */
 import { EmbedderCore } from "./core.js";
-import { embedderError, runtimeStoppedError } from "./types.js";
+import { EMBEDDED_TRACE_API_VERSION, embedderError, runtimeStoppedError } from "./types.js";
 import type {
   CompatibleLifecycleOutcome,
   CompatibleStartOutcome,
+  EmbeddedTraceApi,
+  EmbeddedTraceApiError,
+  EmbeddedTraceDetail,
+  EmbeddedTracePage,
   EventCallback,
   JsonValue,
   ShutdownOutcome,
@@ -29,7 +33,7 @@ type ScriptedResult =
   | { readonly kind: "output"; readonly output: JsonValue }
   | { readonly kind: "error"; readonly code: string; readonly message: string };
 
-export class EmbedderTestDouble implements TraverseEmbedderApi {
+export class EmbedderTestDouble implements TraverseEmbedderApi, EmbeddedTraceApi {
   private readonly core: EmbedderCore;
   private readonly scripted = new Map<string, ScriptedResult>();
 
@@ -80,6 +84,16 @@ export class EmbedderTestDouble implements TraverseEmbedderApi {
     const sessionId = this.core.nextSessionId();
     const requestId = this.core.nextRequestId();
     const executionId = `exec_${requestId}`;
+    this.core.recordTrace({
+      executionId,
+      targetId,
+      outcome: result.kind === "output" ? "completed" : "error",
+      phases: [{ code: result.kind === "output" ? "completed" : "error" }],
+      selectedTarget: { targetId, targetVersion: "1.0.0" },
+      placement: null,
+      failureCode: result.kind === "error" ? result.code : null,
+      stateMachineValid: true,
+    });
     this.core.emit("capability_invoked", sessionId, {
       execution_id: executionId,
       capability_id: targetId,
@@ -105,6 +119,25 @@ export class EmbedderTestDouble implements TraverseEmbedderApi {
 
   subscribe(callback: EventCallback): void {
     this.core.subscribe(callback);
+  }
+
+  embeddedTraceApiVersion(): string {
+    return EMBEDDED_TRACE_API_VERSION;
+  }
+
+  traceList(
+    requestedVersion: string,
+    pageSize: number,
+    cursor: string | null = null,
+  ): EmbeddedTracePage | EmbeddedTraceApiError {
+    return this.core.traceList(requestedVersion, pageSize, cursor);
+  }
+
+  traceGet(
+    requestedVersion: string,
+    traceId: string,
+  ): EmbeddedTraceDetail | EmbeddedTraceApiError {
+    return this.core.traceGet(requestedVersion, traceId);
   }
 
   startCompatible(capabilityId: string, input: JsonValue): CompatibleStartOutcome {

--- a/packages/web/TraverseEmbedder/src/types.ts
+++ b/packages/web/TraverseEmbedder/src/types.ts
@@ -11,6 +11,15 @@ export const EMBEDDER_API_VERSION = "1.0.0";
 /** Conformance suite revision this package certifies against (spec 057). */
 export const EMBEDDER_CONFORMANCE_VERSION = "1.0.0";
 
+/** Implemented additive public Trace API companion version (spec 517). */
+export const EMBEDDED_TRACE_API_VERSION = "1.0.0";
+
+/** Maximum public trace records retained by one embedded session. */
+export const EMBEDDED_TRACE_RETENTION_LIMIT = 100;
+
+/** Largest `trace.list` page returned by this package. */
+export const EMBEDDED_TRACE_MAX_PAGE_SIZE = 100;
+
 /** Application bundle manifest `schema_version` values this package accepts. */
 export const SUPPORTED_BUNDLE_SCHEMA_VERSIONS: readonly string[] = ["1.0.0"];
 
@@ -59,6 +68,65 @@ export interface CompatibleLifecycleOutcome {
 /** `runtime.shutdown` output (always stopped; idempotent). */
 export interface ShutdownOutcome {
   readonly killedInstances: number;
+}
+
+/** Stable public Trace API failures (spec 517 FR-010). */
+export type EmbeddedTraceApiErrorCode =
+  | "invalid_cursor"
+  | "trace_not_found"
+  | "trace_api_unavailable"
+  | "incompatible_version";
+
+/** A safe public Trace API failure. It never contains runtime error details. */
+export interface EmbeddedTraceApiError {
+  readonly code: EmbeddedTraceApiErrorCode;
+  readonly message: string;
+}
+
+/** Safe terminal outcome exposed through the public Trace API. */
+export type EmbeddedTraceOutcome = "completed" | "error";
+
+/** A safe phase classification with no event payload or telemetry attributes. */
+export interface EmbeddedTracePhase {
+  readonly code: string;
+}
+
+/** Safe selected-target evidence from a completed execution. */
+export interface EmbeddedTraceSelectedTarget {
+  readonly targetId: string;
+  readonly targetVersion: string | null;
+}
+
+/** Safe placement evidence from a completed execution. */
+export interface EmbeddedTracePlacement {
+  readonly target: string;
+}
+
+/** Safe list-oriented public record for one completed local execution. */
+export interface EmbeddedTraceSummary {
+  readonly traceId: string;
+  readonly executionId: string;
+  readonly targetId: string;
+  readonly completedAt: string;
+  readonly completionSequence: number;
+  readonly outcome: EmbeddedTraceOutcome;
+}
+
+/** Safe public diagnostic detail for one retained local trace. */
+export interface EmbeddedTraceDetail {
+  readonly summary: EmbeddedTraceSummary;
+  readonly phases: readonly EmbeddedTracePhase[];
+  readonly selectedTarget: EmbeddedTraceSelectedTarget | null;
+  readonly placement: EmbeddedTracePlacement | null;
+  readonly failureCode: string | null;
+  readonly stateMachineValid: boolean | null;
+}
+
+/** Cursor-paged, bounded public Trace API response. */
+export interface EmbeddedTracePage {
+  readonly summaries: readonly EmbeddedTraceSummary[];
+  readonly nextCursor: string | null;
+  readonly retentionLimit: number;
 }
 
 /** JSON value type for wire payloads. */
@@ -139,6 +207,28 @@ export interface TraverseEmbedderApi {
    * NFR-002).
    */
   releaseEvidence(): JsonValue;
+}
+
+/**
+ * The additive `embedded-trace-api/1.0.0` companion surface (spec 517).
+ * It is intentionally separate from `TraverseEmbedderApi` so baseline hosts
+ * and external implementers retain their existing `embedder-api/1.0.0`
+ * compatibility.
+ */
+export interface EmbeddedTraceApi {
+  /** Advertised companion API version. */
+  embeddedTraceApiVersion(): string;
+  /** `trace.list`: safe newest-first summaries for this local session. */
+  traceList(
+    requestedVersion: string,
+    pageSize: number,
+    cursor?: string | null,
+  ): EmbeddedTracePage | EmbeddedTraceApiError;
+  /** `trace.get`: one safe retained detail by opaque public trace ID. */
+  traceGet(
+    requestedVersion: string,
+    traceId: string,
+  ): EmbeddedTraceDetail | EmbeddedTraceApiError;
 }
 
 export function embedderError(code: EmbedderErrorCode, message: string): EmbedderError {

--- a/packages/web/TraverseEmbedder/tests/bundleEmbedder.test.mjs
+++ b/packages/web/TraverseEmbedder/tests/bundleEmbedder.test.mjs
@@ -395,16 +395,18 @@ test("real checked-in traverse-starter bundle loads and executes without a sidec
   const embedder = await initEmbedder(manifestPath);
   const events = collectEvents(embedder);
 
-  // The checked-in process-agent.wasm artifact is a placeholder stub (no
-  // WASI imports, an empty _start body) — see examples/traverse-starter.
   // This proves the full no-sidecar pipeline genuinely runs against the
   // real repository bundle: manifest/workflow resolution, sha-256 digest
   // verification, Traverse Host ABI import validation, and real
-  // WebAssembly.instantiate + invocation. The honest outcome for a stub
-  // with no output is a deserialization failure, not a mocked success.
+  // WebAssembly.instantiate + invocation. Public Trace API records are
+  // independently safe projections, never a serialization of this payload.
   const outcome = embedder.submit("traverse-starter.process", { note: "hello" });
   assert.equal(outcome.status, "accepted");
   const terminal = events[events.length - 1];
-  assert.equal(terminal.event_type, "error");
-  assert.equal(terminal.data.error.code, "output_deserialization_failed");
+  assert.equal(terminal.event_type, "capability_result");
+  const page = embedder.traceList("1.0.0", 10);
+  assert.equal(page.summaries.length, 1);
+  const detail = embedder.traceGet("1.0.0", page.summaries[0].traceId);
+  assert.equal(detail.summary.targetId, "traverse-starter.process");
+  assert.equal(JSON.stringify(detail).includes("hello"), false);
 });

--- a/packages/web/TraverseEmbedder/tests/embedder.test.mjs
+++ b/packages/web/TraverseEmbedder/tests/embedder.test.mjs
@@ -5,6 +5,8 @@ import assert from "node:assert/strict";
 import {
   EMBEDDER_API_VERSION,
   EMBEDDER_CONFORMANCE_VERSION,
+  EMBEDDED_TRACE_API_VERSION,
+  EMBEDDED_TRACE_RETENTION_LIMIT,
   BundleRejectedError,
   EmbedderTestDouble,
   validateBundleCompatibility,
@@ -79,6 +81,52 @@ test("scripted runtime-shaped errors surface as error events", () => {
   assert.equal(events[1].event_type, "error");
   assert.equal(events[1].data.error.code, "execution_failed");
   assert.equal(events[1].data.error.message, "scripted failure");
+});
+
+test("embedded Trace API pages only safe local diagnostic records", () => {
+  const secretInput = "input-secret-never-public";
+  const secretOutput = "output-secret-never-public";
+  const secretError = "error-secret-never-public";
+  const embedder = new EmbedderTestDouble()
+    .withTargetOutput("fixture.success", { secret: secretOutput })
+    .withTargetError("fixture.failure", "execution_failed", secretError);
+
+  embedder.submit("fixture.success", { secret: secretInput });
+  embedder.submit("fixture.failure", { secret: secretInput });
+  const firstPage = embedder.traceList(EMBEDDED_TRACE_API_VERSION, 1);
+
+  assert.equal(firstPage.summaries.length, 1);
+  assert.equal(firstPage.summaries[0].targetId, "fixture.failure");
+  assert.equal(firstPage.summaries[0].outcome, "error");
+  assert.equal(firstPage.retentionLimit, EMBEDDED_TRACE_RETENTION_LIMIT);
+  assert.ok(firstPage.nextCursor);
+
+  const detail = embedder.traceGet(EMBEDDED_TRACE_API_VERSION, firstPage.summaries[0].traceId);
+  assert.equal(detail.failureCode, "execution_failed");
+  assert.equal(detail.phases[0].code, "error");
+  const publicJson = JSON.stringify(detail);
+  assert.equal(publicJson.includes(secretInput), false);
+  assert.equal(publicJson.includes(secretOutput), false);
+  assert.equal(publicJson.includes(secretError), false);
+
+  const secondPage = embedder.traceList(EMBEDDED_TRACE_API_VERSION, 1, firstPage.nextCursor);
+  assert.equal(secondPage.summaries[0].targetId, "fixture.success");
+  assert.equal(secondPage.nextCursor, null);
+});
+
+test("embedded Trace API reports stable version cursor eviction and stopped-host failures", () => {
+  const embedder = new EmbedderTestDouble().withTargetOutput("fixture.success", { ok: true });
+  embedder.submit("fixture.success", {});
+  assert.equal(embedder.traceList("2.0.0", 10).code, "incompatible_version");
+  assert.equal(embedder.traceList(EMBEDDED_TRACE_API_VERSION, 10, "bad").code, "invalid_cursor");
+
+  const firstId = embedder.traceList(EMBEDDED_TRACE_API_VERSION, 1).summaries[0].traceId;
+  for (let index = 0; index < EMBEDDED_TRACE_RETENTION_LIMIT; index += 1) {
+    embedder.submit("fixture.success", { index });
+  }
+  assert.equal(embedder.traceGet(EMBEDDED_TRACE_API_VERSION, firstId).code, "trace_not_found");
+  embedder.shutdown();
+  assert.equal(embedder.traceList(EMBEDDED_TRACE_API_VERSION, 10).code, "trace_api_unavailable");
 });
 
 test("unknown targets are rejected with an error event", () => {
@@ -215,6 +263,7 @@ test("release evidence records package, versions, and bundle identity", () => {
   assert.equal(evidence.kind, "embedder_release_evidence");
   assert.equal(evidence.package.name, "traverse-embedder-web");
   assert.equal(evidence.embedder_api_version, EMBEDDER_API_VERSION);
+  assert.equal(evidence.companion_apis["embedded-trace-api"], EMBEDDED_TRACE_API_VERSION);
   assert.equal(evidence.conformance_version, EMBEDDER_CONFORMANCE_VERSION);
   assert.equal(evidence.runtime.implementation, "test-double");
   assert.equal(evidence.bundle.app_id, "fixture-app");


### PR DESCRIPTION
## Summary

Implements the additive `embedded-trace-api/1.0.0` companion surface for the Rust and Web embedders. The Web package provides the first production host implementation over its existing no-sidecar browser-WASM runtime; both production hosts and deterministic test doubles retain only bounded, process-local safe projections.

## Governing Spec

- `517-embedded-trace-api`
- `068-public-platform-embedder-packages`

## Project Item

`embedded-trace-api` — Public embedded Trace API for in-process hosts (Trace Explorer).

## Definition of Done

- [x] Separate versioned companion API with `trace.list` and `trace.get`; baseline `embedder-api/1.0.0` is unchanged.
- [x] Safe summaries/details omit payloads, caller/correlation data, private trace IDs/hashes, raw telemetry, and error messages/details.
- [x] Deterministic bounded retention, opaque session-scoped cursor handling, eviction, and stopped-host behavior.
- [x] Rust and Web production hosts plus deterministic test doubles share companion semantics.
- [x] Web no-sidecar production proof executes the checked-in bundle and browses its local safe trace.

## Validation

- `npm test` in `packages/web/TraverseEmbedder` — 30 passing tests.
- `cargo test -p traverse-embedder` — 38 passing tests across unit, conformance, and package suites.
- Local LLVM line coverage — 100.00% (1,370/1,370) for `traverse-embedder`.
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/embedded-trace-api-pr-body.md` with `BASE_SHA=origin/main`.
