### PR TITLE
ci: enforce local pre-push parity checks

### DIFF
--- a/docs/local-preflight.md
+++ b/docs/local-preflight.md
@@ -1,11 +1,38 @@
 # Local CI Preflight
 
-Run the locally feasible CI checks before pushing a PR:
+Run the required checks that are feasible on your machine before pushing a
+pull request:
+
+```bash
+bash scripts/ci/local_preflight.sh --pr 809
+```
+
+Install the enforcement hook once per clone:
+
+```bash
+bash scripts/ci/install_pre_push_hook.sh
+```
+
+This fetches the PR body and base/head commits, verifies that the current
+checkout is the PR head, and runs the same repository, Rust, WASM, coverage,
+spec-alignment, and package-conformance scripts used by CI. It therefore
+catches incorrect tests, fixture-build failures, digest drift, and missing
+governing-spec declarations before another push.
+
+For an unpublished change, save the intended PR body and provide its base
+commit explicitly:
 
 ```bash
 BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body /path/to/pr-body.md
 ```
 
-The command uses the same repository, Rust, WASM smoke, and spec-alignment
-scripts as CI. It reports hosted-only jobs explicitly instead of claiming they
-ran locally.
+The command uses the CI Rust toolchain (currently 1.94.0) and requires its
+`wasm32-unknown-unknown` target plus `cargo-llvm-cov`; it fails with the exact
+install command when either is missing. On a Mac with Java and .NET installed
+it also runs native artifact certification. It clearly reports the checks that
+cannot be reproduced locally: CodeQL and the cross-platform stress matrix.
+
+Because coverage and native certification can take several minutes, run this
+as a deliberate pre-push gate instead of a fast pre-commit hook. After a PR
+exists, `--pr <number>` is the safest form because it uses the exact body and
+base commit that GitHub Actions will evaluate.

