### PR TITLE
docs: clarify serve as development and CI topology

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -1095,8 +1095,11 @@ fn help_serve() -> String {
     "traverse-cli serve [--bind <address>] [--port <port>] [--auth <mode>] [--allow-unauthenticated] [--qr]
 
   Purpose:
-    Start a long-running HTTP/JSON API server on 127.0.0.1:8787 by default.
-    Writes .traverse/server.json for local app discovery and exposes:
+    Start a development and CI HTTP/JSON API on 127.0.0.1:8787 by default.
+    This is not the production app topology: production apps embed Traverse
+    through the public embedder packages and require neither a loopback sidecar
+    nor .traverse/server.json discovery. This command writes that file only for
+    local development/CI discovery and exposes:
       GET  /healthz                    Returns the spec 033 health envelope.
       GET  /v1/capabilities            Returns JSON array of registered capabilities.
       POST /v1/capabilities/execute    Accepts RuntimeRequest JSON, returns trace + result.
@@ -5146,8 +5149,8 @@ mod tests {
         canonical_expedition_bundle_path, capability_publish_at, component_new_at, curl_text,
         ensure_clean_registry_checkout, execute_agent, execute_expedition,
         execute_traverse_starter_process, execute_traverse_starter_summarize,
-        execute_traverse_starter_validate, inspect_agent, inspect_bundle, inspect_event,
-        inspect_trace, latest_index_release_asset, load_registered_bundle,
+        execute_traverse_starter_validate, help_serve, inspect_agent, inspect_bundle,
+        inspect_event, inspect_trace, latest_index_release_asset, load_registered_bundle,
         load_registered_bundle_with_public_records, load_runtime_request, parse_command,
         publish_file_sha256_digest, register_bundle, register_generated_app_bundle,
         registry_sync_at, registry_sync_failure_json, reject_private_contract_scope, run_command,
@@ -6556,6 +6559,15 @@ mod tests {
         assert!(text.contains("browser-adapter serve"));
         assert!(text.contains("--bind"));
         assert!(text.contains("Example:"));
+    }
+
+    #[test]
+    fn serve_help_marks_http_discovery_as_development_and_ci_only() {
+        let text = help_serve();
+        assert!(text.contains("development and CI HTTP/JSON API"));
+        assert!(text.contains("not the production app topology"));
+        assert!(text.contains("neither a loopback sidecar"));
+        assert!(text.contains(".traverse/server.json discovery"));
     }
 
     #[test]

--- a/docs/youaskm3-canonical-app-http-path.md
+++ b/docs/youaskm3-canonical-app-http-path.md
@@ -1,12 +1,13 @@
-# Canonical Traverse HTTP App Path for youaskm3
+# Traverse CLI HTTP Development and CI Path
 
-This page is the release-facing HTTP/JSON integration path that `youaskm3` can cite for its first real release.
+This page documents the supported development and CI HTTP/JSON path. It is not
+the production topology for shipped apps.
 
 Supported Traverse baseline: `v0.3.0`
 
 ## What Is Supported
 
-For the first `youaskm3` release, the canonical Traverse app-facing path is a local source-build HTTP/JSON server:
+Use a local source-build HTTP/JSON server for development, diagnosis, and CI:
 
 ```bash
 cargo run -p traverse-cli-rs -- serve
@@ -18,11 +19,20 @@ This starts the governed app-consumable API on `127.0.0.1:8787` by default and w
 .traverse/server.json
 ```
 
-The supported downstream app category is a local app, development shell, or browser-hosted consumer that can read the discovery file or receive the discovered `base_url`, then call the documented HTTP/JSON API.
+The supported consumer is a local app, development shell, or CI harness that
+can read the discovery file or receive the discovered `base_url`.
+
+## Production Apps Embed Traverse
+
+Shipped product apps use the public embedded-runtime packages instead of
+starting `traverse-cli serve`. They execute through their host-owned embedder
+and do not require a loopback sidecar or `.traverse/server.json` discovery.
+See the [Rust embedder package](../crates/traverse-embedder/README.md) and the
+[public embedder specification](../specs/068-public-platform-embedder-packages/spec.md).
 
 ## Public App Surface
 
-The first-release public HTTP/JSON path is governed by:
+The development/CI HTTP path is governed by:
 
 - [specs/033-http-json-api/openapi.yaml](../specs/033-http-json-api/openapi.yaml)
 - [specs/033-http-json-api/spec.md](../specs/033-http-json-api/spec.md)

--- a/quickstart.md
+++ b/quickstart.md
@@ -121,8 +121,11 @@ cargo run -p traverse-cli-rs -- app register \
   --json
 ```
 
-The local HTTP server discovery file remains backward-compatible with the
+The development/CI HTTP server discovery file remains backward-compatible with the
 `v0.3.0` schema. `cargo run -p traverse-cli-rs -- serve` writes
 `.traverse/server.json` with `schema_version: "1.0.0"`, `base_url`,
 `health_url`, `workspace_default`, `pid`, `started_at`, `auth_mode`, and an
 optional `local_dev_token` for loopback development.
+
+Shipped product apps should embed Traverse through the public embedder packages;
+they do not start a loopback sidecar or use `.traverse/server.json` discovery.


### PR DESCRIPTION
## Summary

Clarify that `traverse-cli serve` is the supported development and CI HTTP API,
while shipped product apps use public embedded-runtime packages.

## Governing Spec

- `033-http-json-api`
- `046-public-cli-app-registration`
- `057-embeddable-runtime-host`
- `068-public-platform-embedder-packages`

## Project Item

Closes #810.

## Definition of Done

- `serve` help and public guidance distinguish development/CI HTTP use from production embedding.
- Local discovery remains documented for development while production guidance requires no sidecar or discovery file.

## Validation

- `cargo test -p traverse-cli-rs serve_help_marks_http_discovery_as_development_and_ci_only`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/issue-810-pr-body.md`
