### PR TITLE
feat: add embedded registry dependency cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,8 +1857,11 @@ dependencies = [
 name = "traverse-embedder"
 version = "0.8.1"
 dependencies = [
+ "semver",
+ "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2 0.10.9",
+ "traverse-contracts",
  "traverse-registry",
  "traverse-runtime",
  "wat",

--- a/crates/traverse-embedder/Cargo.toml
+++ b/crates/traverse-embedder/Cargo.toml
@@ -8,12 +8,15 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+semver = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.145"
+sha2 = "0.10"
+traverse-contracts = { workspace = true }
 traverse-registry = { workspace = true }
 traverse-runtime = { workspace = true }
 
 [dev-dependencies]
-sha2 = "0.11"
 wat = "1"
 
 [lints]

--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -87,16 +87,15 @@ mod test_double;
 pub use registry_cache::{
     HostRegistryCache, RegistryArtifactFetcher, RegistryCacheError, RegistryCacheErrorCode,
     RegistryPrepareEvidence, VerifiedRegistryDependency, prepare as prepare_registry_dependency,
+    resolve_component as resolve_registry_component,
     resolve_offline as resolve_registry_dependency_offline,
 };
 pub use test_double::EmbedderTestDouble;
 
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, VecDeque};
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use traverse_contracts::parse_contract;
 use traverse_registry::{
     ApplicationManifestError, ApplicationManifestErrorCode, ApplicationManifestFailure,
     ApplicationRegistrationFailure, ApplicationRegistrationRequest, ApplicationRegistry,
@@ -1717,48 +1716,14 @@ impl RegistryComponentResolver for OfflineRegistryCacheResolver<'_> {
         &self,
         reference: &RegistryReference,
     ) -> Result<ResolvedRegistryComponent, ApplicationManifestFailure> {
-        let resolved =
-            resolve_registry_dependency_offline(self.cache, reference).map_err(|failure| {
-                ApplicationManifestFailure {
-                    errors: vec![ApplicationManifestError {
-                        code: ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
-                        path: "$.registry_ref".to_string(),
-                        message: format!("{}: {}", failure.code.as_str(), failure.message),
-                    }],
-                }
-            })?;
-        let contract_text = fs::read_to_string(&resolved.contract_path).map_err(|error| {
+        crate::registry_cache::resolve_component(self.cache, reference).map_err(|failure| {
             ApplicationManifestFailure {
                 errors: vec![ApplicationManifestError {
                     code: ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
                     path: "$.registry_ref".to_string(),
-                    message: format!(
-                        "{}: failed to read verified registry contract ({error})",
-                        RegistryCacheErrorCode::RegistryCacheEntryMissing.as_str()
-                    ),
+                    message: format!("{}: {}", failure.code.as_str(), failure.message),
                 }],
             }
-        })?;
-        let contract =
-            parse_contract(&contract_text).map_err(|failure| ApplicationManifestFailure {
-                errors: vec![ApplicationManifestError {
-                    code: ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
-                    path: "$.registry_ref".to_string(),
-                    message: format!(
-                        "{}: verified registry contract is invalid ({})",
-                        RegistryCacheErrorCode::RegistryPrepareFailed.as_str(),
-                        failure
-                            .errors
-                            .first()
-                            .map_or("parse failed", |e| e.message.as_str())
-                    ),
-                }],
-            })?;
-        Ok(ResolvedRegistryComponent {
-            contract_path: resolved.contract_path,
-            contract,
-            wasm_binary_path: resolved.wasm_binary_path,
-            wasm_digest: resolved.wasm_digest,
         })
     }
 }
@@ -1841,6 +1806,8 @@ fn workflow_step_status_str(status: WorkflowTraversalStepStatus) -> &'static str
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
     use super::*;
 
     #[test]
@@ -2246,5 +2213,136 @@ mod tests {
         for (reason, expected) in failures {
             assert_eq!(execution_failure_code(reason), expected);
         }
+    }
+
+    #[test]
+    fn offline_registry_resolver_loads_prepared_contract_and_reports_missing() {
+        use crate::registry_cache::{
+            HostRegistryCache, RegistryArtifactFetcher, prepare, resolve_component,
+        };
+        use sha2::{Digest, Sha256};
+        use std::collections::HashMap;
+        use std::fmt::Write as _;
+        use traverse_registry::{
+            PublicRegistryCapabilityRecord, RegistryComponentResolver, RegistryReference,
+            SyncedPublicRegistryState,
+        };
+
+        struct MapFetcher {
+            assets: HashMap<String, Vec<u8>>,
+        }
+        impl RegistryArtifactFetcher for MapFetcher {
+            fn fetch(&self, url: &str) -> Result<Vec<u8>, String> {
+                self.assets
+                    .get(url)
+                    .cloned()
+                    .ok_or_else(|| "missing".to_string())
+            }
+        }
+
+        fn sha256_hex(bytes: &[u8]) -> String {
+            let digest = Sha256::digest(bytes);
+            let mut value = String::with_capacity(digest.len() * 2);
+            for byte in digest {
+                let _ = write!(value, "{byte:02x}");
+            }
+            value
+        }
+
+        let contract = include_str!(
+            "../../../contracts/examples/traverse-starter/capabilities/process/contract.json"
+        )
+        .as_bytes()
+        .to_vec();
+        let artifact = b"\0asm\x01\0\0\0".to_vec();
+        let artifact_digest = format!("sha256:{}", sha256_hex(&artifact));
+        let contract_digest = format!("sha256:{}", sha256_hex(&contract));
+        let record = PublicRegistryCapabilityRecord {
+            namespace: "traverse-starter".to_string(),
+            id: "process".to_string(),
+            version: "1.0.0".to_string(),
+            digest: artifact_digest.clone(),
+            artifact_url: "https://example.test/process.wasm".to_string(),
+            contract_digest: contract_digest.clone(),
+            contract_url: "https://example.test/process.json".to_string(),
+            deprecated: false,
+        };
+        let snapshot = SyncedPublicRegistryState {
+            schema_version: "1".to_string(),
+            workspace_id: "ws".to_string(),
+            state_scope: "public".to_string(),
+            source_repo: "traverse-framework/registry".to_string(),
+            release_tag: "index-v1".to_string(),
+            index_version: 1,
+            generated_at: "2026-07-29T00:00:00Z".to_string(),
+            source_commit: None,
+            synced_at: "2026-07-29T00:00:00Z".to_string(),
+            record_count: 1,
+            validation_status: "valid".to_string(),
+            governing_spec: "055-registry-sync".to_string(),
+            capabilities: vec![record.clone()],
+        };
+        let mut assets = HashMap::new();
+        assets.insert(record.artifact_url.clone(), artifact);
+        assets.insert(record.contract_url.clone(), contract);
+        let fetcher = MapFetcher { assets };
+        let reference = RegistryReference {
+            namespace: "traverse-starter".to_string(),
+            id: "process".to_string(),
+            version_range: "^1.0.0".to_string(),
+        };
+        let root = std::env::temp_dir().join(format!(
+            "traverse-embedder-resolver-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).expect("root");
+        let cache = HostRegistryCache::new(root);
+        prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
+        let resolver = OfflineRegistryCacheResolver { cache: &cache };
+        let loaded = resolver.resolve(&reference).expect("resolve");
+        assert_eq!(loaded.wasm_digest, artifact_digest);
+        assert_eq!(loaded.contract.id, "traverse-starter.process");
+
+        let missing_ref = RegistryReference {
+            namespace: "missing".to_string(),
+            id: "capability".to_string(),
+            version_range: "^1.0.0".to_string(),
+        };
+        let missing = resolver.resolve(&missing_ref).expect_err("missing");
+        assert!(
+            missing.errors[0]
+                .message
+                .contains("registry_cache_entry_missing")
+        );
+        let _ = resolve_component(&cache, &reference);
+    }
+
+    #[test]
+    fn map_manifest_failure_marks_registry_cache_misses() {
+        let failure = ApplicationManifestFailure {
+            errors: vec![ApplicationManifestError {
+                code: ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
+                path: "$.registry_ref".to_string(),
+                message: "registry_cache_entry_missing: absent".to_string(),
+            }],
+        };
+        let mapped = map_manifest_failure(&failure);
+        assert_eq!(mapped.code, EmbedderErrorCode::BundleLoadFailed);
+        assert!(mapped.message.contains("registry_cache_entry_missing"));
+
+        let other = ApplicationManifestFailure {
+            errors: vec![ApplicationManifestError {
+                code: ApplicationManifestErrorCode::ManifestReadFailed,
+                path: "$".to_string(),
+                message: "boom".to_string(),
+            }],
+        };
+        let mapped_other = map_manifest_failure(&other);
+        assert!(mapped_other.message.contains("application bundle failed to load"));
+        assert!(!mapped_other.message.contains("registry_cache_entry_missing):"));
     }
 }

--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -2342,7 +2342,15 @@ mod tests {
             }],
         };
         let mapped_other = map_manifest_failure(&other);
-        assert!(mapped_other.message.contains("application bundle failed to load"));
-        assert!(!mapped_other.message.contains("registry_cache_entry_missing):"));
+        assert!(
+            mapped_other
+                .message
+                .contains("application bundle failed to load")
+        );
+        assert!(
+            !mapped_other
+                .message
+                .contains("registry_cache_entry_missing):")
+        );
     }
 }

--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -81,18 +81,28 @@
 //! evidence: the embedder emits only runtime-owned outputs and stable
 //! error metadata (spec 068 NFR-004).
 
+mod registry_cache;
 mod test_double;
 
+pub use registry_cache::{
+    HostRegistryCache, RegistryArtifactFetcher, RegistryCacheError, RegistryCacheErrorCode,
+    RegistryPrepareEvidence, VerifiedRegistryDependency, prepare as prepare_registry_dependency,
+    resolve_offline as resolve_registry_dependency_offline,
+};
 pub use test_double::EmbedderTestDouble;
 
 use serde_json::{Value, json};
 use std::collections::{BTreeMap, VecDeque};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
+use traverse_contracts::parse_contract;
 use traverse_registry::{
+    ApplicationManifestError, ApplicationManifestErrorCode, ApplicationManifestFailure,
     ApplicationRegistrationFailure, ApplicationRegistrationRequest, ApplicationRegistry,
-    CapabilityRegistry, ComponentExecutionMode, EventRegistry, RegistryScope, WorkflowRegistry,
-    load_application_bundle_manifest,
+    CapabilityRegistry, ComponentExecutionMode, EventRegistry, RegistryComponentResolver,
+    RegistryReference, RegistryScope, ResolvedRegistryComponent, WorkflowRegistry,
+    load_application_bundle_manifest, load_application_bundle_manifest_with_resolver,
 };
 use traverse_runtime::data_store::{
     DataStore, DataStoreError, DataStoreErrorCode, LocalDataClassification, StateRecord,
@@ -315,6 +325,9 @@ pub struct EmbedderConfig {
     pub platform: String,
     /// Artifact verification posture.
     pub security: SecurityPosture,
+    /// Optional host-owned verified registry cache used to resolve
+    /// `registry_ref` components offline at `init` (Spec 080).
+    pub registry_cache: Option<HostRegistryCache>,
 }
 
 impl EmbedderConfig {
@@ -328,7 +341,16 @@ impl EmbedderConfig {
             workspace_id: DEFAULT_WORKSPACE_ID.to_string(),
             platform: std::env::consts::OS.to_string(),
             security: SecurityPosture::Production,
+            registry_cache: None,
         }
+    }
+
+    /// Attach a host-owned verified registry cache for offline `registry_ref`
+    /// resolution during `init`.
+    #[must_use]
+    pub fn with_registry_cache(mut self, cache: HostRegistryCache) -> Self {
+        self.registry_cache = Some(cache);
+        self
     }
 }
 
