### PR TITLE
docs: link traverse-framework/claude-skills from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ browser, edge, or cloud — under the same contract.
 
 → [docs/wasm-agent-authoring-guide.md](docs/wasm-agent-authoring-guide.md)
 
+### An app with an AI coding agent
+
+Building with Claude or another coding agent? [traverse-framework/claude-skills](https://github.com/traverse-framework/claude-skills) hosts Claude Skills that walk through checking the registry, authoring and composing capabilities, and validating them against the real `traverse-cli` — including this platform's current honest limitations.
+
 ### Workflow-backed business logic
 
 Model multi-step business behavior as a workflow. The runtime traverses it


### PR DESCRIPTION
## Summary

- Add a short pointer to the new `traverse-framework/claude-skills` repo in the README "What Can I Build?" section, alongside the existing browser/MCP/WASM entries.

Closes #815

## Governing Spec

- 190-readme-rewrite

## Project Item

- GitHub #815 (documentation backlog; not tracked on org Project 1)

## Definition of Done

- [x] README "What Can I Build?" section links to `traverse-framework/claude-skills`.
- [x] Link is discoverable alongside other build-path entries.

## Validation

- Manual: open README.md and confirm the new "An app with an AI coding agent" subsection links to https://github.com/traverse-framework/claude-skills
- `bash scripts/ci/pr_body_check.sh` / `bash scripts/ci/spec_alignment_check.sh` against this PR body