### PR TITLE
feat: harden local DataStore durability

### DIFF
--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -1,15 +1,22 @@
 //! Portable state access for Traverse capabilities.
 //!
-//! Governed by spec `032-universal-data-access`.
+//! General operations are governed by spec `032-universal-data-access`; the
+//! local-file adapter durability boundary is governed by spec
+//! `518-durable-local-datastore`.
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
+use std::fmt::Write as _;
+use std::fs::{self, File, OpenOptions, TryLockError};
+use std::io::Write;
 use std::path::PathBuf;
 use traverse_contracts::CapabilityContract;
 
 const DATA_STORE_SPEC: &str = "032-universal-data-access";
+const LOCAL_DATA_STORE_FORMAT: &str = "local-datastore/1";
+const LOCAL_DATA_STORE_LOCK_FILE: &str = ".traverse-datastore.lock";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StateRecord {
@@ -58,6 +65,28 @@ pub enum DataStoreErrorCode {
     IoFailure,
     SerializationFailure,
     SyncFailure,
+    IntegrityCheckFailed,
+    StoreLocked,
+    DurabilityCommitFailed,
+}
+
+/// Classification recorded with each locally durable record.
+///
+/// This is metadata only. Encryption and key management are intentionally
+/// deferred to a successor decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalDataClassification {
+    Public,
+    Private,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct LocalDataStoreEnvelope {
+    format: String,
+    classification: LocalDataClassification,
+    record: StateRecord,
+    digest: String,
 }
 
 pub trait DataStore {
@@ -230,9 +259,11 @@ impl<A: DataStore> RuntimeDataStore<A> {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct LocalFileDataStore {
     root: PathBuf,
+    classification: LocalDataClassification,
+    _lock_file: File,
 }
 
 impl LocalFileDataStore {
@@ -240,16 +271,67 @@ impl LocalFileDataStore {
     ///
     /// # Errors
     ///
-    /// Returns [`DataStoreError`] when the root directory cannot be created.
+    /// Returns [`DataStoreError`] when the root directory cannot be created or
+    /// another process owns the store.
     pub fn new(root: impl Into<PathBuf>) -> Result<Self, DataStoreError> {
+        Self::with_classification(root, LocalDataClassification::Private)
+    }
+
+    /// Creates a local filesystem-backed data store with explicit persisted
+    /// record classification.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataStoreError`] when the root directory cannot be created or
+    /// another process owns the store.
+    pub fn with_classification(
+        root: impl Into<PathBuf>,
+        classification: LocalDataClassification,
+    ) -> Result<Self, DataStoreError> {
         let root = root.into();
         fs::create_dir_all(&root).map_err(|error| io_error("create data store root", &error))?;
-        Ok(Self { root })
+        let lock_path = root.join(LOCAL_DATA_STORE_LOCK_FILE);
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|error| io_error("open data store lock", &error))?;
+        lock_file.try_lock().map_err(|error| match error {
+            TryLockError::WouldBlock => data_store_error(
+                DataStoreErrorCode::StoreLocked,
+                "store_locked",
+                json!({ "root": root }),
+            ),
+            TryLockError::Error(error) => io_error("lock data store root", &error),
+        })?;
+        Ok(Self {
+            root,
+            classification,
+            _lock_file: lock_file,
+        })
     }
 
     fn path_for_key(&self, key: &str) -> Result<PathBuf, DataStoreError> {
         validate_key(key)?;
         Ok(self.root.join(format!("{key}.json")))
+    }
+
+    fn temporary_path_for_key(&self, key: &str) -> PathBuf {
+        self.root.join(format!(".{key}.{}.tmp", std::process::id()))
+    }
+
+    fn sync_root(&self) -> Result<(), DataStoreError> {
+        File::open(&self.root)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| {
+                data_store_error(
+                    DataStoreErrorCode::DurabilityCommitFailed,
+                    "durability_commit_failed",
+                    json!({ "root": self.root, "reason": error.to_string() }),
+                )
+            })
     }
 }
 
@@ -261,22 +343,61 @@ impl DataStore for LocalFileDataStore {
         }
         let text =
             fs::read_to_string(&path).map_err(|error| io_error("read state record", &error))?;
-        serde_json::from_str(&text)
-            .map(Some)
-            .map_err(|error| serialization_error("deserialize state record", &error))
+        let value: Value =
+            serde_json::from_str(&text).map_err(|_| integrity_error("malformed_envelope"))?;
+        if value.get("format").is_none() {
+            return Err(integrity_error("legacy_unverified"));
+        }
+        let envelope: LocalDataStoreEnvelope =
+            serde_json::from_value(value).map_err(|_| integrity_error("malformed_envelope"))?;
+        if envelope.format != LOCAL_DATA_STORE_FORMAT {
+            return Err(integrity_error("unknown_format_version"));
+        }
+        let expected_digest = digest_for_record(&envelope.record)?;
+        if envelope.digest != expected_digest {
+            return Err(integrity_error("digest_mismatch"));
+        }
+        Ok(Some(envelope.record))
     }
 
     fn write(&mut self, record: StateRecord) -> Result<(), DataStoreError> {
         let path = self.path_for_key(&record.key)?;
-        let text = serde_json::to_string_pretty(&record)
-            .map_err(|error| serialization_error("serialize state record", &error))?;
-        fs::write(path, text).map_err(|error| io_error("write state record", &error))
+        let envelope = LocalDataStoreEnvelope {
+            format: LOCAL_DATA_STORE_FORMAT.to_string(),
+            classification: self.classification,
+            digest: digest_for_record(&record)?,
+            record,
+        };
+        let text = serde_json::to_vec(&envelope)
+            .map_err(|error| serialization_error("serialize state record envelope", &error))?;
+        let temporary_path = self.temporary_path_for_key(&envelope.record.key);
+        let write_result = (|| {
+            let mut temporary_file = File::create(&temporary_path)
+                .map_err(|error| io_error("create temporary state record", &error))?;
+            temporary_file
+                .write_all(&text)
+                .map_err(|error| io_error("write temporary state record", &error))?;
+            temporary_file.sync_all().map_err(|error| {
+                data_store_error(
+                    DataStoreErrorCode::DurabilityCommitFailed,
+                    "durability_commit_failed",
+                    json!({ "reason": error.to_string(), "stage": "temporary_file" }),
+                )
+            })?;
+            fs::rename(&temporary_path, &path)
+                .map_err(|error| io_error("atomically commit state record", &error))?;
+            self.sync_root()
+        })();
+        if write_result.is_err() && temporary_path.exists() {
+            let _ignored = fs::remove_file(temporary_path).is_ok();
+        }
+        write_result
     }
 
     fn delete(&mut self, key: &str) -> Result<(), DataStoreError> {
         let path = self.path_for_key(key)?;
         match fs::remove_file(path) {
-            Ok(()) => Ok(()),
+            Ok(()) => self.sync_root(),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(error) => Err(io_error("delete state record", &error)),
         }
@@ -299,6 +420,31 @@ impl DataStore for LocalFileDataStore {
         keys.sort();
         Ok(keys)
     }
+}
+
+fn digest_for_record(record: &StateRecord) -> Result<String, DataStoreError> {
+    let canonical = serde_json::to_vec(record)
+        .map_err(|error| serialization_error("serialize canonical state record", &error))?;
+    let digest = Sha256::digest(canonical);
+    let mut hexadecimal = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        write!(&mut hexadecimal, "{byte:02x}").map_err(|_| {
+            data_store_error(
+                DataStoreErrorCode::SerializationFailure,
+                "serialize digest",
+                json!({ "reason": "formatting digest failed" }),
+            )
+        })?;
+    }
+    Ok(format!("sha256:{hexadecimal}"))
+}
+
+fn integrity_error(reason: &str) -> DataStoreError {
+    data_store_error(
+        DataStoreErrorCode::IntegrityCheckFailed,
+        "integrity_check_failed",
+        json!({ "reason": reason }),
+    )
 }
 
 /// Validates a capability state write against the contract-declared state schema.