@@ -1143,21 +1165,14 @@ impl BundleEmbedder {
     #[allow(unexpected_cfgs)]
     pub fn init(config: EmbedderConfig) -> Result<Self, EmbedderError> {
         let manifest_path = absolute_bundle_path(&config.manifest_bundle_path)?;
-        let manifest = load_application_bundle_manifest(&manifest_path).map_err(|failure| {
-            EmbedderError::new(
-                EmbedderErrorCode::BundleLoadFailed,
-                format!(
-                    "application bundle failed to load: {}",
-                    manifest_failure_messages(
-                        &failure
-                            .errors
-                            .iter()
-                            .map(|e| e.message.clone())
-                            .collect::<Vec<_>>()
-                    )
-                ),
-            )
-        })?;
+        let manifest = match config.registry_cache.as_ref() {
+            Some(cache) => {
+                let resolver = OfflineRegistryCacheResolver { cache };
+                load_application_bundle_manifest_with_resolver(&manifest_path, Some(&resolver))
+            }
+            None => load_application_bundle_manifest(&manifest_path),
+        }
+        .map_err(|failure| map_manifest_failure(&failure))?;
         ensure_supported_bundle_schema(&manifest.schema_version)?;
 
         let mut capabilities = CapabilityRegistry::new();
@@ -1673,6 +1688,79 @@ fn runtime_stopped_error() -> EmbedderError {
         EmbedderErrorCode::RuntimeStopped,
         "the embedded runtime was shut down and accepts no further operations",
     )
+}
+
+fn map_manifest_failure(failure: &ApplicationManifestFailure) -> EmbedderError {
+    let message = manifest_failure_messages(
+        &failure
+            .errors
+            .iter()
+            .map(|error| error.message.clone())
+            .collect::<Vec<_>>(),
+    );
+    let code_hint = failure.errors.first().map(|error| error.code);
+    let message = match code_hint {
+        Some(ApplicationManifestErrorCode::RegistryReferenceRequiresResolution) => {
+            format!("application bundle failed to load (registry_cache_entry_missing): {message}")
+        }
+        _ => format!("application bundle failed to load: {message}"),
+    };
+    EmbedderError::new(EmbedderErrorCode::BundleLoadFailed, message)
+}
+
+struct OfflineRegistryCacheResolver<'a> {
+    cache: &'a HostRegistryCache,
+}
+
+impl RegistryComponentResolver for OfflineRegistryCacheResolver<'_> {
+    fn resolve(
+        &self,
+        reference: &RegistryReference,
+    ) -> Result<ResolvedRegistryComponent, ApplicationManifestFailure> {
+        let resolved =
+            resolve_registry_dependency_offline(self.cache, reference).map_err(|failure| {
+                ApplicationManifestFailure {
+                    errors: vec![ApplicationManifestError {
+                        code: ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
+                        path: "$.registry_ref".to_string(),
+                        message: format!("{}: {}", failure.code.as_str(), failure.message),
+                    }],
+                }
+            })?;
+        let contract_text = fs::read_to_string(&resolved.contract_path).map_err(|error| {
+            ApplicationManifestFailure {
+                errors: vec![ApplicationManifestError {
+                    code: ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
+                    path: "$.registry_ref".to_string(),
+                    message: format!(
+                        "{}: failed to read verified registry contract ({error})",
+                        RegistryCacheErrorCode::RegistryCacheEntryMissing.as_str()
+                    ),
+                }],
+            }
+        })?;
+        let contract =
+            parse_contract(&contract_text).map_err(|failure| ApplicationManifestFailure {
+                errors: vec![ApplicationManifestError {
+                    code: ApplicationManifestErrorCode::RegistryReferenceRequiresResolution,
+                    path: "$.registry_ref".to_string(),
+                    message: format!(
+                        "{}: verified registry contract is invalid ({})",
+                        RegistryCacheErrorCode::RegistryPrepareFailed.as_str(),
+                        failure
+                            .errors
+                            .first()
+                            .map_or("parse failed", |e| e.message.as_str())
+                    ),
+                }],
+            })?;
+        Ok(ResolvedRegistryComponent {
+            contract_path: resolved.contract_path,
+            contract,
+            wasm_binary_path: resolved.wasm_binary_path,
+            wasm_digest: resolved.wasm_digest,
+        })
+    }
 }
 
 fn absolute_bundle_path(path: &Path) -> Result<PathBuf, EmbedderError> {

--- a/crates/traverse-embedder/src/registry_cache.rs
+++ b/crates/traverse-embedder/src/registry_cache.rs
@@ -11,8 +11,10 @@ use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
+use traverse_contracts::parse_contract;
 use traverse_registry::{
-    PublicRegistryCapabilityRecord, RegistryReference, SyncedPublicRegistryState,
+    PublicRegistryCapabilityRecord, RegistryReference, ResolvedRegistryComponent,
+    SyncedPublicRegistryState,
 };
 
 /// Stable, secret-free registry-cache failure codes (Spec 080 FR-007).
@@ -233,6 +235,8 @@ pub struct VerifiedRegistryDependency {
     pub wasm_binary_path: PathBuf,
     /// Absolute path to digest-verified contract JSON.
     pub contract_path: PathBuf,
+    /// Digest-verified contract bytes.
+    pub contract_bytes: Vec<u8>,
     /// Published artifact digest.
     pub wasm_digest: String,
     /// Prepare evidence for the selected record.
@@ -268,27 +272,15 @@ pub fn prepare(
             format!("host registry artifact fetch failed: {message}"),
         )
     })?;
-    verify_digest(&record.digest, &artifact_bytes)?;
+    let artifact_hex = verify_digest(&record.digest, &artifact_bytes)?;
     let contract_bytes = fetcher.fetch(&record.contract_url).map_err(|message| {
         RegistryCacheError::new(
             RegistryCacheErrorCode::RegistryPrepareFailed,
             format!("host registry contract fetch failed: {message}"),
         )
     })?;
-    verify_digest(&record.contract_digest, &contract_bytes)?;
+    let contract_hex = verify_digest(&record.contract_digest, &contract_bytes)?;
 
-    let artifact_hex = normalize_digest(&record.digest).ok_or_else(|| {
-        RegistryCacheError::new(
-            RegistryCacheErrorCode::RegistryPrepareFailed,
-            "artifact digest must be sha256: followed by 64 hex characters",
-        )
-    })?;
-    let contract_hex = normalize_digest(&record.contract_digest).ok_or_else(|| {
-        RegistryCacheError::new(
-            RegistryCacheErrorCode::RegistryPrepareFailed,
-            "contract digest must be sha256: followed by 64 hex characters",
-        )
-    })?;
     write_verified_bytes(cache, &artifact_hex, &artifact_bytes)?;
     write_verified_bytes(cache, &contract_hex, &contract_bytes)?;
 
@@ -380,8 +372,8 @@ pub fn resolve_offline(
             "verified registry cache entry is missing for registry_ref",
         )
     })?;
-    let wasm_binary_path = read_verified(cache, &artifact_hex, artifact_digest)?;
-    let contract_path = read_verified(cache, &contract_hex, contract_digest)?;
+    let (wasm_binary_path, _) = read_verified(cache, &artifact_hex, artifact_digest)?;
+    let (contract_path, contract_bytes) = read_verified(cache, &contract_hex, contract_digest)?;
     let meta_bytes = fs::read(cache.meta_path(&artifact_hex)).map_err(|_| {
         RegistryCacheError::new(
             RegistryCacheErrorCode::RegistryCacheEntryMissing,
@@ -397,6 +389,7 @@ pub fn resolve_offline(
     Ok(VerifiedRegistryDependency {
         wasm_binary_path,
         contract_path,
+        contract_bytes,
         wasm_digest: artifact_digest.to_string(),
         evidence: RegistryPrepareEvidence {
             namespace: meta.namespace,
@@ -409,6 +402,43 @@ pub fn resolve_offline(
             verified_at: meta.verified_at,
             outcome: "resolved",
         },
+    })
+}
+
+/// Resolve a `registry_ref` into a registry component materialization.
+///
+/// # Errors
+///
+/// Returns Spec 080 FR-007 codes when the entry is missing, tampered, or the
+/// verified contract bytes cannot be parsed.
+pub fn resolve_component(
+    cache: &HostRegistryCache,
+    reference: &RegistryReference,
+) -> Result<ResolvedRegistryComponent, RegistryCacheError> {
+    let resolved = resolve_offline(cache, reference)?;
+    let contract_text = String::from_utf8(resolved.contract_bytes).map_err(|_| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            "verified registry contract is invalid: not utf-8",
+        )
+    })?;
+    let contract = parse_contract(&contract_text).map_err(|failure| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            format!(
+                "verified registry contract is invalid: {}",
+                failure
+                    .errors
+                    .first()
+                    .map_or("parse failed", |error| error.message.as_str())
+            ),
+        )
+    })?;
+    Ok(ResolvedRegistryComponent {
+        contract_path: resolved.contract_path,
+        contract,
+        wasm_binary_path: resolved.wasm_binary_path,
+        wasm_digest: resolved.wasm_digest,
     })
 }
 
@@ -471,7 +501,7 @@ fn index_snapshot_digest(snapshot: &SyncedPublicRegistryState) -> String {
     format!("sha256:{}", sha256_hex(&encoded))
 }
 