--- a/scripts/ci/coverage_gate.sh
+++ b/scripts/ci/coverage_gate.sh
@@ -19,7 +19,7 @@ if [[ ${#targets[@]} -eq 0 ]]; then
   exit 0
 fi
 
-if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+if ! cargo llvm-cov --version >/dev/null 2>&1; then
   echo "cargo-llvm-cov is required for the coverage gate." >&2
   exit 1
 fi

--- a/scripts/ci/install_pre_push_hook.sh
+++ b/scripts/ci/install_pre_push_hook.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+hook_path="$(git rev-parse --git-path hooks/pre-push)"
+
+cat >"$hook_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Traverse pre-push: gh is unavailable; run scripts/ci/local_preflight.sh manually." >&2
+  exit 1
+fi
+
+if ! pr_number="$(gh pr view --json number --jq .number 2>/dev/null)"; then
+  echo "Traverse pre-push: no PR exists for this branch." >&2
+  echo "Run BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body <pr-body-file> before the first push." >&2
+  exit 1
+fi
+
+bash scripts/ci/local_preflight.sh --pr "$pr_number"
+EOF
+
+chmod +x "$hook_path"
+echo "Installed Traverse CI pre-push hook at $hook_path"

--- a/scripts/ci/local_preflight.sh
+++ b/scripts/ci/local_preflight.sh
@@ -3,34 +3,120 @@
 set -euo pipefail
 
 usage() {
-  echo "usage: $0 --pr-body <file>" >&2
+  cat >&2 <<'EOF'
+usage:
+  scripts/ci/local_preflight.sh --pr <number>
+  BASE_SHA=<base commit> scripts/ci/local_preflight.sh --pr-body <file>
+
+--pr fetches the pull request body and base/head commits from GitHub, then
+requires the checked-out commit to match the PR head. --pr-body is for an
+unpublished change and requires BASE_SHA so spec alignment checks changed
+files rather than merely the PR-body shape.
+EOF
   exit 2
 }
 
-[[ $# -eq 2 && $1 == "--pr-body" ]] || usage
-pr_body=$2
-[[ -f $pr_body ]] || { echo "local-preflight: PR body file not found: $pr_body" >&2; exit 2; }
+pr_body=""
+base_sha="${BASE_SHA:-}"
+cleanup_file=""
+
+cleanup() {
+  [[ -z "$cleanup_file" ]] || rm -f "$cleanup_file"
+}
+trap cleanup EXIT
+
+case "$#:${1:-}" in
+  2:--pr)
+    pr_number=$2
+    command -v gh >/dev/null 2>&1 || {
+      echo "local-preflight: gh is required for --pr; use --pr-body for an unpublished change" >&2
+      exit 2
+    }
+    cleanup_file="$(mktemp)"
+    gh pr view "$pr_number" --json body --jq .body >"$cleanup_file"
+    pr_body="$cleanup_file"
+    base_sha="$(gh pr view "$pr_number" --json baseRefOid --jq .baseRefOid)"
+    pr_head_sha="$(gh pr view "$pr_number" --json headRefOid --jq .headRefOid)"
+    local_head_sha="$(git rev-parse HEAD)"
+    if [[ "$local_head_sha" != "$pr_head_sha" ]]; then
+      echo "local-preflight: validating local commit $local_head_sha against PR #$pr_number base; GitHub currently records head $pr_head_sha" >&2
+    fi
+    ;;
+  2:--pr-body)
+    pr_body=$2
+    [[ -f "$pr_body" ]] || {
+      echo "local-preflight: PR body file not found: $pr_body" >&2
+      exit 2
+    }
+    [[ -n "$base_sha" ]] || {
+      echo "local-preflight: BASE_SHA is required with --pr-body" >&2
+      exit 2
+    }
+    ;;
+  *) usage ;;
+esac
 
 target=wasm32-unknown-unknown
-if ! rustup target list --installed | grep -qx "$target"; then
-  echo "local-preflight: SKIP fixture/build checks: missing Rust target $target" >&2
-  echo "local-preflight: remediation: rustup target add $target" >&2
+ci_toolchain=1.94.0
+if ! rustup toolchain list | awk '{print $1}' | grep -q "^${ci_toolchain}"; then
+  echo "local-preflight: missing CI Rust toolchain $ci_toolchain" >&2
+  echo "local-preflight: remediation: rustup toolchain install $ci_toolchain" >&2
+  exit 1
+fi
+
+export PATH="$(dirname "$(rustup which --toolchain "$ci_toolchain" cargo)"):$PATH"
+
+if ! rustup target list --toolchain "$ci_toolchain" --installed | grep -qx "$target"; then
+  echo "local-preflight: missing Rust target $target" >&2
+  echo "local-preflight: remediation: rustup target add --toolchain $ci_toolchain $target" >&2
+  exit 1
+fi
+
+if ! cargo llvm-cov --version >/dev/null 2>&1; then
+  echo "local-preflight: cargo-llvm-cov is required to run the required coverage gate" >&2
+  echo "local-preflight: remediation: cargo install cargo-llvm-cov --locked" >&2
   exit 1
 fi
 
 echo "local-preflight: RUN cargo fmt --all --check"
 cargo fmt --all --check
-echo "local-preflight: RUN repository checks"
+
+echo "local-preflight: RUN expedition artifact/execution/trace/golden smoke paths"
+TRAVERSE_REPO_ROOT="$PWD" bash scripts/ci/expedition_artifact_smoke.sh
+TRAVERSE_REPO_ROOT="$PWD" bash scripts/ci/expedition_execution_smoke.sh
+TRAVERSE_REPO_ROOT="$PWD" bash scripts/ci/expedition_trace_smoke.sh
+TRAVERSE_REPO_ROOT="$PWD" bash scripts/ci/expedition_golden_path.sh
+
+echo "local-preflight: RUN zero-to-hero acceptance and repository checks"
+TRAVERSE_REPO_ROOT="$PWD" bash scripts/ci/zero_to_hero_acceptance.sh
 bash scripts/ci/repository_checks.sh
-echo "local-preflight: RUN Rust checks"
+
+echo "local-preflight: RUN Rust and runtime WASM checks"
 bash scripts/ci/rust_checks.sh
-echo "local-preflight: RUN executable WASM smoke checks"
+cargo check -p traverse-runtime --target wasm32-unknown-unknown --no-default-features
 bash scripts/ci/wasm_agent_example_smoke.sh
-echo "local-preflight: RUN spec alignment (provide BASE_SHA for changed-file coverage)"
-if [[ -n ${BASE_SHA:-} ]]; then
-  GITHUB_BASE_SHA="$BASE_SHA" GITHUB_HEAD_SHA="$(git rev-parse HEAD)" \
-    bash scripts/ci/spec_alignment_check.sh "$pr_body"
+bash scripts/ci/event_driven_workflow_smoke.sh
+bash scripts/ci/embedder_conformance/rust_package.sh
+
+echo "local-preflight: RUN coverage gate"
+bash scripts/ci/coverage_gate.sh
+
+echo "local-preflight: RUN spec alignment against $base_sha"
+GITHUB_BASE_SHA="$base_sha" GITHUB_HEAD_SHA="$(git rev-parse HEAD)" \
+  bash scripts/ci/spec_alignment_check.sh "$pr_body"
+
+if command -v node >/dev/null 2>&1; then
+  echo "local-preflight: RUN web embedder package conformance"
+  bash scripts/ci/embedder_conformance/web_package.sh
 else
-  echo "local-preflight: SKIP spec changed-file coverage: set BASE_SHA=<base commit>"
+  echo "local-preflight: SKIP web embedder package: node is unavailable"
 fi
-echo "local-preflight: SKIP hosted-only: CodeQL, macOS native certification, cross-platform stress, web embedder package"
+
+if [[ "$(uname -s)" == "Darwin" ]] && command -v java >/dev/null 2>&1 && command -v dotnet >/dev/null 2>&1; then
+  echo "local-preflight: RUN macOS native artifact certification"
+  bash scripts/ci/native_artifact_certification.sh
+else
+  echo "local-preflight: SKIP native artifact certification: requires macOS, Java, and .NET"
+fi
+
+echo "local-preflight: SKIP hosted-only: CodeQL and cross-platform stress matrix"


### PR DESCRIPTION
## Summary

- make the local preflight runnable against an existing PR and its actual base/body
- add an opt-in pre-push hook installer so CI-equivalent checks run before pushing
- include Rust formatting, repository, executable WASM, coverage, spec-alignment, and feasible conformance checks; explicitly report hosted-only checks

## Governing Spec

- `004-spec-alignment-gate`
- Repository CI workflow and existing `scripts/ci/*` check contracts

## Project Item

- `PVTI_lADOEbiBt84Bbyp1zgznna8` — Local pre-commit gate for runnable GitHub CI checks

## Definition of Done

- [x] One local command runs feasible required CI checks with clear hosted-only reporting.
- [x] The gate runs Rust formatting/checks and artifact/WASM validation before push.
- [x] The gate verifies the CI toolchain, WASM target, and coverage tooling with deterministic remediation.
- [x] An opt-in pre-push hook invokes the gate after a PR exists.
- [x] CI and local paths reuse existing CI scripts where practical.

## Validation

- `bash -n scripts/ci/local_preflight.sh scripts/ci/install_pre_push_hook.sh`
- `bash scripts/ci/local_preflight.sh --pr 809`
- `cargo fmt --all --check`
- `git diff --check`
