### PR TITLE
docs: represent current state and roadmap accurately in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,31 @@
 [![Coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)](https://github.com/traverse-framework/traverse/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
-[![Version](https://img.shields.io/badge/version-v0.8.0-blue)](https://github.com/traverse-framework/traverse/releases)
+[![Version](https://img.shields.io/badge/version-v0.8.1-blue)](https://github.com/traverse-framework/traverse/releases)
 
 Your business logic runs in the browser, on your server, and in a cloud function.
 They drift. You maintain three versions of the same behavior.
 Traverse keeps it in one contract and runs it anywhere — with a full execution trace every time.
 
 Traverse is the working implementation of [Universal Microservices Architecture](https://www.universalmicroservices.com/).
+
+---
+
+## Current State & Roadmap
+
+Traverse is pre-1.0 (`v0.8.1`) and evolving under spec-driven governance — every capability below is real, running code, not a plan.
+
+- **8 crates in this repo** plus the capability registry (now its own repo, see below) — 7 of these 9 are [published on crates.io](https://crates.io/search?q=traverse-): runtime, contracts, registry, CLI, MCP server, embedder SDK, and the expedition WASM example. `traverse-native-bridge` and `traverse-swift-host` are newer, not yet published.
+- **87 approved, immutable specs** govern the runtime, contracts, registry, MCP surface, WASM execution, native embedding, and durable local storage. Full list: `jq -r '.specs[].id' specs/governance/approved-specs.json` (or see [Governance](#governance) below).
+- **100% coverage enforced on core logic**, spec-alignment and supply-chain gates on every PR, 5-platform CI matrix (Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64).
+- **Capability registry** was extracted into its own repo, [`traverse-framework/registry`](https://github.com/traverse-framework/registry), so capabilities can be published, versioned, and consumed independently of the runtime.
+- **Reference apps** for multiple platforms (web, iOS, macOS, Android, Windows, Linux, CLI) live in [`traverse-framework/reference-apps`](https://github.com/traverse-framework/reference-apps).
+
+### Where this is going: v1.0.0
+
+v1.0.0 is gated, not a date — governed by [`spec 049-v1-milestone-gate`](specs/049-v1-milestone-gate/spec.md) and checkable locally with `bash scripts/ci/v1_gate_check.sh`. It signals stable public API surfaces, every published crate live on crates.io, and the runtime stress-tested on every supported platform. Full gate conditions: [docs/v1-milestone.md](docs/v1-milestone.md).
+
+Explicitly **not** required for v1.0.0: a reference app in this repo (that's `reference-apps`), an HTTP admin API, a cloud deployment surface, or worker-isolation message passing (planned for v2).
 
 ---
 
@@ -141,15 +159,24 @@ Scaffolds a governed app bundle. Add your capability contracts, workflows, and W
 
 ### Crates
 
+In this repo:
+
 | Crate | Role |
 |---|---|
 | `traverse-runtime` | Core execution engine — validates, places, and executes capabilities |
 | `traverse-contracts` | Contract definitions, parsing, and validation |
-| `traverse-registry` | Capability and event registries with deterministic traversal |
 | `traverse-cli-rs` | Command-line interface (binary: `traverse-cli`) — register, list, validate, run |
 | `traverse-mcp` | Model Context Protocol stdio server and governed MCP-facing surface |
 | `traverse-embedder` | Public Rust embedder SDK (`embedder-api/1.0.0`) for Linux GTK and CLI clients |
 | `traverse-expedition-wasm` | Expedition example domain compiled to `wasm32-wasi` |
+| `traverse-native-bridge` | Deterministic builder for the governed native runtime WebAssembly bridge |
+| `traverse-swift-host` | Apple static-library feasibility host for the Traverse runtime bridge |
+
+In a separate repo:
+
+| Crate | Repo | Role |
+|---|---|---|
+| `traverse-registry` | [`traverse-framework/registry`](https://github.com/traverse-framework/registry) | Capability and event registries with deterministic traversal — extracted from this repo (spec 051) so capabilities can be published and versioned independently |
 
 ---
 
@@ -197,17 +224,13 @@ Traverse is spec-driven. Code must align with an approved, immutable spec or it 
 
 ### Approved Specs
 
-| ID | Spec | Governs |
-|---|---|---|
-| 001 | [foundation-v0-1](specs/001-foundation-v0-1/spec.md) | Core runtime, CLI, MCP surface |
-| 002 | [capability-contracts](specs/002-capability-contracts/spec.md) | Contract definitions and validation |
-| 003 | [event-contracts](specs/003-event-contracts/spec.md) | Event contract definitions |
-| 004 | [spec-alignment-gate](specs/004-spec-alignment-gate/spec.md) | CI merge gate |
-| 005 | [capability-registry](specs/005-capability-registry/spec.md) | Registry behavior |
-| 006 | [runtime-request-execution](specs/006-runtime-request-execution/spec.md) | Execution model |
-| 007 | [workflow-registry-traversal](specs/007-workflow-registry-traversal/spec.md) | Workflow composition |
-| 008 | [expedition-example-domain](specs/008-expedition-example-domain/spec.md) | Example domain |
-| 009 | [expedition-example-artifacts](specs/009-expedition-example-artifacts/spec.md) | Example artifacts |
+87 approved specs currently govern this repo, spanning the runtime, contracts, registry integration, CLI, MCP surface, WASM execution, native embedding, and durable local storage. The list changes as specs are approved — query it instead of reading a snapshot:
+
+```bash
+jq -r '.specs[].id' specs/governance/approved-specs.json
+```
+
+Foundational specs worth reading first: [001-foundation-v0-1](specs/001-foundation-v0-1/spec.md) (core runtime, CLI, MCP surface), [004-spec-alignment-gate](specs/004-spec-alignment-gate/spec.md) (this CI gate), [049-v1-milestone-gate](specs/049-v1-milestone-gate/spec.md) (what v1.0.0 requires).
 
 ---
 
@@ -221,7 +244,7 @@ This project supports AI-assisted development with Codex and Claude Code running
 |---|---|---|
 | Claude Code | [`CLAUDE.md`](CLAUDE.md) | Project context, governance rules, speckit workflow |
 | Codex | [`AGENTS.md`](AGENTS.md) | Project context, coordination rules, speckit workflow |
-| All agents | [`.specify/memory/constitution.md`](.specify/memory/constitution.md) | Governing constitution v1.2.0 |
+| All agents | [`.specify/memory/constitution.md`](.specify/memory/constitution.md) | Governing constitution — mirrors [`traverse-framework/.github`](https://github.com/traverse-framework/.github) at the version in [`.governance-version`](.governance-version) |
 
 ### Agent workflow
 


### PR DESCRIPTION
## Summary

The README no longer represented the project's current state or roadmap:

- Version badge said `v0.8.0`; actual latest release is `v0.8.1`.
- "Approved Specs" was a static table of 9 specs; the repo now has **87** approved specs. Replaced with a live `jq` query plus 3 foundational specs worth reading first — consistent with the org's no-stale-snapshot rule.
- Crate table was missing `traverse-native-bridge` and `traverse-swift-host` (both real, unpublished crates), and still listed `traverse-registry`, which was extracted to [`traverse-framework/registry`](https://github.com/traverse-framework/registry) per spec 051. Split into "in this repo" / "in a separate repo" tables.
- Added a **Current State & Roadmap** section: crates.io publish status (verified live per crate against the crates.io API, not assumed), the v1.0.0 milestone gate (grounded in the existing `docs/v1-milestone.md` and `specs/049-v1-milestone-gate`), and what's explicitly out of scope for v1.0.0.
- "For Agents" hardcoded a constitution version number; now points at `.governance-version`, the actual pin.

All facts were verified against the live repo (crates.io API checks, spec registry count, Cargo.toml version) before writing, not assumed from memory.

## Governing Spec
- `190-readme-rewrite`

## Project Item
- Closes #866

## Definition of Done
- Version badge, crate list, and Approved Specs section match verified current state
- New Current State & Roadmap section grounded in existing docs (`docs/v1-milestone.md`, `specs/049-v1-milestone-gate`)
- No runtime, contract, or CI gate changes (docs-only, per spec 190's own governance note)

## Validation
- All referenced file paths and specs verified to exist in this repo before linking
- crates.io publish status verified per-crate via the crates.io API (not asserted from the milestone doc's older crate count)
- All CI gates green on this PR