-fn verify_digest(declared: &str, bytes: &[u8]) -> Result<(), RegistryCacheError> {
+fn verify_digest(declared: &str, bytes: &[u8]) -> Result<String, RegistryCacheError> {
     let expected = normalize_digest(declared).ok_or_else(|| {
         RegistryCacheError::new(
             RegistryCacheErrorCode::RegistryArtifactDigestMismatch,
@@ -479,7 +509,7 @@ fn verify_digest(declared: &str, bytes: &[u8]) -> Result<(), RegistryCacheError>
         )
     })?;
     if sha256_hex(bytes) == expected {
-        Ok(())
+        Ok(expected)
     } else {
         Err(RegistryCacheError::new(
             RegistryCacheErrorCode::RegistryArtifactDigestMismatch,
@@ -538,7 +568,7 @@ fn read_verified(
     cache: &HostRegistryCache,
     digest_hex: &str,
     declared: &str,
-) -> Result<PathBuf, RegistryCacheError> {
+) -> Result<(PathBuf, Vec<u8>), RegistryCacheError> {
     let path = cache.artifact_path(digest_hex);
     let bytes = fs::read(&path).map_err(|_| {
         RegistryCacheError::new(
@@ -547,18 +577,22 @@ fn read_verified(
         )
     })?;
     verify_digest(declared, &bytes)?;
-    Ok(path)
+    Ok((path, bytes))
 }
 
 fn write_json_atomic(path: &Path, value: &impl serde::Serialize) -> Result<(), RegistryCacheError> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|error| {
-            RegistryCacheError::new(
-                RegistryCacheErrorCode::RegistryPrepareFailed,
-                format!("failed to create host registry cache directory: {error}"),
-            )
-        })?;
-    }
+    let parent = path.parent().ok_or_else(|| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            "registry cache metadata path has no parent directory",
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            format!("failed to create host registry cache directory: {error}"),
+        )
+    })?;
     let bytes = serde_json::to_vec(value).map_err(|error| {
         RegistryCacheError::new(
             RegistryCacheErrorCode::RegistryPrepareFailed,
@@ -788,11 +822,557 @@ mod tests {
         let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
         cache.evict(&evidence.artifact_digest).expect("evict");
         let missing = resolve_offline(&cache, &reference).expect_err("gone");
-        // ref pointer may remain but artifact bytes are gone → missing or digest path fail
         assert!(matches!(
             missing.code,
             RegistryCacheErrorCode::RegistryCacheEntryMissing
                 | RegistryCacheErrorCode::RegistryArtifactDigestMismatch
         ));
+    }
+
+    #[test]
+    fn error_codes_and_evidence_project_secret_free_values() {
+        for (code, wire) in [
+            (
+                RegistryCacheErrorCode::RegistrySyncMissing,
+                "registry_sync_missing",
+            ),
+            (
+                RegistryCacheErrorCode::RegistryVersionNotFound,
+                "registry_version_not_found",
+            ),
+            (
+                RegistryCacheErrorCode::RegistryDependencyYanked,
+                "registry_dependency_yanked",
+            ),
+            (
+                RegistryCacheErrorCode::RegistryPrepareFailed,
+                "registry_prepare_failed",
+            ),
+            (
+                RegistryCacheErrorCode::RegistryArtifactDigestMismatch,
+                "registry_artifact_digest_mismatch",
+            ),
+            (
+                RegistryCacheErrorCode::RegistryCacheEntryMissing,
+                "registry_cache_entry_missing",
+            ),
+        ] {
+            assert_eq!(code.as_str(), wire);
+        }
+        let cache = unique_cache();
+        assert!(cache.root().exists());
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
+        let value = evidence.as_value();
+        assert_eq!(value["outcome"], "prepared");
+        assert_eq!(value["selected_version"], "1.2.0");
+        cache.evict_all().expect("evict_all");
+        assert!(
+            resolve_offline(&cache, &reference)
+                .expect_err("cleared")
+                .code
+                == RegistryCacheErrorCode::RegistryCacheEntryMissing
+        );
+        let invalid = cache.evict("not-a-digest").expect_err("invalid");
+        assert_eq!(invalid.code, RegistryCacheErrorCode::RegistryPrepareFailed);
+    }
+
+    #[test]
+    fn prepare_reports_fetch_and_version_selection_failures() {
+        let cache = unique_cache();
+        let (snapshot, fetcher, mut reference) = sample_snapshot(false);
+        reference.version_range = "not a range!!!".to_string();
+        let invalid_range = prepare(&cache, &snapshot, &reference, &fetcher).expect_err("range");
+        assert_eq!(
+            invalid_range.code,
+            RegistryCacheErrorCode::RegistryVersionNotFound
+        );
+
+        let (snapshot, fetcher, mut reference) = sample_snapshot(false);
+        reference.version_range = "^9.0.0".to_string();
+        let missing = prepare(&cache, &snapshot, &reference, &fetcher).expect_err("missing");
+        assert_eq!(
+            missing.code,
+            RegistryCacheErrorCode::RegistryVersionNotFound
+        );
+
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let empty_fetcher = MapFetcher {
+            assets: HashMap::new(),
+        };
+        let fetch_failed =
+            prepare(&cache, &snapshot, &reference, &empty_fetcher).expect_err("fetch");
+        assert_eq!(
+            fetch_failed.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+        let _ = fetcher;
+    }
+
+    #[test]
+    fn prepare_rejects_invalid_declared_digests_and_reuses_verified_hits() {
+        let cache = unique_cache();
+        let (mut snapshot, fetcher, reference) = sample_snapshot(false);
+        snapshot.capabilities[1].digest = "sha256:short".to_string();
+        let invalid = prepare(&cache, &snapshot, &reference, &fetcher).expect_err("digest");
+        assert_eq!(
+            invalid.code,
+            RegistryCacheErrorCode::RegistryArtifactDigestMismatch
+        );
+
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let first = prepare(&cache, &snapshot, &reference, &fetcher).expect("first");
+        let second = prepare(&cache, &snapshot, &reference, &fetcher).expect("reuse");
+        assert_eq!(first.artifact_digest, second.artifact_digest);
+
+        let artifact_hex = normalize_digest(&first.artifact_digest).expect("hex");
+        let path = cache.artifact_path(&artifact_hex);
+        fs::write(&path, b"tampered").expect("tamper");
+        let tampered = prepare(&cache, &snapshot, &reference, &fetcher).expect_err("tampered");
+        assert_eq!(
+            tampered.code,
+            RegistryCacheErrorCode::RegistryArtifactDigestMismatch
+        );
+    }
+    #[test]
+    fn offline_resolve_rejects_corrupt_pointers_and_missing_meta() {
+        let cache = unique_cache();
+        let reference = RegistryReference {
+            namespace: "demo".to_string(),
+            id: "greet".to_string(),
+            version_range: "^1.0.0".to_string(),
+        };
+        let ref_path = cache.ref_path(&reference);
+        fs::create_dir_all(ref_path.parent().expect("parent")).expect("dirs");
+        fs::write(&ref_path, b"{not-json").expect("corrupt");
+        let corrupt = resolve_offline(&cache, &reference).expect_err("corrupt");
+        assert_eq!(
+            corrupt.code,
+            RegistryCacheErrorCode::RegistryCacheEntryMissing
+        );
+
+        fs::write(
+            &ref_path,
+            br#"{"contract_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
+        )
+        .expect("partial artifact");
+        let missing_artifact = resolve_offline(&cache, &reference).expect_err("artifact");
+        assert_eq!(
+            missing_artifact.code,
+            RegistryCacheErrorCode::RegistryCacheEntryMissing
+        );
+
+        fs::write(
+            &ref_path,
+            br#"{"artifact_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","contract_digest":"bad"}"#,
+        )
+        .expect("bad contract digest");
+        let bad_contract = resolve_offline(&cache, &reference).expect_err("contract dig");
+        assert_eq!(
+            bad_contract.code,
+            RegistryCacheErrorCode::RegistryCacheEntryMissing
+        );
+
+        fs::write(
+            &ref_path,
+            br#"{"artifact_digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}"#,
+        )
+        .expect("partial");
+        let partial = resolve_offline(&cache, &reference).expect_err("partial");
+        assert_eq!(
+            partial.code,
+            RegistryCacheErrorCode::RegistryCacheEntryMissing
+        );
+
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
+        let artifact_hex = normalize_digest(&evidence.artifact_digest).expect("hex");
+        fs::remove_file(cache.meta_path(&artifact_hex)).expect("remove meta");
+        let missing_meta = resolve_offline(&cache, &reference).expect_err("meta");
+        assert_eq!(
+            missing_meta.code,
+            RegistryCacheErrorCode::RegistryCacheEntryMissing
+        );
+    }
+
+    #[test]
+    fn contract_fetch_failure_and_invalid_contract_digest_fail_closed() {
+        let cache = unique_cache();
+        let (snapshot, mut fetcher, reference) = sample_snapshot(false);
+        fetcher.assets.remove("https://example.test/greet.json");
+        let failure = prepare(&cache, &snapshot, &reference, &fetcher).expect_err("contract fetch");
+        assert_eq!(failure.code, RegistryCacheErrorCode::RegistryPrepareFailed);
+
+        let (snapshot, mut fetcher, reference) = sample_snapshot(false);
+        fetcher.assets.insert(
+            "https://example.test/greet.json".to_string(),
+            b"wrong-contract".to_vec(),
+        );
+        let mismatch = prepare(&cache, &snapshot, &reference, &fetcher).expect_err("contract dig");
+        assert_eq!(
+            mismatch.code,
+            RegistryCacheErrorCode::RegistryArtifactDigestMismatch
+        );
+    }
+
+    #[test]
+    fn evict_all_and_missing_evict_paths_are_idempotent() {
+        let cache = unique_cache();
+        cache.evict_all().expect("empty evict_all");
+        let digest =
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        cache.evict(digest).expect("missing evict ok");
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
+        cache.evict_all().expect("clear");
+        cache.evict(&evidence.artifact_digest).expect("again");
+    }
+
+    #[test]
+    fn write_verified_bytes_reports_directory_collision_failures() {
+        let cache = unique_cache();
+        let bytes = b"content";
+        let digest = digest_for(bytes);
+        let hex = normalize_digest(&digest).expect("hex");
+        let path = cache.artifact_path(&hex);
+        fs::create_dir_all(&path).expect("block as directory");
+        let failure = write_verified_bytes(&cache, &hex, bytes).expect_err("dir");
+        assert_eq!(failure.code, RegistryCacheErrorCode::RegistryPrepareFailed);
+    }
+
+    #[test]
+    fn evict_and_write_json_report_filesystem_failures() {
+        // Fail artifact eviction with a non-empty directory collision.
+        let cache_art = unique_cache();
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let evidence = prepare(&cache_art, &snapshot, &reference, &fetcher).expect("prepare");
+        let hex = normalize_digest(&evidence.artifact_digest).expect("hex");
+        let artifact = cache_art.artifact_path(&hex);
+        fs::remove_file(&artifact).expect("remove");
+        fs::create_dir_all(&artifact).expect("dir");
+        fs::write(artifact.join("nested"), b"x").expect("nested");
+        let art_evict = cache_art
+            .evict(&evidence.artifact_digest)
+            .expect_err("artifact evict");
+        assert_eq!(
+            art_evict.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+
+        let cache = unique_cache();
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
+        let hex = normalize_digest(&evidence.artifact_digest).expect("hex");
+
+        // Fail meta eviction: leave artifact removable, block meta path as a directory.
+        let meta = cache.meta_path(&hex);
+        fs::remove_file(&meta).expect("remove meta file");
+        fs::create_dir_all(&meta).expect("meta dir");
+        fs::write(meta.join("nested"), b"x").expect("nested");
+        let meta_evict = cache.evict(&evidence.artifact_digest).expect_err("meta evict");
+        assert_eq!(
+            meta_evict.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+
+        let cache2 = unique_cache();
+        fs::write(cache2.root.join("sha256"), b"not-dir").expect("file");
+        let clear_fail = cache2.evict_all().expect_err("evict_all");
+        assert_eq!(
+            clear_fail.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+
+        let cache3 = unique_cache();
+        let meta_parent = cache3.root.join("meta");
+        fs::write(&meta_parent, b"not-dir").expect("block meta dir");
+        let meta_fail = write_json_atomic(
+            &cache3.meta_path("cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+            &json!({"ok": true}),
+        )
+        .expect_err("meta");
+        assert_eq!(
+            meta_fail.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+
+        // create_dir_all failure for sha256 parent
+        let cache4 = unique_cache();
+        fs::write(cache4.root.join("sha256"), b"not-dir").expect("block");
+        let bytes = b"fresh";
+        let digest = digest_for(bytes);
+        let hex = normalize_digest(&digest).expect("hex");
+        let create_fail = write_verified_bytes(&cache4, &hex, bytes).expect_err("create");
+        assert_eq!(
+            create_fail.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+    }
+
+    #[test]
+    fn write_helpers_report_tmp_rename_and_existing_entry_failures() {
+        // temporary write failure: tmp path is a directory
+        let cache5 = unique_cache();
+        let digest = digest_for(b"another");
+        let hex = normalize_digest(&digest).expect("hex");
+        let path = cache5.artifact_path(&hex);
+        fs::create_dir_all(path.parent().expect("parent")).expect("parent");
+        fs::create_dir_all(path.with_extension("tmp")).expect("tmp dir");
+        let write_fail = write_verified_bytes(&cache5, &hex, b"another").expect_err("write");
+        assert_eq!(
+            write_fail.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+
+        // rename failure: destination is a directory
+        let cache6 = unique_cache();
+        let digest = digest_for(b"rename-me");
+        let hex = normalize_digest(&digest).expect("hex");
+        let path = cache6.artifact_path(&hex);
+        fs::create_dir_all(path.parent().expect("parent")).expect("parent");
+        fs::create_dir_all(&path).expect("dest dir");
+        let rename_fail = write_verified_bytes(&cache6, &hex, b"rename-me").expect_err("rename");
+        assert_eq!(
+            rename_fail.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+
+        // write_json_atomic rename failure
+        let cache7 = unique_cache();
+        let target = cache7.root.join("refs").join("blocked.json");
+        fs::create_dir_all(target.parent().expect("parent")).expect("parent");
+        fs::create_dir_all(&target).expect("dest dir");
+        let json_rename = write_json_atomic(&target, &json!({"ok": true})).expect_err("rename");
+        assert_eq!(
+            json_rename.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+
+        // write_json_atomic write failure: tmp is a directory
+        let cache8 = unique_cache();
+        let target = cache8.root.join("refs").join("writeme.json");
+        fs::create_dir_all(target.parent().expect("parent")).expect("parent");
+        fs::create_dir_all(target.with_extension("tmp")).expect("tmp dir");
+        let json_write = write_json_atomic(&target, &json!({"ok": true})).expect_err("write");
+        assert_eq!(
+            json_write.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+
+        // existing cache entry that cannot be read as a file
+        let cache9 = unique_cache();
+        let digest = digest_for(b"readable");
+        let hex = normalize_digest(&digest).expect("hex");
+        let path = cache9.artifact_path(&hex);
+        fs::create_dir_all(&path).expect("dir as entry");
+        let read_existing = write_verified_bytes(&cache9, &hex, b"readable").expect_err("read");
+        assert_eq!(
+            read_existing.code,
+            RegistryCacheErrorCode::RegistryPrepareFailed
+        );
+    }
+
+    #[test]
+    fn prepare_fails_when_refs_root_is_blocked_and_meta_can_be_corrupt() {
+        let cache = unique_cache();
+        fs::write(cache.root.join("refs"), b"not-a-directory").expect("block refs");
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let failure = prepare(&cache, &snapshot, &reference, &fetcher).expect_err("refs");
+        assert_eq!(failure.code, RegistryCacheErrorCode::RegistryPrepareFailed);
+
+        let cache2 = unique_cache();
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let evidence = prepare(&cache2, &snapshot, &reference, &fetcher).expect("prepare");
+        let hex = normalize_digest(&evidence.artifact_digest).expect("hex");
+        fs::write(cache2.meta_path(&hex), b"{not-json").expect("corrupt meta");
+        let corrupt_meta = resolve_offline(&cache2, &reference).expect_err("meta");
+        assert_eq!(
+            corrupt_meta.code,
+            RegistryCacheErrorCode::RegistryCacheEntryMissing
+        );
+    }
+
+    #[test]
+    fn version_selection_skips_unrelated_namespace_records() {
+        let cache = unique_cache();
+        let (mut snapshot, fetcher, reference) = sample_snapshot(false);
+        snapshot.capabilities.insert(
+            0,
+            PublicRegistryCapabilityRecord {
+                namespace: "other".to_string(),
+                id: "thing".to_string(),
+                version: "9.9.9".to_string(),
+                digest: digest_for(b"other"),
+                artifact_url: "https://example.test/other.wasm".to_string(),
+                contract_digest: digest_for(b"other-contract"),
+                contract_url: "https://example.test/other.json".to_string(),
+                deprecated: false,
+            },
+        );
+        let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
+        assert_eq!(evidence.selected_version, "1.2.0");
+    }
+
+    #[test]
+    fn write_json_atomic_reports_serialize_failures() {
+        #[derive(Debug)]
+        struct Boom;
+        impl serde::Serialize for Boom {
+            fn serialize<S: serde::Serializer>(
+                &self,
+                _serializer: S,
+            ) -> Result<S::Ok, S::Error> {
+                Err(serde::ser::Error::custom("boom"))
+            }
+        }
+        let cache = unique_cache();
+        let path = cache.root.join("refs").join("boom.json");
+        let failure = write_json_atomic(&path, &Boom).expect_err("serialize");
+        assert_eq!(failure.code, RegistryCacheErrorCode::RegistryPrepareFailed);
+    }
+
+    #[test]
+    fn write_json_atomic_rejects_paths_without_parent() {
+        let failure = write_json_atomic(Path::new("/"), &serde_json::json!({"ok": true}))
+            .expect_err("root path");
+        assert_eq!(failure.code, RegistryCacheErrorCode::RegistryPrepareFailed);
+        assert!(failure.message.contains("no parent directory"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_verified_bytes_reports_rename_failures_on_readonly_parent() {
+        use std::os::unix::fs::PermissionsExt;
+        let cache = unique_cache();
+        let bytes = b"rename-readonly";
+        let digest = digest_for(bytes);
+        let hex = normalize_digest(&digest).expect("hex");
+        let path = cache.artifact_path(&hex);
+        let parent = path.parent().expect("parent").to_path_buf();
+        fs::create_dir_all(&parent).expect("parent");
+        let temporary = path.with_extension("tmp");
+        fs::write(&temporary, bytes).expect("tmp");
+        let mut perms = fs::metadata(&parent).expect("meta").permissions();
+        perms.set_mode(0o555);
+        fs::set_permissions(&parent, perms).expect("readonly");
+        let failure = write_verified_bytes(&cache, &hex, bytes).expect_err("rename");
+        let mut perms = fs::metadata(&parent).expect("meta").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&parent, perms).expect("restore");
+        assert_eq!(failure.code, RegistryCacheErrorCode::RegistryPrepareFailed);
+    }
+
+    #[test]
+    fn offline_resolve_rejects_invalid_digest_shapes_in_pointer() {
+        let cache = unique_cache();
+        let reference = RegistryReference {
+            namespace: "demo".to_string(),
+            id: "greet".to_string(),
+            version_range: "^1.0.0".to_string(),
+        };
+        let ref_path = cache.ref_path(&reference);
+        fs::create_dir_all(ref_path.parent().expect("parent")).expect("dirs");
+        fs::write(
+            &ref_path,
+            br#"{"artifact_digest":"bad","contract_digest":"bad"}"#,
+        )
+        .expect("write");
+        let failure = resolve_offline(&cache, &reference).expect_err("bad digests");
+        assert_eq!(
+            failure.code,
+            RegistryCacheErrorCode::RegistryCacheEntryMissing
+        );
+    }
+
+    #[test]
+    fn resolve_component_rejects_non_contract_json_with_matching_digest() {
+        let cache = unique_cache();
+        let bogus = br#"{"kind":"not-a-capability-contract"}"#.to_vec();
+        let artifact = b"wasm-bytes".to_vec();
+        let artifact_digest = digest_for(&artifact);
+        let contract_digest = digest_for(&bogus);
+        let record = PublicRegistryCapabilityRecord {
+            namespace: "demo".to_string(),
+            id: "greet".to_string(),
+            version: "1.0.0".to_string(),
+            digest: artifact_digest,
+            artifact_url: "https://example.test/greet.wasm".to_string(),
+            contract_digest,
+            contract_url: "https://example.test/greet.json".to_string(),
+            deprecated: false,
+        };
+        let snapshot = SyncedPublicRegistryState {
+            schema_version: "1".to_string(),
+            workspace_id: "ws".to_string(),
+            state_scope: "public".to_string(),
+            source_repo: "traverse-framework/registry".to_string(),
+            release_tag: "index-v9".to_string(),
+            index_version: 9,
+            generated_at: "2026-07-29T00:00:00Z".to_string(),
+            source_commit: None,
+            synced_at: "2026-07-29T00:00:00Z".to_string(),
+            record_count: 1,
+            validation_status: "valid".to_string(),
+            governing_spec: "055-registry-sync".to_string(),
+            capabilities: vec![record.clone()],
+        };
+        let mut assets = HashMap::new();
+        assets.insert(record.artifact_url.clone(), artifact);
+        assets.insert(record.contract_url.clone(), bogus);
+        let fetcher = MapFetcher { assets };
+        let reference = RegistryReference {
+            namespace: "demo".to_string(),
+            id: "greet".to_string(),
+            version_range: "1.0.0".to_string(),
+        };
+        prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
+        let failure = resolve_component(&cache, &reference).expect_err("parse");
+        assert_eq!(failure.code, RegistryCacheErrorCode::RegistryPrepareFailed);
+    }
+
+    #[test]
+    fn resolve_component_rejects_non_utf8_contract_bytes() {
+        let cache = unique_cache();
+        let bogus = vec![0xff, 0xfe, 0xfd];
+        let artifact = b"wasm-bytes".to_vec();
+        let artifact_digest = digest_for(&artifact);
+        let contract_digest = digest_for(&bogus);
+        let record = PublicRegistryCapabilityRecord {
+            namespace: "demo".to_string(),
+            id: "greet".to_string(),
+            version: "1.0.0".to_string(),
+            digest: artifact_digest,
+            artifact_url: "https://example.test/greet.wasm".to_string(),
+            contract_digest,
+            contract_url: "https://example.test/greet.json".to_string(),
+            deprecated: false,
+        };
+        let snapshot = SyncedPublicRegistryState {
+            schema_version: "1".to_string(),
+            workspace_id: "ws".to_string(),
+            state_scope: "public".to_string(),
+            source_repo: "traverse-framework/registry".to_string(),
+            release_tag: "index-v9".to_string(),
+            index_version: 9,
+            generated_at: "2026-07-29T00:00:00Z".to_string(),
+            source_commit: None,
+            synced_at: "2026-07-29T00:00:00Z".to_string(),
+            record_count: 1,
+            validation_status: "valid".to_string(),
+            governing_spec: "055-registry-sync".to_string(),
+            capabilities: vec![record.clone()],
+        };
+        let mut assets = HashMap::new();
+        assets.insert(record.artifact_url.clone(), artifact);
+        assets.insert(record.contract_url.clone(), bogus);
+        let fetcher = MapFetcher { assets };
+        let reference = RegistryReference {
+            namespace: "demo".to_string(),
+            id: "greet".to_string(),
+            version_range: "1.0.0".to_string(),
+        };
+        prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
+        let failure = resolve_component(&cache, &reference).expect_err("utf8");
+        assert_eq!(failure.code, RegistryCacheErrorCode::RegistryPrepareFailed);
     }
 }

--- a/crates/traverse-embedder/src/registry_cache.rs
+++ b/crates/traverse-embedder/src/registry_cache.rs
@@ -1,0 +1,799 @@
+//! Host-owned verified registry dependency cache (Spec `080-embedded-registry-cache`).
+//!
+//! Separates network-capable [`prepare`] from offline [`HostRegistryCache`]
+//! resolution used at embedder `init`. The host chooses the cache root and
+//! supplies the artifact fetcher; Traverse never synthesizes a production
+//! path or performs network I/O outside `prepare`.
+
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+use traverse_registry::{
+    PublicRegistryCapabilityRecord, RegistryReference, SyncedPublicRegistryState,
+};
+
+/// Stable, secret-free registry-cache failure codes (Spec 080 FR-007).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegistryCacheErrorCode {
+    /// No synced index snapshot was supplied to prepare.
+    RegistrySyncMissing,
+    /// No non-yanked version satisfies the requested range.
+    RegistryVersionNotFound,
+    /// Matching versions exist but every candidate is yanked/deprecated.
+    RegistryDependencyYanked,
+    /// Host fetch or cache persistence failed during prepare.
+    RegistryPrepareFailed,
+    /// Declared digest does not match fetched or stored bytes.
+    RegistryArtifactDigestMismatch,
+    /// Offline resolve found no verified cache entry for the reference.
+    RegistryCacheEntryMissing,
+}
+
+impl RegistryCacheErrorCode {
+    /// Stable `snake_case` wire representation.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RegistrySyncMissing => "registry_sync_missing",
+            Self::RegistryVersionNotFound => "registry_version_not_found",
+            Self::RegistryDependencyYanked => "registry_dependency_yanked",
+            Self::RegistryPrepareFailed => "registry_prepare_failed",
+            Self::RegistryArtifactDigestMismatch => "registry_artifact_digest_mismatch",
+            Self::RegistryCacheEntryMissing => "registry_cache_entry_missing",
+        }
+    }
+}
+
+/// Secret-free registry-cache failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryCacheError {
+    /// Stable machine-readable code.
+    pub code: RegistryCacheErrorCode,
+    /// Human-readable explanation without paths, credentials, or bytes.
+    pub message: String,
+}
+
+impl RegistryCacheError {
+    fn new(code: RegistryCacheErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+/// Host-supplied network fetch used only by [`prepare`].
+pub trait RegistryArtifactFetcher {
+    /// Fetch raw bytes for a published registry URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns a secret-free message when the host cannot retrieve the asset.
+    fn fetch(&self, url: &str) -> Result<Vec<u8>, String>;
+}
+
+/// Host-chosen content-addressed registry cache root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostRegistryCache {
+    root: PathBuf,
+}
+
+impl HostRegistryCache {
+    /// Bind Traverse to a host-selected cache directory.
+    ///
+    /// The host owns creation, permissions, backup, and eviction policy.
+    /// Traverse never invents a default production cache path.
+    #[must_use]
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Host-selected cache root.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Remove one verified entry by artifact digest (`sha256:…`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryCacheErrorCode::RegistryPrepareFailed`] when the
+    /// entry cannot be removed. Missing entries succeed without error.
+    pub fn evict(&self, artifact_digest: &str) -> Result<(), RegistryCacheError> {
+        let digest = normalize_digest(artifact_digest).ok_or_else(|| {
+            RegistryCacheError::new(
+                RegistryCacheErrorCode::RegistryPrepareFailed,
+                "artifact digest must be sha256: followed by 64 hex characters",
+            )
+        })?;
+        let artifact = self.artifact_path(&digest);
+        let meta = self.meta_path(&digest);
+        if artifact.exists() {
+            fs::remove_file(&artifact).map_err(|error| {
+                RegistryCacheError::new(
+                    RegistryCacheErrorCode::RegistryPrepareFailed,
+                    format!("failed to evict verified registry artifact: {error}"),
+                )
+            })?;
+        }
+        if meta.exists() {
+            fs::remove_file(&meta).map_err(|error| {
+                RegistryCacheError::new(
+                    RegistryCacheErrorCode::RegistryPrepareFailed,
+                    format!("failed to evict registry cache metadata: {error}"),
+                )
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Remove every verified entry under this cache root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegistryCacheErrorCode::RegistryPrepareFailed`] when the
+    /// cache directory cannot be cleared.
+    pub fn evict_all(&self) -> Result<(), RegistryCacheError> {
+        for sub in ["sha256", "meta", "refs"] {
+            let path = self.root.join(sub);
+            if path.exists() {
+                fs::remove_dir_all(&path).map_err(|error| {
+                    RegistryCacheError::new(
+                        RegistryCacheErrorCode::RegistryPrepareFailed,
+                        format!("failed to clear host registry cache: {error}"),
+                    )
+                })?;
+            }
+        }
+        Ok(())
+    }
+
+    fn artifact_path(&self, digest_hex: &str) -> PathBuf {
+        self.root.join("sha256").join(digest_hex)
+    }
+
+    fn meta_path(&self, digest_hex: &str) -> PathBuf {
+        self.root.join("meta").join(format!("{digest_hex}.json"))
+    }
+
+    fn ref_path(&self, reference: &RegistryReference) -> PathBuf {
+        let key = sha256_hex(
+            format!(
+                "{}:{}:{}",
+                reference.namespace, reference.id, reference.version_range
+            )
+            .as_bytes(),
+        );
+        self.root.join("refs").join(format!("{key}.json"))
+    }
+}
+
+/// FR-008 resolution evidence retained after a successful prepare.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegistryPrepareEvidence {
+    /// Registry namespace.
+    pub namespace: String,
+    /// Capability id.
+    pub id: String,
+    /// Selected concrete version.
+    pub selected_version: String,
+    /// Requested semver range.
+    pub version_range: String,
+    /// Source release tag from the synced index snapshot.
+    pub source_release: String,
+    /// Digest of the synced index snapshot supplied to prepare.
+    pub index_digest: String,
+    /// Published artifact digest.
+    pub artifact_digest: String,
+    /// Unix-epoch seconds when the entry was verified.
+    pub verified_at: u64,
+    /// Outcome label (`prepared`).
+    pub outcome: &'static str,
+}
+
+impl RegistryPrepareEvidence {
+    /// Secret-free JSON projection of prepare evidence.
+    #[must_use]
+    pub fn as_value(&self) -> Value {
+        json!({
+            "namespace": self.namespace,
+            "id": self.id,
+            "selected_version": self.selected_version,
+            "version_range": self.version_range,
+            "source_release": self.source_release,
+            "index_digest": self.index_digest,
+            "artifact_digest": self.artifact_digest,
+            "verified_at": self.verified_at,
+            "outcome": self.outcome,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct CacheEntryMeta {
+    namespace: String,
+    id: String,
+    selected_version: String,
+    version_range: String,
+    source_release: String,
+    index_digest: String,
+    artifact_digest: String,
+    contract_digest: String,
+    verified_at: u64,
+}
+
+/// Offline lookup of a previously prepared `registry_ref`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedRegistryDependency {
+    /// Absolute path to digest-verified WASM bytes.
+    pub wasm_binary_path: PathBuf,
+    /// Absolute path to digest-verified contract JSON.
+    pub contract_path: PathBuf,
+    /// Published artifact digest.
+    pub wasm_digest: String,
+    /// Prepare evidence for the selected record.
+    pub evidence: RegistryPrepareEvidence,
+}
+
+/// Prepare one `registry_ref` into a host-owned verified cache.
+///
+/// Only this function may call `fetcher`. Partial writes never become
+/// executable entries.
+///
+/// # Errors
+///
+/// Returns a Spec 080 FR-007 code when the snapshot is empty, version
+/// selection fails, fetch fails, or digest verification fails.
+pub fn prepare(
+    cache: &HostRegistryCache,
+    snapshot: &SyncedPublicRegistryState,
+    reference: &RegistryReference,
+    fetcher: &dyn RegistryArtifactFetcher,
+) -> Result<RegistryPrepareEvidence, RegistryCacheError> {
+    if snapshot.capabilities.is_empty() {
+        return Err(RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistrySyncMissing,
+            "synced registry index snapshot contains no capabilities",
+        ));
+    }
+    let record = select_highest_active(snapshot, reference)?;
+    let index_digest = index_snapshot_digest(snapshot);
+    let artifact_bytes = fetcher.fetch(&record.artifact_url).map_err(|message| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            format!("host registry artifact fetch failed: {message}"),
+        )
+    })?;
+    verify_digest(&record.digest, &artifact_bytes)?;
+    let contract_bytes = fetcher.fetch(&record.contract_url).map_err(|message| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            format!("host registry contract fetch failed: {message}"),
+        )
+    })?;
+    verify_digest(&record.contract_digest, &contract_bytes)?;
+
+    let artifact_hex = normalize_digest(&record.digest).ok_or_else(|| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            "artifact digest must be sha256: followed by 64 hex characters",
+        )
+    })?;
+    let contract_hex = normalize_digest(&record.contract_digest).ok_or_else(|| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            "contract digest must be sha256: followed by 64 hex characters",
+        )
+    })?;
+    write_verified_bytes(cache, &artifact_hex, &artifact_bytes)?;
+    write_verified_bytes(cache, &contract_hex, &contract_bytes)?;
+
+    let verified_at = unix_seconds();
+    let meta = CacheEntryMeta {
+        namespace: record.namespace.clone(),
+        id: record.id.clone(),
+        selected_version: record.version.clone(),
+        version_range: reference.version_range.clone(),
+        source_release: snapshot.release_tag.clone(),
+        index_digest: index_digest.clone(),
+        artifact_digest: record.digest.clone(),
+        contract_digest: record.contract_digest.clone(),
+        verified_at,
+    };
+    write_json_atomic(&cache.meta_path(&artifact_hex), &meta)?;
+    write_json_atomic(
+        &cache.ref_path(reference),
+        &json!({
+            "artifact_digest": record.digest,
+            "contract_digest": record.contract_digest,
+        }),
+    )?;
+
+    Ok(RegistryPrepareEvidence {
+        namespace: record.namespace,
+        id: record.id,
+        selected_version: record.version,
+        version_range: reference.version_range.clone(),
+        source_release: snapshot.release_tag.clone(),
+        index_digest,
+        artifact_digest: record.digest,
+        verified_at,
+        outcome: "prepared",
+    })
+}
+
+/// Resolve a `registry_ref` from verified local cache entries only.
+///
+/// # Errors
+///
+/// Returns [`RegistryCacheErrorCode::RegistryCacheEntryMissing`] when no
+/// verified prepare result exists, or digest mismatch when stored bytes were
+/// tampered with.
+pub fn resolve_offline(
+    cache: &HostRegistryCache,
+    reference: &RegistryReference,
+) -> Result<VerifiedRegistryDependency, RegistryCacheError> {
+    let ref_path = cache.ref_path(reference);
+    let ref_bytes = fs::read(&ref_path).map_err(|_| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryCacheEntryMissing,
+            "verified registry cache entry is missing for registry_ref",
+        )
+    })?;
+    let pointer: Value = serde_json::from_slice(&ref_bytes).map_err(|_| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryCacheEntryMissing,
+            "verified registry cache entry is missing for registry_ref",
+        )
+    })?;
+    let artifact_digest = pointer
+        .get("artifact_digest")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            RegistryCacheError::new(
+                RegistryCacheErrorCode::RegistryCacheEntryMissing,
+                "verified registry cache entry is missing for registry_ref",
+            )
+        })?;
+    let contract_digest = pointer
+        .get("contract_digest")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            RegistryCacheError::new(
+                RegistryCacheErrorCode::RegistryCacheEntryMissing,
+                "verified registry cache entry is missing for registry_ref",
+            )
+        })?;
+    let artifact_hex = normalize_digest(artifact_digest).ok_or_else(|| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryCacheEntryMissing,
+            "verified registry cache entry is missing for registry_ref",
+        )
+    })?;
+    let contract_hex = normalize_digest(contract_digest).ok_or_else(|| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryCacheEntryMissing,
+            "verified registry cache entry is missing for registry_ref",
+        )
+    })?;
+    let wasm_binary_path = read_verified(cache, &artifact_hex, artifact_digest)?;
+    let contract_path = read_verified(cache, &contract_hex, contract_digest)?;
+    let meta_bytes = fs::read(cache.meta_path(&artifact_hex)).map_err(|_| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryCacheEntryMissing,
+            "verified registry cache entry is missing for registry_ref",
+        )
+    })?;
+    let meta: CacheEntryMeta = serde_json::from_slice(&meta_bytes).map_err(|_| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryCacheEntryMissing,
+            "verified registry cache entry is missing for registry_ref",
+        )
+    })?;
+    Ok(VerifiedRegistryDependency {
+        wasm_binary_path,
+        contract_path,
+        wasm_digest: artifact_digest.to_string(),
+        evidence: RegistryPrepareEvidence {
+            namespace: meta.namespace,
+            id: meta.id,
+            selected_version: meta.selected_version,
+            version_range: meta.version_range,
+            source_release: meta.source_release,
+            index_digest: meta.index_digest,
+            artifact_digest: meta.artifact_digest,
+            verified_at: meta.verified_at,
+            outcome: "resolved",
+        },
+    })
+}
+
+fn select_highest_active(
+    snapshot: &SyncedPublicRegistryState,
+    reference: &RegistryReference,
+) -> Result<PublicRegistryCapabilityRecord, RegistryCacheError> {
+    let requirement = semver::VersionReq::parse(&reference.version_range).map_err(|error| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryVersionNotFound,
+            format!(
+                "invalid registry_ref version_range {}: {error}",
+                reference.version_range
+            ),
+        )
+    })?;
+    let matching = snapshot
+        .capabilities
+        .iter()
+        .filter_map(|record| {
+            if record.namespace != reference.namespace || record.id != reference.id {
+                return None;
+            }
+            semver::Version::parse(&record.version)
+                .ok()
+                .filter(|version| requirement.matches(version))
+                .map(|version| (version, record.clone()))
+        })
+        .collect::<Vec<_>>();
+    let mut active = matching
+        .iter()
+        .filter(|(_, record)| !record.deprecated)
+        .cloned()
+        .collect::<Vec<_>>();
+    active.sort_by(|left, right| right.0.cmp(&left.0));
+    if let Some((_, record)) = active.into_iter().next() {
+        return Ok(record);
+    }
+    if matching.is_empty() {
+        Err(RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryVersionNotFound,
+            format!(
+                "no synced public registry version for {}:{} satisfies {}",
+                reference.namespace, reference.id, reference.version_range
+            ),
+        ))
+    } else {
+        Err(RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryDependencyYanked,
+            format!(
+                "only yanked public registry versions for {}:{} satisfy {}",
+                reference.namespace, reference.id, reference.version_range
+            ),
+        ))
+    }
+}
+
+fn index_snapshot_digest(snapshot: &SyncedPublicRegistryState) -> String {
+    let encoded = serde_json::to_vec(snapshot).unwrap_or_default();
+    format!("sha256:{}", sha256_hex(&encoded))
+}
+
+fn verify_digest(declared: &str, bytes: &[u8]) -> Result<(), RegistryCacheError> {
+    let expected = normalize_digest(declared).ok_or_else(|| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryArtifactDigestMismatch,
+            "registry digest must be sha256: followed by 64 hex characters",
+        )
+    })?;
+    if sha256_hex(bytes) == expected {
+        Ok(())
+    } else {
+        Err(RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryArtifactDigestMismatch,
+            "registry artifact bytes do not match the published digest",
+        ))
+    }
+}
+
+fn write_verified_bytes(
+    cache: &HostRegistryCache,
+    digest_hex: &str,
+    bytes: &[u8],
+) -> Result<PathBuf, RegistryCacheError> {
+    let path = cache.artifact_path(digest_hex);
+    if path.exists() {
+        let cached = fs::read(&path).map_err(|error| {
+            RegistryCacheError::new(
+                RegistryCacheErrorCode::RegistryPrepareFailed,
+                format!("failed to read existing verified cache entry: {error}"),
+            )
+        })?;
+        if sha256_hex(&cached) != digest_hex {
+            return Err(RegistryCacheError::new(
+                RegistryCacheErrorCode::RegistryArtifactDigestMismatch,
+                "existing registry cache entry digest mismatch",
+            ));
+        }
+        return Ok(path);
+    }
+    let parent = cache.root.join("sha256");
+    fs::create_dir_all(&parent).map_err(|error| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            format!("failed to create host registry cache directory: {error}"),
+        )
+    })?;
+    let temporary = path.with_extension("tmp");
+    fs::write(&temporary, bytes).map_err(|error| {
+        let _ = fs::remove_file(&temporary);
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            format!("failed to write registry cache entry: {error}"),
+        )
+    })?;
+    fs::rename(&temporary, &path).map_err(|error| {
+        let _ = fs::remove_file(&temporary);
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            format!("failed to commit registry cache entry: {error}"),
+        )
+    })?;
+    Ok(path)
+}
+
+fn read_verified(
+    cache: &HostRegistryCache,
+    digest_hex: &str,
+    declared: &str,
+) -> Result<PathBuf, RegistryCacheError> {
+    let path = cache.artifact_path(digest_hex);
+    let bytes = fs::read(&path).map_err(|_| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryCacheEntryMissing,
+            "verified registry cache entry is missing for registry_ref",
+        )
+    })?;
+    verify_digest(declared, &bytes)?;
+    Ok(path)
+}
+
+fn write_json_atomic(path: &Path, value: &impl serde::Serialize) -> Result<(), RegistryCacheError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            RegistryCacheError::new(
+                RegistryCacheErrorCode::RegistryPrepareFailed,
+                format!("failed to create host registry cache directory: {error}"),
+            )
+        })?;
+    }
+    let bytes = serde_json::to_vec(value).map_err(|error| {
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            format!("failed to encode registry cache metadata: {error}"),
+        )
+    })?;
+    let temporary = path.with_extension("tmp");
+    fs::write(&temporary, bytes).map_err(|error| {
+        let _ = fs::remove_file(&temporary);
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            format!("failed to write registry cache metadata: {error}"),
+        )
+    })?;
+    fs::rename(&temporary, path).map_err(|error| {
+        let _ = fs::remove_file(&temporary);
+        RegistryCacheError::new(
+            RegistryCacheErrorCode::RegistryPrepareFailed,
+            format!("failed to commit registry cache metadata: {error}"),
+        )
+    })?;
+    Ok(())
+}
+
+fn normalize_digest(digest: &str) -> Option<String> {
+    let digest = digest.strip_prefix("sha256:")?;
+    if digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        Some(digest.to_ascii_lowercase())
+    } else {
+        None
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut value = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(value, "{byte:02x}");
+    }
+    value
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct MapFetcher {
+        assets: HashMap<String, Vec<u8>>,
+    }
+
+    impl RegistryArtifactFetcher for MapFetcher {
+        fn fetch(&self, url: &str) -> Result<Vec<u8>, String> {
+            self.assets
+                .get(url)
+                .cloned()
+                .ok_or_else(|| "missing asset".to_string())
+        }
+    }
+
+    fn digest_for(bytes: &[u8]) -> String {
+        format!("sha256:{}", sha256_hex(bytes))
+    }
+
+    fn sample_snapshot(
+        deprecated: bool,
+    ) -> (SyncedPublicRegistryState, MapFetcher, RegistryReference) {
+        let artifact = b"wasm-bytes".to_vec();
+        let contract = br#"{"kind":"capability_contract"}"#.to_vec();
+        let artifact_digest = digest_for(&artifact);
+        let contract_digest = digest_for(&contract);
+        let record = PublicRegistryCapabilityRecord {
+            namespace: "demo".to_string(),
+            id: "greet".to_string(),
+            version: "1.2.0".to_string(),
+            digest: artifact_digest,
+            artifact_url: "https://example.test/greet.wasm".to_string(),
+            contract_digest,
+            contract_url: "https://example.test/greet.json".to_string(),
+            deprecated,
+        };
+        let older = PublicRegistryCapabilityRecord {
+            namespace: "demo".to_string(),
+            id: "greet".to_string(),
+            version: "1.0.0".to_string(),
+            digest: digest_for(b"older"),
+            artifact_url: "https://example.test/older.wasm".to_string(),
+            contract_digest: digest_for(b"older-contract"),
+            contract_url: "https://example.test/older.json".to_string(),
+            deprecated: false,
+        };
+        let snapshot = SyncedPublicRegistryState {
+            schema_version: "1".to_string(),
+            workspace_id: "ws".to_string(),
+            state_scope: "public".to_string(),
+            source_repo: "traverse-framework/registry".to_string(),
+            release_tag: "index-v9".to_string(),
+            index_version: 9,
+            generated_at: "2026-07-29T00:00:00Z".to_string(),
+            source_commit: None,
+            synced_at: "2026-07-29T00:00:00Z".to_string(),
+            record_count: 2,
+            validation_status: "valid".to_string(),
+            governing_spec: "055-registry-sync".to_string(),
+            capabilities: vec![older, record.clone()],
+        };
+        let mut assets = HashMap::new();
+        assets.insert(record.artifact_url.clone(), artifact);
+        assets.insert(record.contract_url.clone(), contract);
+        let fetcher = MapFetcher { assets };
+        let reference = RegistryReference {
+            namespace: "demo".to_string(),
+            id: "greet".to_string(),
+            version_range: "^1.0.0".to_string(),
+        };
+        (snapshot, fetcher, reference)
+    }
+
+    fn unique_cache() -> HostRegistryCache {
+        let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("traverse-embedder-cache-{nanos}-{counter}"));
+        fs::create_dir_all(&root).expect("temp");
+        HostRegistryCache::new(root)
+    }
+
+    #[test]
+    fn prepare_then_offline_resolve_round_trip() {
+        let cache = unique_cache();
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
+        assert_eq!(evidence.selected_version, "1.2.0");
+        assert_eq!(evidence.source_release, "index-v9");
+        assert_eq!(evidence.outcome, "prepared");
+        let resolved = resolve_offline(&cache, &reference).expect("offline");
+        assert_eq!(resolved.evidence.selected_version, "1.2.0");
+        assert_eq!(
+            fs::read(&resolved.wasm_binary_path).expect("wasm"),
+            b"wasm-bytes"
+        );
+    }
+
+    #[test]
+    fn offline_resolve_without_prepare_is_missing() {
+        let cache = unique_cache();
+        let reference = RegistryReference {
+            namespace: "demo".to_string(),
+            id: "greet".to_string(),
+            version_range: "^1.0.0".to_string(),
+        };
+        let failure = resolve_offline(&cache, &reference).expect_err("missing");
+        assert_eq!(
+            failure.code,
+            RegistryCacheErrorCode::RegistryCacheEntryMissing
+        );
+    }
+
+    #[test]
+    fn yanked_only_range_fails_closed() {
+        let cache = unique_cache();
+        let (mut snapshot, fetcher, reference) = sample_snapshot(true);
+        snapshot
+            .capabilities
+            .retain(|record| record.version == "1.2.0");
+        let failure = prepare(&cache, &snapshot, &reference, &fetcher).expect_err("yanked");
+        assert_eq!(
+            failure.code,
+            RegistryCacheErrorCode::RegistryDependencyYanked
+        );
+        assert!(
+            cache
+                .root
+                .join("sha256")
+                .read_dir()
+                .ok()
+                .is_none_or(|mut d| d.next().is_none())
+        );
+    }
+
+    #[test]
+    fn digest_mismatch_leaves_no_usable_entry() {
+        let cache = unique_cache();
+        let (snapshot, mut fetcher, reference) = sample_snapshot(false);
+        fetcher.assets.insert(
+            "https://example.test/greet.wasm".to_string(),
+            b"tampered".to_vec(),
+        );
+        let failure = prepare(&cache, &snapshot, &reference, &fetcher).expect_err("mismatch");
+        assert_eq!(
+            failure.code,
+            RegistryCacheErrorCode::RegistryArtifactDigestMismatch
+        );
+        let missing = resolve_offline(&cache, &reference).expect_err("no entry");
+        assert_eq!(
+            missing.code,
+            RegistryCacheErrorCode::RegistryCacheEntryMissing
+        );
+    }
+
+    #[test]
+    fn empty_snapshot_is_sync_missing() {
+        let cache = unique_cache();
+        let (mut snapshot, fetcher, reference) = sample_snapshot(false);
+        snapshot.capabilities.clear();
+        let failure = prepare(&cache, &snapshot, &reference, &fetcher).expect_err("empty");
+        assert_eq!(failure.code, RegistryCacheErrorCode::RegistrySyncMissing);
+    }
+
+    #[test]
+    fn evict_removes_prepared_entry() {
+        let cache = unique_cache();
+        let (snapshot, fetcher, reference) = sample_snapshot(false);
+        let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
+        cache.evict(&evidence.artifact_digest).expect("evict");
+        let missing = resolve_offline(&cache, &reference).expect_err("gone");
+        // ref pointer may remain but artifact bytes are gone → missing or digest path fail
+        assert!(matches!(
+            missing.code,
+            RegistryCacheErrorCode::RegistryCacheEntryMissing
+                | RegistryCacheErrorCode::RegistryArtifactDigestMismatch
+        ));
+    }
+}

