### PR TITLE
feat: encrypt private DataStore records at rest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +262,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +307,12 @@ checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -465,7 +524,27 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -836,8 +915,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
 ]
 
 [[package]]
@@ -1039,6 +1128,15 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1282,6 +1380,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "polyval"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0fa31d631f2b2cb2a544d0aa321ce847a94764d701ca2becc411138b93d49cd"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,7 +1497,7 @@ checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1398,7 +1507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1409,6 +1518,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -1957,6 +2072,7 @@ dependencies = [
 name = "traverse-runtime"
 version = "0.8.1"
 dependencies = [
+ "aes-gcm",
  "chrono",
  "ed25519-dalek",
  "rayon",
@@ -2007,6 +2123,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
 
 [[package]]
 name = "url"

--- a/crates/traverse-embedder/src/lib.rs
+++ b/crates/traverse-embedder/src/lib.rs
@@ -404,6 +404,14 @@ impl EmbeddedDataStoreError {
             DataStoreErrorCode::NoStateSchemaDeclared => "state_schema_unavailable",
             DataStoreErrorCode::LamportClockOverflow => "lamport_clock_overflow",
             DataStoreErrorCode::SyncFailure => "sync_failed",
+            DataStoreErrorCode::KeyProviderRequired => "key_provider_required",
+            DataStoreErrorCode::KeyNotFound => "key_not_found",
+            DataStoreErrorCode::KeyExpired => "key_expired",
+            DataStoreErrorCode::KeyProviderFailure => "key_provider_failed",
+            DataStoreErrorCode::CryptoFailure => "crypto_failed",
+            DataStoreErrorCode::ClassificationChangeNotAllowed => {
+                "classification_change_not_allowed"
+            }
         };
         Self { code, operation }
     }
@@ -1879,6 +1887,21 @@ mod tests {
                 "lamport_clock_overflow",
             ),
             (DataStoreErrorCode::SyncFailure, "sync_failed"),
