### PR TITLE
docs: approve embedder DataStore integration spec

### DIFF
--- a/docs/adr/0019-embedder-owned-datastore-integration.md
+++ b/docs/adr/0019-embedder-owned-datastore-integration.md
@@ -1,0 +1,30 @@
+# ADR-0019: Make Durable DataStore Reachable Only Through Explicit Embedder Injection
+
+- Status: Accepted
+- Date: 2026-07-27
+- Governing spec: `519-embedder-owned-datastore-integration`
+- Extends: ADR-0018 / Spec 518
+
+## Context
+
+Spec 518 made `LocalFileDataStore` durable and fail-closed but deliberately left generic runtime and CLI execution without a storage root. The remaining reachability gap must not be closed by silently assigning persistence ownership to the runtime.
+
+## Decision
+
+Embedder hosts explicitly construct and inject one DataStore for one host-selected app or workspace scope. The root is opaque to Traverse. The initial host surface is stable, additive, and limited to host-only single-record read, write, and delete operations. Capabilities receive no direct DataStore access.
+
+The store has one fixed public or private classification, one active owner, and stable typed failures. A second owner receives `store_locked`; no lease, concurrent writer, transaction, scan, migration, retention, backup, encryption, sync, or whole-store lifecycle behavior is introduced. Legacy and unknown persisted formats remain fail-closed. State telemetry contains only safe operation metadata.
+
+The first conformance evidence is a Rust embedder example and restart/integrity integration test. Platform-specific lock lifecycle and crash-recovery evidence must be recorded before broadening the supported-platform claim.
+
+## Consequences
+
+- Durable state is reachable without weakening host ownership or tenant isolation.
+- Existing users see no behavior change unless they opt in.
+- Stateful capabilities, multi-process operation, and data lifecycle policy remain separate governed decisions.
+
+## Alternatives Considered
+
+- Runtime/CLI default storage: rejected because it silently chooses ownership and retention.
+- Direct capability storage access: rejected because it bypasses host policy.
+- Best-effort storage failures: rejected because durable state loss must be explicit.

--- a/specs/519-embedder-owned-datastore-integration/spec.md
+++ b/specs/519-embedder-owned-datastore-integration/spec.md
@@ -1,0 +1,45 @@
+# Feature Specification: Embedder-Owned DataStore Integration
+
+**Feature Branch**: `519-embedder-owned-datastore-integration`  
+**Status**: Approved  
+**Supersedes/extends**: `518-durable-local-datastore` for explicit host integration and ownership locking
+
+## Purpose
+
+This specification makes the approved durable local DataStore reachable through a stable, opt-in embedder integration. It does not create default runtime persistence, capability-owned storage, automatic migration, multi-record transactions, scans, replication, or multi-process coordination.
+
+## Decisions
+
+- An embedding host explicitly creates and injects a DataStore. Runtime and CLI paths never choose a root or create persistence implicitly.
+- One injected store belongs to one host-defined app or workspace scope. The root is opaque to Traverse; Traverse does not derive subdirectories or add a second key namespace.
+- Only the host performs explicit single-record read, write, and delete operations. Capabilities do not receive direct storage access.
+- Classification is fixed when the host creates a store. Hosts use separate stores for public and private data.
+- Storage failures are returned as stable typed DataStore errors. They do not alter unrelated capability execution unless the host makes a state operation a prerequisite.
+- `local-datastore/1` is the only accepted persisted format. Unknown and legacy formats fail closed; migration is a separate approved slice.
+- The host owns root creation, retention, backup, restore, and whole-store deletion. Traverse records safe structured metadata only and never records values, sensitive keys, or storage roots.
+
+## Requirements
+
+- **FR-001**: The public host API MUST expose additive, opt-in injection of a host-owned DataStore without changing behavior for hosts that do not configure one.
+- **FR-002**: The injected store MUST be scoped to exactly one host-selected app or workspace boundary; runtime code MUST NOT derive filesystem paths or address another scope.
+- **FR-003**: The first public operation set MUST be read, write, and delete of one validated record. Listing, scanning, batching, transactions, and capability-direct access are out of scope.
+- **FR-004**: Typed DataStore errors, including `store_locked`, `integrity_check_failed`, `durability_commit_failed`, and `storage_io_failed`, MUST cross the host boundary with safe machine-readable detail.
+- **FR-005**: State-operation telemetry MUST contain operation, outcome, classification, and stable error code only. It MUST NOT contain a state value, sensitive key, or storage root.
+- **FR-006**: Local ownership remains exclusive. A second owner of the same root MUST receive `store_locked`; no lease or concurrent multi-process write policy is introduced.
+- **FR-007**: Supported-platform lock lifecycle, owner release, owner-crash recovery, and deterministic unsupported-platform failure behavior MUST be recorded in ADR-0019 before platform-specific implementation is accepted.
+- **FR-008**: A Rust embedder integration example and test MUST inject a private temporary store, persist a record, recreate the host, and verify durable reopen and integrity rejection.
+- **FR-009**: Generic runtime and CLI execution without an injected store MUST create no persistent root and perform no implicit state write.
+
+## Acceptance Criteria
+
+- A host can inject a private or public store for one app/workspace and explicitly read, write, and delete a record.
+- A fresh host instance can reopen the same injected root and read a committed record.
+- A second owner deterministically receives `store_locked` and cannot change the committed record.
+- Tampered, legacy, and unknown-format records return a typed failure without a state value.
+- CI proves the Rust embedder example, restart behavior, safe telemetry, and no-default-persistence behavior.
+
+## Out of Scope
+
+- Capability-direct state permissions or implicit `state_schema` persistence.
+- Retention, compaction, backup, restore, encryption, automatic migration, browser/remote adapters, synchronization, and multi-process coordination.
+- Runtime-managed storage roots, namespaces, or whole-store deletion.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -987,6 +987,20 @@
       ]
     },
     {
+      "id": "519-embedder-owned-datastore-integration",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/519-embedder-owned-datastore-integration/spec.md",
+      "governs": [
+        "crates/traverse-runtime/src/data_store.rs",
+        "crates/traverse-runtime/",
+        "crates/traverse-embedder/",
+        "docs/adr/0019-embedder-owned-datastore-integration.md",
+        "specs/519-embedder-owned-datastore-integration/"
+      ]
+    },
+    {
       "id": "518-durable-local-datastore",
       "version": "1.0.0",
       "status": "approved",


### PR DESCRIPTION
## Summary

- approve Spec 519 for explicit embedder-owned DataStore injection
- record ADR-0019 and register the approved immutable governance surface

## Governing Spec

- `004-spec-alignment-gate`
- `518-durable-local-datastore`
- `519-embedder-owned-datastore-integration`

## Project Item

- Implement approved embedder-owned DataStore injection and Rust conformance

## Definition of Done

- [x] ADR-0019 records the approved boundary and alternatives
- [x] Spec 519 defines explicit host injection, ownership, failures, telemetry, and conformance
- [x] approval registry governs the successor surface

## Validation

- `jq empty specs/governance/approved-specs.json`
- `bash scripts/ci/spec_context_check.sh`