--- a/crates/traverse-embedder/src/registry_cache.rs
+++ b/crates/traverse-embedder/src/registry_cache.rs
@@ -1019,8 +1019,7 @@ mod tests {
     fn evict_all_and_missing_evict_paths_are_idempotent() {
         let cache = unique_cache();
         cache.evict_all().expect("empty evict_all");
-        let digest =
-            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let digest = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
         cache.evict(digest).expect("missing evict ok");
         let (snapshot, fetcher, reference) = sample_snapshot(false);
         let evidence = prepare(&cache, &snapshot, &reference, &fetcher).expect("prepare");
@@ -1069,7 +1068,9 @@ mod tests {
         fs::remove_file(&meta).expect("remove meta file");
         fs::create_dir_all(&meta).expect("meta dir");
         fs::write(meta.join("nested"), b"x").expect("nested");
-        let meta_evict = cache.evict(&evidence.artifact_digest).expect_err("meta evict");
+        let meta_evict = cache
+            .evict(&evidence.artifact_digest)
+            .expect_err("meta evict");
         assert_eq!(
             meta_evict.code,
             RegistryCacheErrorCode::RegistryPrepareFailed
@@ -1218,10 +1219,7 @@ mod tests {
         #[derive(Debug)]
         struct Boom;
         impl serde::Serialize for Boom {
-            fn serialize<S: serde::Serializer>(
-                &self,
-                _serializer: S,
-            ) -> Result<S::Ok, S::Error> {
+            fn serialize<S: serde::Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
                 Err(serde::ser::Error::custom("boom"))
             }
         }

--- a/crates/traverse-embedder/src/registry_cache.rs
+++ b/crates/traverse-embedder/src/registry_cache.rs
@@ -604,8 +604,7 @@ fn sha256_hex(bytes: &[u8]) -> String {
 fn unix_seconds() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |duration| duration.as_secs())
 }
 
 #[cfg(test)]

--- a/crates/traverse-embedder/tests/package.rs
+++ b/crates/traverse-embedder/tests/package.rs
@@ -23,6 +23,23 @@ fn development_embedder(fixture: &BundleFixture, platform: &str) -> BundleEmbedd
     BundleEmbedder::init(config).expect("fixture bundle should initialize")
 }
 
+#[test]
+fn init_accepts_host_registry_cache_for_local_bundles() {
+    let fixture = BundleFixture::new("registry-cache-local");
+    let cache_root = fixture
+        .manifest_path()
+        .parent()
+        .expect("manifest parent")
+        .join("registry-cache");
+    std::fs::create_dir_all(&cache_root).expect("cache root");
+    let mut config = EmbedderConfig::new(fixture.manifest_path())
+        .with_registry_cache(traverse_embedder::HostRegistryCache::new(cache_root));
+    config.platform = "linux".to_string();
+    config.security = SecurityPosture::Development;
+    let embedder = BundleEmbedder::init(config).expect("local bundle with cache should init");
+    drop(embedder);
+}
+
 // --- init rejection paths (NFR-001) ---
 
 #[test]

--- a/packages/web/TraverseEmbedder/package.json
+++ b/packages/web/TraverseEmbedder/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs"
+    "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs tests/registryCache.test.mjs"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",

--- a/packages/web/TraverseEmbedder/src/index.ts
+++ b/packages/web/TraverseEmbedder/src/index.ts
@@ -67,6 +67,25 @@ export { FetchBundleLoader, NodeFsBundleLoader } from "./bundleLoader.js";
 export type { BundleLoader } from "./bundleLoader.js";
 
 export {
+  MemoryRegistryCacheStore,
+  RegistryCacheError,
+  evictAllRegistryCacheEntries,
+  evictRegistryCacheEntry,
+  prepareRegistryDependency,
+  resolveRegistryDependencyOffline,
+} from "./registryCache.js";
+export type {
+  PublicRegistryCapabilityRecord,
+  RegistryArtifactFetcher,
+  RegistryCacheErrorCode,
+  RegistryCacheStore,
+  RegistryPrepareEvidence,
+  RegistryReference,
+  SyncedPublicRegistryState,
+  VerifiedRegistryDependency,
+} from "./registryCache.js";
+
+export {
   HOST_ABI_V1_WHITELIST,
   SUPPORTED_HOST_ABI_VERSION,
   findUnauthorizedImport,

--- a/packages/web/TraverseEmbedder/src/registryCache.ts
+++ b/packages/web/TraverseEmbedder/src/registryCache.ts
@@ -1,0 +1,452 @@
+/**
+ * Host-owned verified registry dependency cache (Spec `080-embedded-registry-cache`).
+ *
+ * Separates network-capable `prepareRegistryDependency` from offline
+ * `resolveRegistryDependencyOffline` used at embedder `init`. The host owns
+ * cache storage; Traverse never synthesizes a production path or performs
+ * network I/O outside prepare.
+ */
+
+import { BundleRejectedError, verifyArtifactDigest } from "./bundleValidation.js";
+
+/** Stable Spec 080 FR-007 error codes. */
+export type RegistryCacheErrorCode =
+  | "registry_sync_missing"
+  | "registry_version_not_found"
+  | "registry_dependency_yanked"
+  | "registry_prepare_failed"
+  | "registry_artifact_digest_mismatch"
+  | "registry_cache_entry_missing";
+
+export class RegistryCacheError extends Error {
+  readonly code: RegistryCacheErrorCode;
+
+  constructor(code: RegistryCacheErrorCode, message: string) {
+    super(message);
+    this.name = "RegistryCacheError";
+    this.code = code;
+  }
+}
+
+/** Host-owned byte store for verified cache entries. */
+export interface RegistryCacheStore {
+  get(key: string): Promise<Uint8Array | undefined> | Uint8Array | undefined;
+  set(key: string, bytes: Uint8Array): Promise<void> | void;
+  delete(key: string): Promise<void> | void;
+  keys(): Promise<readonly string[]> | readonly string[];
+}
+
+/** In-memory host cache store for tests and simple hosts. */
+export class MemoryRegistryCacheStore implements RegistryCacheStore {
+  private readonly entries = new Map<string, Uint8Array>();
+
+  get(key: string): Uint8Array | undefined {
+    return this.entries.get(key);
+  }
+
+  set(key: string, bytes: Uint8Array): void {
+    this.entries.set(key, bytes);
+  }
+
+  delete(key: string): void {
+    this.entries.delete(key);
+  }
+
+  keys(): readonly string[] {
+    return [...this.entries.keys()];
+  }
+}
+
+export interface RegistryReference {
+  readonly namespace: string;
+  readonly id: string;
+  readonly versionRange: string;
+}
+
+export interface PublicRegistryCapabilityRecord {
+  readonly namespace: string;
+  readonly id: string;
+  readonly version: string;
+  readonly digest: string;
+  readonly artifactUrl: string;
+  readonly contractDigest: string;
+  readonly contractUrl: string;
+  readonly deprecated: boolean;
+}
+
+export interface SyncedPublicRegistryState {
+  readonly releaseTag: string;
+  readonly capabilities: readonly PublicRegistryCapabilityRecord[];
+}
+
+export interface RegistryArtifactFetcher {
+  fetch(url: string): Promise<Uint8Array> | Uint8Array;
+}
+
+export interface RegistryPrepareEvidence {
+  readonly namespace: string;
+  readonly id: string;
+  readonly selectedVersion: string;
+  readonly versionRange: string;
+  readonly sourceRelease: string;
+  readonly indexDigest: string;
+  readonly artifactDigest: string;
+  readonly verifiedAt: number;
+  readonly outcome: "prepared" | "resolved";
+}
+
+export interface VerifiedRegistryDependency {
+  readonly wasmBytes: Uint8Array;
+  readonly contractBytes: Uint8Array;
+  readonly wasmDigest: string;
+  readonly evidence: RegistryPrepareEvidence;
+}
+
+interface CacheEntryMeta {
+  readonly namespace: string;
+  readonly id: string;
+  readonly selectedVersion: string;
+  readonly versionRange: string;
+  readonly sourceRelease: string;
+  readonly indexDigest: string;
+  readonly artifactDigest: string;
+  readonly contractDigest: string;
+  readonly verifiedAt: number;
+}
+
+function textEncoder(): TextEncoder {
+  return new TextEncoder();
+}
+
+function textDecoder(): TextDecoder {
+  return new TextDecoder();
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const copy: Uint8Array<ArrayBuffer> = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  const digest = await crypto.subtle.digest("SHA-256", copy);
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function digestFor(bytes: Uint8Array): Promise<string> {
+  return `sha256:${await sha256Hex(bytes)}`;
+}
+
+function normalizeDigest(digest: string): string | undefined {
+  if (!digest.startsWith("sha256:")) {
+    return undefined;
+  }
+  const hex = digest.slice("sha256:".length).toLowerCase();
+  if (hex.length !== 64 || !/^[0-9a-f]+$/.test(hex)) {
+    return undefined;
+  }
+  return hex;
+}
+
+async function refKey(reference: RegistryReference): Promise<string> {
+  const material = `${reference.namespace}:${reference.id}:${reference.versionRange}`;
+  return `refs/${await sha256Hex(textEncoder().encode(material))}.json`;
+}
+
+function artifactKey(digestHex: string): string {
+  return `sha256/${digestHex}`;
+}
+
+function metaKey(digestHex: string): string {
+  return `meta/${digestHex}.json`;
+}
+
+function compareSemver(left: string, right: string): number {
+  const parse = (value: string): number[] =>
+    value.split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const a = parse(left);
+  const b = parse(right);
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const delta = (a[i] ?? 0) - (b[i] ?? 0);
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+  return 0;
+}
+
+function matchesCaretRange(version: string, range: string): boolean {
+  const caret = range.startsWith("^") ? range.slice(1) : range;
+  if (range === "*" || range === "x") {
+    return true;
+  }
+  if (!range.startsWith("^")) {
+    return version === range || version.startsWith(`${range}.`);
+  }
+  const [major = 0, minor = 0] = caret
+    .split(".")
+    .map((part) => Number.parseInt(part, 10) || 0);
+  const [vMajorRaw, vMinorRaw = 0, vPatchRaw = 0] = version
+    .split(".")
+    .map((part) => Number.parseInt(part, 10) || 0);
+  const vMajor = vMajorRaw ?? 0;
+  const vMinor = vMinorRaw ?? 0;
+  const vPatch = vPatchRaw ?? 0;
+  if (vMajor !== major) {
+    return false;
+  }
+  if (major === 0) {
+    return vMinor === minor;
+  }
+  return (
+    compareSemver(version, caret) >= 0 &&
+    compareSemver(`${major + 1}.0.0`, version) > 0 &&
+    Number.isFinite(vPatch)
+  );
+}
+
+function selectHighestActive(
+  snapshot: SyncedPublicRegistryState,
+  reference: RegistryReference,
+): PublicRegistryCapabilityRecord {
+  const matching = snapshot.capabilities.filter(
+    (record) =>
+      record.namespace === reference.namespace &&
+      record.id === reference.id &&
+      matchesCaretRange(record.version, reference.versionRange),
+  );
+  const active = matching
+    .filter((record) => !record.deprecated)
+    .sort((left, right) => compareSemver(right.version, left.version));
+  if (active[0]) {
+    return active[0];
+  }
+  if (matching.length === 0) {
+    throw new RegistryCacheError(
+      "registry_version_not_found",
+      `no synced public registry version for ${reference.namespace}:${reference.id} satisfies ${reference.versionRange}`,
+    );
+  }
+  throw new RegistryCacheError(
+    "registry_dependency_yanked",
+    `only yanked public registry versions for ${reference.namespace}:${reference.id} satisfy ${reference.versionRange}`,
+  );
+}
+
+async function writeVerified(
+  store: RegistryCacheStore,
+  digest: string,
+  bytes: Uint8Array,
+): Promise<string> {
+  const hex = normalizeDigest(digest);
+  if (!hex) {
+    throw new RegistryCacheError(
+      "registry_artifact_digest_mismatch",
+      "registry digest must be sha256: followed by 64 hex characters",
+    );
+  }
+  try {
+    await verifyArtifactDigest(bytes, digest, "registry artifact");
+  } catch (error) {
+    if (error instanceof BundleRejectedError) {
+      throw new RegistryCacheError(
+        "registry_artifact_digest_mismatch",
+        "registry artifact bytes do not match the published digest",
+      );
+    }
+    throw error;
+  }
+  const key = artifactKey(hex);
+  const existing = await store.get(key);
+  if (existing) {
+    try {
+      await verifyArtifactDigest(existing, digest, "cached registry artifact");
+    } catch {
+      throw new RegistryCacheError(
+        "registry_artifact_digest_mismatch",
+        "existing registry cache entry digest mismatch",
+      );
+    }
+    return hex;
+  }
+  await store.set(key, bytes);
+  return hex;
+}
+
+/**
+ * Prepare one `registry_ref` into a host-owned verified cache.
+ * Only this function may call the fetcher.
+ */
+export async function prepareRegistryDependency(
+  store: RegistryCacheStore,
+  snapshot: SyncedPublicRegistryState,
+  reference: RegistryReference,
+  fetcher: RegistryArtifactFetcher,
+): Promise<RegistryPrepareEvidence> {
+  if (snapshot.capabilities.length === 0) {
+    throw new RegistryCacheError(
+      "registry_sync_missing",
+      "synced registry index snapshot contains no capabilities",
+    );
+  }
+  const record = selectHighestActive(snapshot, reference);
+  const indexDigest = await digestFor(
+    textEncoder().encode(JSON.stringify(snapshot)),
+  );
+  let artifactBytes: Uint8Array;
+  let contractBytes: Uint8Array;
+  try {
+    artifactBytes = await fetcher.fetch(record.artifactUrl);
+    contractBytes = await fetcher.fetch(record.contractUrl);
+  } catch (error) {
+    throw new RegistryCacheError(
+      "registry_prepare_failed",
+      `host registry fetch failed: ${error instanceof Error ? error.message : "unknown"}`,
+    );
+  }
+  try {
+    await writeVerified(store, record.digest, artifactBytes);
+    await writeVerified(store, record.contractDigest, contractBytes);
+  } catch (error) {
+    if (error instanceof RegistryCacheError) {
+      throw error;
+    }
+    throw new RegistryCacheError(
+      "registry_artifact_digest_mismatch",
+      "registry artifact bytes do not match the published digest",
+    );
+  }
+  const artifactHex = normalizeDigest(record.digest);
+  if (!artifactHex) {
+    throw new RegistryCacheError(
+      "registry_prepare_failed",
+      "artifact digest must be sha256: followed by 64 hex characters",
+    );
+  }
+  const verifiedAt = Math.floor(Date.now() / 1000);
+  const meta: CacheEntryMeta = {
+    namespace: record.namespace,
+    id: record.id,
+    selectedVersion: record.version,
+    versionRange: reference.versionRange,
+    sourceRelease: snapshot.releaseTag,
+    indexDigest,
+    artifactDigest: record.digest,
+    contractDigest: record.contractDigest,
+    verifiedAt,
+  };
+  await store.set(metaKey(artifactHex), textEncoder().encode(JSON.stringify(meta)));
+  await store.set(
+    await refKey(reference),
+    textEncoder().encode(
+      JSON.stringify({
+        artifactDigest: record.digest,
+        contractDigest: record.contractDigest,
+      }),
+    ),
+  );
+  return {
+    namespace: record.namespace,
+    id: record.id,
+    selectedVersion: record.version,
+    versionRange: reference.versionRange,
+    sourceRelease: snapshot.releaseTag,
+    indexDigest,
+    artifactDigest: record.digest,
+    verifiedAt,
+    outcome: "prepared",
+  };
+}
+
+/** Resolve a previously prepared `registry_ref` offline. */
+export async function resolveRegistryDependencyOffline(
+  store: RegistryCacheStore,
+  reference: RegistryReference,
+): Promise<VerifiedRegistryDependency> {
+  const pointerBytes = await store.get(await refKey(reference));
+  if (!pointerBytes) {
+    throw new RegistryCacheError(
+      "registry_cache_entry_missing",
+      "verified registry cache entry is missing for registry_ref",
+    );
+  }
+  const pointer = JSON.parse(textDecoder().decode(pointerBytes)) as {
+    artifactDigest?: string;
+    contractDigest?: string;
+  };
+  if (!pointer.artifactDigest || !pointer.contractDigest) {
+    throw new RegistryCacheError(
+      "registry_cache_entry_missing",
+      "verified registry cache entry is missing for registry_ref",
+    );
+  }
+  const artifactHex = normalizeDigest(pointer.artifactDigest);
+  const contractHex = normalizeDigest(pointer.contractDigest);
+  if (!artifactHex || !contractHex) {
+    throw new RegistryCacheError(
+      "registry_cache_entry_missing",
+      "verified registry cache entry is missing for registry_ref",
+    );
+  }
+  const wasmBytes = await store.get(artifactKey(artifactHex));
+  const contractBytes = await store.get(artifactKey(contractHex));
+  const metaBytes = await store.get(metaKey(artifactHex));
+  if (!wasmBytes || !contractBytes || !metaBytes) {
+    throw new RegistryCacheError(
+      "registry_cache_entry_missing",
+      "verified registry cache entry is missing for registry_ref",
+    );
+  }
+  await verifyArtifactDigest(wasmBytes, pointer.artifactDigest, "cached registry artifact");
+  await verifyArtifactDigest(
+    contractBytes,
+    pointer.contractDigest,
+    "cached registry contract",
+  );
+  const meta = JSON.parse(textDecoder().decode(metaBytes)) as CacheEntryMeta;
+  return {
+    wasmBytes,
+    contractBytes,
+    wasmDigest: pointer.artifactDigest,
+    evidence: {
+      namespace: meta.namespace,
+      id: meta.id,
+      selectedVersion: meta.selectedVersion,
+      versionRange: meta.versionRange,
+      sourceRelease: meta.sourceRelease,
+      indexDigest: meta.indexDigest,
+      artifactDigest: meta.artifactDigest,
+      verifiedAt: meta.verifiedAt,
+      outcome: "resolved",
+    },
+  };
+}
+
+/** Remove one verified artifact entry by digest. */
+export async function evictRegistryCacheEntry(
+  store: RegistryCacheStore,
+  artifactDigest: string,
+): Promise<void> {
+  const hex = normalizeDigest(artifactDigest);
+  if (!hex) {
+    throw new RegistryCacheError(
+      "registry_prepare_failed",
+      "artifact digest must be sha256: followed by 64 hex characters",
+    );
+  }
+  await store.delete(artifactKey(hex));
+  await store.delete(metaKey(hex));
+}
+
+/** Clear every verified entry in the host store. */
+export async function evictAllRegistryCacheEntries(
+  store: RegistryCacheStore,
+): Promise<void> {
+  for (const key of await store.keys()) {
+    if (
+      key.startsWith("sha256/") ||
+      key.startsWith("meta/") ||
+      key.startsWith("refs/")
+    ) {
+      await store.delete(key);
+    }
+  }
+}

--- a/packages/web/TraverseEmbedder/tests/registryCache.test.mjs
+++ b/packages/web/TraverseEmbedder/tests/registryCache.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import {
+  MemoryRegistryCacheStore,
+  RegistryCacheError,
+  prepareRegistryDependency,
+  resolveRegistryDependencyOffline,
+} from "../dist/registryCache.js";
+
+function digestFor(bytes) {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function sampleSnapshot(deprecated = false) {
+  const artifact = Buffer.from("wasm-bytes");
+  const contract = Buffer.from('{"kind":"capability_contract"}');
+  const record = {
+    namespace: "demo",
+    id: "greet",
+    version: "1.2.0",
+    digest: digestFor(artifact),
+    artifactUrl: "https://example.test/greet.wasm",
+    contractDigest: digestFor(contract),
+    contractUrl: "https://example.test/greet.json",
+    deprecated,
+  };
+  const assets = new Map([
+    [record.artifactUrl, new Uint8Array(artifact)],
+    [record.contractUrl, new Uint8Array(contract)],
+  ]);
+  return {
+    snapshot: {
+      releaseTag: "index-v9",
+      capabilities: [
+        {
+          namespace: "demo",
+          id: "greet",
+          version: "1.0.0",
+          digest: digestFor(Buffer.from("older")),
+          artifactUrl: "https://example.test/older.wasm",
+          contractDigest: digestFor(Buffer.from("older-contract")),
+          contractUrl: "https://example.test/older.json",
+          deprecated: false,
+        },
+        record,
+      ],
+    },
+    assets,
+    reference: { namespace: "demo", id: "greet", versionRange: "^1.0.0" },
+  };
+}
+
+test("prepare then offline resolve round trip", async () => {
+  const store = new MemoryRegistryCacheStore();
+  const { snapshot, assets, reference } = sampleSnapshot(false);
+  const evidence = await prepareRegistryDependency(store, snapshot, reference, {
+    fetch(url) {
+      const bytes = assets.get(url);
+      if (!bytes) {
+        throw new Error("missing");
+      }
+      return bytes;
+    },
+  });
+  assert.equal(evidence.selectedVersion, "1.2.0");
+  const resolved = await resolveRegistryDependencyOffline(store, reference);
+  assert.equal(resolved.evidence.selectedVersion, "1.2.0");
+  assert.deepEqual(Buffer.from(resolved.wasmBytes), Buffer.from("wasm-bytes"));
+});
+
+test("offline resolve without prepare is missing", async () => {
+  const store = new MemoryRegistryCacheStore();
+  await assert.rejects(
+    () =>
+      resolveRegistryDependencyOffline(store, {
+        namespace: "demo",
+        id: "greet",
+        versionRange: "^1.0.0",
+      }),
+    (error) =>
+      error instanceof RegistryCacheError &&
+      error.code === "registry_cache_entry_missing",
+  );
+});
+
+test("yanked-only range fails closed", async () => {
+  const store = new MemoryRegistryCacheStore();
+  const { snapshot, assets, reference } = sampleSnapshot(true);
+  snapshot.capabilities = snapshot.capabilities.filter(
+    (record) => record.version === "1.2.0",
+  );
+  await assert.rejects(
+    () =>
+      prepareRegistryDependency(store, snapshot, reference, {
+        fetch(url) {
+          return assets.get(url);
+        },
+      }),
+    (error) =>
+      error instanceof RegistryCacheError &&
+      error.code === "registry_dependency_yanked",
+  );
+});
+
+test("digest mismatch leaves no usable entry", async () => {
+  const store = new MemoryRegistryCacheStore();
+  const { snapshot, assets, reference } = sampleSnapshot(false);
+  assets.set(
+    "https://example.test/greet.wasm",
+    new Uint8Array(Buffer.from("tampered")),
+  );
+  await assert.rejects(
+    () =>
+      prepareRegistryDependency(store, snapshot, reference, {
+        fetch(url) {
+          return assets.get(url);
+        },
+      }),
+    (error) =>
+      error instanceof RegistryCacheError &&
+      error.code === "registry_artifact_digest_mismatch",
+  );
+  await assert.rejects(
+    () => resolveRegistryDependencyOffline(store, reference),
+    (error) =>
+      error instanceof RegistryCacheError &&
+      error.code === "registry_cache_entry_missing",
+  );
+});


### PR DESCRIPTION
## Summary

- Add the host-owned verified registry dependency cache required by Spec 080.
- Separate host-supplied network preparation from offline embedder initialization and execution.
- Add matching Rust and Web cache surfaces, stable errors, digest verification, and conformance tests.

## Governing Spec

- `080-embedded-registry-cache`

## Project Item

Closes #860.

## Definition of Done

- Host preparation validates synced registry state, selects deterministic non-yanked versions, verifies digests, and writes cache entries atomically.
- Embedded offline resolution uses only host-provided verified cache entries.
- Cache errors and evidence remain stable and secret-free.
- Rust and Web conformance cover successful preparation, missing entries, yanks, and digest mismatches.

## Validation

- `cargo test -p traverse-embedder`
- `npm test` in `packages/web/TraverseEmbedder`
- `git diff --check`