@@ -479,8 +625,8 @@ fn data_store_error(code: DataStoreErrorCode, message: &str, details: Value) -> 
 fn io_error(action: &str, error: &std::io::Error) -> DataStoreError {
     data_store_error(
         DataStoreErrorCode::IoFailure,
-        action,
-        json!({ "error": error.to_string() }),
+        "storage_io_failed",
+        json!({ "action": action, "reason": error.to_string() }),
     )
 }
 
@@ -759,7 +905,8 @@ mod tests {
         let invalid_json = adapter
             .read("broken")
             .expect_err("invalid json should fail");
-        assert_eq!(invalid_json.code, DataStoreErrorCode::SerializationFailure);
+        assert_eq!(invalid_json.code, DataStoreErrorCode::IntegrityCheckFailed);
+        assert_eq!(invalid_json.message, "integrity_check_failed");
     }
 
     #[test]
@@ -818,6 +965,7 @@ mod tests {
         fs::write(root.join("skip.txt"), "not state").expect("non-json fixture should write");
         let adapter = LocalFileDataStore::new(&root).expect("local adapter should initialize");
         assert!(adapter.list_keys().expect("list should succeed").is_empty());
+        drop(adapter);
         let mut delete_missing =
             LocalFileDataStore::new(&root).expect("local adapter should initialize");
         delete_missing
@@ -833,6 +981,92 @@ mod tests {
         fs::write(&file_root, "not a directory").expect("file root fixture should write");
         let io_failure = LocalFileDataStore::new(&file_root).expect_err("file root should fail");
         assert_eq!(io_failure.code, DataStoreErrorCode::IoFailure);
+    }
+
+    #[test]
+    fn local_file_adapter_writes_integrity_envelope_and_reopens() {
+        let root = temp_root("integrity-envelope");
+        let record = record("draft", "writer-a", 1, json!("ready"));
+        let mut adapter =
+            LocalFileDataStore::with_classification(&root, LocalDataClassification::Public)
+                .expect("local adapter should initialize");
+        adapter.write(record.clone()).expect("write should succeed");
+
+        let envelope: LocalDataStoreEnvelope = serde_json::from_slice(
+            &fs::read(root.join("draft.json")).expect("envelope should be present"),
+        )
+        .expect("envelope should deserialize");
+        assert_eq!(envelope.format, LOCAL_DATA_STORE_FORMAT);
+        assert_eq!(envelope.classification, LocalDataClassification::Public);
+        assert_eq!(
+            envelope.digest,
+            digest_for_record(&record).expect("digest should compute")
+        );
+
+        drop(adapter);
+        let reopened = LocalFileDataStore::new(&root).expect("reopen should acquire lock");
+        assert_eq!(
+            reopened.read("draft").expect("read should succeed"),
+            Some(record)
+        );
+    }
+
+    #[test]
+    fn local_file_adapter_rejects_tampered_and_legacy_records() {
+        let root = temp_root("tampered");
+        let mut adapter = LocalFileDataStore::new(&root).expect("local adapter should initialize");
+        adapter
+            .write(record("draft", "writer-a", 1, json!("ready")))
+            .expect("write should succeed");
+
+        let mut envelope: Value = serde_json::from_slice(
+            &fs::read(root.join("draft.json")).expect("envelope should be present"),
+        )
+        .expect("fixture should deserialize");
+        envelope["record"]["value"] = json!("tampered");
+        fs::write(
+            root.join("draft.json"),
+            serde_json::to_vec(&envelope).expect("fixture should serialize"),
+        )
+        .expect("tampered fixture should write");
+        let tampered = adapter.read("draft").expect_err("tampering must fail");
+        assert_eq!(tampered.code, DataStoreErrorCode::IntegrityCheckFailed);
+        assert_eq!(tampered.details["reason"], "digest_mismatch");
+
+        fs::write(
+            root.join("legacy.json"),
+            serde_json::to_vec(&record("legacy", "writer-a", 1, json!("old")))
+                .expect("legacy fixture should serialize"),
+        )
+        .expect("legacy fixture should write");
+        let legacy = adapter.read("legacy").expect_err("legacy must fail closed");
+        assert_eq!(legacy.code, DataStoreErrorCode::IntegrityCheckFailed);
+        assert_eq!(legacy.details["reason"], "legacy_unverified");
+    }
+
+    #[test]
+    fn local_file_adapter_ignores_temporary_records_and_rejects_second_owner() {
+        let root = temp_root("temporary-and-lock");
+        let mut adapter = LocalFileDataStore::new(&root).expect("local adapter should initialize");
+        adapter
+            .write(record("draft", "writer-a", 1, json!("committed")))
+            .expect("write should succeed");
+        fs::write(root.join(".draft.temporary.tmp"), "incomplete")
+            .expect("temporary fixture should write");
+
+        assert_eq!(
+            adapter.list_keys().expect("listing should succeed"),
+            vec!["draft".to_string()]
+        );
+        assert_eq!(
+            adapter
+                .read("draft")
+                .expect("committed read should succeed"),
+            Some(record("draft", "writer-a", 1, json!("committed")))
+        );
+        let second_owner = LocalFileDataStore::new(&root).expect_err("second owner must fail");
+        assert_eq!(second_owner.code, DataStoreErrorCode::StoreLocked);
+        assert_eq!(second_owner.message, "store_locked");
     }
 
     fn record(key: &str, writer_id: &str, lamport_clock: u64, value: Value) -> StateRecord {

--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -8,7 +8,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::Write as _;
 use std::fs::{self, File, OpenOptions, TryLockError};
 use std::io::Write;
 use std::path::PathBuf;
@@ -17,6 +16,7 @@ use traverse_contracts::CapabilityContract;
 const DATA_STORE_SPEC: &str = "032-universal-data-access";
 const LOCAL_DATA_STORE_FORMAT: &str = "local-datastore/1";
 const LOCAL_DATA_STORE_LOCK_FILE: &str = ".traverse-datastore.lock";
+const HEXADECIMAL_DIGITS: &[u8; 16] = b"0123456789abcdef";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StateRecord {
@@ -298,14 +298,9 @@ impl LocalFileDataStore {
             .truncate(false)
             .open(&lock_path)
             .map_err(|error| io_error("open data store lock", &error))?;
-        lock_file.try_lock().map_err(|error| match error {
-            TryLockError::WouldBlock => data_store_error(
-                DataStoreErrorCode::StoreLocked,
-                "store_locked",
-                json!({ "root": root }),
-            ),
-            TryLockError::Error(error) => io_error("lock data store root", &error),
-        })?;
+        lock_file
+            .try_lock()
+            .map_err(|error| lock_error(error, &root))?;
         Ok(Self {
             root,
             classification,
@@ -325,13 +320,7 @@ impl LocalFileDataStore {
     fn sync_root(&self) -> Result<(), DataStoreError> {
         File::open(&self.root)
             .and_then(|directory| directory.sync_all())
-            .map_err(|error| {
-                data_store_error(
-                    DataStoreErrorCode::DurabilityCommitFailed,
-                    "durability_commit_failed",
-                    json!({ "root": self.root, "reason": error.to_string() }),
-                )
-            })
+            .map_err(|error| durability_error(&self.root, "parent_directory", &error))
     }
 }
 
@@ -377,20 +366,14 @@ impl DataStore for LocalFileDataStore {
             temporary_file
                 .write_all(&text)
                 .map_err(|error| io_error("write temporary state record", &error))?;
-            temporary_file.sync_all().map_err(|error| {
-                data_store_error(
-                    DataStoreErrorCode::DurabilityCommitFailed,
-                    "durability_commit_failed",
-                    json!({ "reason": error.to_string(), "stage": "temporary_file" }),
-                )
-            })?;
+            temporary_file
+                .sync_all()
+                .map_err(|error| durability_error(&self.root, "temporary_file", &error))?;
             fs::rename(&temporary_path, &path)
                 .map_err(|error| io_error("atomically commit state record", &error))?;
             self.sync_root()
         })();
-        if write_result.is_err() && temporary_path.exists() {
-            let _ignored = fs::remove_file(temporary_path).is_ok();
-        }
+        discard_temporary_record(&temporary_path);
         write_result
     }
 
@@ -428,15 +411,35 @@ fn digest_for_record(record: &StateRecord) -> Result<String, DataStoreError> {
     let digest = Sha256::digest(canonical);
     let mut hexadecimal = String::with_capacity(digest.len() * 2);
     for byte in digest {
-        write!(&mut hexadecimal, "{byte:02x}").map_err(|_| {
-            data_store_error(
-                DataStoreErrorCode::SerializationFailure,
-                "serialize digest",
-                json!({ "reason": "formatting digest failed" }),
-            )
-        })?;
+        hexadecimal.push(char::from(HEXADECIMAL_DIGITS[usize::from(byte >> 4)]));
+        hexadecimal.push(char::from(HEXADECIMAL_DIGITS[usize::from(byte & 0x0f)]));
     }
     Ok(format!("sha256:{hexadecimal}"))
+}
+
+fn lock_error(error: TryLockError, root: &PathBuf) -> DataStoreError {
+    match error {
+        TryLockError::WouldBlock => data_store_error(
+            DataStoreErrorCode::StoreLocked,
+            "store_locked",
+            json!({ "root": root }),
+        ),
+        TryLockError::Error(error) => io_error("lock data store root", &error),
+    }
+}
+
+fn durability_error(root: &PathBuf, stage: &str, error: &std::io::Error) -> DataStoreError {
+    data_store_error(
+        DataStoreErrorCode::DurabilityCommitFailed,
+        "durability_commit_failed",
+        json!({ "root": root, "stage": stage, "reason": error.to_string() }),
+    )
+}
+
+fn discard_temporary_record(path: &PathBuf) {
+    if path.exists() {
+        let _ignored = fs::remove_file(path).is_ok();
+    }
 }
 
 fn integrity_error(reason: &str) -> DataStoreError {
@@ -1067,6 +1070,60 @@ mod tests {
         let second_owner = LocalFileDataStore::new(&root).expect_err("second owner must fail");
         assert_eq!(second_owner.code, DataStoreErrorCode::StoreLocked);
         assert_eq!(second_owner.message, "store_locked");
+    }
+
+    #[test]
+    fn local_file_adapter_reports_unknown_version_and_helper_failures_stably() {
+        let root = temp_root("helper-failures");
+        let mut adapter = LocalFileDataStore::new(&root).expect("local adapter should initialize");
+        adapter
+            .write(record("draft", "writer-a", 1, json!("ready")))
+            .expect("write should succeed");
+
+        let mut envelope: Value = serde_json::from_slice(
+            &fs::read(root.join("draft.json")).expect("envelope should be present"),
+        )
+        .expect("fixture should deserialize");
+        envelope["format"] = json!("local-datastore/unsupported");
+        fs::write(
+            root.join("draft.json"),
+            serde_json::to_vec(&envelope).expect("fixture should serialize"),
+        )
+        .expect("unknown-version fixture should write");
+        let unknown_version = adapter
+            .read("draft")
+            .expect_err("unknown format version must fail");
+        assert_eq!(
+            unknown_version.code,
+            DataStoreErrorCode::IntegrityCheckFailed
+        );
+        assert_eq!(unknown_version.details["reason"], "unknown_format_version");
+
+        let lock_io = lock_error(
+            TryLockError::Error(std::io::Error::other("lock device failure")),
+            &root,
+        );
+        assert_eq!(lock_io.code, DataStoreErrorCode::IoFailure);
+        assert_eq!(lock_io.message, "storage_io_failed");
+
+        let durability = durability_error(
+            &root,
+            "temporary_file",
+            &std::io::Error::other("sync failure"),
+        );
+        assert_eq!(durability.code, DataStoreErrorCode::DurabilityCommitFailed);
+        assert_eq!(durability.message, "durability_commit_failed");
+
+        let temporary = root.join(".orphan.tmp");
+        fs::write(&temporary, "incomplete").expect("temporary fixture should write");
+        discard_temporary_record(&temporary);
+        assert!(!temporary.exists());
+        discard_temporary_record(&temporary);
+
+        let parse_error = serde_json::from_str::<Value>("{")
+            .expect_err("invalid fixture must produce a serialization error");
+        let serialization = serialization_error("deserialize fixture", &parse_error);
+        assert_eq!(serialization.code, DataStoreErrorCode::SerializationFailure);
     }
 
     fn record(key: &str, writer_id: &str, lamport_clock: u64, value: Value) -> StateRecord {

--- a/scripts/ci/coverage_gate.sh
+++ b/scripts/ci/coverage_gate.sh
@@ -24,6 +24,22 @@ if ! cargo llvm-cov --version >/dev/null 2>&1; then
   exit 1
 fi
 
+if [[ -z "${LLVM_COV:-}" || -z "${LLVM_PROFDATA:-}" ]]; then
+  if command -v rustup >/dev/null 2>&1; then
+    active_toolchain="$(rustup show active-toolchain | awk 'NR == 1 { print $1 }')"
+    toolchain_root="$(rustup run "${active_toolchain}" rustc --print sysroot)"
+    toolchain_host="$(rustup run "${active_toolchain}" rustc -vV | awk '/^host: / { print $2 }')"
+  else
+    toolchain_root="$(rustc --print sysroot)"
+    toolchain_host="$(rustc -vV | awk '/^host: / { print $2 }')"
+  fi
+  llvm_bin_dir="${toolchain_root}/lib/rustlib/${toolchain_host}/bin"
+  if [[ -x "${llvm_bin_dir}/llvm-cov" && -x "${llvm_bin_dir}/llvm-profdata" ]]; then
+    export LLVM_COV="${LLVM_COV:-${llvm_bin_dir}/llvm-cov}"
+    export LLVM_PROFDATA="${LLVM_PROFDATA:-${llvm_bin_dir}/llvm-profdata}"
+  fi
+fi
+
 failed=0
 
 for entry in "${targets[@]}"; do

--- a/scripts/ci/local_preflight.sh
+++ b/scripts/ci/local_preflight.sh
@@ -112,11 +112,18 @@ else
   echo "local-preflight: SKIP web embedder package: node is unavailable"
 fi
 
-if [[ "$(uname -s)" == "Darwin" ]] && command -v java >/dev/null 2>&1 && command -v dotnet >/dev/null 2>&1; then
+android_sdk="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}"
+android_local_properties="packages/kotlin/TraverseEmbedder/local.properties"
+if [[ -z "$android_sdk" && -f "$android_local_properties" ]]; then
+  android_sdk="$(awk -F= '$1 == "sdk.dir" { print substr($0, index($0, "=") + 1); exit }' "$android_local_properties" | sed 's#\\\\:#:#g')"
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]] && command -v java >/dev/null 2>&1 && command -v dotnet >/dev/null 2>&1 && [[ -n "$android_sdk" && -d "$android_sdk" ]]; then
+  export ANDROID_HOME="$android_sdk"
   echo "local-preflight: RUN macOS native artifact certification"
   bash scripts/ci/native_artifact_certification.sh
 else
-  echo "local-preflight: SKIP native artifact certification: requires macOS, Java, and .NET"
+  echo "local-preflight: SKIP native artifact certification: requires macOS, Java, .NET, and an Android SDK"
 fi
 
 echo "local-preflight: SKIP hosted-only: CodeQL and cross-platform stress matrix"


### PR DESCRIPTION
## Summary

- replace plain local DataStore records with the governed local-datastore/1 envelope
- add SHA-256 integrity verification, atomic durable commits, classification metadata, and exclusive root ownership
- reject legacy, malformed, unknown-version, and tampered records without returning state

## Governing Spec

- `032-universal-data-access`
- `518-durable-local-datastore`
- `004-spec-alignment-gate`

## Project Item

- Implement governed durable local DataStore adapter

## Definition of Done

- Envelope writes and reopen reads carry verified integrity and explicit classification metadata.
- Interrupted temporary records stay invisible; legacy and tampered files fail closed.
- A second local process receives `store_locked` instead of racing committed state.
- Stable integrity, storage I/O, and durability failures are machine-readable.
- The local pre-push coverage gate resolves the repository Rust toolchain LLVM tools before running.

## Validation

- `cargo test -p traverse-runtime`
- `cargo clippy -p traverse-runtime --lib -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
