### PR TITLE
feat(registry): materialize synced component references

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -1784,13 +1784,10 @@ impl RegistryComponentResolver for SyncedRegistryComponentResolver<'_> {
             &reference.version_range,
         )
         .map_err(|failure| {
-            registry_resolution_failure(
-                failure
-                    .errors
-                    .first()
-                    .map(|error| error.message.clone())
-                    .unwrap_or_else(|| "public registry resolution failed".to_string()),
-            )
+            registry_resolution_failure(failure.errors.first().map_or_else(
+                || "public registry resolution failed".to_string(),
+                |error| error.message.clone(),
+            ))
         })?;
         let contract_path = cache_registry_asset(
             self.workspace_root,
@@ -5787,6 +5784,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)] // Exercises the complete synced-reference registration flow.
     fn synced_registry_reference_validates_registers_and_reuses_verified_cache() {
         let state_root = unique_temp_dir();
         let fixture_root = unique_temp_dir();

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -23,14 +23,16 @@ use traverse_contracts::{
 };
 use traverse_contracts::{ViolationRecord, reference_connector_contracts};
 use traverse_registry::{
+    ApplicationManifestError, ApplicationManifestErrorCode, ApplicationManifestFailure,
     ApplicationRegistrationRequest, ApplicationRegistry, ArtifactDigests, BinaryFormat,
     BinaryReference, CapabilityArtifactRecord, CapabilityRegistration, CapabilityRegistry,
     ComposabilityMetadata, CompositionKind, CompositionPattern, ConnectorRegistration,
     DiscoveryQuery, EventRegistration, EventRegistry, ImplementationKind, LookupScope,
-    PublicRegistryCapabilityRecord, PublicRegistryIndex, RegistryBundle, RegistryProvenance,
-    RegistryScope, SourceKind, SourceReference, WorkflowReference, WorkflowRegistration,
-    WorkflowRegistry, load_application_bundle_manifest, load_registry_bundle,
-    write_synced_public_registry_state,
+    PublicRegistryCapabilityRecord, PublicRegistryIndex, RegistryBundle, RegistryComponentResolver,
+    RegistryProvenance, RegistryReference, RegistryScope, ResolvedRegistryComponent, SourceKind,
+    SourceReference, WorkflowReference, WorkflowRegistration, WorkflowRegistry,
+    load_application_bundle_manifest, load_application_bundle_manifest_with_resolver,
+    load_registry_bundle, write_synced_public_registry_state,
 };
 use traverse_runtime::executor::{SUPPORTED_HOST_ABI_VERSION, verify_wasm_host_abi_bytes};
 use traverse_runtime::{
@@ -1730,6 +1732,119 @@ fn app_register(
     app_register_at(&base_dir, manifest_path, workspace_id, json_output)
 }
 
+struct SyncedRegistryComponentResolver<'a> {
+    workspace_root: &'a Path,
+    workspace_id: &'a str,
+}
+
+impl RegistryComponentResolver for SyncedRegistryComponentResolver<'_> {
+    fn resolve(
+        &self,
+        reference: &RegistryReference,
+    ) -> Result<ResolvedRegistryComponent, ApplicationManifestFailure> {
+        let record = traverse_registry::resolve_synced_public_registry_range(
+            self.workspace_root,
+            self.workspace_id,
+            &reference.namespace,
+            &reference.id,
+            &reference.version_range,
+        )
+        .map_err(|failure| {
+            registry_resolution_failure(
+                failure
+                    .errors
+                    .first()
+                    .map(|error| error.message.clone())
+                    .unwrap_or_else(|| "public registry resolution failed".to_string()),
+            )
+        })?;
+        let contract_path = cache_registry_asset(
+            self.workspace_root,
+            &record.contract_url,
+            &record.contract_digest,
+        )?;
+        let contract_text = fs::read_to_string(&contract_path).map_err(|error| {
+            registry_resolution_failure(format!("failed to read cached registry contract: {error}"))
+        })?;
+        let contract = parse_contract(&contract_text).map_err(|failure| {
+            registry_resolution_failure(format!(
+                "cached registry contract is invalid: {}",
+                failure.errors[0].message
+            ))
+        })?;
+        let wasm_binary_path =
+            cache_registry_asset(self.workspace_root, &record.artifact_url, &record.digest)?;
+        Ok(ResolvedRegistryComponent {
+            contract_path,
+            contract,
+            wasm_binary_path,
+            wasm_digest: record.digest,
+        })
+    }
+}
+
+fn registry_resolution_failure(message: String) -> ApplicationManifestFailure {
+    ApplicationManifestFailure {
+        errors: vec![ApplicationManifestError {
+            code: ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
+            path: "$.registry_ref".to_string(),
+            message,
+        }],
+    }
+}
+
+fn cache_registry_asset(
+    workspace_root: &Path,
+    url: &str,
+    expected_digest: &str,
+) -> Result<PathBuf, ApplicationManifestFailure> {
+    let digest = expected_digest
+        .strip_prefix("sha256:")
+        .unwrap_or(expected_digest);
+    if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(registry_resolution_failure(
+            "registry asset has invalid SHA-256 digest".to_string(),
+        ));
+    }
+    let cache_path = workspace_root.join(".traverse/cache/sha256").join(digest);
+    if cache_path.exists() {
+        let bytes = fs::read(&cache_path).map_err(|error| {
+            registry_resolution_failure(format!("failed to read cached registry asset: {error}"))
+        })?;
+        if sha256_hex(&bytes) == digest.to_ascii_lowercase() {
+            return Ok(cache_path);
+        }
+        return Err(registry_resolution_failure(
+            "cached registry asset digest mismatch".to_string(),
+        ));
+    }
+    let output = std::process::Command::new("curl")
+        .args(["-fsSL", url])
+        .output()
+        .map_err(|error| {
+            registry_resolution_failure(format!("failed to fetch registry asset: {error}"))
+        })?;
+    if !output.status.success() || sha256_hex(&output.stdout) != digest.to_ascii_lowercase() {
+        return Err(registry_resolution_failure(
+            "registry asset download or digest verification failed".to_string(),
+        ));
+    }
+    let parent = cache_path.parent().ok_or_else(|| {
+        registry_resolution_failure("registry cache path has no parent".to_string())
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        registry_resolution_failure(format!("failed to create registry cache: {error}"))
+    })?;
+    let temporary = cache_path.with_extension("tmp");
+    fs::write(&temporary, output.stdout).map_err(|error| {
+        registry_resolution_failure(format!("failed to write registry cache: {error}"))
+    })?;
+    fs::rename(&temporary, &cache_path).map_err(|error| {
+        registry_resolution_failure(format!("failed to commit registry cache: {error}"))
+    })?;
+    Ok(cache_path)
+}
+
 fn app_register_at(
     base_dir: &Path,
     manifest_path: &Path,
@@ -1750,21 +1865,26 @@ fn app_register_at(
         return render_app_registration_failure(manifest_path, workspace_id, vec![error], None);
     }
 
-    let manifest = match load_application_bundle_manifest(manifest_path) {
-        Ok(manifest) => manifest,
-        Err(failure) => {
-            return render_app_registration_failure(
-                manifest_path,
-                workspace_id,
-                failure
-                    .errors
-                    .into_iter()
-                    .map(AppValidationError::from_manifest_error)
-                    .collect(),
-                None,
-            );
-        }
+    let resolver = SyncedRegistryComponentResolver {
+        workspace_root: base_dir,
+        workspace_id,
     };
+    let manifest =
+        match load_application_bundle_manifest_with_resolver(manifest_path, Some(&resolver)) {
+            Ok(manifest) => manifest,
+            Err(failure) => {
+                return render_app_registration_failure(
+                    manifest_path,
+                    workspace_id,
+                    failure
+                        .errors
+                        .into_iter()
+                        .map(AppValidationError::from_manifest_error)
+                        .collect(),
+                    None,
+                );
+            }
+        };
 
     let state_path =
         app_registration_state_path(base_dir, workspace_id, &manifest.app_id, &manifest.version);

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -31,8 +31,9 @@ use traverse_registry::{
     PublicRegistryCapabilityRecord, PublicRegistryIndex, RegistryBundle, RegistryComponentResolver,
     RegistryProvenance, RegistryReference, RegistryScope, ResolvedRegistryComponent, SourceKind,
     SourceReference, WorkflowReference, WorkflowRegistration, WorkflowRegistry,
-    load_application_bundle_manifest, load_application_bundle_manifest_with_resolver,
-    load_registry_bundle, write_synced_public_registry_state,
+    cache_verified_public_registry_bytes, load_application_bundle_manifest,
+    load_application_bundle_manifest_with_resolver, load_registry_bundle,
+    public_registry_cache_path, write_synced_public_registry_state,
 };
 use traverse_runtime::executor::{SUPPORTED_HOST_ABI_VERSION, verify_wasm_host_abi_bytes};
 use traverse_runtime::{
@@ -426,7 +427,7 @@ fn help_app_new() -> String {
 }
 
 fn help_app_validate() -> String {
-    "traverse-cli app validate --manifest <path> --json
+    "traverse-cli app validate --manifest <path> [--workspace <workspace-id>] --json
 
   Purpose:
     Validate a downstream application manifest, component manifests,
@@ -440,6 +441,7 @@ fn help_app_validate() -> String {
     --json              Emit machine-readable validation evidence.
 
   Optional flags:
+    --workspace <id>    Resolve registry-ref components from this locally synced workspace.
     --help              Print this help text.
 
   Example:
@@ -1010,9 +1012,13 @@ fn parse_app_validate_command(args: &[String]) -> Result<Command, String> {
     if !args.iter().any(|a| a == "--json") {
         return Err("app validate requires --json for stable setup evidence".to_string());
     }
+    let workspace_id = parse_string_flag(args, "--workspace");
+    if args.iter().any(|arg| arg == "--workspace") && workspace_id.is_none() {
+        return Err("--workspace requires a value".to_string());
+    }
     Ok(Command::AppValidate {
         manifest_path: PathBuf::from(manifest_path),
-        workspace_id: parse_string_flag(args, "--workspace"),
+        workspace_id,
         json_output: true,
     })
 }
@@ -1706,6 +1712,18 @@ fn app_validate(
     workspace_id: Option<&str>,
     json_output: bool,
 ) -> Result<String, CliError> {
+    let base_dir = std::env::current_dir().map_err(|error| {
+        CliError::IoError(format!("failed to resolve current directory: {error}"))
+    })?;
+    app_validate_at(&base_dir, manifest_path, workspace_id, json_output)
+}
+
+fn app_validate_at(
+    base_dir: &Path,
+    manifest_path: &Path,
+    workspace_id: Option<&str>,
+    json_output: bool,
+) -> Result<String, CliError> {
     if !json_output {
         return Err(CliError::UsageError(
             "app validate requires --json for stable setup evidence".to_string(),
@@ -1717,11 +1735,8 @@ fn app_validate(
     }
 
     let manifest = if let Some(workspace_id) = workspace_id {
-        let base_dir = std::env::current_dir().map_err(|error| {
-            CliError::IoError(format!("failed to resolve current directory: {error}"))
-        })?;
         let resolver = SyncedRegistryComponentResolver {
-            workspace_root: &base_dir,
+            workspace_root: base_dir,
             workspace_id,
         };
         load_application_bundle_manifest_with_resolver(manifest_path, Some(&resolver))
@@ -1817,25 +1832,14 @@ fn cache_registry_asset(
     url: &str,
     expected_digest: &str,
 ) -> Result<PathBuf, ApplicationManifestFailure> {
-    let digest = expected_digest
-        .strip_prefix("sha256:")
-        .unwrap_or(expected_digest);
-    if digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        return Err(registry_resolution_failure(
-            "registry asset has invalid SHA-256 digest".to_string(),
-        ));
-    }
-    let cache_path = workspace_root.join(".traverse/cache/sha256").join(digest);
-    if cache_path.exists() {
-        let bytes = fs::read(&cache_path).map_err(|error| {
+    if let Some(cache_path) = public_registry_cache_path(workspace_root, expected_digest)
+        && cache_path.exists()
+    {
+        let cached = fs::read(&cache_path).map_err(|error| {
             registry_resolution_failure(format!("failed to read cached registry asset: {error}"))
         })?;
-        if sha256_hex(&bytes) == digest.to_ascii_lowercase() {
-            return Ok(cache_path);
-        }
-        return Err(registry_resolution_failure(
-            "cached registry asset digest mismatch".to_string(),
-        ));
+        return cache_verified_public_registry_bytes(workspace_root, expected_digest, &cached)
+            .map_err(|failure| registry_resolution_failure(failure.message));
     }
     let output = std::process::Command::new("curl")
         .args(["-fsSL", url])
@@ -1843,25 +1847,13 @@ fn cache_registry_asset(
         .map_err(|error| {
             registry_resolution_failure(format!("failed to fetch registry asset: {error}"))
         })?;
-    if !output.status.success() || sha256_hex(&output.stdout) != digest.to_ascii_lowercase() {
+    if !output.status.success() {
         return Err(registry_resolution_failure(
-            "registry asset download or digest verification failed".to_string(),
+            "registry asset download failed".to_string(),
         ));
     }
-    let parent = cache_path.parent().ok_or_else(|| {
-        registry_resolution_failure("registry cache path has no parent".to_string())
-    })?;
-    fs::create_dir_all(parent).map_err(|error| {
-        registry_resolution_failure(format!("failed to create registry cache: {error}"))
-    })?;
-    let temporary = cache_path.with_extension("tmp");
-    fs::write(&temporary, output.stdout).map_err(|error| {
-        registry_resolution_failure(format!("failed to write registry cache: {error}"))
-    })?;
-    fs::rename(&temporary, &cache_path).map_err(|error| {
-        registry_resolution_failure(format!("failed to commit registry cache: {error}"))
-    })?;
-    Ok(cache_path)
+    cache_verified_public_registry_bytes(workspace_root, expected_digest, &output.stdout)
+        .map_err(|failure| registry_resolution_failure(failure.message))
 }
 
 fn app_register_at(
@@ -5153,15 +5145,16 @@ mod tests {
         CapabilityPublishRequest, CliError, Command, ExpeditionExampleExecutor,
         FetchedRegistryIndex, PublishCommandOutput, PublishProcessRunner, RealPublishProcessRunner,
         RegistryIndexFetcher, RegistrySyncError, app_new_at, app_register_at,
-        app_registration_state_path, app_validate, canonical_expedition_bundle_path,
-        capability_publish_at, component_new_at, curl_text, ensure_clean_registry_checkout,
-        execute_agent, execute_expedition, execute_traverse_starter_process,
-        execute_traverse_starter_summarize, execute_traverse_starter_validate, inspect_agent,
-        inspect_bundle, inspect_event, inspect_trace, latest_index_release_asset,
-        load_registered_bundle, load_registered_bundle_with_public_records, load_runtime_request,
-        parse_command, publish_file_sha256_digest, register_bundle, register_generated_app_bundle,
+        app_registration_state_path, app_validate, app_validate_at,
+        canonical_expedition_bundle_path, capability_publish_at, component_new_at, curl_text,
+        ensure_clean_registry_checkout, execute_agent, execute_expedition,
+        execute_traverse_starter_process, execute_traverse_starter_summarize,
+        execute_traverse_starter_validate, inspect_agent, inspect_bundle, inspect_event,
+        inspect_trace, latest_index_release_asset, load_registered_bundle,
+        load_registered_bundle_with_public_records, load_runtime_request, parse_command,
+        publish_file_sha256_digest, register_bundle, register_generated_app_bundle,
         registry_sync_at, registry_sync_failure_json, reject_private_contract_scope, run_command,
-        validate_registry_path_segment,
+        sha256_hex, validate_registry_path_segment,
     };
     use crate::agent_packages::fnv1a64;
     use serde_json::Value;
@@ -5174,7 +5167,7 @@ mod tests {
     use traverse_contracts::parse_contract;
     use traverse_registry::{
         PublicRegistryCapabilityRecord, PublicRegistryIndex, load_application_bundle_manifest,
-        load_synced_public_registry_state,
+        load_synced_public_registry_state, write_synced_public_registry_state,
     };
 
     #[test]
@@ -5790,6 +5783,124 @@ mod tests {
         assert_eq!(
             first_json["registration_fingerprint"],
             second_json["registration_fingerprint"]
+        );
+    }
+
+    #[test]
+    fn synced_registry_reference_validates_registers_and_reuses_verified_cache() {
+        let state_root = unique_temp_dir();
+        let fixture_root = unique_temp_dir();
+        let repo = repo_root();
+        let contract_path = repo.join(
+            "contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+        );
+        let artifact_path = repo.join(
+            "examples/agents/team-readiness-agent/artifacts/validate-team-readiness-agent.wasm",
+        );
+        let contract_digest = format!(
+            "sha256:{}",
+            sha256_hex(&fs::read(&contract_path).expect("contract artifact should read"))
+        );
+        let artifact_digest = format!(
+            "sha256:{}",
+            sha256_hex(&fs::read(&artifact_path).expect("wasm artifact should read"))
+        );
+        let manifest_path =
+            write_app_validate_fixture(&fixture_root, &artifact_digest, &artifact_digest, None);
+        let component_path = fixture_root.join("component.manifest.json");
+        let mut component: Value = serde_json::from_str(
+            &fs::read_to_string(&component_path).expect("component manifest should read"),
+        )
+        .expect("component manifest should parse");
+        let component_object = component
+            .as_object_mut()
+            .expect("component manifest should be an object");
+        component_object.remove("contract_path");
+        component_object.remove("wasm_binary_path");
+        component_object.remove("wasm_digest");
+        component_object.insert(
+            "registry_ref".to_string(),
+            serde_json::json!({
+                "namespace": "fixture",
+                "id": "expedition.planning.validate-team-readiness",
+                "version_range": "^1.0.0"
+            }),
+        );
+        fs::write(
+            &component_path,
+            serde_json::to_string_pretty(&component).expect("component manifest should serialize"),
+        )
+        .expect("component manifest should write");
+        write_synced_public_registry_state(
+            &state_root,
+            "local",
+            "fixture-registry",
+            "fixture-v1",
+            "2026-07-22T00:00:00Z",
+            PublicRegistryIndex {
+                index_version: 1,
+                generated_at: "2026-07-22T00:00:00Z".to_string(),
+                source_commit: None,
+                capabilities: vec![PublicRegistryCapabilityRecord {
+                    namespace: "fixture".to_string(),
+                    id: "expedition.planning.validate-team-readiness".to_string(),
+                    version: "1.0.0".to_string(),
+                    digest: artifact_digest.clone(),
+                    artifact_url: format!("file://{}", artifact_path.display()),
+                    contract_digest: contract_digest.clone(),
+                    contract_url: format!("file://{}", contract_path.display()),
+                    deprecated: false,
+                }],
+            },
+        )
+        .expect("synced fixture state should persist");
+
+        let validation = app_validate_at(&state_root, &manifest_path, Some("local"), true)
+            .expect("synced registry component should validate");
+        let validation_json: Value =
+            serde_json::from_str(&validation).expect("validation output must be JSON");
+        assert_eq!(validation_json["status"], "validated");
+
+        let registration = app_register_at(&state_root, &manifest_path, "local", true)
+            .expect("synced registry component should register");
+        let registration_json: Value =
+            serde_json::from_str(&registration).expect("registration output must be JSON");
+        let cache_root = state_root.join(".traverse/cache/sha256");
+        assert_eq!(registration_json["status"], "registered");
+        assert_eq!(
+            registration_json["components"][0]["artifact_ref"],
+            Value::String(
+                cache_root
+                    .join(artifact_digest.trim_start_matches("sha256:"))
+                    .display()
+                    .to_string()
+            )
+        );
+        assert!(
+            cache_root
+                .join(contract_digest.trim_start_matches("sha256:"))
+                .exists()
+        );
+        assert!(
+            cache_root
+                .join(artifact_digest.trim_start_matches("sha256:"))
+                .exists()
+        );
+
+        let unsynced_root = unique_temp_dir();
+        let unsynced = app_register_at(&unsynced_root, &manifest_path, "local", true)
+            .expect("missing sync should render stable JSON evidence");
+        let unsynced_json: Value =
+            serde_json::from_str(&unsynced).expect("registration output must be JSON");
+        assert_eq!(unsynced_json["status"], "failed");
+        assert_eq!(
+            unsynced_json["errors"][0]["code"],
+            "registry_reference_requires_resolution"
+        );
+        assert!(
+            unsynced_json["errors"][0]["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("registry sync"))
         );
     }
 

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -58,6 +58,7 @@ enum Command {
     },
     AppValidate {
         manifest_path: PathBuf,
+        workspace_id: Option<String>,
         json_output: bool,
     },
     AppRegister {
@@ -249,8 +250,9 @@ fn run_command(command: Command) -> Result<String, CliError> {
         } => app_new(&app_id, register, workspace_id.as_deref()),
         Command::AppValidate {
             manifest_path,
+            workspace_id,
             json_output,
-        } => app_validate(&manifest_path, json_output),
+        } => app_validate(&manifest_path, workspace_id.as_deref(), json_output),
         Command::AppRegister {
             manifest_path,
             workspace_id,
@@ -1010,6 +1012,7 @@ fn parse_app_validate_command(args: &[String]) -> Result<Command, String> {
     }
     Ok(Command::AppValidate {
         manifest_path: PathBuf::from(manifest_path),
+        workspace_id: parse_string_flag(args, "--workspace"),
         json_output: true,
     })
 }
@@ -1698,7 +1701,11 @@ fn register_generated_app_bundle(
     ))
 }
 
-fn app_validate(manifest_path: &Path, json_output: bool) -> Result<String, CliError> {
+fn app_validate(
+    manifest_path: &Path,
+    workspace_id: Option<&str>,
+    json_output: bool,
+) -> Result<String, CliError> {
     if !json_output {
         return Err(CliError::UsageError(
             "app validate requires --json for stable setup evidence".to_string(),
@@ -1709,7 +1716,19 @@ fn app_validate(manifest_path: &Path, json_output: bool) -> Result<String, CliEr
         return render_app_validation_failure(manifest_path, vec![error]);
     }
 
-    match load_application_bundle_manifest(manifest_path) {
+    let manifest = if let Some(workspace_id) = workspace_id {
+        let base_dir = std::env::current_dir().map_err(|error| {
+            CliError::IoError(format!("failed to resolve current directory: {error}"))
+        })?;
+        let resolver = SyncedRegistryComponentResolver {
+            workspace_root: &base_dir,
+            workspace_id,
+        };
+        load_application_bundle_manifest_with_resolver(manifest_path, Some(&resolver))
+    } else {
+        load_application_bundle_manifest(manifest_path)
+    };
+    match manifest {
         Ok(manifest) => render_app_validation_success(manifest_path, &manifest),
         Err(failure) => Ok(render_app_validation_failure(
             manifest_path,
@@ -5303,6 +5322,7 @@ mod tests {
             Command::AppValidate {
                 manifest_path,
                 json_output,
+                ..
             } => {
                 assert_eq!(
                     manifest_path,
@@ -5588,7 +5608,8 @@ mod tests {
         let manifest_path =
             repo_root().join("examples/applications/expedition-readiness/app.manifest.json");
 
-        let output = app_validate(&manifest_path, true).expect("app validation should succeed");
+        let output =
+            app_validate(&manifest_path, None, true).expect("app validation should succeed");
         let json: Value = serde_json::from_str(&output).expect("validation output must be JSON");
 
         assert_eq!(json["status"], "validated");
@@ -5619,7 +5640,7 @@ mod tests {
         );
 
         let output =
-            app_validate(&manifest_path, true).expect("validation failure is JSON evidence");
+            app_validate(&manifest_path, None, true).expect("validation failure is JSON evidence");
         let json: Value = serde_json::from_str(&output).expect("failure output must be JSON");
 
         assert_eq!(json["status"], "failed");
@@ -5648,7 +5669,7 @@ mod tests {
         .expect("manifest must write");
 
         let output =
-            app_validate(&manifest_path, true).expect("validation failure is JSON evidence");
+            app_validate(&manifest_path, None, true).expect("validation failure is JSON evidence");
         let json: Value = serde_json::from_str(&output).expect("failure output must be JSON");
 
         assert_eq!(json["status"], "failed");
@@ -5679,7 +5700,7 @@ mod tests {
         .expect("manifest must write");
 
         let output =
-            app_validate(&manifest_path, true).expect("validation failure is JSON evidence");
+            app_validate(&manifest_path, None, true).expect("validation failure is JSON evidence");
         let json: Value = serde_json::from_str(&output).expect("failure output must be JSON");
 
         assert_eq!(json["status"], "failed");
@@ -5709,7 +5730,8 @@ mod tests {
             })),
         );
 
-        let output = app_validate(&manifest_path, true).expect("app validation should succeed");
+        let output =
+            app_validate(&manifest_path, None, true).expect("app validation should succeed");
         let json: Value = serde_json::from_str(&output).expect("validation output must be JSON");
 
         assert_eq!(json["status"], "validated");
@@ -7686,6 +7708,7 @@ mod tests {
             },
             Command::AppValidate {
                 manifest_path: missing.clone(),
+                workspace_id: None,
                 json_output: false,
             },
             Command::AppRegister {

--- a/crates/traverse-registry/src/application_manifest.rs
+++ b/crates/traverse-registry/src/application_manifest.rs
@@ -430,7 +430,8 @@ pub struct WasmComponentManifest {
     pub execution_mode: ComponentExecutionMode,
     pub capability_id: String,
     pub capability_version: String,
-    pub contract_path: String,
+    pub contract_path: Option<String>,
+    pub registry_ref: Option<RegistryReference>,
     pub wasm_binary_path: Option<String>,
     pub wasm_digest: Option<String>,
     pub platforms: Vec<String>,
@@ -440,6 +441,14 @@ pub struct WasmComponentManifest {
     pub dependencies: Vec<WasmComponentDependency>,
     pub connector_requirements: Vec<ConnectorRequirement>,
     pub validation_evidence: Vec<Value>,
+}
+
+/// A public capability dependency resolved from synced registry state.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct RegistryReference {
+    pub namespace: String,
+    pub id: String,
+    pub version_range: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -490,6 +499,9 @@ pub enum ApplicationManifestErrorCode {
     CompatibleComponentMissingPlatforms,
     CompatibleComponentInvalidWasmFields,
     WasmComponentMissingWasmFields,
+    ComponentSourceMustBeExclusive,
+    RegistryReferenceInvalid,
+    RegistryReferenceRequiresResolution,
     ComponentDependencyMustBeConcrete,
     UnsupportedModelInterface,
     ModelDependencyMissingCandidates,
@@ -591,7 +603,10 @@ struct WasmComponentManifestSerde {
     execution_mode: Option<String>,
     capability_id: String,
     capability_version: String,
-    contract_path: String,
+    #[serde(default)]
+    contract_path: Option<String>,
+    #[serde(default)]
+    registry_ref: Option<RegistryReference>,
     #[serde(default)]
     wasm_binary_path: Option<String>,
     #[serde(default)]
@@ -1771,13 +1786,24 @@ fn load_component(
         })?;
 
     let execution_mode = parse_component_execution_mode(&component, &manifest_path)?;
+    validate_component_source(&component, &manifest_path)?;
+    if component.registry_ref.is_some() {
+        return Err(single_error(
+            ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
+            manifest_path.display().to_string(),
+            format!(
+                "component {}@{} uses registry_ref and must be resolved during app registration",
+                component.component_id, component.version
+            ),
+        ));
+    }
     let expected_component_digest =
         ensure_component_reference_matches(reference, &component, execution_mode, &manifest_path)?;
     validate_component_execution_mode(&component, execution_mode, &manifest_path)?;
     ensure_concrete_component_dependencies(&component.dependencies, &manifest_path)?;
 
     let component_dir = manifest_path.parent().unwrap_or(manifest_dir);
-    let contract_path = component_dir.join(&component.contract_path);
+    let contract_path = component_dir.join(component.contract_path.as_deref().unwrap_or_default());
     let contract = load_component_contract(&contract_path, &component)?;
     let (wasm_binary_path, verified_wasm_digest) = if execution_mode == ComponentExecutionMode::Wasm
     {
@@ -1812,6 +1838,50 @@ fn load_component(
         wasm_binary_path,
         verified_wasm_digest,
     })
+}
+
+fn validate_component_source(
+    component: &WasmComponentManifestSerde,
+    manifest_path: &Path,
+) -> Result<(), ApplicationManifestFailure> {
+    let has_local_source = component.contract_path.as_deref().is_some_and(has_text);
+    let has_registry_source = component.registry_ref.is_some();
+    if has_local_source == has_registry_source {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ComponentSourceMustBeExclusive,
+            manifest_path.display().to_string(),
+            format!(
+                "component {}@{} must declare exactly one of contract_path or registry_ref",
+                component.component_id, component.version
+            ),
+        ));
+    }
+    if let Some(reference) = &component.registry_ref {
+        if !has_text(&reference.namespace)
+            || !has_text(&reference.id)
+            || !has_text(&reference.version_range)
+        {
+            return Err(single_error(
+                ApplicationManifestErrorCode::RegistryReferenceInvalid,
+                manifest_path.display().to_string(),
+                format!(
+                    "component {}@{} registry_ref requires non-empty namespace, id, and version_range",
+                    component.component_id, component.version
+                ),
+            ));
+        }
+        if component.wasm_binary_path.is_some() || component.wasm_digest.is_some() {
+            return Err(single_error(
+                ApplicationManifestErrorCode::ComponentSourceMustBeExclusive,
+                manifest_path.display().to_string(),
+                format!(
+                    "component {}@{} registry_ref must not declare local WASM fields",
+                    component.component_id, component.version
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn ensure_component_reference_matches(
@@ -2094,6 +2164,7 @@ fn to_component_manifest(
         capability_id: component.capability_id,
         capability_version: component.capability_version,
         contract_path: component.contract_path,
+        registry_ref: component.registry_ref,
         wasm_binary_path: component.wasm_binary_path,
         wasm_digest: component.wasm_digest,
         platforms: component.platforms,

--- a/crates/traverse-registry/src/application_manifest.rs
+++ b/crates/traverse-registry/src/application_manifest.rs
@@ -451,6 +451,24 @@ pub struct RegistryReference {
     pub version_range: String,
 }
 
+/// Locally verified material for a public component selected from synced state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedRegistryComponent {
+    pub contract_path: PathBuf,
+    pub contract: CapabilityContract,
+    pub wasm_binary_path: PathBuf,
+    pub wasm_digest: String,
+}
+
+/// Resolves a registry reference without granting application loading network access.
+pub trait RegistryComponentResolver {
+    /// Returns a digest-verified cached component selected from local synced state.
+    fn resolve(
+        &self,
+        reference: &RegistryReference,
+    ) -> Result<ResolvedRegistryComponent, ApplicationManifestFailure>;
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ComponentExecutionMode {
     Wasm,
@@ -677,6 +695,22 @@ struct ModelCandidateSerde {
 pub fn load_application_bundle_manifest(
     manifest_path: &Path,
 ) -> Result<ApplicationBundleManifest, ApplicationManifestFailure> {
+    load_application_bundle_manifest_with_resolver(manifest_path, None)
+}
+
+/// Loads an application manifest using a caller-provided public-component resolver.
+///
+/// The resolver must use already-synced local registry state and verified cache
+/// material; this function never performs network I/O.
+///
+/// # Errors
+///
+/// Returns [`ApplicationManifestFailure`] when the manifest is invalid or a
+/// referenced public component cannot be resolved by the supplied resolver.
+pub fn load_application_bundle_manifest_with_resolver(
+    manifest_path: &Path,
+    resolver: Option<&dyn RegistryComponentResolver>,
+) -> Result<ApplicationBundleManifest, ApplicationManifestFailure> {
     let manifest_dir = manifest_path.parent().ok_or_else(|| {
         single_error(
             ApplicationManifestErrorCode::ManifestParentMissing,
@@ -718,7 +752,7 @@ pub fn load_application_bundle_manifest(
     let components = manifest
         .components
         .iter()
-        .map(|component| load_component(manifest_dir, component))
+        .map(|component| load_component(manifest_dir, component, resolver))
         .collect::<Result<Vec<_>, _>>()?;
     let state_machine = validate_state_machine(&manifest, &components)?;
 
@@ -1748,6 +1782,7 @@ fn looks_like_placeholder(value: &str) -> bool {
 fn load_component(
     manifest_dir: &Path,
     reference: &ApplicationComponentRef,
+    resolver: Option<&dyn RegistryComponentResolver>,
 ) -> Result<ApplicationComponent, ApplicationManifestFailure> {
     let manifest_path = manifest_dir.join(&reference.manifest_path);
     if !manifest_path.is_file() {
@@ -1787,20 +1822,41 @@ fn load_component(
 
     let execution_mode = parse_component_execution_mode(&component, &manifest_path)?;
     validate_component_source(&component, &manifest_path)?;
-    if component.registry_ref.is_some() {
-        return Err(single_error(
-            ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
-            manifest_path.display().to_string(),
-            format!(
-                "component {}@{} uses registry_ref and must be resolved during app registration",
-                component.component_id, component.version
-            ),
-        ));
-    }
-    let expected_component_digest =
-        ensure_component_reference_matches(reference, &component, execution_mode, &manifest_path)?;
     validate_component_execution_mode(&component, execution_mode, &manifest_path)?;
     ensure_concrete_component_dependencies(&component.dependencies, &manifest_path)?;
+
+    if let Some(registry_ref) = component.registry_ref.as_ref() {
+        let resolver = resolver.ok_or_else(|| {
+            single_error(
+                ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
+                manifest_path.display().to_string(),
+                format!(
+                    "component {}@{} uses registry_ref and must be resolved during app registration",
+                    component.component_id, component.version
+                ),
+            )
+        })?;
+        let resolved = resolver.resolve(registry_ref)?;
+        ensure_registry_component_reference_matches(
+            reference,
+            &component,
+            &resolved,
+            &manifest_path,
+        )?;
+        ensure_resolved_contract_matches(&resolved.contract, &component, &manifest_path)?;
+        return Ok(ApplicationComponent {
+            reference: reference.clone(),
+            manifest_path,
+            manifest: to_component_manifest(component, execution_mode),
+            contract_path: resolved.contract_path,
+            contract: resolved.contract,
+            wasm_binary_path: Some(resolved.wasm_binary_path),
+            verified_wasm_digest: Some(resolved.wasm_digest),
+        });
+    }
+
+    let expected_component_digest =
+        ensure_component_reference_matches(reference, &component, execution_mode, &manifest_path)?;
 
     let component_dir = manifest_path.parent().unwrap_or(manifest_dir);
     let contract_path = component_dir.join(component.contract_path.as_deref().unwrap_or_default());
@@ -1838,6 +1894,58 @@ fn load_component(
         wasm_binary_path,
         verified_wasm_digest,
     })
+}
+
+fn ensure_registry_component_reference_matches(
+    reference: &ApplicationComponentRef,
+    component: &WasmComponentManifestSerde,
+    resolved: &ResolvedRegistryComponent,
+    manifest_path: &Path,
+) -> Result<(), ApplicationManifestFailure> {
+    if reference.component_id != component.component_id || reference.version != component.version {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ComponentReferenceMismatch,
+            manifest_path.display().to_string(),
+            "component reference does not match registry-ref component metadata".to_string(),
+        ));
+    }
+    let expected = normalize_sha256_digest(&reference.digest).ok_or_else(|| {
+        single_error(
+            ApplicationManifestErrorCode::InvalidDigestMetadata,
+            "$.components[].digest".to_string(),
+            "component reference declares invalid digest metadata".to_string(),
+        )
+    })?;
+    let actual = normalize_sha256_digest(&resolved.wasm_digest).ok_or_else(|| {
+        single_error(
+            ApplicationManifestErrorCode::InvalidDigestMetadata,
+            manifest_path.display().to_string(),
+            "resolved registry component declares invalid digest metadata".to_string(),
+        )
+    })?;
+    if expected != actual {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ComponentDigestMismatch,
+            manifest_path.display().to_string(),
+            "registry component digest does not match the application reference".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_resolved_contract_matches(
+    contract: &CapabilityContract,
+    component: &WasmComponentManifestSerde,
+    manifest_path: &Path,
+) -> Result<(), ApplicationManifestFailure> {
+    if contract.id != component.capability_id || contract.version != component.capability_version {
+        return Err(single_error(
+            ApplicationManifestErrorCode::ComponentContractMismatch,
+            manifest_path.display().to_string(),
+            "resolved registry contract does not match component capability metadata".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn validate_component_source(

--- a/crates/traverse-registry/src/application_manifest.rs
+++ b/crates/traverse-registry/src/application_manifest.rs
@@ -463,6 +463,11 @@ pub struct ResolvedRegistryComponent {
 /// Resolves a registry reference without granting application loading network access.
 pub trait RegistryComponentResolver {
     /// Returns a digest-verified cached component selected from local synced state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an application-manifest failure when the referenced component
+    /// cannot be resolved or verified from the local synced state.
     fn resolve(
         &self,
         reference: &RegistryReference,
@@ -1779,6 +1784,7 @@ fn looks_like_placeholder(value: &str) -> bool {
         .any(|marker| lowered.contains(marker))
 }
 
+#[allow(clippy::too_many_lines)] // Coordinates the complete local and synced component validation flow.
 fn load_component(
     manifest_dir: &Path,
     reference: &ApplicationComponentRef,
@@ -1836,22 +1842,22 @@ fn load_component(
                 ),
             )
         })?;
-        let resolved = resolver.resolve(registry_ref)?;
+        let resolved_component = resolver.resolve(registry_ref)?;
         ensure_registry_component_reference_matches(
             reference,
             &component,
-            &resolved,
+            &resolved_component,
             &manifest_path,
         )?;
-        ensure_resolved_contract_matches(&resolved.contract, &component, &manifest_path)?;
+        ensure_resolved_contract_matches(&resolved_component.contract, &component, &manifest_path)?;
         return Ok(ApplicationComponent {
             reference: reference.clone(),
             manifest_path,
             manifest: to_component_manifest(component, execution_mode),
-            contract_path: resolved.contract_path,
-            contract: resolved.contract,
-            wasm_binary_path: Some(resolved.wasm_binary_path),
-            verified_wasm_digest: Some(resolved.wasm_digest),
+            contract_path: resolved_component.contract_path,
+            contract: resolved_component.contract,
+            wasm_binary_path: Some(resolved_component.wasm_binary_path),
+            verified_wasm_digest: Some(resolved_component.wasm_digest),
         });
     }
 

--- a/crates/traverse-registry/tests/application_manifest.rs
+++ b/crates/traverse-registry/tests/application_manifest.rs
@@ -70,6 +70,116 @@ fn defaults_component_execution_mode_to_wasm() {
 }
 
 #[test]
+fn rejects_component_without_a_local_or_registry_source() {
+    let fixture = AppFixture::new("missing-component-source");
+    fixture.write_component_manifest(&json!({ "contract_path": null }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("component source is required");
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentSourceMustBeExclusive
+    );
+}
+
+#[test]
+fn rejects_component_with_both_local_and_registry_sources() {
+    let fixture = AppFixture::new("duplicate-component-source");
+    fixture.write_component_manifest(&json!({
+        "registry_ref": { "namespace": "traverse-starter", "id": "traverse-starter.process", "version_range": "^1.0.0" }
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("component sources must be exclusive");
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentSourceMustBeExclusive
+    );
+}
+
+#[test]
+fn rejects_incomplete_registry_reference() {
+    let fixture = AppFixture::new("invalid-registry-reference");
+    fixture.write_component_manifest(&json!({
+        "contract_path": null,
+        "wasm_binary_path": null,
+        "wasm_digest": null,
+        "registry_ref": { "namespace": "", "id": "traverse-starter.process", "version_range": "^1.0.0" }
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("registry reference fields are required");
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::RegistryReferenceInvalid
+    );
+}
+
+#[test]
+fn rejects_registry_reference_with_local_wasm_fields() {
+    let fixture = AppFixture::new("registry-reference-local-wasm");
+    fixture.write_component_manifest(&json!({
+        "contract_path": null,
+        "registry_ref": { "namespace": "traverse-starter", "id": "traverse-starter.process", "version_range": "^1.0.0" }
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("registry reference cannot declare local wasm fields");
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentSourceMustBeExclusive
+    );
+}
+
+#[test]
+fn registry_reference_requires_registration_resolution() {
+    let fixture = AppFixture::new("registry-reference-resolution");
+    fixture.write_component_manifest(&json!({
+        "contract_path": null,
+        "wasm_binary_path": null,
+        "wasm_digest": null,
+        "registry_ref": { "namespace": "traverse-starter", "id": "traverse-starter.process", "version_range": "^1.0.0" }
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        "sha256:5647c39a1d25d8728350f9619025292a62e78a602068a2ad9b6f075751c93d99",
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+
+    let failure = load_application_bundle_manifest(&fixture.app_manifest_path())
+        .expect_err("registry reference must be resolved during registration");
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::RegistryReferenceRequiresResolution
+    );
+}
+
+#[test]
 fn component_execution_mode_renders_manifest_values() {
     assert_eq!(
         traverse_registry::ComponentExecutionMode::Wasm.as_str(),
@@ -2642,6 +2752,10 @@ impl AppFixture {
             .get("wrapper_path")
             .cloned()
             .unwrap_or(Value::Null);
+        let registry_ref = overrides
+            .get("registry_ref")
+            .cloned()
+            .unwrap_or(Value::Null);
         let component = json!({
             "component_id": component_id,
             "version": version,
@@ -2650,6 +2764,7 @@ impl AppFixture {
             "capability_id": capability_id,
             "capability_version": capability_version,
             "contract_path": contract_path,
+            "registry_ref": registry_ref,
             "wasm_binary_path": wasm_binary_path,
             "wasm_digest": wasm_digest,
             "platforms": platforms,

--- a/crates/traverse-registry/tests/application_manifest.rs
+++ b/crates/traverse-registry/tests/application_manifest.rs
@@ -7,14 +7,28 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use traverse_contracts::{ExecutionTarget, parse_event_contract};
+use traverse_contracts::{ExecutionTarget, parse_contract, parse_event_contract};
 use traverse_registry::{
     ApplicationManifestErrorCode, ApplicationRegistrationErrorCode, ApplicationRegistrationRequest,
     ApplicationRegistrationStatus, ApplicationRegistry, ApplicationStateTransitionConditionOp,
     CapabilityRegistry, EventRegistration, EventRegistry, LookupScope, ModelCandidateRejectionCode,
-    ModelResolutionEvidence, ModelResolutionPhase, RegistryScope, SelectedModelCandidate,
-    WorkflowRegistry, load_application_bundle_manifest,
+    ModelResolutionEvidence, ModelResolutionPhase, RegistryComponentResolver, RegistryReference,
+    RegistryScope, ResolvedRegistryComponent, SelectedModelCandidate, WorkflowRegistry,
+    load_application_bundle_manifest, load_application_bundle_manifest_with_resolver,
 };
+
+struct StaticRegistryResolver {
+    component: ResolvedRegistryComponent,
+}
+
+impl RegistryComponentResolver for StaticRegistryResolver {
+    fn resolve(
+        &self,
+        _reference: &RegistryReference,
+    ) -> Result<ResolvedRegistryComponent, traverse_registry::ApplicationManifestFailure> {
+        Ok(self.component.clone())
+    }
+}
 
 #[test]
 fn loads_checked_in_application_manifest_with_real_wasm_component() {
@@ -176,6 +190,48 @@ fn registry_reference_requires_registration_resolution() {
     assert_eq!(
         failure.errors[0].code,
         ApplicationManifestErrorCode::RegistryReferenceRequiresResolution
+    );
+}
+
+#[test]
+fn loads_registry_reference_from_caller_verified_material() {
+    let fixture = AppFixture::new("resolved-registry-reference");
+    let wasm_digest = fixture.write_wasm("registry component bytes");
+    fixture.write_component_manifest(&json!({
+        "contract_path": null,
+        "wasm_binary_path": null,
+        "wasm_digest": null,
+        "registry_ref": { "namespace": "traverse-starter", "id": "traverse-starter.process", "version_range": "^1.0.0" }
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        "expedition.readiness.validate-team-readiness-component",
+        "1.0.0",
+        &format!("sha256:{wasm_digest}"),
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+    let contract_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+        "../../contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+    );
+    let contract =
+        parse_contract(&fs::read_to_string(&contract_path).expect("contract fixture should read"))
+            .expect("contract fixture should parse");
+    let resolver = StaticRegistryResolver {
+        component: ResolvedRegistryComponent {
+            contract_path,
+            contract,
+            wasm_binary_path: fixture.wasm_path(),
+            wasm_digest: format!("sha256:{wasm_digest}"),
+        },
+    };
+
+    let bundle = load_application_bundle_manifest_with_resolver(
+        &fixture.app_manifest_path(),
+        Some(&resolver),
+    )
+    .expect("caller-verified registry material should load");
+    assert_eq!(
+        bundle.components[0].verified_wasm_digest,
+        Some(format!("sha256:{wasm_digest}"))
     );
 }
 

--- a/crates/traverse-registry/tests/application_manifest.rs
+++ b/crates/traverse-registry/tests/application_manifest.rs
@@ -236,6 +236,162 @@ fn loads_registry_reference_from_caller_verified_material() {
 }
 
 #[test]
+fn rejects_resolved_registry_component_with_mismatched_reference_identity() {
+    let fixture = AppFixture::new("registry-reference-identity-mismatch");
+    let resolver = resolved_registry_reference_fixture(
+        &fixture,
+        "other.component",
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        readiness_contract_path(),
+    );
+
+    let failure = load_application_bundle_manifest_with_resolver(
+        &fixture.app_manifest_path(),
+        Some(&resolver),
+    )
+    .expect_err("registry resolution must preserve application component identity");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentReferenceMismatch
+    );
+}
+
+#[test]
+fn rejects_resolved_registry_component_with_invalid_application_digest() {
+    let fixture = AppFixture::new("registry-reference-invalid-application-digest");
+    let resolver = resolved_registry_reference_fixture(
+        &fixture,
+        "expedition.readiness.validate-team-readiness-component",
+        "not-a-digest",
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        readiness_contract_path(),
+    );
+
+    let failure = load_application_bundle_manifest_with_resolver(
+        &fixture.app_manifest_path(),
+        Some(&resolver),
+    )
+    .expect_err("registry resolution must require a valid application digest");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::InvalidDigestMetadata
+    );
+}
+
+#[test]
+fn rejects_resolved_registry_component_with_invalid_resolved_digest() {
+    let fixture = AppFixture::new("registry-reference-invalid-resolved-digest");
+    let resolver = resolved_registry_reference_fixture(
+        &fixture,
+        "expedition.readiness.validate-team-readiness-component",
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "not-a-digest",
+        readiness_contract_path(),
+    );
+
+    let failure = load_application_bundle_manifest_with_resolver(
+        &fixture.app_manifest_path(),
+        Some(&resolver),
+    )
+    .expect_err("registry resolution must require a valid resolved digest");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::InvalidDigestMetadata
+    );
+}
+
+#[test]
+fn rejects_resolved_registry_component_with_digest_mismatch() {
+    let fixture = AppFixture::new("registry-reference-digest-mismatch");
+    let resolver = resolved_registry_reference_fixture(
+        &fixture,
+        "expedition.readiness.validate-team-readiness-component",
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        readiness_contract_path(),
+    );
+
+    let failure = load_application_bundle_manifest_with_resolver(
+        &fixture.app_manifest_path(),
+        Some(&resolver),
+    )
+    .expect_err("registry resolution must preserve the application digest");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentDigestMismatch
+    );
+}
+
+#[test]
+fn rejects_resolved_registry_component_with_contract_identity_mismatch() {
+    let fixture = AppFixture::new("registry-reference-contract-mismatch");
+    let resolver = resolved_registry_reference_fixture(
+        &fixture,
+        "expedition.readiness.validate-team-readiness-component",
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+            "../../contracts/examples/expedition/capabilities/interpret-expedition-intent/contract.json",
+        ),
+    );
+
+    let failure = load_application_bundle_manifest_with_resolver(
+        &fixture.app_manifest_path(),
+        Some(&resolver),
+    )
+    .expect_err("registry resolution must preserve the component capability identity");
+
+    assert_eq!(
+        failure.errors[0].code,
+        ApplicationManifestErrorCode::ComponentContractMismatch
+    );
+}
+
+fn resolved_registry_reference_fixture(
+    fixture: &AppFixture,
+    reference_component_id: &str,
+    reference_digest: &str,
+    resolved_digest: &str,
+    contract_path: PathBuf,
+) -> StaticRegistryResolver {
+    fixture.write_wasm("registry component bytes");
+    fixture.write_component_manifest(&json!({
+        "contract_path": null,
+        "wasm_binary_path": null,
+        "wasm_digest": null,
+        "registry_ref": { "namespace": "traverse-starter", "id": "traverse-starter.process", "version_range": "^1.0.0" }
+    }));
+    fixture.write_app_manifest(&json!([component_ref(
+        reference_component_id,
+        "1.0.0",
+        reference_digest,
+        "components/validate-team-readiness/component.manifest.json",
+    )]));
+    let contract =
+        parse_contract(&fs::read_to_string(&contract_path).expect("contract fixture should read"))
+            .expect("contract fixture should parse");
+    StaticRegistryResolver {
+        component: ResolvedRegistryComponent {
+            contract_path,
+            contract,
+            wasm_binary_path: fixture.wasm_path(),
+            wasm_digest: resolved_digest.to_string(),
+        },
+    }
+}
+
+fn readiness_contract_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(
+        "../../contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+    )
+}
+
+#[test]
 fn component_execution_mode_renders_manifest_values() {
     assert_eq!(
         traverse_registry::ComponentExecutionMode::Wasm.as_str(),


### PR DESCRIPTION
## Summary

- Add dual-mode component-manifest validation and synced-registry materialization.
- Resolve registry-ref-only components exclusively from synced workspace state, using the shared digest-verified cache.

## Governing Spec

- `054-public-scope-registry-ref`
- `055-registry-sync`
- `063-registry-contract-materialization`

## Project Item

- `PVTI_lADOEbiBt84Bbyp1zgzmSTM`

## Definition of Done

- [x] Component manifests accept exactly one local source or `registry_ref`, with stable errors for invalid references.
- [x] `app validate --workspace` and `app register` resolve only locally synced records and persist verified contract/WASM cache entries.
- [x] Registration records the cached artifact reference and no-sync resolution reports stable JSON evidence.
- [x] Resolver identity, digest, and contract mismatch paths are covered.

## Validation

- `cargo test -p traverse-registry --test application_manifest --quiet` (87 passed)
- `cargo test -p traverse-cli-rs --quiet` (304 passed, 7 ignored)
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh /private/tmp/dual-mode-component-registry-ref-pr-body.md`
- `bash scripts/ci/coverage_gate.sh` (registry: 100.00%, 12,955/12,955 lines)
