### PR TITLE
docs: clarify embedded production posture

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -647,7 +647,10 @@ fn help_agent_execute() -> String {
     "traverse-cli agent execute <manifest-path> <request-path>
 
   Purpose:
-    Load a governed WASM agent package and execute it against a runtime request.
+    Load a governed WASM agent package and execute it against a runtime request
+    directly in this process. This command does not require `traverse-cli serve`
+    or `.traverse/server.json`; shipped product apps use public embedded-host
+    packages rather than this development/CI command.
     Validates the package binary digest, registers the capability, and runs the
     request through the Traverse runtime.
 
@@ -1095,8 +1098,8 @@ fn help_serve() -> String {
     "traverse-cli serve [--bind <address>] [--port <port>] [--auth <mode>] [--allow-unauthenticated] [--qr]
 
   Purpose:
-    Start a long-running HTTP/JSON API server on 127.0.0.1:8787 by default.
-    Writes .traverse/server.json for local app discovery and exposes:
+    Start a development/CI HTTP/JSON API server on 127.0.0.1:8787 by default.
+    Writes .traverse/server.json for local discovery and exposes:
       GET  /healthz                    Returns the spec 033 health envelope.
       GET  /v1/capabilities            Returns JSON array of registered capabilities.
       POST /v1/capabilities/execute    Accepts RuntimeRequest JSON, returns trace + result.
@@ -1104,6 +1107,10 @@ fn help_serve() -> String {
     Loopback callers (127.0.0.1 / ::1) are allowed without authentication. All
     other callers must supply an Authorization: Bearer <token> header unless
     --allow-unauthenticated is set.
+
+    This server is not the production topology for shipped apps. Production
+    consumers use public embedded-host packages and require neither a loopback
+    sidecar nor `.traverse/server.json` discovery.
 
   Optional flags:
     --bind <address>           Address and port to listen on (default: 127.0.0.1:8787,
@@ -6443,6 +6450,7 @@ mod tests {
         assert!(text.contains("<manifest-path>"));
         assert!(text.contains("<request-path>"));
         assert!(text.contains("Example:"));
+        assert!(text.contains("does not require `traverse-cli serve`"));
     }
 
     #[test]
@@ -6556,6 +6564,21 @@ mod tests {
         assert!(text.contains("browser-adapter serve"));
         assert!(text.contains("--bind"));
         assert!(text.contains("Example:"));
+    }
+
+    #[test]
+    fn parse_command_returns_development_serve_help_on_help_flag() {
+        let args = vec![
+            "traverse-cli".to_string(),
+            "serve".to_string(),
+            "--help".to_string(),
+        ];
+        let result = parse_command(&args);
+        assert!(result.is_err(), "expected Err for --help");
+        let text = result.err().unwrap_or_default();
+        assert!(text.contains("development/CI HTTP/JSON API server"));
+        assert!(text.contains("not the production topology"));
+        assert!(text.contains(".traverse/server.json"));
     }
 
     #[test]

--- a/docs/app-consumable-entry-path.md
+++ b/docs/app-consumable-entry-path.md
@@ -8,7 +8,10 @@ This is the canonical documentation path for humans and coding agents working on
 2. Open [quickstart.md](../quickstart.md)
 3. Use the relevant deeper docs only after the quickstart path is clear:
    - [docs/cli-reference.md](cli-reference.md)
-   - [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
+  - [crates/traverse-embedder/README.md](../crates/traverse-embedder/README.md)
+    for the production embedded-host path
+  - [docs/youaskm3-canonical-app-http-path.md](youaskm3-canonical-app-http-path.md)
+    for the development/CI HTTP path
    - [docs/app-consumable-acceptance.md](app-consumable-acceptance.md)
    - [docs/app-consumable-release-checklist.md](app-consumable-release-checklist.md)
    - [docs/app-consumable-consumer-bundle.md](app-consumable-consumer-bundle.md)
@@ -29,7 +32,11 @@ If a new human or agent asks where to begin, point them to the README first and 
 
 - The README is the front door.
 - The quickstart is the first executable consumer path.
-- The canonical `youaskm3` HTTP path explains how downstream apps consume `traverse-cli serve`, `.traverse/server.json`, registration, execution, and trace fetch on the released `v0.3.0` baseline.
+- The embedded-host package documentation is the production path for shipped
+  apps: no `traverse-cli serve` sidecar or `.traverse/server.json` discovery is
+  required. The `youaskm3` HTTP path remains a development/CI walkthrough for
+  local registration, execution, and trace fetch on the released `v0.3.0`
+  baseline.
 - The CLI reference explains the supported command surface and separates public commands from internal/test-only paths.
 - The versioned consumer bundle explains what a downstream app installs and which released surfaces it may rely on.
 - The package release pointer explains how the governed app-consumable package release is identified downstream.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -44,6 +44,7 @@ traverse-cli expedition execute --help
 traverse-cli event inspect --help
 traverse-cli trace inspect --help
 traverse-cli browser-adapter serve --help
+traverse-cli serve --help
 ```
 
 Help output is written to stderr and the process exits with a non-zero code,
@@ -60,6 +61,7 @@ consistent with error output behaviour across the CLI.
 | `app register --manifest <path> --workspace <workspace-id> --json` | Validate a downstream app manifest and atomically persist local workspace registration state. | `cargo run -p traverse-cli-rs -- app register --manifest examples/applications/expedition-readiness/app.manifest.json --workspace local --json` | Prints JSON with `status: registered` or `status: already_registered`, app identity, workspace id, `state_scope: workspace_persisted`, `state_path`, digest evidence, and runtime references. |
 | `component new <component-id>` | Create a governed WASM component package scaffold under `components/<component-id>`. | `cargo run -p traverse-cli-rs -- component new knowledge.retrieve` | Creates a component `manifest.json`, draft capability `contract.json`, Rust package shell, source directory, and artifact directory without creating executable WASM behavior. |
 | `browser-adapter serve [--bind <address>]` | Start the local browser adapter for the governed browser consumer path. | `cargo run -p traverse-cli-rs -- browser-adapter serve --bind 127.0.0.1:4174` | Prints `local browser adapter listening on http://...` and stays running until stopped. |
+| `serve [--bind <address>] [--port <N>]` | Start the development/CI HTTP/JSON API and local discovery file. It is not the production topology for shipped apps. | `cargo run -p traverse-cli-rs -- serve` | Prints the local URL and writes `.traverse/server.json`; production apps use public embedded-host packages instead. |
 | `agent inspect <manifest-path>` | Load and summarize a governed WASM agent package manifest. | `cargo run -p traverse-cli-rs -- agent inspect examples/agents/expedition-intent-agent/manifest.json` | Prints `path`, `package_id`, `package_version`, `capability_id`, binary location, digest, and model/workflow references. |
 | `agent execute <manifest-path> <request-path>` | Load a governed WASM agent package and execute it against a runtime request. | `cargo run -p traverse-cli-rs -- agent execute examples/agents/expedition-intent-agent/manifest.json examples/agents/runtime-requests/interpret-expedition-intent.json` | Prints `request_id`, `execution_id`, `package_id`, `capability_id`, `trace_ref`, `status`, and capability-specific result fields. |
 | `event inspect <contract-path>` | Parse and validate an event contract. | `cargo run -p traverse-cli-rs -- event inspect contracts/examples/expedition/events/expedition-objective-captured/contract.json` | Prints `path`, `id`, `version`, lifecycle, classification, publisher/subscriber counts, and publisher/subscriber ids. |

--- a/docs/youaskm3-canonical-app-http-path.md
+++ b/docs/youaskm3-canonical-app-http-path.md
@@ -1,12 +1,13 @@
-# Canonical Traverse HTTP App Path for youaskm3
+# Traverse Development/CI HTTP App Path for youaskm3
 
-This page is the release-facing HTTP/JSON integration path that `youaskm3` can cite for its first real release.
+This page documents the supported local development and CI HTTP/JSON workflow.
+It is not the production topology for shipped Traverse apps.
 
 Supported Traverse baseline: `v0.3.0`
 
 ## What Is Supported
 
-For the first `youaskm3` release, the canonical Traverse app-facing path is a local source-build HTTP/JSON server:
+For local development, diagnosis, and CI, `youaskm3` can use a local source-build HTTP/JSON server:
 
 ```bash
 cargo run -p traverse-cli-rs -- serve
@@ -18,7 +19,18 @@ This starts the governed app-consumable API on `127.0.0.1:8787` by default and w
 .traverse/server.json
 ```
 
-The supported downstream app category is a local app, development shell, or browser-hosted consumer that can read the discovery file or receive the discovered `base_url`, then call the documented HTTP/JSON API.
+The supported consumer category for this workflow is a local app, development
+shell, or browser-hosted test consumer that can read the discovery file or
+receive the discovered `base_url`, then call the documented HTTP/JSON API.
+
+## Production Apps Use Embedded Hosts
+
+Shipped product apps use the public embedded-host packages described in
+[`crates/traverse-embedder/README.md`](../crates/traverse-embedder/README.md).
+They execute through an in-process host boundary and require neither a
+loopback `traverse-cli serve` sidecar nor `.traverse/server.json` discovery.
+The HTTP server remains supported for local development and CI; it is not a
+hosted or multi-tenant runtime product.
 
 ## Public App Surface
 


### PR DESCRIPTION
## Summary

Clarify that `traverse-cli serve` is a supported development/CI HTTP API while
shipped product apps use embedded hosts.

## Governing Spec

Specs 033, 046, 057, and 068.

## Project Item

Closes #810. Parent: #826.

## Definition of Done

- `serve` and `agent execute` help state the embedded-first production posture.
- HTTP documentation is explicitly development/CI-only and links to embedder guidance.
- No runtime execution behavior changes.

## Validation

- `cargo fmt --check`
- `cargo test -p traverse-cli-rs parse_command_returns_ --bin traverse-cli`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh pr-body.md`