+            (
+                DataStoreErrorCode::KeyProviderRequired,
+                "key_provider_required",
+            ),
+            (DataStoreErrorCode::KeyNotFound, "key_not_found"),
+            (DataStoreErrorCode::KeyExpired, "key_expired"),
+            (
+                DataStoreErrorCode::KeyProviderFailure,
+                "key_provider_failed",
+            ),
+            (DataStoreErrorCode::CryptoFailure, "crypto_failed"),
+            (
+                DataStoreErrorCode::ClassificationChangeNotAllowed,
+                "classification_change_not_allowed",
+            ),
         ];
         for (code, expected) in codes {
             let error = EmbeddedDataStoreError::from_error(

--- a/crates/traverse-embedder/tests/conformance.rs
+++ b/crates/traverse-embedder/tests/conformance.rs
@@ -9,14 +9,15 @@ use common::{
     RENDER_CAPABILITY_ID, collect_events, snapshot,
 };
 use serde_json::{Value, json};
+use std::sync::Arc;
 use traverse_embedder::{
     BundleEmbedder, CompatibleLifecycleStatus, EMBEDDED_TRACE_API_VERSION, EmbeddedTraceApi,
     EmbeddedTraceOutcome, EmbedderConfig, EmbedderErrorCode, HostDataStore, SecurityPosture,
     SubmitStatus, TraverseEmbedderApi,
 };
 use traverse_runtime::data_store::{
-    DataStore, DataStoreError, DataStoreErrorCode, LocalDataClassification, LocalFileDataStore,
-    StateRecord,
+    DataStore, DataStoreError, DataStoreErrorCode, InMemoryKeyProvider, KeyProvider,
+    LocalDataClassification, LocalFileDataStore, StateRecord,
 };
 
 struct FailingDataStore {
@@ -283,7 +284,11 @@ fn host_injected_datastore_reopens_without_leaking_record_metadata_to_events() {
     ));
     let mut first = development_embedder(&fixture, "linux");
     let events = collect_events(&mut first);
-    let store = LocalFileDataStore::new(&root).expect("host should create store");
+    let provider: Arc<dyn KeyProvider> =
+        Arc::new(InMemoryKeyProvider::new("embedder-test", [17; 32]));
+    let store = LocalFileDataStore::new(&root)
+        .expect("host should create store")
+        .with_key_provider(Arc::clone(&provider));
     first.inject_data_store(HostDataStore::new(store, LocalDataClassification::Private));
     let record = StateRecord {
         key: "host-note".to_string(),
@@ -297,7 +302,9 @@ fn host_injected_datastore_reopens_without_leaking_record_metadata_to_events() {
     drop(first);
 
     let mut second = development_embedder(&fixture, "linux");
-    let reopened = LocalFileDataStore::new(&root).expect("host should reopen released store");
+    let reopened = LocalFileDataStore::new(&root)
+        .expect("host should reopen released store")
+        .with_key_provider(provider);
     second.inject_data_store(HostDataStore::new(
         reopened,
         LocalDataClassification::Private,
@@ -394,6 +401,21 @@ fn host_datastore_failure_codes_are_safe_and_classified() {
             "lamport_clock_overflow",
         ),
         (DataStoreErrorCode::SyncFailure, "sync_failed"),
+        (
+            DataStoreErrorCode::KeyProviderRequired,
+            "key_provider_required",
+        ),
+        (DataStoreErrorCode::KeyNotFound, "key_not_found"),
+        (DataStoreErrorCode::KeyExpired, "key_expired"),
+        (
+            DataStoreErrorCode::KeyProviderFailure,
+            "key_provider_failed",
+        ),
+        (DataStoreErrorCode::CryptoFailure, "crypto_failed"),
+        (
+            DataStoreErrorCode::ClassificationChangeNotAllowed,
+            "classification_change_not_allowed",
+        ),
     ];
 
     for (code, expected) in cases {

--- a/crates/traverse-runtime/Cargo.toml
+++ b/crates/traverse-runtime/Cargo.toml
@@ -22,6 +22,7 @@ uuid = { version = "1", features = ["v4", "js"] }
 chrono = { version = "0.4", features = ["serde"] }
 rayon = { version = "1.11", optional = true }
 zip = { version = "2", default-features = false, features = ["deflate"] }
+aes-gcm = { version = "0.11.0", features = ["zeroize"] }
 
 [features]
 default = ["native-executors", "wasmtime-executor"]

--- a/crates/traverse-runtime/Cargo.toml
+++ b/crates/traverse-runtime/Cargo.toml
@@ -22,12 +22,15 @@ uuid = { version = "1", features = ["v4", "js"] }
 chrono = { version = "0.4", features = ["serde"] }
 rayon = { version = "1.11", optional = true }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-aes-gcm = { version = "0.11.0", features = ["zeroize"] }
+aes-gcm = { version = "0.11.0", optional = true, features = ["zeroize"] }
 
 [features]
-default = ["native-executors", "wasmtime-executor"]
+default = ["native-executors", "wasmtime-executor", "datastore-encryption"]
 native-executors = ["dep:rayon"]
 wasmtime-executor = ["dep:wasmtime", "dep:wasmtime-wasi"]
+# Local-file private-record AEAD (Spec 084). Omitted from wasm32
+# `--no-default-features` checks so getrandom backends are not required.
+datastore-encryption = ["dep:aes-gcm"]
 
 [dev-dependencies]
 wat = "1"

--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -12,7 +12,11 @@ pub use maintenance::{
     MaintenanceError, MaintenanceErrorCode, MaintenanceEvidence, RetentionPolicy,
 };
 
-use aes_gcm::aead::{Aead, Generate, KeyInit, Payload};
+#[cfg(feature = "datastore-encryption")]
+use aes_gcm::aead::consts::U12;
+#[cfg(feature = "datastore-encryption")]
+use aes_gcm::aead::{Aead, KeyInit, Payload};
+#[cfg(feature = "datastore-encryption")]
 use aes_gcm::{Aes256Gcm, Nonce};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -617,6 +621,7 @@ impl DataStore for LocalFileDataStore {
 }
 
 impl LocalFileDataStore {
+    #[cfg(feature = "datastore-encryption")]
     fn encrypt_private_record(
         &self,
         record: StateRecord,
@@ -629,7 +634,7 @@ impl LocalFileDataStore {
                 .map_err(|error| serialization_error("serialize private state record", &error))?,
         );
         let cipher = Aes256Gcm::new_from_slice(key.as_ref()).map_err(|_| crypto_error())?;
-        let nonce = Nonce::generate();
+        let nonce = fresh_aes_nonce();
         let aad = private_record_aad(&key_id, &record.key);
         let ciphertext = cipher
             .encrypt(
@@ -656,6 +661,15 @@ impl LocalFileDataStore {
         })
     }
 
+    #[cfg(not(feature = "datastore-encryption"))]
+    fn encrypt_private_record(
+        &self,
+        _record: StateRecord,
+    ) -> Result<LocalDataStoreEnvelope, DataStoreError> {
+        Err(encryption_feature_disabled())
+    }
+
+    #[cfg(feature = "datastore-encryption")]
     fn decrypt_private_envelope(
         &self,
         requested_key: &str,
@@ -711,6 +725,16 @@ impl LocalFileDataStore {
         Ok(Some(record))
     }
 
+    #[cfg(not(feature = "datastore-encryption"))]
+    fn decrypt_private_envelope(
+        &self,
+        _requested_key: &str,
+        _envelope: LocalDataStoreEnvelope,
+    ) -> Result<Option<StateRecord>, DataStoreError> {
+        Err(encryption_feature_disabled())
+    }
+
+    #[cfg(feature = "datastore-encryption")]
     fn required_key_provider(&self) -> Result<&dyn KeyProvider, DataStoreError> {
         self.key_provider.as_deref().ok_or_else(|| {
             data_store_error(
@@ -769,6 +793,7 @@ fn digest_for_private_envelope(
     format!("sha256:{}", hex_encode(&hasher.finalize()))
 }
 
+#[cfg(feature = "datastore-encryption")]
 fn private_record_aad(key_id: &str, record_key: &str) -> Vec<u8> {
     let mut aad = Vec::new();
     append_length_prefixed(&mut aad, key_id.as_bytes());
@@ -782,6 +807,7 @@ fn update_length_prefixed(hasher: &mut Sha256, value: &[u8]) {
     hasher.update(value);
 }
 
+#[cfg(feature = "datastore-encryption")]
 fn append_length_prefixed(output: &mut Vec<u8>, value: &[u8]) {
     output.extend_from_slice(&value.len().to_le_bytes());
     output.extend_from_slice(value);
@@ -819,6 +845,7 @@ fn decode_hex_digit(value: u8) -> Option<u8> {
     }
 }
 
+#[cfg(feature = "datastore-encryption")]
 fn map_key_provider_error(error: KeyProviderError) -> DataStoreError {
     let code = match error.code {
         KeyProviderErrorCode::MissingKey => DataStoreErrorCode::KeyNotFound,
@@ -833,6 +860,7 @@ fn map_key_provider_error(error: KeyProviderError) -> DataStoreError {
     )
 }
 
+#[cfg(feature = "datastore-encryption")]
 fn key_provider_error_code(code: KeyProviderErrorCode) -> &'static str {
     match code {
         KeyProviderErrorCode::MissingKey => "missing_key",
@@ -841,12 +869,32 @@ fn key_provider_error_code(code: KeyProviderErrorCode) -> &'static str {
     }
 }
 
+#[cfg(feature = "datastore-encryption")]
 fn crypto_error() -> DataStoreError {
     data_store_error(
         DataStoreErrorCode::CryptoFailure,
         "crypto_failed",
         json!({ "reason": "encryption_failed" }),
     )
+}
+
+#[cfg(not(feature = "datastore-encryption"))]
+fn encryption_feature_disabled() -> DataStoreError {
+    data_store_error(
+        DataStoreErrorCode::KeyProviderRequired,
+        "key_provider_required",
+        json!({ "reason": "datastore_encryption_feature_disabled" }),
+    )
+}
+
+#[cfg(feature = "datastore-encryption")]
+fn fresh_aes_nonce() -> Nonce<U12> {
+    // Host-local UUID entropy avoids aes-gcm's getrandom Generate path so
+    // wasm32 `--no-default-features` checks do not require a getrandom backend.
+    let entropy = *uuid::Uuid::new_v4().as_bytes();
+    let mut nonce_bytes = [0_u8; 12];
+    nonce_bytes.copy_from_slice(&entropy[..12]);
+    Nonce::<U12>::from(nonce_bytes)
 }
 
 fn lock_error(error: TryLockError) -> DataStoreError {
@@ -2029,6 +2077,7 @@ mod tests {
         assert_eq!(error.details["reason"], reason);
     }
 
+    #[cfg(feature = "datastore-encryption")]
     fn encrypted_fixture(
         record_key: &str,
         key_id: &str,
@@ -2036,7 +2085,7 @@ mod tests {
         plaintext: &[u8],
     ) -> LocalDataStoreEnvelope {
         let cipher = Aes256Gcm::new_from_slice(&key).expect("valid AES-256 key");
-        let nonce = Nonce::generate();
+        let nonce = fresh_aes_nonce();
         let ciphertext = cipher
             .encrypt(
                 &nonce,

--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -12,6 +12,8 @@ pub use maintenance::{
     MaintenanceError, MaintenanceErrorCode, MaintenanceEvidence, RetentionPolicy,
 };
 
+use aes_gcm::aead::{Aead, Generate, KeyInit, Payload};
+use aes_gcm::{Aes256Gcm, Nonce};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -19,7 +21,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions, TryLockError};
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::Arc;
 use traverse_contracts::CapabilityContract;
+use zeroize::Zeroizing;
 
 const DATA_STORE_SPEC: &str = "032-universal-data-access";
 const LOCAL_DATA_STORE_FORMAT: &str = "local-datastore/1";
@@ -76,12 +80,15 @@ pub enum DataStoreErrorCode {
     IntegrityCheckFailed,
     StoreLocked,
     DurabilityCommitFailed,
+    KeyProviderRequired,
+    KeyNotFound,
+    KeyExpired,
+    KeyProviderFailure,
+    CryptoFailure,
+    ClassificationChangeNotAllowed,
 }
 
 /// Classification recorded with each locally durable record.
-///
-/// This is metadata only. Encryption and key management are intentionally
-/// deferred to a successor decision.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LocalDataClassification {
@@ -93,12 +100,138 @@ pub enum LocalDataClassification {
 struct LocalDataStoreEnvelope {
     format: String,
     classification: LocalDataClassification,
-    record: StateRecord,
     digest: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    record: Option<StateRecord>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    record_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    key_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    nonce: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ciphertext: Option<String>,
     /// Host-supplied RFC3339 instant stamped at write time for age-based prune.
     /// Absent on legacy envelopes; age prune treats missing stamps as retained.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     retained_at: Option<String>,
+}
+
+/// Stable, secret-free key-provider failure codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KeyProviderErrorCode {
+    MissingKey,
+    ExpiredKeyId,
+    ProviderFailure,
+}
+
+/// A key-provider failure that never includes key material or provider internals.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyProviderError {
+    pub code: KeyProviderErrorCode,
+    pub message: String,
+}
+
+impl KeyProviderError {
+    #[must_use]
+    pub fn missing_key() -> Self {
+        Self {
+            code: KeyProviderErrorCode::MissingKey,
+            message: "key_not_found".to_string(),
+        }
+    }
+
+    #[must_use]
+    pub fn expired_key_id() -> Self {
+        Self {
+            code: KeyProviderErrorCode::ExpiredKeyId,
+            message: "key_expired".to_string(),
+        }
+    }
+
+    #[must_use]
+    pub fn provider_failure() -> Self {
+        Self {
+            code: KeyProviderErrorCode::ProviderFailure,
+            message: "key_provider_failed".to_string(),
+        }
+    }
+}
+
+/// Host-owned source of AES-256 keys.
+pub trait KeyProvider: Send + Sync {
+    /// Returns the key id used for new private writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns a secret-free [`KeyProviderError`] when no write key is available.
+    fn active_key_id(&self) -> Result<String, KeyProviderError>;
+
+    /// Returns key material for an envelope key id.
+    ///
+    /// # Errors
+    ///
+    /// Returns a secret-free [`KeyProviderError`] for missing, expired, or
+    /// unavailable keys.
+    fn key_for(&self, key_id: &str) -> Result<Zeroizing<[u8; 32]>, KeyProviderError>;
+}
+
+/// In-memory provider for tests and host wiring.
+#[derive(Clone)]
+pub struct InMemoryKeyProvider {
+    active_key_id: String,
+    keys: BTreeMap<String, Zeroizing<[u8; 32]>>,
+    expired_key_ids: BTreeSet<String>,
+}
+
+impl InMemoryKeyProvider {
+    #[must_use]
+    pub fn new(active_key_id: impl Into<String>, key: [u8; 32]) -> Self {
+        let active_key_id = active_key_id.into();
+        let mut keys = BTreeMap::new();
+        keys.insert(active_key_id.clone(), Zeroizing::new(key));
+        Self {
+            active_key_id,
+            keys,
+            expired_key_ids: BTreeSet::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_read_key(mut self, key_id: impl Into<String>, key: [u8; 32]) -> Self {
+        self.keys.insert(key_id.into(), Zeroizing::new(key));
+        self
+    }
+
+    #[must_use]
+    pub fn with_expired_key_id(mut self, key_id: impl Into<String>) -> Self {
+        self.expired_key_ids.insert(key_id.into());
+        self
+    }
+}
+
+impl KeyProvider for InMemoryKeyProvider {
+    fn active_key_id(&self) -> Result<String, KeyProviderError> {
+        if self.expired_key_ids.contains(&self.active_key_id) {
+            return Err(KeyProviderError::expired_key_id());
+        }
+        if self.keys.contains_key(&self.active_key_id) {
+            Ok(self.active_key_id.clone())
+        } else {
+            Err(KeyProviderError::missing_key())
+        }
+    }
+
+    fn key_for(&self, key_id: &str) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+        if self.expired_key_ids.contains(key_id) {
+            return Err(KeyProviderError::expired_key_id());
+        }
+        self.keys
+            .get(key_id)
+            .cloned()
+            .ok_or_else(KeyProviderError::missing_key)
+    }
 }
 
 pub trait DataStore {
@@ -271,13 +404,25 @@ impl<A: DataStore> RuntimeDataStore<A> {
     }
 }
 
-#[derive(Debug)]
 pub struct LocalFileDataStore {
     root: PathBuf,
     classification: LocalDataClassification,
     lock_file: File,
+    key_provider: Option<Arc<dyn KeyProvider>>,
     /// Host-supplied retained-at stamp applied to subsequent writes (no OS clock).
     write_retained_at: Option<String>,
+}
+
+impl std::fmt::Debug for LocalFileDataStore {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LocalFileDataStore")
+            .field("root", &self.root)
+            .field("classification", &self.classification)
+            .field("key_provider_configured", &self.key_provider.is_some())
+            .field("write_retained_at", &self.write_retained_at)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Drop for LocalFileDataStore {
@@ -323,8 +468,16 @@ impl LocalFileDataStore {
             root,
             classification,
             lock_file,
+            key_provider: None,
             write_retained_at: None,
         })
+    }
+
+    /// Configures the host-owned key provider used for private records.
+    #[must_use]
+    pub fn with_key_provider(mut self, key_provider: Arc<dyn KeyProvider>) -> Self {
+        self.key_provider = Some(key_provider);
+        self
     }
 
     /// Sets the host-supplied retained-at stamp used by subsequent writes.
@@ -375,25 +528,49 @@ impl DataStore for LocalFileDataStore {
         if envelope.format != LOCAL_DATA_STORE_FORMAT {
             return Err(integrity_error("unknown_format_version"));
         }
-        let expected_digest = digest_for_record(&envelope.record)?;
-        if envelope.digest != expected_digest {
-            return Err(integrity_error("digest_mismatch"));
+        match envelope.classification {
+            LocalDataClassification::Public => {
+                let record = envelope
+                    .record
+                    .ok_or_else(|| integrity_error("malformed_envelope"))?;
+                if envelope.key_id.is_some()
+                    || envelope.nonce.is_some()
+                    || envelope.ciphertext.is_some()
+                    || envelope.record_key.is_some()
+                {
+                    return Err(integrity_error("malformed_envelope"));
+                }
+                let expected_digest = digest_for_record(&record)?;
+                if envelope.digest != expected_digest {
+                    return Err(integrity_error("digest_mismatch"));
+                }
+                Ok(Some(record))
+            }
+            LocalDataClassification::Private => self.decrypt_private_envelope(key, envelope),
         }
-        Ok(Some(envelope.record))
     }
 
     fn write(&mut self, record: StateRecord) -> Result<(), DataStoreError> {
         let path = self.path_for_key(&record.key)?;
-        let envelope = LocalDataStoreEnvelope {
-            format: LOCAL_DATA_STORE_FORMAT.to_string(),
-            classification: self.classification,
-            digest: digest_for_record(&record)?,
-            retained_at: self.write_retained_at.clone(),
-            record,
+        self.ensure_classification_unchanged(&path)?;
+        let record_key = record.key.clone();
+        let envelope = match self.classification {
+            LocalDataClassification::Public => LocalDataStoreEnvelope {
+                format: LOCAL_DATA_STORE_FORMAT.to_string(),
+                classification: self.classification,
+                digest: digest_for_record(&record)?,
+                record: Some(record),
+                record_key: None,
+                key_id: None,
+                nonce: None,
+                ciphertext: None,
+                retained_at: self.write_retained_at.clone(),
+            },
+            LocalDataClassification::Private => self.encrypt_private_record(record)?,
         };
         let text = serde_json::to_vec(&envelope)
             .map_err(|error| serialization_error("serialize state record envelope", &error))?;
-        let temporary_path = self.temporary_path_for_key(&envelope.record.key);
+        let temporary_path = self.temporary_path_for_key(&record_key);
         let write_result = (|| {
             let mut temporary_file = File::create(&temporary_path)
                 .map_err(|error| io_error("create temporary state record", &error))?;
@@ -439,6 +616,132 @@ impl DataStore for LocalFileDataStore {
     }
 }
 
+impl LocalFileDataStore {
+    fn encrypt_private_record(
+        &self,
+        record: StateRecord,
+    ) -> Result<LocalDataStoreEnvelope, DataStoreError> {
+        let provider = self.required_key_provider()?;
+        let key_id = provider.active_key_id().map_err(map_key_provider_error)?;
+        let key = provider.key_for(&key_id).map_err(map_key_provider_error)?;
+        let plaintext = Zeroizing::new(
+            serde_json::to_vec(&record)
+                .map_err(|error| serialization_error("serialize private state record", &error))?,
+        );
+        let cipher = Aes256Gcm::new_from_slice(key.as_ref()).map_err(|_| crypto_error())?;
+        let nonce = Nonce::generate();
+        let aad = private_record_aad(&key_id, &record.key);
+        let ciphertext = cipher
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: plaintext.as_ref(),
+                    aad: &aad,
+                },
+            )
+            .map_err(|_| crypto_error())?;
+        let nonce = hex_encode(&nonce);
+        let ciphertext = hex_encode(&ciphertext);
+        let digest = digest_for_private_envelope(&key_id, &record.key, &nonce, &ciphertext);
+        Ok(LocalDataStoreEnvelope {
+            format: LOCAL_DATA_STORE_FORMAT.to_string(),
+            classification: LocalDataClassification::Private,
+            digest,
+            record: None,
+            record_key: Some(record.key),
+            key_id: Some(key_id),
+            nonce: Some(nonce),
+            ciphertext: Some(ciphertext),
+            retained_at: self.write_retained_at.clone(),
+        })
+    }
+
+    fn decrypt_private_envelope(
+        &self,
+        requested_key: &str,
+        envelope: LocalDataStoreEnvelope,
+    ) -> Result<Option<StateRecord>, DataStoreError> {
+        if envelope.record.is_some() {
+            return Err(integrity_error("malformed_envelope"));
+        }
+        let record_key = envelope
+            .record_key
+            .ok_or_else(|| integrity_error("malformed_envelope"))?;
+        let key_id = envelope
+            .key_id
+            .ok_or_else(|| integrity_error("malformed_envelope"))?;
+        let nonce_hex = envelope
+            .nonce
+            .ok_or_else(|| integrity_error("malformed_envelope"))?;
+        let ciphertext_hex = envelope
+            .ciphertext
+            .ok_or_else(|| integrity_error("malformed_envelope"))?;
+        if record_key != requested_key {
+            return Err(integrity_error("record_key_mismatch"));
+        }
+        let expected_digest =
+            digest_for_private_envelope(&key_id, &record_key, &nonce_hex, &ciphertext_hex);
+        if envelope.digest != expected_digest {
+            return Err(integrity_error("digest_mismatch"));
+        }
+        let provider = self.required_key_provider()?;
+        let key = provider.key_for(&key_id).map_err(map_key_provider_error)?;
+        let nonce_bytes = hex_decode(&nonce_hex)?;
+        let nonce = Nonce::try_from(nonce_bytes.as_slice())
+            .map_err(|_| integrity_error("invalid_nonce"))?;
+        let ciphertext = hex_decode(&ciphertext_hex)?;
+        let cipher = Aes256Gcm::new_from_slice(key.as_ref()).map_err(|_| crypto_error())?;
+        let aad = private_record_aad(&key_id, &record_key);
+        let plaintext = Zeroizing::new(
+            cipher
+                .decrypt(
+                    &nonce,
+                    Payload {
+                        msg: &ciphertext,
+                        aad: &aad,
+                    },
+                )
+                .map_err(|_| integrity_error("authentication_failed"))?,
+        );
+        let record: StateRecord = serde_json::from_slice(&plaintext)
+            .map_err(|_| integrity_error("malformed_plaintext"))?;
+        if record.key != record_key {
+            return Err(integrity_error("record_key_mismatch"));
+        }
+        Ok(Some(record))
+    }
+
+    fn required_key_provider(&self) -> Result<&dyn KeyProvider, DataStoreError> {
+        self.key_provider.as_deref().ok_or_else(|| {
+            data_store_error(
+                DataStoreErrorCode::KeyProviderRequired,
+                "key_provider_required",
+                json!({ "reason": "private_record" }),
+            )
+        })
+    }
+
+    fn ensure_classification_unchanged(&self, path: &PathBuf) -> Result<(), DataStoreError> {
+        if !path.exists() {
+            return Ok(());
+        }
+        let bytes = fs::read(path).map_err(|error| io_error("read existing envelope", &error))?;
+        let envelope: LocalDataStoreEnvelope =
+            serde_json::from_slice(&bytes).map_err(|_| integrity_error("malformed_envelope"))?;
+        if envelope.format != LOCAL_DATA_STORE_FORMAT {
+            return Err(integrity_error("unknown_format_version"));
+        }
+        if envelope.classification != self.classification {
+            return Err(data_store_error(
+                DataStoreErrorCode::ClassificationChangeNotAllowed,
+                "classification_change_not_allowed",
+                json!({ "reason": "delete_before_reclassifying" }),
+            ));
+        }
+        Ok(())
+    }
+}
+
 fn digest_for_record(record: &StateRecord) -> Result<String, DataStoreError> {
     let canonical = serde_json::to_vec(record)
         .map_err(|error| serialization_error("serialize canonical state record", &error))?;
@@ -449,6 +752,101 @@ fn digest_for_record(record: &StateRecord) -> Result<String, DataStoreError> {
         hexadecimal.push(char::from(HEXADECIMAL_DIGITS[usize::from(byte & 0x0f)]));
     }
     Ok(format!("sha256:{hexadecimal}"))
+}
+
+fn digest_for_private_envelope(
+    key_id: &str,
+    record_key: &str,
+    nonce: &str,
+    ciphertext: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    update_length_prefixed(&mut hasher, key_id.as_bytes());
+    update_length_prefixed(&mut hasher, record_key.as_bytes());
+    update_length_prefixed(&mut hasher, b"private");
+    update_length_prefixed(&mut hasher, nonce.as_bytes());
+    update_length_prefixed(&mut hasher, ciphertext.as_bytes());
+    format!("sha256:{}", hex_encode(&hasher.finalize()))
+}
+
+fn private_record_aad(key_id: &str, record_key: &str) -> Vec<u8> {
+    let mut aad = Vec::new();
+    append_length_prefixed(&mut aad, key_id.as_bytes());
+    append_length_prefixed(&mut aad, record_key.as_bytes());
+    append_length_prefixed(&mut aad, b"private");
+    aad
+}
+
+fn update_length_prefixed(hasher: &mut Sha256, value: &[u8]) {
+    hasher.update(value.len().to_le_bytes());
+    hasher.update(value);
+}
+
+fn append_length_prefixed(output: &mut Vec<u8>, value: &[u8]) {
+    output.extend_from_slice(&value.len().to_le_bytes());
+    output.extend_from_slice(value);
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut hexadecimal = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        hexadecimal.push(char::from(HEXADECIMAL_DIGITS[usize::from(byte >> 4)]));
+        hexadecimal.push(char::from(HEXADECIMAL_DIGITS[usize::from(byte & 0x0f)]));
+    }
+    hexadecimal
+}
+
+fn hex_decode(value: &str) -> Result<Vec<u8>, DataStoreError> {
+    if !value.len().is_multiple_of(2) {
+        return Err(integrity_error("invalid_hex"));
+    }
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = decode_hex_digit(pair[0]).ok_or_else(|| integrity_error("invalid_hex"))?;
+            let low = decode_hex_digit(pair[1]).ok_or_else(|| integrity_error("invalid_hex"))?;
+            Ok((high << 4) | low)
+        })
+        .collect()
+}
+
+fn decode_hex_digit(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        _ => None,
+    }
+}
+
+fn map_key_provider_error(error: KeyProviderError) -> DataStoreError {
+    let code = match error.code {
+        KeyProviderErrorCode::MissingKey => DataStoreErrorCode::KeyNotFound,
+        KeyProviderErrorCode::ExpiredKeyId => DataStoreErrorCode::KeyExpired,
+        KeyProviderErrorCode::ProviderFailure => DataStoreErrorCode::KeyProviderFailure,
+    };
+    let message = error.message;
+    data_store_error(
+        code,
+        &message,
+        json!({ "provider_error_code": key_provider_error_code(error.code) }),
+    )
+}
+
+fn key_provider_error_code(code: KeyProviderErrorCode) -> &'static str {
+    match code {
+        KeyProviderErrorCode::MissingKey => "missing_key",
+        KeyProviderErrorCode::ExpiredKeyId => "expired_key_id",
+        KeyProviderErrorCode::ProviderFailure => "provider_failure",
+    }
+}
+
+fn crypto_error() -> DataStoreError {
+    data_store_error(
+        DataStoreErrorCode::CryptoFailure,
+        "crypto_failed",
+        json!({ "reason": "encryption_failed" }),
+    )
 }
 
 fn lock_error(error: TryLockError) -> DataStoreError {
@@ -714,6 +1112,18 @@ mod tests {
     #[derive(Debug, Clone, Default)]
     struct PhantomKeyStore;
 
+    struct FailingKeyProvider;
+
+    impl KeyProvider for FailingKeyProvider {
+        fn active_key_id(&self) -> Result<String, KeyProviderError> {
+            Err(KeyProviderError::provider_failure())
+        }
+
+        fn key_for(&self, _key_id: &str) -> Result<Zeroizing<[u8; 32]>, KeyProviderError> {
+            Err(KeyProviderError::provider_failure())
+        }
+    }
+
     impl DataStore for MemoryDataStore {
         fn read(&self, key: &str) -> Result<Option<StateRecord>, DataStoreError> {
             Ok(self.records.get(key).cloned())
@@ -762,7 +1172,7 @@ mod tests {
     #[test]
     fn runtime_data_store_validates_writes_and_reads_from_local_file_adapter() {
         let root = temp_root("valid");
-        let adapter = LocalFileDataStore::new(&root).expect("local adapter should initialize");
+        let adapter = public_store(&root);
         let mut store = RuntimeDataStore::new(adapter, "writer-a");
         let contract = stateful_contract(Some(json!({
             "type": "object",
@@ -1064,9 +1474,340 @@ mod tests {
     }
 
     #[test]
+    fn private_records_encrypt_reopen_and_require_provider() {
+        let root = temp_root("private-encryption");
+        let provider: Arc<dyn KeyProvider> = Arc::new(InMemoryKeyProvider::new("key-1", [7; 32]));
+        let original = record("secret", "writer-a", 1, json!("classified value"));
+        let mut store = LocalFileDataStore::new(&root)
+            .expect("private store should open")
+            .with_key_provider(Arc::clone(&provider));
+        store.write(original.clone()).expect("private write");
+
+        let bytes = fs::read(root.join("secret.json")).expect("private envelope");
+        let text = String::from_utf8(bytes.clone()).expect("json utf8");
+        let envelope: LocalDataStoreEnvelope =
+            serde_json::from_slice(&bytes).expect("private envelope shape");
+        assert_eq!(envelope.classification, LocalDataClassification::Private);
+        assert!(envelope.record.is_none());
+        assert_eq!(envelope.record_key.as_deref(), Some("secret"));
+        assert_eq!(envelope.key_id.as_deref(), Some("key-1"));
+        assert!(envelope.nonce.is_some());
+        assert!(envelope.ciphertext.is_some());
+        assert!(!text.contains("classified value"));
+        assert!(!text.contains(&hex_encode(&[7; 32])));
+
+        let first_nonce = envelope.nonce;
+        store.write(original.clone()).expect("second private write");
+        let second: LocalDataStoreEnvelope =
+            serde_json::from_slice(&fs::read(root.join("secret.json")).expect("second envelope"))
+                .expect("second envelope shape");
+        assert_ne!(first_nonce, second.nonce);
+        drop(store);
+
+        let reopened = LocalFileDataStore::new(&root)
+            .expect("private store should reopen")
+            .with_key_provider(Arc::clone(&provider));
+        assert_eq!(
+            reopened.read("secret").expect("private read"),
+            Some(original)
+        );
+        drop(reopened);
+
+        let no_provider = LocalFileDataStore::new(&root).expect("store without provider opens");
+        let read_error = no_provider
+            .read("secret")
+            .expect_err("private read must require provider");
+        assert_eq!(read_error.code, DataStoreErrorCode::KeyProviderRequired);
+    }
+
+    #[test]
+    fn private_write_without_provider_fails_before_commit_and_public_crud_works() {
+        let private_root = temp_root("private-provider-required");
+        let mut private =
+            LocalFileDataStore::new(&private_root).expect("private store should open");
+        let error = private
+            .write(record("secret", "writer-a", 1, json!("value")))
+            .expect_err("private write must fail");
+        assert_eq!(error.code, DataStoreErrorCode::KeyProviderRequired);
+        assert!(!private_root.join("secret.json").exists());
+
+        let public_root = temp_root("public-without-provider");
+        let mut public = public_store(&public_root);
+        let public_record = record("cache", "writer-a", 1, json!("visible"));
+        public.write(public_record.clone()).expect("public write");
+        assert_eq!(
+            public.read("cache").expect("public read"),
+            Some(public_record)
+        );
+        public.delete("cache").expect("public delete");
+        assert!(public.list_keys().expect("public list").is_empty());
+    }
+
+    #[test]
+    fn private_authentication_and_key_provider_failures_are_stable() {
+        let root = temp_root("private-authentication");
+        let key = [9; 32];
+        let provider: Arc<dyn KeyProvider> =
+            Arc::new(InMemoryKeyProvider::new("key-a", key).with_read_key("key-b", key));
+        let mut store = LocalFileDataStore::new(&root)
+            .expect("private store should open")
+            .with_key_provider(Arc::clone(&provider));
+        store
+            .write(record("secret", "writer-a", 1, json!("value")))
+            .expect("private write");
+
+        let path = root.join("secret.json");
+        let mut envelope: LocalDataStoreEnvelope =
+            serde_json::from_slice(&fs::read(&path).expect("envelope")).expect("shape");
+        let original_envelope = envelope.clone();
+        let mut ciphertext =
+            hex_decode(envelope.ciphertext.as_deref().expect("ciphertext")).expect("valid hex");
+        ciphertext[0] ^= 1;
+        envelope.ciphertext = Some(hex_encode(&ciphertext));
+        envelope.digest = digest_for_private_envelope(
+            envelope.key_id.as_deref().expect("key id"),
+            envelope.record_key.as_deref().expect("record key"),
+            envelope.nonce.as_deref().expect("nonce"),
+            envelope.ciphertext.as_deref().expect("ciphertext"),
+        );
+        fs::write(&path, serde_json::to_vec(&envelope).expect("serialize")).expect("tamper");
+        let ciphertext_authentication = store
+            .read("secret")
+            .expect_err("ciphertext tampering must fail");
+        assert_eq!(
+            ciphertext_authentication.code,
+            DataStoreErrorCode::IntegrityCheckFailed
+        );
+        assert_eq!(
+            ciphertext_authentication.details["reason"],
+            "authentication_failed"
+        );
+
+        envelope = original_envelope;
+        envelope.key_id = Some("key-b".to_string());
+        envelope.digest = digest_for_private_envelope(
+            "key-b",
+            envelope.record_key.as_deref().expect("record key"),
+            envelope.nonce.as_deref().expect("nonce"),
+            envelope.ciphertext.as_deref().expect("ciphertext"),
+        );
+        fs::write(&path, serde_json::to_vec(&envelope).expect("serialize")).expect("tamper");
+        let authentication = store.read("secret").expect_err("AAD tampering must fail");
+        assert_eq!(
+            authentication.code,
+            DataStoreErrorCode::IntegrityCheckFailed
+        );
+        assert_eq!(authentication.details["reason"], "authentication_failed");
+        drop(store);
+
+        let missing_provider: Arc<dyn KeyProvider> =
+            Arc::new(InMemoryKeyProvider::new("other", [3; 32]));
+        let missing = LocalFileDataStore::new(&root)
+            .expect("reopen")
+            .with_key_provider(missing_provider)
+            .read("secret")
+            .expect_err("missing key must fail");
+        assert_eq!(missing.code, DataStoreErrorCode::KeyNotFound);
+        assert_eq!(missing.message, "key_not_found");
+
+        let expired_provider: Arc<dyn KeyProvider> =
+            Arc::new(InMemoryKeyProvider::new("key-b", key).with_expired_key_id("key-b"));
+        let expired = LocalFileDataStore::new(&root)
+            .expect("reopen")
+            .with_key_provider(expired_provider)
+            .read("secret")
+            .expect_err("expired key must fail");
+        assert_eq!(expired.code, DataStoreErrorCode::KeyExpired);
+
+        let failing_provider: Arc<dyn KeyProvider> = Arc::new(FailingKeyProvider);
+        let failure_root = temp_root("provider-failure");
+        let provider_failure = LocalFileDataStore::new(&failure_root)
+            .expect("open")
+            .with_key_provider(failing_provider)
+            .write(record("secret", "writer-a", 1, json!("value")))
+            .expect_err("provider failure must fail");
+        assert_eq!(
+            provider_failure.code,
+            DataStoreErrorCode::KeyProviderFailure
+        );
+        assert_eq!(provider_failure.message, "key_provider_failed");
+    }
+
+    #[test]
+    fn classification_change_requires_delete_before_write() {
+        let root = temp_root("classification-immutable");
+        let mut public = public_store(&root);
+        public
+            .write(record("shared", "writer-a", 1, json!("public")))
+            .expect("public write");
+        drop(public);
+
+        let provider: Arc<dyn KeyProvider> = Arc::new(InMemoryKeyProvider::new("key-1", [4; 32]));
+        let mut private = LocalFileDataStore::new(&root)
+            .expect("private reopen")
+            .with_key_provider(provider);
+        let rejected = private
+            .write(record("shared", "writer-a", 2, json!("private")))
+            .expect_err("in-place reclassification must fail");
+        assert_eq!(
+            rejected.code,
+            DataStoreErrorCode::ClassificationChangeNotAllowed
+        );
+        private.delete("shared").expect("delete old classification");
+        private
+            .write(record("shared", "writer-a", 2, json!("private")))
+            .expect("write after delete");
+    }
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn private_envelope_corruption_and_error_helpers_fail_closed() {
+        let root = temp_root("private-corruption-branches");
+        let key = [23; 32];
+        let provider: Arc<dyn KeyProvider> = Arc::new(InMemoryKeyProvider::new("key-1", key));
+        let mut store = LocalFileDataStore::new(&root)
+            .expect("open")
+            .with_key_provider(Arc::clone(&provider));
+        store
+            .write(record("secret", "writer-a", 1, json!("value")))
+            .expect("write");
+        let path = root.join("secret.json");
+        let original: LocalDataStoreEnvelope =
+            serde_json::from_slice(&fs::read(&path).expect("read")).expect("shape");
+
+        let mut plaintext_leak = original.clone();
+        plaintext_leak.record = Some(record("secret", "writer-a", 1, json!("value")));
+        write_envelope_fixture(&path, &plaintext_leak);
+        assert_integrity_reason(&store, "malformed_envelope");
+
+        let mut wrong_key = original.clone();
+        wrong_key.record_key = Some("other".to_string());
+        wrong_key.digest = digest_for_private_envelope(
+            wrong_key.key_id.as_deref().expect("key id"),
+            "other",
+            wrong_key.nonce.as_deref().expect("nonce"),
+            wrong_key.ciphertext.as_deref().expect("ciphertext"),
+        );
+        write_envelope_fixture(&path, &wrong_key);
+        assert_integrity_reason(&store, "record_key_mismatch");
+
+        let mut bad_digest = original.clone();
+        bad_digest.digest = "sha256:deadbeef".to_string();
+        write_envelope_fixture(&path, &bad_digest);
+        assert_integrity_reason(&store, "digest_mismatch");
+
+        let mut odd_nonce = original.clone();
+        odd_nonce.nonce = Some("0".to_string());
+        odd_nonce.digest = digest_for_private_envelope(
+            odd_nonce.key_id.as_deref().expect("key id"),
+            odd_nonce.record_key.as_deref().expect("record key"),
+            "0",
+            odd_nonce.ciphertext.as_deref().expect("ciphertext"),
+        );
+        write_envelope_fixture(&path, &odd_nonce);
+        assert_integrity_reason(&store, "invalid_hex");
+
+        let mut invalid_nonce = original.clone();
+        invalid_nonce.nonce = Some("00".to_string());
+        invalid_nonce.digest = digest_for_private_envelope(
+            invalid_nonce.key_id.as_deref().expect("key id"),
+            invalid_nonce.record_key.as_deref().expect("record key"),
+            "00",
+            invalid_nonce.ciphertext.as_deref().expect("ciphertext"),
+        );
+        write_envelope_fixture(&path, &invalid_nonce);
+        assert_integrity_reason(&store, "invalid_nonce");
+
+        let mut invalid_ciphertext = original.clone();
+        invalid_ciphertext.ciphertext = Some("gg".to_string());
+        invalid_ciphertext.digest = digest_for_private_envelope(
+            invalid_ciphertext.key_id.as_deref().expect("key id"),
+            invalid_ciphertext
+                .record_key
+                .as_deref()
+                .expect("record key"),
+            invalid_ciphertext.nonce.as_deref().expect("nonce"),
+            "gg",
+        );
+        write_envelope_fixture(&path, &invalid_ciphertext);
+        assert_integrity_reason(&store, "invalid_hex");
+
+        let malformed_plaintext = encrypted_fixture("secret", "key-1", key, b"not-json".as_slice());
+        write_envelope_fixture(&path, &malformed_plaintext);
+        assert_integrity_reason(&store, "malformed_plaintext");
+
+        let mismatched_record =
+            serde_json::to_vec(&record("other", "writer-a", 1, json!("value"))).expect("serialize");
+        let mismatched_plaintext = encrypted_fixture("secret", "key-1", key, &mismatched_record);
+        write_envelope_fixture(&path, &mismatched_plaintext);
+        assert_integrity_reason(&store, "record_key_mismatch");
+
+        let mut unknown_format = original;
+        unknown_format.format = "local-datastore/unknown".to_string();
+        write_envelope_fixture(&path, &unknown_format);
+        let unknown = store
+            .write(record("secret", "writer-a", 2, json!("new")))
+            .expect_err("unknown existing format");
+        assert_eq!(unknown.details["reason"], "unknown_format_version");
+
+        assert_eq!(crypto_error().code, DataStoreErrorCode::CryptoFailure);
+        assert_eq!(
+            FailingKeyProvider
+                .key_for("key-1")
+                .expect_err("provider failure")
+                .code,
+            KeyProviderErrorCode::ProviderFailure
+        );
+        assert_eq!(KeyProviderError::missing_key().message, "key_not_found");
+        for code in [
+            KeyProviderErrorCode::MissingKey,
+            KeyProviderErrorCode::ExpiredKeyId,
+            KeyProviderErrorCode::ProviderFailure,
+        ] {
+            let encoded = serde_json::to_vec(&code).expect("serialize provider code");
+            let decoded: KeyProviderErrorCode =
+                serde_json::from_slice(&encoded).expect("deserialize provider code");
+            assert_eq!(decoded, code);
+        }
+
+        let mut missing_active = InMemoryKeyProvider::new("missing", [1; 32]);
+        missing_active.keys.clear();
+        assert_eq!(
+            missing_active
+                .active_key_id()
+                .expect_err("missing active key")
+                .code,
+            KeyProviderErrorCode::MissingKey
+        );
+        let expired_active =
+            InMemoryKeyProvider::new("expired", [1; 32]).with_expired_key_id("expired");
+        assert_eq!(
+            expired_active
+                .active_key_id()
+                .expect_err("expired active key")
+                .code,
+            KeyProviderErrorCode::ExpiredKeyId
+        );
+        assert!(format!("{store:?}").contains("key_provider_configured"));
+
+        let public_root = temp_root("public-extra-encryption-fields");
+        let mut public = public_store(&public_root);
+        public
+            .write(record("cache", "writer-a", 1, json!("value")))
+            .expect("public write");
+        let public_path = public_root.join("cache.json");
+        let mut public_envelope: LocalDataStoreEnvelope =
+            serde_json::from_slice(&fs::read(&public_path).expect("read")).expect("shape");
+        public_envelope.key_id = Some("unexpected".to_string());
+        write_envelope_fixture(&public_path, &public_envelope);
+        let malformed_public = public.read("cache").expect_err("extra private metadata");
+        assert_eq!(malformed_public.details["reason"], "malformed_envelope");
+    }
+
+    #[test]
     fn local_file_adapter_rejects_tampered_and_legacy_records() {
         let root = temp_root("tampered");
-        let mut adapter = LocalFileDataStore::new(&root).expect("local adapter should initialize");
+        let mut adapter = public_store(&root);
         adapter
             .write(record("draft", "writer-a", 1, json!("ready")))
             .expect("write should succeed");
@@ -1099,7 +1840,7 @@ mod tests {
     #[test]
     fn local_file_adapter_ignores_temporary_records_and_rejects_second_owner() {
         let root = temp_root("temporary-and-lock");
-        let mut adapter = LocalFileDataStore::new(&root).expect("local adapter should initialize");
+        let mut adapter = public_store(&root);
         adapter
             .write(record("draft", "writer-a", 1, json!("committed")))
             .expect("write should succeed");
@@ -1139,7 +1880,7 @@ mod tests {
     #[test]
     fn local_file_adapter_rejects_cross_process_owner_and_recovers_after_exit() {
         let root = temp_root("cross-process-lock");
-        let mut initial_owner = LocalFileDataStore::new(&root).expect("initial owner should open");
+        let mut initial_owner = public_store(&root);
         let committed = record("draft", "writer-a", 1, json!("committed"));
         initial_owner
             .write(committed.clone())
@@ -1169,7 +1910,7 @@ mod tests {
     #[test]
     fn local_file_adapter_recovers_after_lock_owner_crash() {
         let root = temp_root("owner-crash-lock");
-        let mut initial_owner = LocalFileDataStore::new(&root).expect("initial owner should open");
+        let mut initial_owner = public_store(&root);
         initial_owner
             .write(record("draft", "writer-a", 1, json!("committed")))
             .expect("initial write should succeed");
@@ -1192,7 +1933,7 @@ mod tests {
     #[test]
     fn local_file_adapter_reports_unknown_version_and_helper_failures_stably() {
         let root = temp_root("helper-failures");
-        let mut adapter = LocalFileDataStore::new(&root).expect("local adapter should initialize");
+        let mut adapter = public_store(&root);
         adapter
             .write(record("draft", "writer-a", 1, json!("ready")))
             .expect("write should succeed");
@@ -1267,6 +2008,57 @@ mod tests {
 
     fn temp_root(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!("traverse-data-store-{name}-{}", Uuid::new_v4()))
+    }
+
+    fn public_store(root: &Path) -> LocalFileDataStore {
+        LocalFileDataStore::with_classification(root, LocalDataClassification::Public)
+            .expect("public local adapter should initialize")
+    }
+
+    fn write_envelope_fixture(path: &Path, envelope: &LocalDataStoreEnvelope) {
+        fs::write(
+            path,
+            serde_json::to_vec(envelope).expect("serialize envelope"),
+        )
+        .expect("write envelope");
+    }
+
+    fn assert_integrity_reason(store: &LocalFileDataStore, reason: &str) {
+        let error = store.read("secret").expect_err("corruption must fail");
+        assert_eq!(error.code, DataStoreErrorCode::IntegrityCheckFailed);
+        assert_eq!(error.details["reason"], reason);
+    }
+
+    fn encrypted_fixture(
+        record_key: &str,
+        key_id: &str,
+        key: [u8; 32],
+        plaintext: &[u8],
+    ) -> LocalDataStoreEnvelope {
+        let cipher = Aes256Gcm::new_from_slice(&key).expect("valid AES-256 key");
+        let nonce = Nonce::generate();
+        let ciphertext = cipher
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: plaintext,
+                    aad: &private_record_aad(key_id, record_key),
+                },
+            )
+            .expect("fixture encryption");
+        let nonce = hex_encode(&nonce);
+        let ciphertext = hex_encode(&ciphertext);
+        LocalDataStoreEnvelope {
+            format: LOCAL_DATA_STORE_FORMAT.to_string(),
+            classification: LocalDataClassification::Private,
+            digest: digest_for_private_envelope(key_id, record_key, &nonce, &ciphertext),
+            record: None,
+            record_key: Some(record_key.to_string()),
+            key_id: Some(key_id.to_string()),
+            nonce: Some(nonce),
+            ciphertext: Some(ciphertext),
+            retained_at: None,
+        }
     }
 
     fn lock_child_ready_path(root: &Path) -> PathBuf {

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -4,7 +4,8 @@
 
 use super::{
     DataStoreError, LOCAL_DATA_STORE_FORMAT, LOCAL_DATA_STORE_LOCK_FILE, LocalDataClassification,
-    LocalDataStoreEnvelope, digest_for_record, lock_error, validate_key,
+    LocalDataStoreEnvelope, digest_for_private_envelope, digest_for_record, hex_decode, lock_error,
+    validate_key,
 };
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
@@ -354,16 +355,9 @@ impl DataStoreMaintenance for LocalFileDataStoreMaintenance {
         let _ = parse_as_of(as_of)?;
         let verified = verify_backup_archive(archive)?;
         let parent = restore_parent(&self.root)?;
-        let temp_root = parent.join(format!(
-            ".traverse-datastore-restore-{}-{}",
-            std::process::id(),
-            as_of.replace(':', "")
-        ));
-        let backup_root = parent.join(format!(
-            ".traverse-datastore-replaced-{}-{}",
-            std::process::id(),
-            as_of.replace(':', "")
-        ));
+        let work_suffix = restore_work_suffix(&self.root, as_of);
+        let temp_root = parent.join(format!(".traverse-datastore-restore-{work_suffix}"));
+        let backup_root = parent.join(format!(".traverse-datastore-replaced-{work_suffix}"));
         let _ = fs::remove_dir_all(&temp_root);
         let _ = fs::remove_dir_all(&backup_root);
         fs::create_dir_all(&temp_root)
@@ -478,15 +472,79 @@ fn parse_envelope_bytes(bytes: &[u8]) -> Result<LocalDataStoreEnvelope, Maintena
             details: json!({ "reason": "unknown_format_version", "format": envelope.format }),
         });
     }
-    let expected = digest_for_record(&envelope.record).map_err(map_data_store_error)?;
+    let key = envelope_record_key(&envelope)?;
+    let expected = match envelope.classification {
+        LocalDataClassification::Public => {
+            if envelope.key_id.is_some()
+                || envelope.record_key.is_some()
+                || envelope.nonce.is_some()
+                || envelope.ciphertext.is_some()
+            {
+                return Err(malformed_envelope_error());
+            }
+            digest_for_record(
+                envelope
+                    .record
+                    .as_ref()
+                    .ok_or_else(malformed_envelope_error)?,
+            )
+            .map_err(map_data_store_error)?
+        }
+        LocalDataClassification::Private => {
+            if envelope.record.is_some() {
+                return Err(malformed_envelope_error());
+            }
+            let key_id = envelope
+                .key_id
+                .as_deref()
+                .ok_or_else(malformed_envelope_error)?;
+            let nonce = envelope
+                .nonce
+                .as_deref()
+                .ok_or_else(malformed_envelope_error)?;
+            let ciphertext = envelope
+                .ciphertext
+                .as_deref()
+                .ok_or_else(malformed_envelope_error)?;
+            let nonce_bytes = hex_decode(nonce).map_err(|_| malformed_envelope_error())?;
+            let ciphertext_bytes =
+                hex_decode(ciphertext).map_err(|_| malformed_envelope_error())?;
+            if nonce_bytes.len() != 12 || ciphertext_bytes.len() < 16 {
+                return Err(malformed_envelope_error());
+            }
+            digest_for_private_envelope(key_id, &key, nonce, ciphertext)
+        }
+    };
     if envelope.digest != expected {
         return Err(MaintenanceError {
             code: MaintenanceErrorCode::RestoreVerifyFailed,
             message: "restore_verify_failed".to_string(),
-            details: json!({ "reason": "digest_mismatch", "key": envelope.record.key }),
+            details: json!({ "reason": "digest_mismatch", "key": key }),
         });
     }
     Ok(envelope)
+}
+
+fn envelope_record_key(envelope: &LocalDataStoreEnvelope) -> Result<String, MaintenanceError> {
+    match envelope.classification {
+        LocalDataClassification::Public => envelope
+            .record
+            .as_ref()
+            .map(|record| record.key.clone())
+            .ok_or_else(malformed_envelope_error),
+        LocalDataClassification::Private => envelope
+            .record_key
+            .clone()
+            .ok_or_else(malformed_envelope_error),
+    }
+}
+
+fn malformed_envelope_error() -> MaintenanceError {
+    MaintenanceError {
+        code: MaintenanceErrorCode::RestoreVerifyFailed,
+        message: "restore_verify_failed".to_string(),
+        details: json!({ "reason": "malformed_envelope" }),
+    }
 }
 
 fn archive_content_digest_from_members(members: &[(&str, &[u8])]) -> String {
@@ -502,6 +560,16 @@ fn archive_content_digest_from_members(members: &[(&str, &[u8])]) -> String {
 
 fn sha256_hex(bytes: &[u8]) -> String {
     format!("sha256:{}", hex_encode(&Sha256::digest(bytes)))
+}
+
+fn restore_work_suffix(root: &Path, as_of: &str) -> String {
+    let root_digest = hex_encode(&Sha256::digest(root.as_os_str().as_encoded_bytes()));
+    format!(
+        "{}-{}-{}",
+        std::process::id(),
+        &root_digest[..16],
+        as_of.replace(':', "")
+    )
 }
 
 fn hex_encode(digest: &[u8]) -> String {
@@ -610,7 +678,7 @@ fn verify_manifest_member_payloads(
             });
         }
         let envelope = parse_envelope_bytes(&bytes)?;
-        if envelope.record.key != entry.key {
+        if envelope_record_key(&envelope)? != entry.key {
             return Err(MaintenanceError {
                 code: MaintenanceErrorCode::BackupVerifyFailed,
                 message: "backup_verify_failed".to_string(),
@@ -891,11 +959,13 @@ mod tests {
 
     use super::*;
     use crate::data_store::{
-        DataStore, DataStoreError, DataStoreErrorCode, LocalFileDataStore, StateRecord,
+        DataStore, DataStoreError, DataStoreErrorCode, InMemoryKeyProvider, KeyProvider,
+        LocalFileDataStore, StateRecord,
     };
     use serde_json::json;
     use std::fs::{self, File, OpenOptions, TryLockError};
     use std::path::Path;
+    use std::sync::Arc;
     use uuid::Uuid;
 
     fn temp_root(label: &str) -> PathBuf {
@@ -909,7 +979,9 @@ mod tests {
     }
 
     fn seed_store(root: &Path, count: usize, stamp: Option<&str>) -> LocalFileDataStore {
-        let mut store = LocalFileDataStore::new(root).expect("open");
+        let mut store =
+            LocalFileDataStore::with_classification(root, LocalDataClassification::Public)
+                .expect("open");
         if let Some(stamp) = stamp {
             store.set_write_retained_at(Some(stamp.to_string()));
         }
@@ -1025,7 +1097,9 @@ mod tests {
         }
         // Mutate store then restore.
         {
-            let mut store = LocalFileDataStore::new(&root).expect("open");
+            let mut store =
+                LocalFileDataStore::with_classification(&root, LocalDataClassification::Public)
+                    .expect("open");
             store
                 .write(StateRecord {
                     key: "extra".to_string(),
@@ -1063,6 +1137,42 @@ mod tests {
                 .restore(&empty_archive, "2026-07-29T00:00:00Z")
                 .expect("empty restore");
         }
+    }
+
+    #[test]
+    fn backup_restore_verifies_private_envelopes_without_plaintext() {
+        let root = temp_root("private-backup");
+        let provider: Arc<dyn KeyProvider> =
+            Arc::new(InMemoryKeyProvider::new("backup-key", [11; 32]));
+        let expected = StateRecord {
+            key: "secret".to_string(),
+            value: json!({ "private": true }),
+            lamport_clock: 1,
+            writer_id: "host".to_string(),
+        };
+        let mut store = LocalFileDataStore::new(&root)
+            .expect("open")
+            .with_key_provider(Arc::clone(&provider));
+        store.write(expected.clone()).expect("private write");
+        drop(store);
+
+        let archive = root
+            .parent()
+            .expect("parent")
+            .join(format!("private-{}.zip", Uuid::new_v4()));
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        maintenance
+            .backup(&archive, "2026-07-29T00:00:00Z")
+            .expect("private backup");
+        maintenance
+            .restore(&archive, "2026-07-29T05:00:00Z")
+            .expect("private restore");
+        drop(maintenance);
+
+        let reopened = LocalFileDataStore::new(&root)
+            .expect("reopen")
+            .with_key_provider(provider);
+        assert_eq!(reopened.read("secret").expect("decrypt"), Some(expected));
     }
 
     #[test]
@@ -1330,6 +1440,48 @@ mod tests {
             .expect_err("digest");
         assert_eq!(digest_err.code, MaintenanceErrorCode::RestoreVerifyFailed);
         assert_eq!(digest_err.details["reason"], "digest_mismatch");
+
+        let public_with_private_metadata = json!({
+            "format": LOCAL_DATA_STORE_FORMAT,
+            "classification": "public",
+            "record": record,
+            "digest": digest,
+            "key_id": "unexpected"
+        });
+        let public_shape = parse_envelope_bytes(
+            &serde_json::to_vec(&public_with_private_metadata).expect("serialize"),
+        )
+        .expect_err("public private metadata");
+        assert_eq!(public_shape.details["reason"], "malformed_envelope");
+
+        let private_with_plaintext = json!({
+            "format": LOCAL_DATA_STORE_FORMAT,
+            "classification": "private",
+            "record": record,
+            "record_key": "k",
+            "key_id": "key-1",
+            "nonce": "000000000000000000000000",
+            "ciphertext": "00000000000000000000000000000000",
+            "digest": "sha256:00"
+        });
+        let private_shape =
+            parse_envelope_bytes(&serde_json::to_vec(&private_with_plaintext).expect("serialize"))
+                .expect_err("private plaintext");
+        assert_eq!(private_shape.details["reason"], "malformed_envelope");
+
+        let private_short_nonce = json!({
+            "format": LOCAL_DATA_STORE_FORMAT,
+            "classification": "private",
+            "record_key": "k",
+            "key_id": "key-1",
+            "nonce": "00",
+            "ciphertext": "00000000000000000000000000000000",
+            "digest": "sha256:00"
+        });
+        let private_lengths =
+            parse_envelope_bytes(&serde_json::to_vec(&private_short_nonce).expect("serialize"))
+                .expect_err("private lengths");
+        assert_eq!(private_lengths.details["reason"], "malformed_envelope");
     }
 
     #[test]
@@ -1615,10 +1767,11 @@ mod tests {
         let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
         let parent = root.parent().expect("parent");
         let backup_root = parent.join(format!(
-            ".traverse-datastore-replaced-{}-{}",
-            std::process::id(),
-            "2026-07-29T01:00:00Z".replace(':', "")
+            ".traverse-datastore-replaced-{}",
+            restore_work_suffix(&root, "2026-07-29T01:00:00Z")
         ));
+        let _ = fs::remove_dir_all(&backup_root);
+        let _ = fs::remove_file(&backup_root);
         fs::write(&backup_root, "blocker").expect("blocker");
         let blocked = maintenance
             .restore(&archive, "2026-07-29T01:00:00Z")


### PR DESCRIPTION
## Summary
- Add host `KeyProvider` + in-memory provider and AES-256-GCM encryption for private `LocalFileDataStore` envelopes.
- Keep public records on the existing integrity-only path; fail closed with `key_provider_required` when private ops lack a provider.
- Keep Spec 083 backup/restore verifying encrypted envelopes without plaintext.

## Governing Spec
- `084-datastore-encryption-at-rest`

## Project Item
- Closes #864

## Definition of Done
- [x] KeyProvider port and test/in-memory provider
- [x] Private write/read encrypt/decrypt with AAD binding; public unchanged
- [x] `key_provider_required` when provider missing for private ops
- [x] Classification immutable; key_id stored; no in-place rotation API
- [x] Tests for restart decrypt, tamper fail-closed, missing provider
- [x] PR linked to Project 1 / issue #864

## Validation
- `cargo test -p traverse-runtime --lib data_store`
- `cargo clippy -p traverse-runtime --all-targets -- -D warnings`
- `bash scripts/ci/coverage_gate.sh`
