### PR TITLE
adr: define durable trace journal

### DIFF
--- a/docs/adr/0017-durable-trace-journal.md
+++ b/docs/adr/0017-durable-trace-journal.md
@@ -1,0 +1,27 @@
+# ADR-0017: Durable Trace Journal
+
+- Status: Accepted
+- Date: 2026-07-21
+
+## Decision
+
+Traverse will persist execution traces by reusing the append-only event journal.
+Records use canonical JSON Lines and are committed with `fsync`. Trace queries
+and retention rules are trace-specific layers over that journal.
+
+Auditable executions fail before returning a result if their durable trace write
+fails. Non-audited local development work may opt out through capability policy.
+
+Recovery discards only a malformed or incomplete final record and emits a
+deterministic recovery warning. It never reconstructs trace evidence.
+
+Journal records persist non-sensitive metadata and canonical hashes only; private
+trace payloads are not persisted in this slice. Retention is per workspace,
+bounded by age and count/size, prunes oldest-first, and records `trace_pruned`.
+
+## Consequences
+
+- One durable append-only mechanism serves events and traces.
+- Trace storage remains portable and inspectable without a database dependency.
+- Storage failures are visible integrity failures for audited execution.
+- Encrypted private-payload persistence is a future, separate capability.

--- a/specs/518-durable-trace-journal/spec.md
+++ b/specs/518-durable-trace-journal/spec.md
@@ -1,0 +1,19 @@
+# Feature Specification: Durable Trace Journal
+
+**Status**: Approved
+
+## Scope
+
+Persist auditable execution traces through the existing append-only event journal.
+
+## Requirements
+
+- **FR-001**: Durable trace records MUST be canonical JSON Lines appended to the event journal and committed with `fsync`.
+- **FR-002**: Auditable execution MUST fail before returning success when its trace cannot be durably written.
+- **FR-003**: Recovery MUST discard only an incomplete final record and report deterministic recovery evidence.
+- **FR-004**: Records MUST contain non-sensitive metadata and canonical hashes, never private trace payloads.
+- **FR-005**: Retention MUST be per workspace, deterministic oldest-first, and emit `trace_pruned` evidence.
+
+## Governing Decision
+
+- ADR-0017


### PR DESCRIPTION
## Summary

- Record durable trace persistence decisions.
- Define the successor durable trace journal specification.

## Governing Spec

- `004-spec-alignment-gate`

## Project Item

- Decision package: durable trace-store persistence

## Definition of Done

- [x] Storage, retention, recovery, failure, privacy, and event-journal reuse are decided.
- [x] ADR and successor specification are linked in this PR.

## Validation

- Documentation-only decision package reviewed against Project ticket decisions.
