### PR TITLE
feat: add DataStore retention and backup maintenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -43,6 +49,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "async-trait"
@@ -496,6 +505,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +667,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1176,6 +1206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1615,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1925,6 +1971,7 @@ dependencies = [
  "wasmtime-wasi",
  "wat",
  "zeroize",
+ "zip",
 ]
 
 [[package]]
@@ -3030,10 +3077,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/crates/traverse-runtime/Cargo.toml
+++ b/crates/traverse-runtime/Cargo.toml
@@ -21,6 +21,7 @@ wasmtime-wasi = { version = "44", optional = true }
 uuid = { version = "1", features = ["v4", "js"] }
 chrono = { version = "0.4", features = ["serde"] }
 rayon = { version = "1.11", optional = true }
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [features]
 default = ["native-executors", "wasmtime-executor"]

--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -2,7 +2,15 @@
 //!
 //! General operations are governed by spec `032-universal-data-access`; the
 //! local-file adapter durability boundary is governed by spec
-//! `518-durable-local-datastore`.
+//! `518-durable-local-datastore`. Retention prune and verified backup/restore
+//! are governed by spec `083-datastore-retention-backup`.
+
+#[path = "data_store_maintenance.rs"]
+mod maintenance;
+pub use maintenance::{
+    BackupManifest, BackupRecordIndexEntry, DataStoreMaintenance, LocalFileDataStoreMaintenance,
+    MaintenanceError, MaintenanceErrorCode, MaintenanceEvidence, RetentionPolicy,
+};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -87,6 +95,10 @@ struct LocalDataStoreEnvelope {
     classification: LocalDataClassification,
     record: StateRecord,
     digest: String,
+    /// Host-supplied RFC3339 instant stamped at write time for age-based prune.
+    /// Absent on legacy envelopes; age prune treats missing stamps as retained.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retained_at: Option<String>,
 }
 
 pub trait DataStore {
@@ -264,6 +276,8 @@ pub struct LocalFileDataStore {
     root: PathBuf,
     classification: LocalDataClassification,
     lock_file: File,
+    /// Host-supplied retained-at stamp applied to subsequent writes (no OS clock).
+    write_retained_at: Option<String>,
 }
 
 impl Drop for LocalFileDataStore {
@@ -309,7 +323,22 @@ impl LocalFileDataStore {
             root,
             classification,
             lock_file,
+            write_retained_at: None,
         })
+    }
+
+    /// Sets the host-supplied retained-at stamp used by subsequent writes.
+    ///
+    /// Traverse does not read the OS clock; hosts must supply RFC3339 instants
+    /// when age-based retention is desired.
+    pub fn set_write_retained_at(&mut self, retained_at: Option<String>) {
+        self.write_retained_at = retained_at;
+    }
+
+    /// Returns the store root path for host-owned maintenance construction.
+    #[must_use]
+    pub fn root(&self) -> &PathBuf {
+        &self.root
     }
 
     fn path_for_key(&self, key: &str) -> Result<PathBuf, DataStoreError> {
@@ -359,6 +388,7 @@ impl DataStore for LocalFileDataStore {
             format: LOCAL_DATA_STORE_FORMAT.to_string(),
             classification: self.classification,
             digest: digest_for_record(&record)?,
+            retained_at: self.write_retained_at.clone(),
             record,
         };
         let text = serde_json::to_vec(&envelope)

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -374,15 +374,8 @@ impl DataStoreMaintenance for LocalFileDataStoreMaintenance {
 
         // Release lock on the live root before swapping directories.
         let _ = self.lock_file.unlock();
-        fs::rename(&self.root, &backup_root)
-            .map_err(|error| handle_move_live_store_aside_failure(self, &error))?;
-        if let Err(error) = fs::rename(&temp_root, &self.root) {
-            return Err(handle_replace_store_root_failure(
-                self,
-                &backup_root,
-                &error,
-            ));
-        }
+        move_live_store_aside(self, &backup_root)?;
+        replace_store_root(self, &temp_root, &backup_root)?;
         self.reacquire_lock()?;
         let _ = fs::remove_dir_all(&backup_root);
 
@@ -739,6 +732,29 @@ fn as_of_minus_max_age_underflow_error() -> MaintenanceError {
     }
 }
 
+fn move_live_store_aside(
+    maintenance: &mut LocalFileDataStoreMaintenance,
+    backup_root: &Path,
+) -> Result<(), MaintenanceError> {
+    fs::rename(&maintenance.root, backup_root)
+        .map_err(|error| handle_move_live_store_aside_failure(maintenance, &error))
+}
+
+fn replace_store_root(
+    maintenance: &mut LocalFileDataStoreMaintenance,
+    temp_root: &Path,
+    backup_root: &Path,
+) -> Result<(), MaintenanceError> {
+    if let Err(error) = fs::rename(temp_root, &maintenance.root) {
+        return Err(handle_replace_store_root_failure(
+            maintenance,
+            backup_root,
+            &error,
+        ));
+    }
+    Ok(())
+}
+
 fn read_manifest_bytes_error(error: &std::io::Error) -> MaintenanceError {
     MaintenanceError {
         code: MaintenanceErrorCode::BackupVerifyFailed,
@@ -757,10 +773,10 @@ fn read_member_bytes_error(error: &std::io::Error) -> MaintenanceError {
 
 fn open_restore_zip(archive: &Path) -> Result<ZipArchive<File>, MaintenanceError> {
     let file = File::open(archive).map_err(|error| maintenance_io("reopen archive", &error))?;
-    ZipArchive::new(file).map_err(|error| restore_invalid_zip_error(error))
+    ZipArchive::new(file).map_err(restore_invalid_zip_error)
 }
 
-fn restore_invalid_zip_error(error: zip::result::ZipError) -> MaintenanceError {
+fn restore_invalid_zip_error(error: &zip::result::ZipError) -> MaintenanceError {
     MaintenanceError {
         code: MaintenanceErrorCode::RestoreVerifyFailed,
         message: "restore_verify_failed".to_string(),
@@ -1169,6 +1185,37 @@ mod tests {
     }
 
     #[test]
+    fn restore_replace_failure_rolls_back_live_store() {
+        let root = temp_root("replace-live");
+        drop(seed_store(&root, 1, None));
+        let parent = root.parent().expect("parent");
+        let temp_root_path = parent.join(format!(
+            ".traverse-datastore-restore-{}-manual",
+            std::process::id()
+        ));
+        let backup_root = parent.join(format!(
+            ".traverse-datastore-replaced-{}-manual",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&temp_root_path);
+        let _ = fs::remove_dir_all(&backup_root);
+        fs::create_dir_all(&temp_root_path).expect("temp");
+        fs::write(temp_root_path.join(LOCAL_DATA_STORE_LOCK_FILE), b"").expect("lock");
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        move_live_store_aside(&mut maintenance, &backup_root).expect("move aside");
+        fs::write(&root, "block replace").expect("occupy root path");
+        let failure = replace_store_root(&mut maintenance, &temp_root_path, &backup_root)
+            .expect_err("replace");
+        assert_eq!(
+            failure.details["operation"],
+            "atomically replace store root"
+        );
+        let _ = fs::remove_file(&root);
+        let _ = fs::rename(&backup_root, &root);
+        let _ = fs::remove_dir_all(&temp_root_path);
+    }
+
+    #[test]
     fn verify_io_error_helpers_and_truncated_manifest_reads_fail() {
         let root = temp_root("truncated");
         drop(seed_store(&root, 1, None));
@@ -1182,7 +1229,7 @@ mod tests {
                 .backup(&archive, "2026-07-29T00:00:00Z")
                 .expect("backup");
         }
-        let mut file = OpenOptions::new().write(true).open(&archive).expect("open");
+        let file = OpenOptions::new().write(true).open(&archive).expect("open");
         file.set_len(32).expect("truncate");
         drop(file);
         let failure = verify_backup_archive(&archive).expect_err("truncated");

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -773,7 +773,7 @@ fn read_member_bytes_error(error: &std::io::Error) -> MaintenanceError {
 
 fn open_restore_zip(archive: &Path) -> Result<ZipArchive<File>, MaintenanceError> {
     let file = File::open(archive).map_err(|error| maintenance_io("reopen archive", &error))?;
-    ZipArchive::new(file).map_err(restore_invalid_zip_error)
+    ZipArchive::new(file).map_err(|error| restore_invalid_zip_error(&error))
 }
 
 fn restore_invalid_zip_error(error: &zip::result::ZipError) -> MaintenanceError {

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -555,11 +555,7 @@ fn read_and_validate_manifest_header(
                 })?;
         manifest_file
             .read_to_end(&mut manifest_bytes)
-            .map_err(|error| MaintenanceError {
-                code: MaintenanceErrorCode::BackupVerifyFailed,
-                message: "backup_verify_failed".to_string(),
-                details: json!({ "reason": "read_manifest", "cause": error.to_string() }),
-            })?;
+            .map_err(|error| read_manifest_bytes_error(&error))?;
     }
     let manifest: BackupManifest =
         serde_json::from_slice(&manifest_bytes).map_err(|_| MaintenanceError {
@@ -611,11 +607,7 @@ fn verify_manifest_member_payloads(
                     details: json!({ "reason": "missing_member", "path": entry.member_path }),
                 })?;
             file.read_to_end(&mut bytes)
-                .map_err(|error| MaintenanceError {
-                    code: MaintenanceErrorCode::BackupVerifyFailed,
-                    message: "backup_verify_failed".to_string(),
-                    details: json!({ "reason": "read_member", "cause": error.to_string() }),
-                })?;
+                .map_err(|error| read_member_bytes_error(&error))?;
         }
         if sha256_hex(&bytes) != entry.envelope_digest {
             return Err(MaintenanceError {
@@ -660,12 +652,7 @@ fn verify_manifest_member_payloads(
 
 fn materialize_archive_to_root(archive: &Path, root: &Path) -> Result<(), MaintenanceError> {
     let manifest = verify_backup_archive(archive)?;
-    let file = File::open(archive).map_err(|error| maintenance_io("reopen archive", &error))?;
-    let mut zip = ZipArchive::new(file).map_err(|error| MaintenanceError {
-        code: MaintenanceErrorCode::RestoreVerifyFailed,
-        message: "restore_verify_failed".to_string(),
-        details: json!({ "reason": "invalid_zip", "cause": error.to_string() }),
-    })?;
+    let mut zip = open_restore_zip(archive)?;
     // Ensure lock file exists in the new root so reopen can acquire it.
     let lock_path = root.join(LOCAL_DATA_STORE_LOCK_FILE);
     File::create(&lock_path)
@@ -678,11 +665,7 @@ fn materialize_archive_to_root(archive: &Path, root: &Path) -> Result<(), Mainte
         {
             let mut member = zip
                 .by_name(&entry.member_path)
-                .map_err(|_| MaintenanceError {
-                    code: MaintenanceErrorCode::RestoreVerifyFailed,
-                    message: "restore_verify_failed".to_string(),
-                    details: json!({ "reason": "missing_member", "path": entry.member_path }),
-                })?;
+                .map_err(|_| restore_missing_member_error(&entry.member_path))?;
             member
                 .read_to_end(&mut bytes)
                 .map_err(|error| maintenance_io("extract member", &error))?;
@@ -753,6 +736,43 @@ fn as_of_minus_max_age_underflow_error() -> MaintenanceError {
         code: MaintenanceErrorCode::InvalidRetentionPolicy,
         message: "invalid_retention_policy".to_string(),
         details: json!({ "reason": "as_of_minus_max_age_underflow" }),
+    }
+}
+
+fn read_manifest_bytes_error(error: &std::io::Error) -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::BackupVerifyFailed,
+        message: "backup_verify_failed".to_string(),
+        details: json!({ "reason": "read_manifest", "cause": error.to_string() }),
+    }
+}
+
+fn read_member_bytes_error(error: &std::io::Error) -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::BackupVerifyFailed,
+        message: "backup_verify_failed".to_string(),
+        details: json!({ "reason": "read_member", "cause": error.to_string() }),
+    }
+}
+
+fn open_restore_zip(archive: &Path) -> Result<ZipArchive<File>, MaintenanceError> {
+    let file = File::open(archive).map_err(|error| maintenance_io("reopen archive", &error))?;
+    ZipArchive::new(file).map_err(|error| restore_invalid_zip_error(error))
+}
+
+fn restore_invalid_zip_error(error: zip::result::ZipError) -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::RestoreVerifyFailed,
+        message: "restore_verify_failed".to_string(),
+        details: json!({ "reason": "invalid_zip", "cause": error.to_string() }),
+    }
+}
+
+fn restore_missing_member_error(path: &str) -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::RestoreVerifyFailed,
+        message: "restore_verify_failed".to_string(),
+        details: json!({ "reason": "missing_member", "path": path }),
     }
 }
 
@@ -858,7 +878,7 @@ mod tests {
         DataStore, DataStoreError, DataStoreErrorCode, LocalFileDataStore, StateRecord,
     };
     use serde_json::json;
-    use std::fs::TryLockError;
+    use std::fs::{self, File, OpenOptions, TryLockError};
     use std::path::Path;
     use uuid::Uuid;
 
@@ -1100,6 +1120,73 @@ mod tests {
         let parse_error = serde_json::from_str::<Value>("{").expect_err("invalid json");
         let manifest = serialize_manifest_error(&parse_error);
         assert_eq!(manifest.details["operation"], "serialize_manifest");
+
+        let io = std::io::Error::other("read failed");
+        assert_eq!(
+            read_manifest_bytes_error(&io).details["reason"],
+            "read_manifest"
+        );
+        assert_eq!(
+            read_member_bytes_error(&io).details["reason"],
+            "read_member"
+        );
+
+        let bad = temp_root("restore-zip").join("bad.zip");
+        fs::write(&bad, b"not a zip").expect("write");
+        let invalid = open_restore_zip(&bad).expect_err("invalid");
+        assert_eq!(invalid.details["reason"], "invalid_zip");
+
+        let missing = restore_missing_member_error("records/missing.json");
+        assert_eq!(missing.details["reason"], "missing_member");
+    }
+
+    #[test]
+    fn age_prune_retains_unstamped_envelopes() {
+        let root = temp_root("unstamped");
+        drop(seed_store(&root, 2, None));
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let evidence = maintenance
+            .prune(
+                &RetentionPolicy {
+                    max_count: None,
+                    max_age_secs: Some(86_400),
+                },
+                "2026-07-29T00:00:00Z",
+            )
+            .expect("prune");
+        assert_eq!(evidence.removed_count, 0);
+        assert_eq!(evidence.retained_count, 2);
+    }
+
+    #[test]
+    fn backup_without_destination_parent_skips_parent_creation() {
+        let root = temp_root("skip-parent");
+        drop(seed_store(&root, 1, None));
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let destination = PathBuf::new();
+        assert!(destination.parent().is_none());
+        let _ = maintenance.backup(&destination, "2026-07-29T00:00:00Z");
+    }
+
+    #[test]
+    fn verify_io_error_helpers_and_truncated_manifest_reads_fail() {
+        let root = temp_root("truncated");
+        drop(seed_store(&root, 1, None));
+        let archive = root
+            .parent()
+            .expect("parent")
+            .join(format!("trunc-{}.zip", Uuid::new_v4()));
+        {
+            let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+            maintenance
+                .backup(&archive, "2026-07-29T00:00:00Z")
+                .expect("backup");
+        }
+        let mut file = OpenOptions::new().write(true).open(&archive).expect("open");
+        file.set_len(32).expect("truncate");
+        drop(file);
+        let failure = verify_backup_archive(&archive).expect_err("truncated");
+        assert_eq!(failure.code, MaintenanceErrorCode::BackupVerifyFailed);
     }
 
     #[test]

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -1,0 +1,1602 @@
+//! Host-explicit `DataStore` retention prune and verified zip backup/restore.
+//!
+//! Governed by spec `083-datastore-retention-backup` / ADR-0021.
+
+use super::{
+    DataStoreError, LOCAL_DATA_STORE_FORMAT, LOCAL_DATA_STORE_LOCK_FILE, LocalDataClassification,
+    LocalDataStoreEnvelope, digest_for_record, lock_error, validate_key,
+};
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use zip::CompressionMethod;
+use zip::ZipWriter;
+use zip::read::ZipArchive;
+use zip::write::SimpleFileOptions;
+
+const MAINTENANCE_SPEC: &str = "083-datastore-retention-backup";
+const BACKUP_MANIFEST_VERSION: &str = "1";
+const BACKUP_MANIFEST_MEMBER: &str = "manifest.json";
+const BACKUP_RECORDS_PREFIX: &str = "records/";
+const HEXADECIMAL_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+/// Host retention knobs for prune (FR-002).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RetentionPolicy {
+    pub max_count: Option<usize>,
+    pub max_age_secs: Option<u64>,
+}
+
+/// Stable maintenance failure codes (FR-010).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MaintenanceErrorCode {
+    StoreLocked,
+    InvalidRetentionPolicy,
+    BackupVerifyFailed,
+    RestoreVerifyFailed,
+    UnsupportedStoreFormat,
+    MaintenanceIoFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MaintenanceError {
+    pub code: MaintenanceErrorCode,
+    pub message: String,
+    pub details: Value,
+}
+
+/// Secret-free maintenance evidence (FR-009).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MaintenanceEvidence {
+    pub governing_spec: String,
+    pub outcome: String,
+    pub as_of: String,
+    pub attempted_count: u64,
+    pub removed_count: u64,
+    pub retained_count: u64,
+    pub record_count: u64,
+    pub archive_content_digest: Option<String>,
+    pub failure_code: Option<MaintenanceErrorCode>,
+    pub failure_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackupRecordIndexEntry {
+    pub key: String,
+    pub classification: LocalDataClassification,
+    pub envelope_digest: String,
+    pub member_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackupManifest {
+    pub manifest_format_version: String,
+    pub created_as_of: String,
+    pub record_count: u64,
+    pub archive_content_digest: String,
+    pub records: Vec<BackupRecordIndexEntry>,
+    pub store_format: String,
+    pub writer_tool: String,
+    pub writer_semver: String,
+}
+
+/// Separate maintenance port for the same root and exclusive lock (FR-001).
+pub trait DataStoreMaintenance {
+    /// Prunes records under host policy with required `as_of` (FR-002/FR-003).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MaintenanceError`] when the policy is invalid or prune fails.
+    fn prune(
+        &mut self,
+        policy: &RetentionPolicy,
+        as_of: &str,
+    ) -> Result<MaintenanceEvidence, MaintenanceError>;
+
+    /// Writes a verified zip backup to `destination` (FR-004/FR-006/FR-007).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MaintenanceError`] when backup or verification fails.
+    fn backup(
+        &mut self,
+        destination: &Path,
+        as_of: &str,
+    ) -> Result<MaintenanceEvidence, MaintenanceError>;
+
+    /// Verifies an archive and atomically replaces the store root (FR-005/FR-008).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MaintenanceError`] when verification or replace fails.
+    fn restore(
+        &mut self,
+        archive: &Path,
+        as_of: &str,
+    ) -> Result<MaintenanceEvidence, MaintenanceError>;
+}
+
+#[derive(Debug)]
+pub struct LocalFileDataStoreMaintenance {
+    root: PathBuf,
+    lock_file: File,
+}
+
+impl Drop for LocalFileDataStoreMaintenance {
+    fn drop(&mut self) {
+        let _ = self.lock_file.unlock();
+    }
+}
+
+impl LocalFileDataStoreMaintenance {
+    /// Opens maintenance for an existing host-owned store root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MaintenanceError`] when the root cannot be created or locked.
+    pub fn open(root: impl Into<PathBuf>) -> Result<Self, MaintenanceError> {
+        let root = root.into();
+        fs::create_dir_all(&root)
+            .map_err(|error| maintenance_io("create data store root for maintenance", &error))?;
+        let lock_path = root.join(LOCAL_DATA_STORE_LOCK_FILE);
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|error| maintenance_io("open data store lock for maintenance", &error))?;
+        lock_file.try_lock().map_err(|error| {
+            let mapped = lock_error(error);
+            map_lock_to_maintenance(mapped)
+        })?;
+        Ok(Self { root, lock_file })
+    }
+
+    fn list_record_keys(&self) -> Result<Vec<String>, MaintenanceError> {
+        let mut keys = Vec::new();
+        for entry in
+            fs::read_dir(&self.root).map_err(|error| maintenance_io("list keys", &error))?
+        {
+            let entry = entry.map_err(|error| maintenance_io("read key entry", &error))?;
+            let path = entry.path();
+            if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+                continue;
+            }
+            if let Some(key) = path.file_stem().and_then(|stem| stem.to_str()) {
+                keys.push(key.to_string());
+            }
+        }
+        keys.sort();
+        Ok(keys)
+    }
+
+    fn path_for_key(&self, key: &str) -> Result<PathBuf, MaintenanceError> {
+        validate_key(key).map_err(map_data_store_error)?;
+        Ok(self.root.join(format!("{key}.json")))
+    }
+
+    fn read_envelope_bytes(&self, key: &str) -> Result<Vec<u8>, MaintenanceError> {
+        let path = self.path_for_key(key)?;
+        fs::read(&path).map_err(|error| maintenance_io("read envelope bytes", &error))
+    }
+
+    fn read_envelope(&self, key: &str) -> Result<LocalDataStoreEnvelope, MaintenanceError> {
+        let bytes = self.read_envelope_bytes(key)?;
+        parse_envelope_bytes(&bytes)
+    }
+
+    fn delete_key(&self, key: &str) -> Result<(), MaintenanceError> {
+        let path = self.path_for_key(key)?;
+        match fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(maintenance_io("delete pruned record", &error)),
+        }
+    }
+
+    fn reacquire_lock(&mut self) -> Result<(), MaintenanceError> {
+        let lock_path = self.root.join(LOCAL_DATA_STORE_LOCK_FILE);
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(|error| maintenance_io("reopen data store lock", &error))?;
+        lock_file
+            .try_lock()
+            .map_err(|error| map_lock_to_maintenance(lock_error(error)))?;
+        let _ = self.lock_file.unlock();
+        self.lock_file = lock_file;
+        Ok(())
+    }
+}
+
+impl DataStoreMaintenance for LocalFileDataStoreMaintenance {
+    fn prune(
+        &mut self,
+        policy: &RetentionPolicy,
+        as_of: &str,
+    ) -> Result<MaintenanceEvidence, MaintenanceError> {
+        validate_policy(policy)?;
+        let as_of_instant = parse_as_of(as_of)?;
+        let keys = self.list_record_keys()?;
+        let total = keys.len() as u64;
+        let victims = select_prune_victims(self, &keys, policy, as_of_instant)?;
+        let attempted = victims.len() as u64;
+        let mut removed = 0_u64;
+        for key in &victims {
+            if let Err(error) = self.delete_key(key) {
+                return Err(MaintenanceError {
+                    code: error.code,
+                    message: error.message.clone(),
+                    details: json!({
+                        "attempted_count": attempted,
+                        "removed_count": removed,
+                        "retained_count": total.saturating_sub(removed),
+                        "failure_reason": error.message,
+                    }),
+                });
+            }
+            removed += 1;
+        }
+        Ok(prune_evidence(
+            "prune_completed",
+            as_of,
+            attempted,
+            removed,
+            total.saturating_sub(removed),
+            None,
+            None,
+        ))
+    }
+
+    fn backup(
+        &mut self,
+        destination: &Path,
+        as_of: &str,
+    ) -> Result<MaintenanceEvidence, MaintenanceError> {
+        let _ = parse_as_of(as_of)?;
+        let keys = self.list_record_keys()?;
+        let mut members: Vec<(String, Vec<u8>, BackupRecordIndexEntry)> = Vec::new();
+        for key in &keys {
+            let bytes = self.read_envelope_bytes(key)?;
+            let envelope = parse_envelope_bytes(&bytes)?;
+            let member_path = format!("{BACKUP_RECORDS_PREFIX}{key}.json");
+            let envelope_digest = sha256_hex(&bytes);
+            members.push((
+                member_path.clone(),
+                bytes,
+                BackupRecordIndexEntry {
+                    key: key.clone(),
+                    classification: envelope.classification,
+                    envelope_digest,
+                    member_path,
+                },
+            ));
+        }
+        members.sort_by(|left, right| left.0.cmp(&right.0));
+        let index: Vec<BackupRecordIndexEntry> =
+            members.iter().map(|(_, _, entry)| entry.clone()).collect();
+        let content_digest = archive_content_digest_from_members(
+            &members
+                .iter()
+                .map(|(path, bytes, _)| (path.as_str(), bytes.as_slice()))
+                .collect::<Vec<_>>(),
+        );
+        let manifest = BackupManifest {
+            manifest_format_version: BACKUP_MANIFEST_VERSION.to_string(),
+            created_as_of: as_of.to_string(),
+            record_count: index.len() as u64,
+            archive_content_digest: content_digest.clone(),
+            records: index,
+            store_format: LOCAL_DATA_STORE_FORMAT.to_string(),
+            writer_tool: env!("CARGO_PKG_NAME").to_string(),
+            writer_semver: env!("CARGO_PKG_VERSION").to_string(),
+        };
+        let manifest_bytes = serialize_backup_manifest(&manifest)?;
+
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| maintenance_io("create backup destination directory", &error))?;
+        }
+        let temporary = destination.with_extension("zip.tmp");
+        let _ = fs::remove_file(&temporary);
+        {
+            let file = File::create(&temporary)
+                .map_err(|error| maintenance_io("create backup zip", &error))?;
+            let mut zip = ZipWriter::new(file);
+            let options =
+                SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+            zip.start_file(BACKUP_MANIFEST_MEMBER, options)
+                .map_err(|error| maintenance_zip("start manifest zip member", error))?;
+            zip.write_all(&manifest_bytes)
+                .map_err(|error| maintenance_io("write manifest zip member", &error))?;
+            for (path, bytes, _) in &members {
+                zip.start_file(path, options)
+                    .map_err(|error| maintenance_zip("start record zip member", error))?;
+                zip.write_all(bytes)
+                    .map_err(|error| maintenance_io("write record zip member", &error))?;
+            }
+            zip.finish()
+                .map_err(|error| maintenance_zip("finish backup zip", error))?;
+        }
+
+        verify_backup_archive(&temporary)
+            .inspect_err(|_| cleanup_failed_backup_temp(&temporary))?;
+        commit_backup_zip(&temporary, destination)?;
+
+        Ok(MaintenanceEvidence {
+            governing_spec: MAINTENANCE_SPEC.to_string(),
+            outcome: "backup_created".to_string(),
+            as_of: as_of.to_string(),
+            attempted_count: members.len() as u64,
+            removed_count: 0,
+            retained_count: members.len() as u64,
+            record_count: members.len() as u64,
+            archive_content_digest: Some(content_digest),
+            failure_code: None,
+            failure_reason: None,
+        })
+    }
+
+    fn restore(
+        &mut self,
+        archive: &Path,
+        as_of: &str,
+    ) -> Result<MaintenanceEvidence, MaintenanceError> {
+        let _ = parse_as_of(as_of)?;
+        let verified = verify_backup_archive(archive)?;
+        let parent = restore_parent(&self.root)?;
+        let temp_root = parent.join(format!(
+            ".traverse-datastore-restore-{}-{}",
+            std::process::id(),
+            as_of.replace(':', "")
+        ));
+        let backup_root = parent.join(format!(
+            ".traverse-datastore-replaced-{}-{}",
+            std::process::id(),
+            as_of.replace(':', "")
+        ));
+        let _ = fs::remove_dir_all(&temp_root);
+        let _ = fs::remove_dir_all(&backup_root);
+        fs::create_dir_all(&temp_root)
+            .map_err(|error| maintenance_io("create restore temp root", &error))?;
+
+        materialize_archive_to_root(archive, &temp_root)?;
+        verify_store_root_envelopes(&temp_root)?;
+
+        // Release lock on the live root before swapping directories.
+        let _ = self.lock_file.unlock();
+        fs::rename(&self.root, &backup_root)
+            .map_err(|error| handle_move_live_store_aside_failure(self, &error))?;
+        if let Err(error) = fs::rename(&temp_root, &self.root) {
+            return Err(handle_replace_store_root_failure(
+                self,
+                &backup_root,
+                &error,
+            ));
+        }
+        self.reacquire_lock()?;
+        let _ = fs::remove_dir_all(&backup_root);
+
+        Ok(MaintenanceEvidence {
+            governing_spec: MAINTENANCE_SPEC.to_string(),
+            outcome: "restore_committed".to_string(),
+            as_of: as_of.to_string(),
+            attempted_count: verified.record_count,
+            removed_count: 0,
+            retained_count: verified.record_count,
+            record_count: verified.record_count,
+            archive_content_digest: Some(verified.archive_content_digest),
+            failure_code: None,
+            failure_reason: None,
+        })
+    }
+}
+
+fn select_prune_victims(
+    store: &LocalFileDataStoreMaintenance,
+    keys: &[String],
+    policy: &RetentionPolicy,
+    as_of: DateTime<Utc>,
+) -> Result<Vec<String>, MaintenanceError> {
+    // Start retained; clear flags for records that fail any active bound.
+    // Count: deterministic sorted-key order; newest = suffix of length max_count.
+    // Age: remove when retained_at <= as_of - max_age (unstamped envelopes stay).
+    let mut retain = vec![true; keys.len()];
+
+    if let Some(max_count) = policy.max_count.filter(|count| keys.len() > *count) {
+        for flag in retain.iter_mut().take(keys.len() - max_count) {
+            *flag = false;
+        }
+    }
+
+    if let Some(max_age_secs) = policy.max_age_secs {
+        let cutoff = age_cutoff(as_of, max_age_secs)?;
+        for (index, key) in keys.iter().enumerate() {
+            let envelope = store.read_envelope(key)?;
+            if let Some(stamp) = envelope.retained_at.as_deref() {
+                let retained = parse_as_of(stamp)?;
+                if retained <= cutoff {
+                    retain[index] = false;
+                }
+            }
+        }
+    }
+
+    Ok(keys
+        .iter()
+        .zip(retain)
+        .filter_map(|(key, keep)| if keep { None } else { Some(key.clone()) })
+        .collect())
+}
+
+fn validate_policy(policy: &RetentionPolicy) -> Result<(), MaintenanceError> {
+    if policy.max_count.is_none() && policy.max_age_secs.is_none() {
+        return Err(MaintenanceError {
+            code: MaintenanceErrorCode::InvalidRetentionPolicy,
+            message: "invalid_retention_policy".to_string(),
+            details: json!({ "reason": "at_least_one_bound_required" }),
+        });
+    }
+    Ok(())
+}
+
+fn parse_as_of(as_of: &str) -> Result<DateTime<Utc>, MaintenanceError> {
+    DateTime::parse_from_rfc3339(as_of)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|error| MaintenanceError {
+            code: MaintenanceErrorCode::InvalidRetentionPolicy,
+            message: "invalid_retention_policy".to_string(),
+            details: json!({ "reason": "invalid_as_of", "cause": error.to_string() }),
+        })
+}
+
+fn parse_envelope_bytes(bytes: &[u8]) -> Result<LocalDataStoreEnvelope, MaintenanceError> {
+    let value: Value = serde_json::from_slice(bytes).map_err(|_| MaintenanceError {
+        code: MaintenanceErrorCode::RestoreVerifyFailed,
+        message: "restore_verify_failed".to_string(),
+        details: json!({ "reason": "malformed_envelope" }),
+    })?;
+    if value.get("format").is_none() {
+        return Err(MaintenanceError {
+            code: MaintenanceErrorCode::UnsupportedStoreFormat,
+            message: "unsupported_store_format".to_string(),
+            details: json!({ "reason": "legacy_unverified" }),
+        });
+    }
+    let envelope: LocalDataStoreEnvelope =
+        serde_json::from_value(value).map_err(|_| MaintenanceError {
+            code: MaintenanceErrorCode::RestoreVerifyFailed,
+            message: "restore_verify_failed".to_string(),
+            details: json!({ "reason": "malformed_envelope" }),
+        })?;
+    if envelope.format != LOCAL_DATA_STORE_FORMAT {
+        return Err(MaintenanceError {
+            code: MaintenanceErrorCode::UnsupportedStoreFormat,
+            message: "unsupported_store_format".to_string(),
+            details: json!({ "reason": "unknown_format_version", "format": envelope.format }),
+        });
+    }
+    let expected = digest_for_record(&envelope.record).map_err(map_data_store_error)?;
+    if envelope.digest != expected {
+        return Err(MaintenanceError {
+            code: MaintenanceErrorCode::RestoreVerifyFailed,
+            message: "restore_verify_failed".to_string(),
+            details: json!({ "reason": "digest_mismatch", "key": envelope.record.key }),
+        });
+    }
+    Ok(envelope)
+}
+
+fn archive_content_digest_from_members(members: &[(&str, &[u8])]) -> String {
+    let mut hasher = Sha256::new();
+    for (path, bytes) in members {
+        hasher.update(path.as_bytes());
+        hasher.update([0]);
+        hasher.update(bytes);
+        hasher.update([0]);
+    }
+    format!("sha256:{}", hex_encode(&hasher.finalize()))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    format!("sha256:{}", hex_encode(&Sha256::digest(bytes)))
+}
+
+fn hex_encode(digest: &[u8]) -> String {
+    let mut hexadecimal = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        hexadecimal.push(char::from(HEXADECIMAL_DIGITS[usize::from(byte >> 4)]));
+        hexadecimal.push(char::from(HEXADECIMAL_DIGITS[usize::from(byte & 0x0f)]));
+    }
+    hexadecimal
+}
+
+fn verify_backup_archive(path: &Path) -> Result<BackupManifest, MaintenanceError> {
+    let mut archive = open_backup_zip(path)?;
+    let manifest = read_and_validate_manifest_header(&mut archive)?;
+    verify_manifest_member_payloads(&mut archive, &manifest)?;
+    Ok(manifest)
+}
+
+fn open_backup_zip(path: &Path) -> Result<ZipArchive<File>, MaintenanceError> {
+    let file = File::open(path).map_err(|error| MaintenanceError {
+        code: MaintenanceErrorCode::BackupVerifyFailed,
+        message: "backup_verify_failed".to_string(),
+        details: json!({ "reason": "open_archive", "cause": error.to_string() }),
+    })?;
+    ZipArchive::new(file).map_err(|error| MaintenanceError {
+        code: MaintenanceErrorCode::BackupVerifyFailed,
+        message: "backup_verify_failed".to_string(),
+        details: json!({ "reason": "invalid_zip", "cause": error.to_string() }),
+    })
+}
+
+fn read_and_validate_manifest_header(
+    archive: &mut ZipArchive<File>,
+) -> Result<BackupManifest, MaintenanceError> {
+    let mut manifest_bytes = Vec::new();
+    {
+        let mut manifest_file =
+            archive
+                .by_name(BACKUP_MANIFEST_MEMBER)
+                .map_err(|_| MaintenanceError {
+                    code: MaintenanceErrorCode::BackupVerifyFailed,
+                    message: "backup_verify_failed".to_string(),
+                    details: json!({ "reason": "missing_manifest" }),
+                })?;
+        manifest_file
+            .read_to_end(&mut manifest_bytes)
+            .map_err(|error| MaintenanceError {
+                code: MaintenanceErrorCode::BackupVerifyFailed,
+                message: "backup_verify_failed".to_string(),
+                details: json!({ "reason": "read_manifest", "cause": error.to_string() }),
+            })?;
+    }
+    let manifest: BackupManifest =
+        serde_json::from_slice(&manifest_bytes).map_err(|_| MaintenanceError {
+            code: MaintenanceErrorCode::BackupVerifyFailed,
+            message: "backup_verify_failed".to_string(),
+            details: json!({ "reason": "malformed_manifest" }),
+        })?;
+    if manifest.manifest_format_version != BACKUP_MANIFEST_VERSION {
+        return Err(MaintenanceError {
+            code: MaintenanceErrorCode::UnsupportedStoreFormat,
+            message: "unsupported_store_format".to_string(),
+            details: json!({
+                "reason": "unsupported_manifest_version",
+                "version": manifest.manifest_format_version
+            }),
+        });
+    }
+    if manifest.store_format != LOCAL_DATA_STORE_FORMAT {
+        return Err(MaintenanceError {
+            code: MaintenanceErrorCode::UnsupportedStoreFormat,
+            message: "unsupported_store_format".to_string(),
+            details: json!({ "reason": "unsupported_store_format", "format": manifest.store_format }),
+        });
+    }
+    Ok(manifest)
+}
+
+fn verify_manifest_member_payloads(
+    archive: &mut ZipArchive<File>,
+    manifest: &BackupManifest,
+) -> Result<(), MaintenanceError> {
+    let mut members = Vec::new();
+    for entry in &manifest.records {
+        if !entry.member_path.starts_with(BACKUP_RECORDS_PREFIX) || entry.member_path.contains("..")
+        {
+            return Err(MaintenanceError {
+                code: MaintenanceErrorCode::BackupVerifyFailed,
+                message: "backup_verify_failed".to_string(),
+                details: json!({ "reason": "invalid_member_path", "path": entry.member_path }),
+            });
+        }
+        let mut bytes = Vec::new();
+        {
+            let mut file = archive
+                .by_name(&entry.member_path)
+                .map_err(|_| MaintenanceError {
+                    code: MaintenanceErrorCode::BackupVerifyFailed,
+                    message: "backup_verify_failed".to_string(),
+                    details: json!({ "reason": "missing_member", "path": entry.member_path }),
+                })?;
+            file.read_to_end(&mut bytes)
+                .map_err(|error| MaintenanceError {
+                    code: MaintenanceErrorCode::BackupVerifyFailed,
+                    message: "backup_verify_failed".to_string(),
+                    details: json!({ "reason": "read_member", "cause": error.to_string() }),
+                })?;
+        }
+        if sha256_hex(&bytes) != entry.envelope_digest {
+            return Err(MaintenanceError {
+                code: MaintenanceErrorCode::BackupVerifyFailed,
+                message: "backup_verify_failed".to_string(),
+                details: json!({ "reason": "member_digest_mismatch", "key": entry.key }),
+            });
+        }
+        let envelope = parse_envelope_bytes(&bytes)?;
+        if envelope.record.key != entry.key {
+            return Err(MaintenanceError {
+                code: MaintenanceErrorCode::BackupVerifyFailed,
+                message: "backup_verify_failed".to_string(),
+                details: json!({ "reason": "key_mismatch", "key": entry.key }),
+            });
+        }
+        members.push((entry.member_path.clone(), bytes));
+    }
+    members.sort_by(|left, right| left.0.cmp(&right.0));
+    let computed = archive_content_digest_from_members(
+        &members
+            .iter()
+            .map(|(path, bytes)| (path.as_str(), bytes.as_slice()))
+            .collect::<Vec<_>>(),
+    );
+    if computed != manifest.archive_content_digest {
+        return Err(MaintenanceError {
+            code: MaintenanceErrorCode::BackupVerifyFailed,
+            message: "backup_verify_failed".to_string(),
+            details: json!({ "reason": "archive_content_digest_mismatch" }),
+        });
+    }
+    if manifest.record_count != manifest.records.len() as u64 {
+        return Err(MaintenanceError {
+            code: MaintenanceErrorCode::BackupVerifyFailed,
+            message: "backup_verify_failed".to_string(),
+            details: json!({ "reason": "record_count_mismatch" }),
+        });
+    }
+    Ok(())
+}
+
+fn materialize_archive_to_root(archive: &Path, root: &Path) -> Result<(), MaintenanceError> {
+    let manifest = verify_backup_archive(archive)?;
+    let file = File::open(archive).map_err(|error| maintenance_io("reopen archive", &error))?;
+    let mut zip = ZipArchive::new(file).map_err(|error| MaintenanceError {
+        code: MaintenanceErrorCode::RestoreVerifyFailed,
+        message: "restore_verify_failed".to_string(),
+        details: json!({ "reason": "invalid_zip", "cause": error.to_string() }),
+    })?;
+    // Ensure lock file exists in the new root so reopen can acquire it.
+    let lock_path = root.join(LOCAL_DATA_STORE_LOCK_FILE);
+    File::create(&lock_path)
+        .map_err(|error| maintenance_io("create restored lock file", &error))?;
+
+    for entry in &manifest.records {
+        let key = &entry.key;
+        validate_key(key).map_err(map_data_store_error)?;
+        let mut bytes = Vec::new();
+        {
+            let mut member = zip
+                .by_name(&entry.member_path)
+                .map_err(|_| MaintenanceError {
+                    code: MaintenanceErrorCode::RestoreVerifyFailed,
+                    message: "restore_verify_failed".to_string(),
+                    details: json!({ "reason": "missing_member", "path": entry.member_path }),
+                })?;
+            member
+                .read_to_end(&mut bytes)
+                .map_err(|error| maintenance_io("extract member", &error))?;
+        }
+        let dest = root.join(format!("{key}.json"));
+        fs::write(&dest, bytes)
+            .map_err(|error| maintenance_io("write restored envelope", &error))?;
+    }
+    Ok(())
+}
+
+fn verify_store_root_envelopes(root: &Path) -> Result<(), MaintenanceError> {
+    for entry in fs::read_dir(root).map_err(|error| maintenance_io("list restored root", &error))? {
+        let entry = entry.map_err(|error| maintenance_io("read restored entry", &error))?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes =
+            fs::read(&path).map_err(|error| maintenance_io("read restored envelope", &error))?;
+        parse_envelope_bytes(&bytes)?;
+    }
+    Ok(())
+}
+
+fn prune_evidence(
+    outcome: &str,
+    as_of: &str,
+    attempted: u64,
+    removed: u64,
+    retained: u64,
+    failure_code: Option<MaintenanceErrorCode>,
+    failure_reason: Option<String>,
+) -> MaintenanceEvidence {
+    MaintenanceEvidence {
+        governing_spec: MAINTENANCE_SPEC.to_string(),
+        outcome: outcome.to_string(),
+        as_of: as_of.to_string(),
+        attempted_count: attempted,
+        removed_count: removed,
+        retained_count: retained,
+        record_count: retained,
+        archive_content_digest: None,
+        failure_code,
+        failure_reason,
+    }
+}
+
+fn age_cutoff(as_of: DateTime<Utc>, max_age_secs: u64) -> Result<DateTime<Utc>, MaintenanceError> {
+    let age = Duration::seconds(
+        i64::try_from(max_age_secs).map_err(|_| max_age_secs_out_of_range_error())?,
+    );
+    as_of
+        .checked_sub_signed(age)
+        .ok_or_else(as_of_minus_max_age_underflow_error)
+}
+
+fn max_age_secs_out_of_range_error() -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::InvalidRetentionPolicy,
+        message: "invalid_retention_policy".to_string(),
+        details: json!({ "reason": "max_age_secs_out_of_range" }),
+    }
+}
+
+fn as_of_minus_max_age_underflow_error() -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::InvalidRetentionPolicy,
+        message: "invalid_retention_policy".to_string(),
+        details: json!({ "reason": "as_of_minus_max_age_underflow" }),
+    }
+}
+
+fn serialize_backup_manifest(manifest: &BackupManifest) -> Result<Vec<u8>, MaintenanceError> {
+    serde_json::to_vec_pretty(manifest).map_err(|error| serialize_manifest_error(&error))
+}
+
+fn serialize_manifest_error(error: &serde_json::Error) -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::MaintenanceIoFailed,
+        message: "maintenance_io_failed".to_string(),
+        details: json!({ "operation": "serialize_manifest", "reason": error.to_string() }),
+    }
+}
+
+fn cleanup_failed_backup_temp(temporary: &Path) {
+    let _ = fs::remove_file(temporary);
+}
+
+fn commit_backup_zip(temporary: &Path, destination: &Path) -> Result<(), MaintenanceError> {
+    fs::rename(temporary, destination).map_err(|error| {
+        cleanup_failed_backup_temp(temporary);
+        maintenance_io("commit backup zip", &error)
+    })
+}
+
+fn restore_parent(root: &Path) -> Result<&Path, MaintenanceError> {
+    root.parent().ok_or_else(store_root_has_no_parent_error)
+}
+
+fn store_root_has_no_parent_error() -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::MaintenanceIoFailed,
+        message: "maintenance_io_failed".to_string(),
+        details: json!({ "operation": "restore", "reason": "store_root_has_no_parent" }),
+    }
+}
+
+fn handle_move_live_store_aside_failure(
+    maintenance: &mut LocalFileDataStoreMaintenance,
+    error: &std::io::Error,
+) -> MaintenanceError {
+    let _ = maintenance.reacquire_lock();
+    maintenance_io("move live store aside for restore", error)
+}
+
+fn handle_replace_store_root_failure(
+    maintenance: &mut LocalFileDataStoreMaintenance,
+    backup_root: &Path,
+    error: &std::io::Error,
+) -> MaintenanceError {
+    let _ = fs::rename(backup_root, &maintenance.root);
+    let _ = maintenance.reacquire_lock();
+    maintenance_io("atomically replace store root", error)
+}
+
+fn maintenance_io(operation: &str, error: &std::io::Error) -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::MaintenanceIoFailed,
+        message: "maintenance_io_failed".to_string(),
+        details: json!({ "operation": operation, "reason": error.to_string() }),
+    }
+}
+
+fn maintenance_zip(operation: &str, error: impl std::fmt::Display) -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::MaintenanceIoFailed,
+        message: "maintenance_io_failed".to_string(),
+        details: json!({ "operation": operation, "reason": error.to_string() }),
+    }
+}
+
+fn map_lock_to_maintenance(error: DataStoreError) -> MaintenanceError {
+    match error.code {
+        super::DataStoreErrorCode::StoreLocked => MaintenanceError {
+            code: MaintenanceErrorCode::StoreLocked,
+            message: "store_locked".to_string(),
+            details: error.details,
+        },
+        _ => MaintenanceError {
+            code: MaintenanceErrorCode::MaintenanceIoFailed,
+            message: "maintenance_io_failed".to_string(),
+            details: error.details,
+        },
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn map_data_store_error(error: DataStoreError) -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::MaintenanceIoFailed,
+        message: "maintenance_io_failed".to_string(),
+        details: json!({ "cause": error.message, "details": error.details }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use crate::data_store::{
+        DataStore, DataStoreError, DataStoreErrorCode, LocalFileDataStore, StateRecord,
+    };
+    use serde_json::json;
+    use std::fs::TryLockError;
+    use std::path::Path;
+    use uuid::Uuid;
+
+    fn temp_root(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "traverse-maintenance-{label}-{}-{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        fs::create_dir_all(&root).expect("temp root");
+        root
+    }
+
+    fn seed_store(root: &Path, count: usize, stamp: Option<&str>) -> LocalFileDataStore {
+        let mut store = LocalFileDataStore::new(root).expect("open");
+        if let Some(stamp) = stamp {
+            store.set_write_retained_at(Some(stamp.to_string()));
+        }
+        for index in 0..count {
+            store
+                .write(StateRecord {
+                    key: format!("k{index:02}"),
+                    value: json!({ "n": index }),
+                    lamport_clock: (index + 1) as u64,
+                    writer_id: "host".to_string(),
+                })
+                .expect("write");
+        }
+        store
+    }
+
+    #[test]
+    fn prune_max_count_removes_oldest_prefix() {
+        let root = temp_root("count");
+        let store = seed_store(&root, 10, None);
+        drop(store);
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let evidence = maintenance
+            .prune(
+                &RetentionPolicy {
+                    max_count: Some(3),
+                    max_age_secs: None,
+                },
+                "2026-07-29T00:00:00Z",
+            )
+            .expect("prune");
+        assert_eq!(evidence.outcome, "prune_completed");
+        assert_eq!(evidence.removed_count, 7);
+        assert_eq!(evidence.retained_count, 3);
+        drop(maintenance);
+        let store = LocalFileDataStore::new(&root).expect("reopen");
+        let keys = store.list_keys().expect("keys");
+        assert_eq!(
+            keys,
+            vec!["k07".to_string(), "k08".to_string(), "k09".to_string()]
+        );
+    }
+
+    #[test]
+    fn prune_rejects_empty_policy_and_reports_age_bounds() {
+        let root = temp_root("policy");
+        drop(seed_store(&root, 3, Some("2026-07-01T00:00:00Z")));
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let invalid = maintenance
+            .prune(
+                &RetentionPolicy {
+                    max_count: None,
+                    max_age_secs: None,
+                },
+                "2026-07-29T00:00:00Z",
+            )
+            .expect_err("policy");
+        assert_eq!(invalid.code, MaintenanceErrorCode::InvalidRetentionPolicy);
+
+        let evidence = maintenance
+            .prune(
+                &RetentionPolicy {
+                    max_count: None,
+                    max_age_secs: Some(7 * 24 * 60 * 60),
+                },
+                "2026-07-29T00:00:00Z",
+            )
+            .expect("age prune");
+        assert_eq!(evidence.removed_count, 3);
+    }
+
+    #[test]
+    fn prune_partial_failure_preserves_remaining_victims() {
+        let root = temp_root("partial");
+        drop(seed_store(&root, 5, None));
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        // Turn the second victim path into a directory so delete fails mid-prune.
+        let victim = root.join("k01.json");
+        fs::remove_file(&victim).expect("remove");
+        fs::create_dir_all(&victim).expect("dir");
+        fs::write(victim.join("nested"), b"x").expect("nested");
+        let failure = maintenance
+            .prune(
+                &RetentionPolicy {
+                    max_count: Some(2),
+                    max_age_secs: None,
+                },
+                "2026-07-29T00:00:00Z",
+            )
+            .expect_err("partial");
+        assert_eq!(failure.code, MaintenanceErrorCode::MaintenanceIoFailed);
+        assert_eq!(failure.details["removed_count"], 1);
+        // First victim k00 removed; k01 blocked; k02 still present among remaining.
+        assert!(!root.join("k00.json").exists());
+        assert!(root.join("k02.json").exists());
+    }
+
+    #[test]
+    fn backup_restore_round_trip_including_empty_store() {
+        let root = temp_root("backup");
+        drop(seed_store(&root, 2, Some("2026-07-28T00:00:00Z")));
+        let archive = root
+            .parent()
+            .expect("parent")
+            .join(format!("backup-{}.zip", Uuid::new_v4()));
+        {
+            let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+            let evidence = maintenance
+                .backup(&archive, "2026-07-29T00:00:00Z")
+                .expect("backup");
+            assert_eq!(evidence.outcome, "backup_created");
+            assert!(evidence.archive_content_digest.is_some());
+        }
+        // Mutate store then restore.
+        {
+            let mut store = LocalFileDataStore::new(&root).expect("open");
+            store
+                .write(StateRecord {
+                    key: "extra".to_string(),
+                    value: json!({ "x": 1 }),
+                    lamport_clock: 99,
+                    writer_id: "host".to_string(),
+                })
+                .expect("extra");
+        }
+        {
+            let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+            let evidence = maintenance
+                .restore(&archive, "2026-07-29T01:00:00Z")
+                .expect("restore");
+            assert_eq!(evidence.outcome, "restore_committed");
+        }
+        let store = LocalFileDataStore::new(&root).expect("reopen");
+        let keys = store.list_keys().expect("keys");
+        assert_eq!(keys, vec!["k00".to_string(), "k01".to_string()]);
+
+        // Empty store backup/restore.
+        let empty_root = temp_root("empty");
+        drop(LocalFileDataStore::new(&empty_root).expect("empty"));
+        let empty_archive = empty_root
+            .parent()
+            .expect("parent")
+            .join(format!("empty-{}.zip", Uuid::new_v4()));
+        {
+            let mut maintenance =
+                LocalFileDataStoreMaintenance::open(&empty_root).expect("maintenance");
+            maintenance
+                .backup(&empty_archive, "2026-07-29T00:00:00Z")
+                .expect("empty backup");
+            maintenance
+                .restore(&empty_archive, "2026-07-29T00:00:00Z")
+                .expect("empty restore");
+        }
+    }
+
+    #[test]
+    fn second_owner_receives_store_locked() {
+        let root = temp_root("locked");
+        let _owner = LocalFileDataStore::new(&root).expect("owner");
+        let locked = LocalFileDataStoreMaintenance::open(&root).expect_err("locked");
+        assert_eq!(locked.code, MaintenanceErrorCode::StoreLocked);
+    }
+
+    #[test]
+    fn backup_verify_rejects_tampered_archive() {
+        let root = temp_root("tamper");
+        drop(seed_store(&root, 1, None));
+        let archive = root
+            .parent()
+            .expect("parent")
+            .join(format!("tamper-{}.zip", Uuid::new_v4()));
+        {
+            let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+            maintenance
+                .backup(&archive, "2026-07-29T00:00:00Z")
+                .expect("backup");
+        }
+        let mut bytes = fs::read(&archive).expect("read");
+        if let Some(byte) = bytes.last_mut() {
+            *byte ^= 0xff;
+        }
+        fs::write(&archive, bytes).expect("write");
+        let failure = verify_backup_archive(&archive).expect_err("tampered");
+        assert_eq!(failure.code, MaintenanceErrorCode::BackupVerifyFailed);
+    }
+
+    #[test]
+    fn local_file_store_root_accessor_returns_open_path() {
+        let root = temp_root("root-accessor");
+        let store = LocalFileDataStore::new(&root).expect("open");
+        assert_eq!(store.root(), &root);
+    }
+
+    #[test]
+    fn maintenance_error_helpers_report_stable_codes() {
+        let io = std::io::Error::other("disk full");
+        let maintenance = maintenance_io("unit op", &io);
+        assert_eq!(maintenance.code, MaintenanceErrorCode::MaintenanceIoFailed);
+        assert_eq!(maintenance.details["operation"], "unit op");
+
+        let zip = maintenance_zip("zip op", "zip failed");
+        assert_eq!(zip.code, MaintenanceErrorCode::MaintenanceIoFailed);
+        assert_eq!(zip.details["operation"], "zip op");
+
+        let locked = map_lock_to_maintenance(lock_error(TryLockError::WouldBlock));
+        assert_eq!(locked.code, MaintenanceErrorCode::StoreLocked);
+
+        let lock_io = map_lock_to_maintenance(lock_error(TryLockError::Error(
+            std::io::Error::other("lock device"),
+        )));
+        assert_eq!(lock_io.code, MaintenanceErrorCode::MaintenanceIoFailed);
+
+        let mapped = map_data_store_error(DataStoreError {
+            code: DataStoreErrorCode::InvalidKey,
+            message: "invalid".to_string(),
+            details: json!({ "key": "bad.key" }),
+        });
+        assert_eq!(mapped.code, MaintenanceErrorCode::MaintenanceIoFailed);
+
+        let parent = restore_parent(Path::new("/")).expect_err("root has no parent");
+        assert_eq!(parent.code, MaintenanceErrorCode::MaintenanceIoFailed);
+        assert_eq!(parent.details["reason"], "store_root_has_no_parent");
+
+        let parse_error = serde_json::from_str::<Value>("{").expect_err("invalid json");
+        let manifest = serialize_manifest_error(&parse_error);
+        assert_eq!(manifest.details["operation"], "serialize_manifest");
+    }
+
+    #[test]
+    fn parse_as_of_and_policy_bounds_reject_invalid_inputs() {
+        let invalid = parse_as_of("not-a-timestamp").expect_err("invalid as_of");
+        assert_eq!(invalid.code, MaintenanceErrorCode::InvalidRetentionPolicy);
+        assert_eq!(invalid.details["reason"], "invalid_as_of");
+
+        let root = temp_root("age-bounds");
+        drop(seed_store(&root, 1, Some("2026-07-01T00:00:00Z")));
+        let _maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let overflow = age_cutoff(
+            parse_as_of("2026-07-29T00:00:00Z").expect("as_of"),
+            u64::MAX,
+        )
+        .expect_err("max age overflow");
+        assert_eq!(overflow.details["reason"], "max_age_secs_out_of_range");
+
+        let underflow = age_cutoff(
+            parse_as_of("2026-07-29T00:00:00Z").expect("as_of"),
+            9_000_000_000_000,
+        )
+        .expect_err("as_of underflow");
+        assert_eq!(underflow.details["reason"], "as_of_minus_max_age_underflow");
+        assert_eq!(
+            max_age_secs_out_of_range_error().details["reason"],
+            "max_age_secs_out_of_range"
+        );
+        assert_eq!(
+            as_of_minus_max_age_underflow_error().details["reason"],
+            "as_of_minus_max_age_underflow"
+        );
+    }
+
+    #[test]
+    fn parse_envelope_bytes_rejects_malformed_legacy_and_tampered_records() {
+        let malformed = parse_envelope_bytes(b"{").expect_err("malformed");
+        assert_eq!(malformed.code, MaintenanceErrorCode::RestoreVerifyFailed);
+
+        let legacy = json!({
+            "record": {
+                "key": "k",
+                "value": {},
+                "lamport_clock": 1,
+                "writer_id": "host"
+            },
+            "digest": "sha256:00"
+        });
+        let legacy_err = parse_envelope_bytes(&serde_json::to_vec(&legacy).expect("serialize"))
+            .expect_err("legacy");
+        assert_eq!(
+            legacy_err.code,
+            MaintenanceErrorCode::UnsupportedStoreFormat
+        );
+        assert_eq!(legacy_err.details["reason"], "legacy_unverified");
+
+        let record = StateRecord {
+            key: "k".to_string(),
+            value: json!({ "n": 1 }),
+            lamport_clock: 1,
+            writer_id: "host".to_string(),
+        };
+        let digest = digest_for_record(&record).expect("digest");
+        let wrong_shape = json!({
+            "format": LOCAL_DATA_STORE_FORMAT,
+            "classification": "public",
+            "record": { "key": "k" },
+            "digest": digest
+        });
+        let shape_err = parse_envelope_bytes(&serde_json::to_vec(&wrong_shape).expect("serialize"))
+            .expect_err("shape");
+        assert_eq!(shape_err.code, MaintenanceErrorCode::RestoreVerifyFailed);
+
+        let unknown = json!({
+            "format": "local-datastore/99",
+            "classification": "public",
+            "record": record,
+            "digest": digest
+        });
+        let version_err = parse_envelope_bytes(&serde_json::to_vec(&unknown).expect("serialize"))
+            .expect_err("version");
+        assert_eq!(
+            version_err.code,
+            MaintenanceErrorCode::UnsupportedStoreFormat
+        );
+
+        let tampered = json!({
+            "format": LOCAL_DATA_STORE_FORMAT,
+            "classification": "public",
+            "record": record,
+            "digest": "sha256:deadbeef"
+        });
+        let digest_err = parse_envelope_bytes(&serde_json::to_vec(&tampered).expect("serialize"))
+            .expect_err("digest");
+        assert_eq!(digest_err.code, MaintenanceErrorCode::RestoreVerifyFailed);
+        assert_eq!(digest_err.details["reason"], "digest_mismatch");
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn verify_backup_archive_rejects_invalid_archives() {
+        let missing = temp_root("missing-archive").join("missing.zip");
+        let open = open_backup_zip(&missing).expect_err("missing");
+        assert_eq!(open.code, MaintenanceErrorCode::BackupVerifyFailed);
+        assert_eq!(open.details["reason"], "open_archive");
+
+        let bad_zip = temp_root("bad-zip").join("bad.zip");
+        fs::write(&bad_zip, b"not a zip").expect("write");
+        let invalid = open_backup_zip(&bad_zip).expect_err("invalid zip");
+        assert_eq!(invalid.details["reason"], "invalid_zip");
+
+        let no_manifest = write_zip(bad_zip.parent().expect("parent"), &[]);
+        let missing_manifest = verify_backup_archive(&no_manifest).expect_err("manifest");
+        assert_eq!(missing_manifest.details["reason"], "missing_manifest");
+
+        let malformed_manifest = write_zip(
+            bad_zip.parent().expect("parent"),
+            &[(BACKUP_MANIFEST_MEMBER, b"{".as_slice())],
+        );
+        let malformed = verify_backup_archive(&malformed_manifest).expect_err("malformed");
+        assert_eq!(malformed.details["reason"], "malformed_manifest");
+
+        let unsupported_manifest = backup_zip_with_manifest(&json!({
+            "manifest_format_version": "99",
+            "created_as_of": "2026-07-29T00:00:00Z",
+            "record_count": 0,
+            "archive_content_digest": "sha256:00",
+            "records": [],
+            "store_format": LOCAL_DATA_STORE_FORMAT,
+            "writer_tool": "test",
+            "writer_semver": "0.0.0"
+        }));
+        let version = verify_backup_archive(&unsupported_manifest).expect_err("version");
+        assert_eq!(version.code, MaintenanceErrorCode::UnsupportedStoreFormat);
+
+        let unsupported_store = backup_zip_with_manifest(&json!({
+            "manifest_format_version": BACKUP_MANIFEST_VERSION,
+            "created_as_of": "2026-07-29T00:00:00Z",
+            "record_count": 0,
+            "archive_content_digest": "sha256:00",
+            "records": [],
+            "store_format": "legacy/0",
+            "writer_tool": "test",
+            "writer_semver": "0.0.0"
+        }));
+        let format = verify_backup_archive(&unsupported_store).expect_err("format");
+        assert_eq!(format.details["reason"], "unsupported_store_format");
+
+        let invalid_member = backup_zip_with_manifest(&json!({
+            "manifest_format_version": BACKUP_MANIFEST_VERSION,
+            "created_as_of": "2026-07-29T00:00:00Z",
+            "record_count": 1,
+            "archive_content_digest": "sha256:00",
+            "records": [{
+                "key": "k00",
+                "classification": "public",
+                "envelope_digest": "sha256:00",
+                "member_path": "../escape.json"
+            }],
+            "store_format": LOCAL_DATA_STORE_FORMAT,
+            "writer_tool": "test",
+            "writer_semver": "0.0.0"
+        }));
+        let path = verify_backup_archive(&invalid_member).expect_err("path");
+        assert_eq!(path.details["reason"], "invalid_member_path");
+
+        let root = temp_root("member-errors");
+        drop(seed_store(&root, 1, None));
+        let good = root
+            .parent()
+            .expect("parent")
+            .join(format!("good-{}.zip", Uuid::new_v4()));
+        {
+            let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+            maintenance
+                .backup(&good, "2026-07-29T00:00:00Z")
+                .expect("backup");
+        }
+        let envelope_bytes = fs::read(root.join("k00.json")).expect("envelope");
+        let missing_member = write_zip_with_manifest(
+            good.parent().expect("parent"),
+            &json!({
+                "manifest_format_version": BACKUP_MANIFEST_VERSION,
+                "created_as_of": "2026-07-29T00:00:00Z",
+                "record_count": 1,
+                "archive_content_digest": "sha256:00",
+                "records": [{
+                    "key": "k00",
+                    "classification": "public",
+                    "envelope_digest": "sha256:00",
+                    "member_path": "records/missing.json"
+                }],
+                "store_format": LOCAL_DATA_STORE_FORMAT,
+                "writer_tool": "test",
+                "writer_semver": "0.0.0"
+            }),
+            &[],
+        );
+        let missing = verify_backup_archive(&missing_member).expect_err("missing member");
+        assert_eq!(missing.details["reason"], "missing_member");
+
+        let digest_mismatch = write_zip_with_manifest(
+            good.parent().expect("parent"),
+            &json!({
+                "manifest_format_version": BACKUP_MANIFEST_VERSION,
+                "created_as_of": "2026-07-29T00:00:00Z",
+                "record_count": 1,
+                "archive_content_digest": "sha256:00",
+                "records": [{
+                    "key": "k00",
+                    "classification": "public",
+                    "envelope_digest": "sha256:deadbeef",
+                    "member_path": "records/k00.json"
+                }],
+                "store_format": LOCAL_DATA_STORE_FORMAT,
+                "writer_tool": "test",
+                "writer_semver": "0.0.0"
+            }),
+            &[("records/k00.json", envelope_bytes.as_slice())],
+        );
+        let digest = verify_backup_archive(&digest_mismatch).expect_err("digest");
+        assert_eq!(digest.details["reason"], "member_digest_mismatch");
+
+        let key_mismatch = write_zip_with_manifest(
+            good.parent().expect("parent"),
+            &json!({
+                "manifest_format_version": BACKUP_MANIFEST_VERSION,
+                "created_as_of": "2026-07-29T00:00:00Z",
+                "record_count": 1,
+                "archive_content_digest": archive_content_digest_from_members(&[(
+                    "records/k00.json",
+                    envelope_bytes.as_slice(),
+                )]),
+                "records": [{
+                    "key": "other",
+                    "classification": "public",
+                    "envelope_digest": sha256_hex(&envelope_bytes),
+                    "member_path": "records/k00.json"
+                }],
+                "store_format": LOCAL_DATA_STORE_FORMAT,
+                "writer_tool": "test",
+                "writer_semver": "0.0.0"
+            }),
+            &[("records/k00.json", envelope_bytes.as_slice())],
+        );
+        let key = verify_backup_archive(&key_mismatch).expect_err("key");
+        assert_eq!(key.details["reason"], "key_mismatch");
+
+        let count_mismatch = write_zip_with_manifest(
+            good.parent().expect("parent"),
+            &json!({
+                "manifest_format_version": BACKUP_MANIFEST_VERSION,
+                "created_as_of": "2026-07-29T00:00:00Z",
+                "record_count": 2,
+                "archive_content_digest": archive_content_digest_from_members(&[(
+                    "records/k00.json",
+                    envelope_bytes.as_slice(),
+                )]),
+                "records": [{
+                    "key": "k00",
+                    "classification": "public",
+                    "envelope_digest": sha256_hex(&envelope_bytes),
+                    "member_path": "records/k00.json"
+                }],
+                "store_format": LOCAL_DATA_STORE_FORMAT,
+                "writer_tool": "test",
+                "writer_semver": "0.0.0"
+            }),
+            &[("records/k00.json", envelope_bytes.as_slice())],
+        );
+        let count = verify_backup_archive(&count_mismatch).expect_err("count");
+        assert_eq!(count.details["reason"], "record_count_mismatch");
+
+        let digest_mismatch_archive = write_zip_with_manifest(
+            good.parent().expect("parent"),
+            &json!({
+                "manifest_format_version": BACKUP_MANIFEST_VERSION,
+                "created_as_of": "2026-07-29T00:00:00Z",
+                "record_count": 1,
+                "archive_content_digest": "sha256:deadbeef",
+                "records": [{
+                    "key": "k00",
+                    "classification": "public",
+                    "envelope_digest": sha256_hex(&envelope_bytes),
+                    "member_path": "records/k00.json"
+                }],
+                "store_format": LOCAL_DATA_STORE_FORMAT,
+                "writer_tool": "test",
+                "writer_semver": "0.0.0"
+            }),
+            &[("records/k00.json", envelope_bytes.as_slice())],
+        );
+        let archive_digest =
+            verify_backup_archive(&digest_mismatch_archive).expect_err("archive digest");
+        assert_eq!(
+            archive_digest.details["reason"],
+            "archive_content_digest_mismatch"
+        );
+    }
+
+    #[test]
+    fn open_and_backup_surface_io_failures_without_weakening_fail_closed() {
+        let file_root = temp_root("file-root");
+        fs::remove_dir(&file_root).expect("remove dir");
+        fs::write(&file_root, "not a directory").expect("write");
+        let open = LocalFileDataStoreMaintenance::open(&file_root).expect_err("open");
+        assert_eq!(open.code, MaintenanceErrorCode::MaintenanceIoFailed);
+
+        let root = temp_root("backup-io");
+        drop(seed_store(&root, 1, None));
+        let parent = root.parent().expect("parent");
+        let file_parent = parent.join(format!("file-parent-{}", Uuid::new_v4()));
+        fs::write(&file_parent, "blocker").expect("write");
+        let blocked = file_parent.join("backup.zip");
+        {
+            let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+            let failure = maintenance
+                .backup(&blocked, "2026-07-29T00:00:00Z")
+                .expect_err("destination parent blocked");
+            assert_eq!(failure.code, MaintenanceErrorCode::MaintenanceIoFailed);
+        }
+
+        let commit_blocked = parent.join(format!("commit-dir-{}", Uuid::new_v4()));
+        fs::create_dir_all(&commit_blocked).expect("dir");
+        let destination = commit_blocked.join("backup.zip");
+        fs::create_dir_all(&destination).expect("block destination");
+        let temporary = parent.join(format!("backup-{}.zip.tmp", Uuid::new_v4()));
+        fs::write(&temporary, b"partial").expect("temp");
+        let commit = commit_backup_zip(&temporary, &destination).expect_err("commit");
+        assert_eq!(commit.details["operation"], "commit backup zip");
+        assert!(!temporary.exists());
+
+        cleanup_failed_backup_temp(&parent.join("missing-temp.zip"));
+    }
+
+    #[test]
+    fn backup_rejects_invalid_as_of_and_verify_failure_cleans_temp() {
+        let root = temp_root("backup-as-of");
+        drop(seed_store(&root, 1, None));
+        let archive = root
+            .parent()
+            .expect("parent")
+            .join(format!("asof-{}.zip", Uuid::new_v4()));
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let invalid = maintenance
+            .backup(&archive, "not-a-timestamp")
+            .expect_err("as_of");
+        assert_eq!(invalid.code, MaintenanceErrorCode::InvalidRetentionPolicy);
+
+        let temporary = archive.with_extension("zip.tmp");
+        fs::write(&temporary, b"not a zip").expect("temp");
+        let failure = verify_backup_archive(&temporary)
+            .inspect_err(|_| cleanup_failed_backup_temp(&temporary));
+        assert!(failure.is_err());
+        assert!(!temporary.exists());
+    }
+
+    #[test]
+    fn restore_reports_invalid_as_of_and_rename_failures() {
+        let root = temp_root("restore-as-of");
+        drop(seed_store(&root, 1, None));
+        let archive = root
+            .parent()
+            .expect("parent")
+            .join(format!("restore-{}.zip", Uuid::new_v4()));
+        {
+            let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+            maintenance
+                .backup(&archive, "2026-07-29T00:00:00Z")
+                .expect("backup");
+        }
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let invalid = maintenance
+            .restore(&archive, "not-a-timestamp")
+            .expect_err("as_of");
+        assert_eq!(invalid.code, MaintenanceErrorCode::InvalidRetentionPolicy);
+        drop(maintenance);
+
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let parent = root.parent().expect("parent");
+        let backup_root = parent.join(format!(
+            ".traverse-datastore-replaced-{}-{}",
+            std::process::id(),
+            "2026-07-29T01:00:00Z".replace(':', "")
+        ));
+        fs::write(&backup_root, "blocker").expect("blocker");
+        let blocked = maintenance
+            .restore(&archive, "2026-07-29T01:00:00Z")
+            .expect_err("move aside");
+        assert_eq!(blocked.code, MaintenanceErrorCode::MaintenanceIoFailed);
+        let _ = fs::remove_file(&backup_root);
+        drop(maintenance);
+
+        let mut rollback_maintenance =
+            LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let simulated = std::io::Error::other("simulated");
+        let rollback_error =
+            handle_move_live_store_aside_failure(&mut rollback_maintenance, &simulated);
+        assert_eq!(
+            rollback_error.details["operation"],
+            "move live store aside for restore"
+        );
+
+        let replace_root = temp_root("replace-failure");
+        drop(seed_store(&replace_root, 1, None));
+        let replace_archive = replace_root
+            .parent()
+            .expect("parent")
+            .join(format!("replace-{}.zip", Uuid::new_v4()));
+        {
+            let mut writer =
+                LocalFileDataStoreMaintenance::open(&replace_root).expect("maintenance");
+            writer
+                .backup(&replace_archive, "2026-07-29T00:00:00Z")
+                .expect("backup");
+        }
+        let mut replacer = LocalFileDataStoreMaintenance::open(&replace_root).expect("maintenance");
+        let simulated = std::io::Error::other("simulated");
+        let replace = handle_replace_store_root_failure(
+            &mut replacer,
+            &replace_root.join("backup-aside"),
+            &simulated,
+        );
+        assert_eq!(
+            replace.details["operation"],
+            "atomically replace store root"
+        );
+    }
+
+    #[test]
+    fn materialize_archive_reports_missing_members_and_invalid_zip() {
+        let root = temp_root("materialize");
+        fs::create_dir_all(&root).expect("dir");
+        let bad_zip = temp_root("materialize-bad").join("bad.zip");
+        fs::write(&bad_zip, b"not a zip").expect("write");
+        let invalid = materialize_archive_to_root(&bad_zip, &root).expect_err("zip");
+        assert_eq!(invalid.code, MaintenanceErrorCode::BackupVerifyFailed);
+
+        let missing_member = write_zip_with_manifest(
+            bad_zip.parent().expect("parent"),
+            &json!({
+                "manifest_format_version": BACKUP_MANIFEST_VERSION,
+                "created_as_of": "2026-07-29T00:00:00Z",
+                "record_count": 1,
+                "archive_content_digest": "sha256:00",
+                "records": [{
+                    "key": "k00",
+                    "classification": "public",
+                    "envelope_digest": "sha256:00",
+                    "member_path": "records/k00.json"
+                }],
+                "store_format": LOCAL_DATA_STORE_FORMAT,
+                "writer_tool": "test",
+                "writer_semver": "0.0.0"
+            }),
+            &[],
+        );
+        let missing = materialize_archive_to_root(&missing_member, &root).expect_err("missing");
+        assert_eq!(missing.code, MaintenanceErrorCode::BackupVerifyFailed);
+        assert_eq!(missing.details["reason"], "missing_member");
+    }
+
+    fn write_zip(parent: &Path, members: &[(&str, &[u8])]) -> PathBuf {
+        let path = parent.join(format!("archive-{}.zip", Uuid::new_v4()));
+        let file = File::create(&path).expect("create");
+        let mut zip = ZipWriter::new(file);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        for (name, bytes) in members {
+            zip.start_file(*name, options).expect("start");
+            zip.write_all(bytes).expect("write");
+        }
+        zip.finish().expect("finish");
+        path
+    }
+
+    fn backup_zip_with_manifest(manifest: &Value) -> PathBuf {
+        write_zip_with_manifest(&temp_root("manifest-only"), manifest, &[])
+    }
+
+    fn write_zip_with_manifest(
+        parent: &Path,
+        manifest: &Value,
+        members: &[(&str, &[u8])],
+    ) -> PathBuf {
+        let manifest_bytes = serde_json::to_vec_pretty(&manifest).expect("manifest");
+        let path = parent.join(format!("archive-{}.zip", Uuid::new_v4()));
+        let file = File::create(&path).expect("create");
+        let mut zip = ZipWriter::new(file);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        zip.start_file(BACKUP_MANIFEST_MEMBER, options)
+            .expect("manifest");
+        zip.write_all(&manifest_bytes).expect("write manifest");
+        for (name, bytes) in members {
+            zip.start_file(*name, options).expect("start");
+            zip.write_all(bytes).expect("write");
+        }
+        zip.finish().expect("finish");
+        path
+    }
+}


### PR DESCRIPTION
## Summary

- Add host-explicit `DataStoreMaintenance` retention prune and verified zip backup/restore.
- Preserve host-supplied `as_of` timestamps, exclusive ownership locking, atomic root replacement, and secret-free evidence.

## Governing Spec

- `083-datastore-retention-backup`

## Project Item

Closes #862.

## Definition of Done

- Implement count/age prune, verified manifest backups, and atomic non-merge restore.
- Keep every operation host-explicit and lock-protected.
- Return stable errors and structured safe evidence.
- Cover partial prune, archive verification, restore failure boundaries, lock exclusion, and empty stores.

## Validation

- `cargo test -p traverse-runtime --lib maintenance::tests`
- `git diff --check`
