### PR TITLE
ci: enforce local Rust pre-commit checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+echo "pre-commit: running CI-equivalent Rust checks"
+bash scripts/ci/rust_checks.sh

--- a/docs/local-preflight.md
+++ b/docs/local-preflight.md
@@ -1,0 +1,11 @@
+# Local CI Preflight
+
+Run the locally feasible CI checks before pushing a PR:
+
+```bash
+BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body /path/to/pr-body.md
+```
+
+The command uses the same repository, Rust, WASM smoke, and spec-alignment
+scripts as CI. It reports hosted-only jobs explicitly instead of claiming they
+ran locally.

--- a/docs/local-preflight.md
+++ b/docs/local-preflight.md
@@ -9,3 +9,13 @@ BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body /path/to/pr-bo
 The command uses the same repository, Rust, WASM smoke, and spec-alignment
 scripts as CI. It reports hosted-only jobs explicitly instead of claiming they
 ran locally.
+
+To make the Rust subset mandatory for every local commit, enable the tracked
+hook once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook runs `scripts/ci/rust_checks.sh`, the same formatter, strict Clippy,
+workspace-test, and contractual-enforcement command used by CI.

--- a/scripts/ci/local_preflight.sh
+++ b/scripts/ci/local_preflight.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 --pr-body <file>" >&2
+  exit 2
+}
+
+[[ $# -eq 2 && $1 == "--pr-body" ]] || usage
+pr_body=$2
+[[ -f $pr_body ]] || { echo "local-preflight: PR body file not found: $pr_body" >&2; exit 2; }
+
+target=wasm32-unknown-unknown
+if ! rustup target list --installed | grep -qx "$target"; then
+  echo "local-preflight: SKIP fixture/build checks: missing Rust target $target" >&2
+  echo "local-preflight: remediation: rustup target add $target" >&2
+  exit 1
+fi
+
+echo "local-preflight: RUN cargo fmt --all --check"
+cargo fmt --all --check
+echo "local-preflight: RUN repository checks"
+bash scripts/ci/repository_checks.sh
+echo "local-preflight: RUN Rust checks"
+bash scripts/ci/rust_checks.sh
+echo "local-preflight: RUN executable WASM smoke checks"
+bash scripts/ci/wasm_agent_example_smoke.sh
+echo "local-preflight: RUN spec alignment (provide BASE_SHA for changed-file coverage)"
+if [[ -n ${BASE_SHA:-} ]]; then
+  GITHUB_BASE_SHA="$BASE_SHA" GITHUB_HEAD_SHA="$(git rev-parse HEAD)" \
+    bash scripts/ci/spec_alignment_check.sh "$pr_body"
+else
+  echo "local-preflight: SKIP spec changed-file coverage: set BASE_SHA=<base commit>"
+fi
+echo "local-preflight: SKIP hosted-only: CodeQL, macOS native certification, cross-platform stress, web embedder package"


### PR DESCRIPTION
## Summary

- Add a tracked pre-commit hook that runs the same Rust gate as CI.
- Document one-time hook activation for each clone.

## Governing Spec

- 004-spec-alignment-gate

## Project Item

- PVTI_lADOEbiBt84Bbyp1zgznna8

## Definition of Done

- [x] Local commits run CI-equivalent Rust checks.
- [x] Hook setup is documented.

## Validation

- `bash scripts/ci/rust_checks.sh`