### PR TITLE
docs: plan production app readiness baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,10 @@ gh project item-edit --project-id PVT_kwDOEbiBt84Bbyp1 \
 ```
 
 Status option IDs for reference: Ready `f75ad846`, In Progress `47fc9ee4`, Done `98236657`, Blocked `294b89f5`.
+
+## Active Technologies
+- Rust 1.94+; host packages in TypeScript, Swift, Kotlin, and .NET + Cargo workspace, serde, semver, existing registry and embedder packages (524-production-app-readiness)
+- host-owned verified artifact cache, append-only trace journal, host-owned file-backed DataStore v2 (524-production-app-readiness)
+
+## Recent Changes
+- 524-production-app-readiness: Added Rust 1.94+; host packages in TypeScript, Swift, Kotlin, and .NET + Cargo workspace, serde, semver, existing registry and embedder packages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Traverse Development Guidelines
 
-Auto-generated. Last updated: 2026-07-03
+Auto-generated. Last updated: 2026-07-28
 
 ## Governance
 
@@ -9,6 +9,8 @@ This repo's constitution, NFRs, quality standards, antipatterns, compatibility p
 Repo-specific product scope stays here: see `specs/001-foundation-v0-1/spec.md` for this repo's v0.1 scope, and `specs/051-registry-extraction/spec.md` for the in-progress registry extraction.
 
 ## Active Technologies
+- Rust 1.94+; host packages in TypeScript, Swift, Kotlin, and .NET + Cargo workspace, serde, semver, existing registry and embedder packages (524-production-app-readiness)
+- host-owned verified artifact cache, append-only trace journal, host-owned file-backed DataStore v2 (524-production-app-readiness)
 
 - Rust 1.94+
 - Cargo workspace
@@ -67,3 +69,6 @@ jq -r '.specs[].id' specs/governance/approved-specs.json
 
 <!-- MANUAL ADDITIONS START -->
 <!-- MANUAL ADDITIONS END -->
+
+## Recent Changes
+- 524-production-app-readiness: Added Rust 1.94+; host packages in TypeScript, Swift, Kotlin, and .NET + Cargo workspace, serde, semver, existing registry and embedder packages

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1088,3 +1088,33 @@ migration, backup, restore, or downgrade.
 The safety and ownership policy is approved. No format transition or
 implementation is authorized until a successor specification names the exact
 source-to-target format, backup representation, stable errors, and host API.
+
+## Decision 38: Establish the Production App Readiness Baseline
+
+- **Date**: 2026-07-28
+- **Status**: Accepted
+- **Planning spec**: `524-production-app-readiness`
+- **Extends**: Decisions 34–37 and Specs 079–082
+
+### Decision
+
+Traverse v1's production bar is an embedded multi-platform app that consumes
+verified registry capabilities offline, retains safe audit traces across
+restart, and upgrades host-owned local state without data loss. The registry
+has Certified, Community, and Kit/example tiers; discovery defaults to
+Certified; production bundles use committed exact lockfiles and host-prepared
+verified cache generations. Updates are explicit and reversible, and security
+yanks are enforced through locally known deadlines or minimum-safe versions.
+
+Certified capability admission requires signed provenance, validation,
+conformance evidence, and maintainer support policy. Certified platform status
+requires equal conformance across Web, Linux/Rust, Apple, Android, and
+Windows/.NET. Trace and state ownership, encryption keys, tenancy, and user
+authorization remain host-owned. The durable journal is separate from
+DataStore; `local-datastore/2` is the first explicit file-backed migration
+target; roots are single-writer in v1.
+
+### Outcome
+
+This decision is decomposed into bounded successor specifications and tickets;
+it is not itself an implementation authorization.

--- a/specs/524-production-app-readiness/checklists/requirements.md
+++ b/specs/524-production-app-readiness/checklists/requirements.md
@@ -1,0 +1,10 @@
+# Specification Quality Checklist: Production App Readiness Baseline
+
+**Purpose**: Validate planning completeness before decomposition.
+**Feature**: [spec.md](../spec.md)
+
+- [x] Approved decisions are cited and no user-direction gap remains.
+- [x] Scope is split into bounded successor slices.
+- [x] Requirements and success criteria are testable.
+- [x] Host ownership, offline behavior, trust tiers, lifecycle, traces, state, and platform parity are explicit.
+- [x] No implementation is authorized by the umbrella baseline.

--- a/specs/524-production-app-readiness/contracts/production-readiness-boundaries.md
+++ b/specs/524-production-app-readiness/contracts/production-readiness-boundaries.md
@@ -1,0 +1,13 @@
+# Production Readiness Boundary Contracts
+
+- `prepare`: host supplies network-capable source and cache writer; returns a
+  verified immutable lock/cache generation plus evidence.
+- `init` and `execute`: accept only active verified local generation; perform no
+  network access.
+- `activate` and `rollback`: host-directed, atomic generation state changes.
+- `migrate` and `restore`: host-directed v1-to-v2 state transitions with
+  verified backup and stable safe errors.
+- `trace.list`, `trace.get`, and `trace.export`: workspace-authorized safe
+  projections only; exports are explicit and redacted.
+
+Exact public API shapes belong to the bounded successor specs.

--- a/specs/524-production-app-readiness/data-model.md
+++ b/specs/524-production-app-readiness/data-model.md
@@ -1,0 +1,10 @@
+# Data Model
+
+| Entity | Required fields | Rules |
+| --- | --- | --- |
+| RegistryTier | tier, publisher, support state | Certified is default-visible; Community/Kit require opt-in. |
+| ResolvedLockGeneration | app id, exact version, artifact digest, publisher, tier, source release/index digest | Immutable after preparation; active generation is explicit. |
+| VerifiedCacheGeneration | generation id, lock digest, verified entries, activation state | Only verified active entries may initialize embedded runtime. |
+| SecurityYankPolicy | artifact identity, minimum-safe-version and/or deadline | Blocks Certified execution only when locally known and applicable. |
+| DurableTraceJournal | workspace id, safe trace record, retention state, prune evidence | Never contains raw request/output payloads. |
+| DataStoreMigration | source/target format, backup identity, verification result, restore outcome | Host-directed and single-writer only. |

--- a/specs/524-production-app-readiness/plan.md
+++ b/specs/524-production-app-readiness/plan.md
@@ -1,0 +1,68 @@
+# Implementation Plan: Production App Readiness Baseline
+
+**Branch**: `524-production-app-readiness` | **Date**: 2026-07-28 | **Spec**: [spec.md](spec.md)
+**Input**: Approved Decision 38 and the product-planning specification.
+
+## Summary
+
+Plan the v1 production-app bar as five independently governed delivery slices:
+registry trust/lockfiles, embedded cache lifecycle, durable traces,
+`local-datastore/2`, and cross-platform certification. The plan preserves
+embedded offline execution, host ownership, and deterministic evidence.
+
+## Technical Context
+
+**Language/Version**: Rust 1.94+; host packages in TypeScript, Swift, Kotlin, and .NET
+**Primary Dependencies**: Cargo workspace, serde, semver, existing registry and embedder packages
+**Storage**: host-owned verified artifact cache, append-only trace journal, host-owned file-backed DataStore v2
+**Testing**: cargo test, conformance scripts, cross-platform native artifact certification, deterministic CLI smoke paths
+**Target Platform**: Web, Linux/Rust, Apple, Android, Windows/.NET
+**Project Type**: runtime library, CLI, cross-platform embedder packages
+**Performance Goals**: offline initialization and execution perform no network I/O; bounded retention is deterministic
+**Constraints**: host owns roots, keys, tenancy, network preparation, and user authorization; v1 is single-writer per DataStore root
+**Scale/Scope**: five successor specs and bounded tickets; no monolithic implementation
+
+## Constitution Check
+
+| Gate | Result | Evidence |
+| --- | --- | --- |
+| Capability-first boundaries | Pass | Each slice is a bounded host/runtime capability, not an app UI flow. |
+| Contracts and immutable specs | Pass | Each implementation slice needs its own approved successor spec and contract changes. |
+| Portability | Pass | Host-specific storage/network work is behind public host boundaries. |
+| Explainability | Pass | Lock, cache, migration, retention, and yank outcomes require stable evidence. |
+| Small verifiable slices | Pass | Delivery order is independently testable; no slice claims the whole baseline. |
+
+## Delivery Sequence
+
+1. **Registry trust and lockfile** — define tier metadata, default discovery,
+   Certified admission, lockfile schema, normal/security yank lifecycle, and
+   90-day deprecation policy.
+2. **Embedded cache lifecycle** — implement explicit prepare, generation
+   activation, rollback, offline initialization, and security-yank enforcement.
+3. **Durable trace productization** — wire the approved trace journal into the
+   embedded host surface, retention defaults, authorization, and safe export.
+4. **DataStore v2** — specify exact envelope, backup, restore, encryption
+   disclosure, single-writer behavior, and v1-to-v2 migration conformance.
+5. **Platform certification** — add common conformance tests and Certified vs
+   Preview classification across all five primary hosts.
+
+## Dependency Rules
+
+- Slice 1 must precede Slice 2 because cache preparation consumes lock/tier/yank semantics.
+- Slice 2 must precede registry-only Reference Apps cutover.
+- Slices 3 and 4 may proceed independently after their successor specs are approved.
+- Slice 5 consumes the common acceptance contracts from Slices 2–4.
+
+## Project Structure
+
+```text
+crates/traverse-cli/              # registry discovery, preparation, evidence
+crates/traverse-runtime/          # offline execution, traces, DataStore contract
+crates/traverse-embedder/         # host-facing preparation/init interfaces
+packages/{web,swift,kotlin,dotnet}/TraverseEmbedder/
+specs/524-production-app-readiness/ # planning baseline and design artifacts
+docs/decision-log.md              # accepted product direction
+```
+
+**Structure Decision**: preserve the existing multi-package workspace; each
+successor spec names exact governed files before any implementation starts.

--- a/specs/524-production-app-readiness/quickstart.md
+++ b/specs/524-production-app-readiness/quickstart.md
@@ -1,0 +1,9 @@
+# Planning Quickstart
+
+1. Treat Decision 38 and `spec.md` as the approved product direction.
+2. Create one issue, Project 1 item, successor spec, and PR for exactly one
+   delivery slice in `plan.md`.
+3. Do not implement the umbrella baseline directly.
+4. Require each successor spec to name governed files, stable evidence, and its
+   independent conformance test before moving it to Ready.
+5. Cut Reference Apps to registry-only components only after Slice 2 passes.

--- a/specs/524-production-app-readiness/research.md
+++ b/specs/524-production-app-readiness/research.md
@@ -1,0 +1,32 @@
+# Research: Production App Readiness Baseline
+
+## Decision: Embedded offline execution is the production topology
+
+**Rationale**: It avoids runtime network ambiguity and preserves host-owned
+identity, storage, and update control. HTTP remains a development/CI surface.
+
+**Alternatives considered**: Sidecar-first production was rejected because it
+would reintroduce deployment and network coupling into every host.
+
+## Decision: Resolve once, run from a verified generation
+
+**Rationale**: Exact lock identity plus content-addressed cache yields
+reproducible execution, explicit updates, and rollback.
+
+**Alternatives considered**: Runtime range resolution or network fallback were
+rejected because they make offline and security outcomes ambiguous.
+
+## Decision: Separate safe trace journal from application state
+
+**Rationale**: Audit retention and redaction have different ownership and
+lifecycle from user state. Decision 34 and Spec 079 already establish this.
+
+## Decision: File-backed DataStore v2 before broader adapters
+
+**Rationale**: An explicit v1-to-v2 migration proves recoverable evolution
+without prematurely selecting cloud sync, IndexedDB, database, or key systems.
+
+## Decision: Common certification, not weakest-platform support
+
+**Rationale**: Certified status is a product promise. A host failing cache,
+rollback, trace-restart, or resource-control conformance is Preview.

--- a/specs/524-production-app-readiness/spec.md
+++ b/specs/524-production-app-readiness/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Production App Readiness Baseline
+
+**Feature Branch**: `524-production-app-readiness`
+**Created**: 2026-07-28
+**Status**: Draft — approved planning baseline; each implementation slice requires normal governance approval.
+**Input**: Maintainer-approved brainstorming and Decisions 34–38 in `docs/decision-log.md`.
+
+## Purpose
+
+Define the v1 product bar for a real multi-platform application using Traverse.
+An app can consume verified registry capabilities offline, execute them in an
+embedded host, retain safe audit traces across restart, and upgrade local state
+without data loss. This specification is a planning baseline, not an
+implementation authorization or a replacement for the bounded successor specs.
+
+## User Scenarios & Testing
+
+### User Story 1 - Prepare and run a verified app offline (Priority: P1)
+
+An app maintainer resolves declared capability ranges into an exact lockfile,
+prepares verified artifacts into a host-owned cache, and ships an embedded app
+that runs without network access.
+
+**Independent Test**: A reviewer prepares a bundle, disconnects the host, and
+executes every locked capability using only the active cache generation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Certified capability range and a valid registry snapshot, **When**
+   the host prepares the app, **Then** it writes a lockfile and verified cache
+   generation containing exact version, digest, publisher, tier, and provenance.
+2. **Given** an active verified generation and no registry network access,
+   **When** the app initializes and executes, **Then** it performs no network
+   request and reports stale provenance when applicable.
+
+### User Story 2 - Upgrade safely and respond to publisher lifecycle changes (Priority: P1)
+
+An app maintainer prepares an update beside the active generation, activates it
+atomically, rolls back explicitly when needed, and receives deterministic yank
+or security-yank behavior.
+
+**Independent Test**: A reviewer activates an update, rolls back to the prior
+generation, and verifies normal and security-yank handling without ambiguous
+runtime resolution.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new valid lock generation, **When** the host activates it,
+   **Then** the prior verified generation remains available for explicit rollback.
+2. **Given** a normal yanked version, **When** preparation runs, **Then** it is
+   rejected while an existing active generation remains runnable.
+3. **Given** a locally known security yank past its deadline, **When** a
+   Certified host executes it, **Then** execution fails closed with upgrade guidance.
+
+### User Story 3 - Operate durable state and safe audit evidence (Priority: P1)
+
+An authorized workspace user can retain safe traces and migrate host-owned
+local state without assigning data roots, encryption keys, or tenancy to
+Traverse.
+
+**Independent Test**: A reviewer restarts a host, reads safe durable traces,
+migrates a `local-datastore/1` fixture to v2 with verified backup, and confirms
+that a second owner is rejected.
+
+**Acceptance Scenarios**:
+
+1. **Given** auditable execution, **When** it succeeds, **Then** its safe trace
+   survives restart, applies the configured retention limit, and records pruning.
+2. **Given** an owned v1 DataStore root, **When** the host explicitly requests
+   an approved v1-to-v2 migration, **Then** source preservation, backup,
+   verification, and explicit restore are available.
+3. **Given** a second process opens the same root, **When** it requests access,
+   **Then** it receives `store_locked` and cannot modify state.
+
+### User Story 4 - Discover trusted capabilities across supported platforms (Priority: P2)
+
+An app author sees Certified capabilities by default, opts into Community or
+Kit content deliberately, and receives the same production guarantees across
+Web, Linux/Rust, Apple, Android, and Windows/.NET.
+
+**Independent Test**: The same locked bundle passes the certified conformance
+suite on every supported platform; a non-conforming platform is marked Preview.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Production bundles MUST resolve declared ranges to a committed
+  lockfile with exact artifact identity and provenance before initialization.
+- **FR-002**: Embedded initialization and execution MUST consume only a
+  host-prepared verified cache and MUST perform no runtime network lookup.
+- **FR-003**: Registry discovery MUST show Certified results by default and
+  require explicit opt-in for Community and Kit/example results.
+- **FR-004**: Registry records and discovery results MUST show tier, publisher,
+  support state, deprecation/yank state, and provenance.
+- **FR-005**: Hosts MUST prepare updates beside the active generation and
+  atomically activate or explicitly roll back a verified generation.
+- **FR-006**: Normal yanks MUST reject new preparation; security yanks MUST
+  enforce locally known deadlines or minimum-safe-version policy for Certified hosts.
+- **FR-007**: Certified tier admission MUST require verified publisher identity,
+  signed immutable provenance, automated validation, conformance evidence, and
+  maintainer-approved support/deprecation policy.
+- **FR-008**: Durable traces MUST remain separate from DataStore, persist only
+  safe evidence, be workspace-authorized, and default to 30 days or 10,000
+  traces per workspace, oldest-first with pruning evidence.
+- **FR-009**: The first DataStore transition MUST be from
+  `local-datastore/1` to a host-owned, file-backed `local-datastore/2`, with
+  verified backup and explicit restore.
+- **FR-010**: DataStore and journal encryption keys, roots, tenancy mapping,
+  and host-user authorization MUST remain host-owned and opaque to Traverse.
+- **FR-011**: A v1 DataStore root MUST be single-writer; concurrent ownership
+  MUST fail closed.
+- **FR-012**: A platform may be Certified only after it passes the same
+  embedded execution, verified-cache, update/rollback, and trace-restart
+  conformance suite as every other Certified platform.
+- **FR-013**: Normal Certified deprecation MUST provide at least 90 days'
+  notice and a replacement or migration path; security lifecycle actions follow
+  FR-006.
+
+## Key Entities
+
+- **RegistryTier**: Certified, Community, or Kit/example trust classification.
+- **ResolvedLockGeneration**: Immutable app dependency resolution with exact
+  identity, digest, publisher tier, and registry provenance.
+- **VerifiedCacheGeneration**: Host-owned verified artifact set eligible for
+  embedded initialization and explicit activation or rollback.
+- **SecurityYankPolicy**: A published minimum-safe-version and/or deadline
+  associated with a yanked artifact.
+- **DurableTraceJournal**: Workspace-scoped safe audit evidence with retention
+  and pruning events, distinct from application state.
+- **DataStoreMigration**: An explicit host-directed v1-to-v2 transition with
+  source verification, backup, commit, restore, and stable outcome.
+
+## Success Criteria
+
+- **SC-001**: A disconnected host executes 100% of a prepared locked bundle
+  without runtime network access.
+- **SC-002**: A reviewer can activate and explicitly roll back a verified
+  generation without losing the prior runnable generation.
+- **SC-003**: An auditable trace remains readable after restart and honors both
+  configured age and count retention thresholds with pruning evidence.
+- **SC-004**: A v1-to-v2 migration preserves all valid source records or leaves
+  the prior committed representation intact on every injected failure boundary.
+- **SC-005**: Every Certified platform passes one common production conformance
+  suite; platforms that do not pass are visibly Preview.
+
+## Assumptions and Boundaries
+
+- Embedded hosting is the production path; HTTP serving remains development,
+  CI, or explicitly future remote-host work.
+- Community and Kit content are never implicitly trusted by production apps.
+- Browser/remote synchronization, multi-process coordination, key rotation,
+  and private trace-payload persistence require separate successor specs.
+- This baseline is decomposed before implementation; no single ticket may claim
+  the entire scope.
+
+## Required Decomposition
+
+1. Tiered registry trust, discovery, publisher lifecycle, and production lockfile.
+2. Embedded cache preparation, activation, rollback, and security-yank enforcement.
+3. Durable trace journal integration, retention, authorization, and export policy.
+4. `local-datastore/2` format, explicit migration, backup/restore, encryption disclosure, and single-writer conformance.
+5. Cross-platform Certified conformance suite and Preview classification.


### PR DESCRIPTION
## Summary

Record Decision 38 and the approved planning baseline for production app readiness.

## Governing Spec

- `070-runtime-event-sink-boundary`
- `079-durable-trace-journal`
- `080-embedded-registry-cache`
- `081-registry-browse-search`
- `082-datastore-format-migration`

## Project Item

Planning-only decomposition of the post-#826 production app readiness direction.

## Definition of Done

- Records approved product decisions as a planning source of truth.
- Defines bounded successor slices and dependencies.
- Authorizes no implementation directly.

## Validation

- `git diff --check`