### PR TITLE
docs: approve registry and durability decisions

### DIFF
--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -7199,7 +7199,10 @@ mod tests {
             .expect("time must be valid")
             .as_nanos();
         let sequence = NEXT_TEST_ROOT.fetch_add(1, Ordering::Relaxed);
-        std::env::temp_dir().join(format!("traverse-cli-http-api-tests-{suffix}-{sequence}"))
+        let process_id = std::process::id();
+        std::env::temp_dir().join(format!(
+            "traverse-cli-http-api-tests-{process_id}-{suffix}-{sequence}"
+        ))
     }
 
     fn persist_test_workspace(registry_root: &Path, workspace_id: &str, owner_subject: &str) {

--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -266,6 +266,12 @@ pub struct LocalFileDataStore {
     _lock_file: File,
 }
 
+impl Drop for LocalFileDataStore {
+    fn drop(&mut self) {
+        let _ = self._lock_file.unlock();
+    }
+}
+
 impl LocalFileDataStore {
     /// Creates a local filesystem-backed data store rooted at `root`.
     ///

--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -263,12 +263,12 @@ impl<A: DataStore> RuntimeDataStore<A> {
 pub struct LocalFileDataStore {
     root: PathBuf,
     classification: LocalDataClassification,
-    _lock_file: File,
+    lock_file: File,
 }
 
 impl Drop for LocalFileDataStore {
     fn drop(&mut self) {
-        let _ = self._lock_file.unlock();
+        let _ = self.lock_file.unlock();
     }
 }
 
@@ -308,7 +308,7 @@ impl LocalFileDataStore {
         Ok(Self {
             root,
             classification,
-            _lock_file: lock_file,
+            lock_file,
         })
     }
 

--- a/docs/adr/0020-explicit-datastore-format-migration.md
+++ b/docs/adr/0020-explicit-datastore-format-migration.md
@@ -1,6 +1,6 @@
 # ADR-0020: Keep DataStore Format Migration Explicit and Host-Owned
 
-- Status: Proposed
+- Status: Accepted
 - Governing spec: `522-datastore-format-migration` (Draft)
 - Extends: ADR-0018 and ADR-0019
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1005,3 +1005,86 @@ immutable, each governing exactly the source file(s) it describes.
 actually embedded in `traverse-registry`'s shipped code. All existing
 `traverse-registry` and `traverse-cli` tests pass unchanged in behavior —
 only the literal spec-ID strings changed.
+
+## Decision 34: Persist Auditable Traces in a Separate Durable Journal
+
+- **Date**: 2026-07-28
+- **Status**: Accepted
+- **Governing spec**: `079-durable-trace-journal`
+- **Related ADR**: ADR-0017
+
+### Decision
+
+Persist auditable execution traces through the append-only event journal, not
+the host-owned DataStore. The journal may use the same host-selected storage
+infrastructure, but trace privacy, retention, recovery, and failure semantics
+remain independent. Audited execution fails before success is returned when
+its durable trace cannot be committed; private trace payloads remain outside
+this slice.
+
+### Outcome
+
+The durable trace journal is an approved, separately governed product surface.
+It does not assign a DataStore root to the runtime or expand DataStore format
+migration scope.
+
+## Decision 35: Prepare Registry Dependencies in a Host-Owned Offline Cache
+
+- **Date**: 2026-07-28
+- **Status**: Accepted
+- **Governing spec**: `080-embedded-registry-cache`
+- **Related issue**: #826
+
+### Decision
+
+Production embedders prepare `registry_ref` dependencies explicitly using a
+host-provided network source and content-addressed cache. Initialization and
+execution consume only verified local cache entries and never use a CLI
+sidecar, an App-References manifest rewrite, or runtime network fallback.
+
+### Outcome
+
+Host-native resolution is the sole supported production path for
+`registry_ref`; application wrappers may automate preparation but do not own a
+separate materialization architecture.
+
+## Decision 36: Make Synced Registry Discovery Local and Offline-First
+
+- **Date**: 2026-07-28
+- **Status**: Accepted
+- **Governing spec**: `081-registry-browse-search`
+- **Related issue**: #814
+
+### Decision
+
+`traverse-cli registry list` and `search` operate only on the locally synced
+public index. Contract summaries are fetched and cached only through an
+explicit action; valid stale local state remains discoverable with provenance,
+and runtime execution never performs discovery network access.
+
+### Outcome
+
+Registry discovery becomes a deterministic, offline-capable CLI feature
+without changing the thin contract-first registry index.
+
+## Decision 37: Keep DataStore Format Migration Explicit and Host-Owned
+
+- **Date**: 2026-07-28
+- **Status**: Accepted
+- **Governing spec**: `082-datastore-format-migration`
+- **Related ADR**: ADR-0020
+- **Related pull request**: #839
+
+### Decision
+
+Only the host owning a durable DataStore root may request a named migration.
+Every migration validates its source, preserves a verified backup, verifies
+the target before atomic commit, and exposes explicit verified restore. The
+runtime and ordinary CLI commands never discover a root or perform implicit
+migration, backup, restore, or downgrade.
+
+### Outcome
+
+The safety and ownership policy is approved. No format transition or
+implementation is authorized until a successor specification names the exact
+source-to-target format, backup representation, stable errors, and host API.

--- a/specs/518-durable-trace-journal/spec.md
+++ b/specs/518-durable-trace-journal/spec.md
@@ -1,10 +1,14 @@
 # Feature Specification: Durable Trace Journal
 
 **Status**: Approved
+**Canonical governing ID**: `079-durable-trace-journal`
 
 ## Scope
 
 Persist auditable execution traces through the existing append-only event journal.
+The trace journal is separate from the host-owned DataStore: it may share
+host-selected storage infrastructure, but retains independent trace privacy,
+recovery, and retention semantics.
 
 ## Requirements
 
@@ -17,3 +21,4 @@ Persist auditable execution traces through the existing append-only event journa
 ## Governing Decision
 
 - ADR-0017
+- Decision 34 in `docs/decision-log.md`

--- a/specs/520-embedded-registry-cache/spec.md
+++ b/specs/520-embedded-registry-cache/spec.md
@@ -1,7 +1,8 @@
 # Feature Specification: Embedded Registry Dependency Cache
 
 **Feature Branch**: `520-embedded-registry-cache`  
-**Status**: Draft — approved ticket #831 scope; publication requires normal governance approval.  
+**Status**: Approved
+**Canonical governing ID**: `080-embedded-registry-cache`
 **Input**: Traverse #831; successors to Specs 054 and 055; production boundary from Specs 057 and 068.
 
 ## Purpose
@@ -9,6 +10,8 @@
 Define the host-owned preparation and verified local-cache contract that lets a
 production embedder resolve an application bundle's `registry_ref` dependencies
 without a CLI sidecar, App-References manifest rewrite, or runtime network use.
+
+This specification derives from Decision 35 in the decision log.
 
 ## Boundary and Ownership
 

--- a/specs/521-registry-browse-search/spec.md
+++ b/specs/521-registry-browse-search/spec.md
@@ -1,6 +1,7 @@
 # Feature Specification: Synced Registry Browse and Search
 
-**Status**: Draft; implementation authorization requires normal approval.  
+**Status**: Approved
+**Canonical governing ID**: `081-registry-browse-search`
 **Input**: Traverse #832; extends Specs 054 and 055.
 
 ## Purpose
@@ -8,6 +9,8 @@
 Define deterministic local CLI discovery for the synced public registry index,
 without changing its thin contract-first format or introducing runtime network
 lookup.
+
+This specification derives from Decision 36 in the decision log.
 
 ## Requirements
 

--- a/specs/522-datastore-format-migration/checklists/requirements.md
+++ b/specs/522-datastore-format-migration/checklists/requirements.md
@@ -1,9 +1,9 @@
 # Specification Quality Checklist: Explicit DataStore Format Migration and Recovery
 
-**Purpose**: Validate Draft Spec 522 before approval.  
+**Purpose**: Validate approved Spec 522's policy boundary.
 **Feature**: [spec.md](../spec.md)
 
 - [x] Scope and host ownership are explicit.
 - [x] Source compatibility, backup, rollback, and failure behavior are testable.
 - [x] Runtime and generic CLI non-goals are explicit.
-- [ ] Formal human approval and an approved target transition remain required.
+- [x] Formal human approval recorded on 2026-07-28; an approved target transition remains required before implementation.

--- a/specs/522-datastore-format-migration/spec.md
+++ b/specs/522-datastore-format-migration/spec.md
@@ -1,6 +1,7 @@
 # Feature Specification: Explicit DataStore Format Migration and Recovery
 
-**Status**: Draft  
+**Status**: Approved
+**Canonical governing ID**: `082-datastore-format-migration`
 **Extends**: `518-durable-local-datastore`, `519-embedder-owned-datastore-integration`
 
 ## Purpose
@@ -69,8 +70,8 @@ record.
 
 ## Compatibility
 
-`local-datastore/1` remains the only currently accepted format. This Draft
-does not authorize a new format or any implementation. Existing legacy and
+`local-datastore/1` remains the only currently accepted format. This approved
+policy does not authorize a new format or any implementation. Existing legacy and
 unknown-format behavior remains fail-closed.
 
 ## Definition of Done

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1012,6 +1012,52 @@
         "docs/adr/0018-durable-local-datastore.md",
         "specs/518-durable-local-datastore/"
       ]
+    },
+    {
+      "id": "079-durable-trace-journal",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/518-durable-trace-journal/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "docs/adr/0017-durable-trace-journal.md",
+        "specs/518-durable-trace-journal/"
+      ]
+    },
+    {
+      "id": "080-embedded-registry-cache",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/520-embedded-registry-cache/spec.md",
+      "governs": [
+        "crates/traverse-embedder/",
+        "packages/web/TraverseEmbedder/",
+        "specs/520-embedded-registry-cache/"
+      ]
+    },
+    {
+      "id": "081-registry-browse-search",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/521-registry-browse-search/spec.md",
+      "governs": [
+        "crates/traverse-cli/",
+        "specs/521-registry-browse-search/"
+      ]
+    },
+    {
+      "id": "082-datastore-format-migration",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/522-datastore-format-migration/spec.md",
+      "governs": [
+        "docs/adr/0020-explicit-datastore-format-migration.md",
+        "specs/522-datastore-format-migration/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Record the approved registry discovery, embedded cache, durable trace, and DataStore migration policy decisions.

## Governing Spec

- `001-foundation-v0-1`
- `004-spec-alignment-gate`
- `070-runtime-event-sink-boundary`
- `518-durable-local-datastore`
- `079-durable-trace-journal`
- `080-embedded-registry-cache`
- `081-registry-browse-search`
- `082-datastore-format-migration`

## Project Item

Project 1: approve the registry and durability decision set; #814 is unblocked for implementation.

## Definition of Done

- Durable traces use a separate append-only journal, not the DataStore.
- Production embedders use host-prepared verified offline registry caches.
- Synced registry browse/search is approved as local and offline-first.
- DataStore migration is explicit and host-owned; no target format or implementation is authorized yet.

## Validation

- `git diff --check`
- `jq empty specs/governance/approved-specs.json`
- `bash scripts/ci/repository_checks.sh`
