### PR TITLE
feat: add golden registry consumer app

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -6284,31 +6284,7 @@ mod tests {
             sha256_hex(&fs::read(&artifact_path).expect("wasm artifact should read"))
         );
         let manifest_path =
-            write_app_validate_fixture(&fixture_root, &artifact_digest, &artifact_digest, None);
-        let component_path = fixture_root.join("component.manifest.json");
-        let mut component: Value = serde_json::from_str(
-            &fs::read_to_string(&component_path).expect("component manifest should read"),
-        )
-        .expect("component manifest should parse");
-        let component_object = component
-            .as_object_mut()
-            .expect("component manifest should be an object");
-        component_object.remove("contract_path");
-        component_object.remove("wasm_binary_path");
-        component_object.remove("wasm_digest");
-        component_object.insert(
-            "registry_ref".to_string(),
-            serde_json::json!({
-                "namespace": "fixture",
-                "id": "expedition.planning.validate-team-readiness",
-                "version_range": "^1.0.0"
-            }),
-        );
-        fs::write(
-            &component_path,
-            serde_json::to_string_pretty(&component).expect("component manifest should serialize"),
-        )
-        .expect("component manifest should write");
+            write_registry_ref_app_fixture(&fixture_root, &artifact_digest, "^1.0.0");
         write_synced_public_registry_state(
             &state_root,
             "local",
@@ -6364,9 +6340,19 @@ mod tests {
                 .join(artifact_digest.trim_start_matches("sha256:"))
                 .exists()
         );
+    }
 
-        let unsynced_root = unique_temp_dir();
-        let unsynced = app_register_at(&unsynced_root, &manifest_path, "local", true)
+    #[test]
+    fn registry_reference_without_sync_returns_actionable_error() {
+        let state_root = unique_temp_dir();
+        let fixture_root = unique_temp_dir();
+        let manifest_path = write_registry_ref_app_fixture(
+            &fixture_root,
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+            "^1.0.0",
+        );
+
+        let unsynced = app_register_at(&state_root, &manifest_path, "local", true)
             .expect("missing sync should render stable JSON evidence");
         let unsynced_json: Value =
             serde_json::from_str(&unsynced).expect("registration output must be JSON");
@@ -6378,8 +6364,59 @@ mod tests {
         assert!(
             unsynced_json["errors"][0]["message"]
                 .as_str()
-                .is_some_and(|message| message.contains("registry sync"))
+                .is_some_and(|message| message
+                    == "workspace local has no synced public registry state; run traverse-cli registry sync")
         );
+    }
+
+    #[test]
+    fn deprecated_only_registry_range_fails_closed() {
+        let state_root = unique_temp_dir();
+        let fixture_root = unique_temp_dir();
+        let digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+        let manifest_path =
+            write_registry_ref_app_fixture(&fixture_root, digest, ">=1.0.0, <1.1.0");
+        let mut deprecated = registry_record_fixture(
+            "fixture",
+            "expedition.planning.validate-team-readiness",
+            "1.0.1",
+        );
+        deprecated.digest = digest.to_string();
+        deprecated.deprecated = true;
+        let active = registry_record_fixture(
+            "fixture",
+            "expedition.planning.validate-team-readiness",
+            "1.1.0",
+        );
+        write_synced_public_registry_state(
+            &state_root,
+            "local",
+            "fixture-registry",
+            "fixture-v1",
+            "2026-07-22T00:00:00Z",
+            PublicRegistryIndex {
+                index_version: 1,
+                generated_at: "2026-07-22T00:00:00Z".to_string(),
+                source_commit: None,
+                capabilities: vec![deprecated, active],
+            },
+        )
+        .expect("synced fixture state should persist");
+
+        let output = app_register_at(&state_root, &manifest_path, "local", true)
+            .expect("deprecated-only range should render stable JSON evidence");
+        let json: Value = serde_json::from_str(&output).expect("registration output must be JSON");
+
+        assert_eq!(json["status"], "failed");
+        assert_eq!(
+            json["errors"][0]["code"],
+            "registry_reference_requires_resolution"
+        );
+        assert_eq!(
+            json["errors"][0]["message"],
+            "only deprecated public registry versions for fixture:expedition.planning.validate-team-readiness satisfy >=1.0.0, <1.1.0"
+        );
+        assert!(!state_root.join(".traverse/workspaces/local/apps").exists());
     }
 
     #[test]
@@ -7865,6 +7902,40 @@ mod tests {
             contract_url: "https://example.test/contract.json".to_string(),
             deprecated: false,
         }
+    }
+
+    fn write_registry_ref_app_fixture(
+        temp_dir: &Path,
+        artifact_digest: &str,
+        version_range: &str,
+    ) -> PathBuf {
+        let manifest_path =
+            write_app_validate_fixture(temp_dir, artifact_digest, artifact_digest, None);
+        let component_path = temp_dir.join("component.manifest.json");
+        let mut component: Value = serde_json::from_str(
+            &fs::read_to_string(&component_path).expect("component manifest should read"),
+        )
+        .expect("component manifest should parse");
+        let component_object = component
+            .as_object_mut()
+            .expect("component manifest should be an object");
+        component_object.remove("contract_path");
+        component_object.remove("wasm_binary_path");
+        component_object.remove("wasm_digest");
+        component_object.insert(
+            "registry_ref".to_string(),
+            serde_json::json!({
+                "namespace": "fixture",
+                "id": "expedition.planning.validate-team-readiness",
+                "version_range": version_range
+            }),
+        );
+        fs::write(
+            component_path,
+            serde_json::to_string_pretty(&component).expect("component manifest should serialize"),
+        )
+        .expect("component manifest should write");
+        manifest_path
     }
 
     fn write_app_validate_fixture(

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -230,8 +230,9 @@ Use these in order:
 
 1. [examples/hello-world/README.md](../examples/hello-world/README.md) for the smallest runnable Traverse example
 2. [quickstart.md](../quickstart.md) for the first browser-consumable flow
-3. [docs/expedition-example-authoring.md](./expedition-example-authoring.md) for the full governed expedition artifact set
-4. [docs/wasm-agent-authoring-guide.md](./wasm-agent-authoring-guide.md) for packaged WASM agent authoring
-5. [docs/wasm-microservice-authoring-guide.md](./wasm-microservice-authoring-guide.md) for packaged WASM microservice authoring
+3. [examples/applications/registry-consumer/README.md](../examples/applications/registry-consumer/README.md) for an application composed entirely from synced public `registry_ref` capabilities
+4. [docs/expedition-example-authoring.md](./expedition-example-authoring.md) for the full governed expedition artifact set
+5. [docs/wasm-agent-authoring-guide.md](./wasm-agent-authoring-guide.md) for packaged WASM agent authoring
+6. [docs/wasm-microservice-authoring-guide.md](./wasm-microservice-authoring-guide.md) for packaged WASM microservice authoring
 
 If a local command or CI check fails while you work through those paths, use [docs/troubleshooting.md](./troubleshooting.md).

--- a/examples/applications/registry-consumer/README.md
+++ b/examples/applications/registry-consumer/README.md
@@ -1,0 +1,24 @@
+# Registry Consumer Golden App
+
+This application composes the published `traverse-starter.validate`,
+`traverse-starter.process`, and `traverse-starter.summarize` capabilities. Every
+component uses `registry_ref`; no component points at a checked-in contract or
+WASM binary.
+
+From the repository root, sync the public registry before validating or
+registering the app:
+
+```bash
+cargo run -p traverse-cli-rs -- registry sync --workspace local-default --json
+cargo run -p traverse-cli-rs -- app validate \
+  --manifest examples/applications/registry-consumer/app.manifest.json \
+  --workspace local-default \
+  --json
+cargo run -p traverse-cli-rs -- app register \
+  --manifest examples/applications/registry-consumer/app.manifest.json \
+  --workspace local-default \
+  --json
+```
+
+The component versions and digests are pinned to the active `1.1.0` public
+records. Deprecated `1.0.x` records are intentionally excluded.

--- a/examples/applications/registry-consumer/app.manifest.json
+++ b/examples/applications/registry-consumer/app.manifest.json
@@ -1,0 +1,69 @@
+{
+  "app_id": "registry-consumer",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "workspace_defaults": {
+    "workspace_id": "local-default",
+    "registry_scope": "private"
+  },
+  "components": [
+    {
+      "component_id": "registry-consumer.validate-component",
+      "version": "1.0.0",
+      "digest": "sha256:7b7f4e7cff89190f965ddfab8611c1a872c9636196a863884dee28d2335b7858",
+      "manifest_path": "components/validate/component.manifest.json"
+    },
+    {
+      "component_id": "registry-consumer.process-component",
+      "version": "1.0.0",
+      "digest": "sha256:3b1e45d5d49f5e52524aa8a6420444c2fc97351c283e47fcddb5f46200030f24",
+      "manifest_path": "components/process/component.manifest.json"
+    },
+    {
+      "component_id": "registry-consumer.summarize-component",
+      "version": "1.0.0",
+      "digest": "sha256:0918755a5bff7fdb1e614003a610482c8b4482b3f08f630c86c9dbba4c437150",
+      "manifest_path": "components/summarize/component.manifest.json"
+    }
+  ],
+  "workflows": [
+    {
+      "workflow_id": "registry-consumer.pipeline",
+      "workflow_version": "1.0.0",
+      "path": "workflows/pipeline.json"
+    }
+  ],
+  "model_dependencies": [],
+  "config_schema": {
+    "type": "object",
+    "required": [
+      "workspace_id"
+    ],
+    "properties": {
+      "workspace_id": {
+        "type": "string"
+      },
+      "processing_mode": {
+        "type": "string",
+        "enum": [
+          "deterministic"
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "default_config": {
+    "workspace_id": "local-default",
+    "processing_mode": "deterministic"
+  },
+  "placement_policy": {
+    "preferred_targets": [
+      "local"
+    ],
+    "allow_fallback": false
+  },
+  "public_surfaces": [
+    "cli",
+    "http_json"
+  ]
+}

--- a/examples/applications/registry-consumer/components/process/component.manifest.json
+++ b/examples/applications/registry-consumer/components/process/component.manifest.json
@@ -1,0 +1,30 @@
+{
+  "component_id": "registry-consumer.process-component",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "capability_id": "traverse-starter.process",
+  "capability_version": "1.1.0",
+  "registry_ref": {
+    "namespace": "traverse-starter",
+    "id": "traverse-starter.process",
+    "version_range": "=1.1.0"
+  },
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "device"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "published_registry_fixture",
+      "status": "passed",
+      "produced_by": "registry_consumer_golden_app"
+    }
+  ]
+}

--- a/examples/applications/registry-consumer/components/summarize/component.manifest.json
+++ b/examples/applications/registry-consumer/components/summarize/component.manifest.json
@@ -1,0 +1,30 @@
+{
+  "component_id": "registry-consumer.summarize-component",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "capability_id": "traverse-starter.summarize",
+  "capability_version": "1.1.0",
+  "registry_ref": {
+    "namespace": "traverse-starter",
+    "id": "traverse-starter.summarize",
+    "version_range": "=1.1.0"
+  },
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "device"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "published_registry_fixture",
+      "status": "passed",
+      "produced_by": "registry_consumer_golden_app"
+    }
+  ]
+}

--- a/examples/applications/registry-consumer/components/validate/component.manifest.json
+++ b/examples/applications/registry-consumer/components/validate/component.manifest.json
@@ -1,0 +1,30 @@
+{
+  "component_id": "registry-consumer.validate-component",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "capability_id": "traverse-starter.validate",
+  "capability_version": "1.1.0",
+  "registry_ref": {
+    "namespace": "traverse-starter",
+    "id": "traverse-starter.validate",
+    "version_range": "=1.1.0"
+  },
+  "runtime_constraints": {
+    "host_api_access": "none",
+    "network_access": "forbidden",
+    "filesystem_access": "none"
+  },
+  "permitted_targets": [
+    "local",
+    "device"
+  ],
+  "dependencies": [],
+  "connector_requirements": [],
+  "validation_evidence": [
+    {
+      "evidence_type": "published_registry_fixture",
+      "status": "passed",
+      "produced_by": "registry_consumer_golden_app"
+    }
+  ]
+}

--- a/examples/applications/registry-consumer/workflows/pipeline.json
+++ b/examples/applications/registry-consumer/workflows/pipeline.json
@@ -1,0 +1,132 @@
+{
+  "kind": "workflow_definition",
+  "schema_version": "1.0.0",
+  "id": "registry-consumer.pipeline",
+  "name": "pipeline",
+  "version": "1.0.0",
+  "lifecycle": "active",
+  "owner": {
+    "team": "traverse-core",
+    "contact": "enrico.piovesan10@gmail.com"
+  },
+  "summary": "Validate, process, and summarize a note using only published registry capabilities.",
+  "inputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "note"
+      ],
+      "properties": {
+        "note": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "outputs": {
+    "schema": {
+      "type": "object",
+      "required": [
+        "validate",
+        "process",
+        "summarize"
+      ],
+      "properties": {
+        "validate": {
+          "type": "object"
+        },
+        "process": {
+          "type": "object"
+        },
+        "summarize": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "nodes": [
+    {
+      "node_id": "validate_note",
+      "capability_id": "traverse-starter.validate",
+      "capability_version": "1.1.0",
+      "input": {
+        "from_workflow_input": [
+          "note"
+        ]
+      },
+      "output": {
+        "to_workflow_state": [],
+        "publish_to_state_as": "validate"
+      }
+    },
+    {
+      "node_id": "process_note",
+      "capability_id": "traverse-starter.process",
+      "capability_version": "1.1.0",
+      "input": {
+        "from_workflow_input": [
+          "note"
+        ]
+      },
+      "output": {
+        "to_workflow_state": [
+          "title",
+          "tags",
+          "noteType",
+          "suggestedNextAction",
+          "status"
+        ],
+        "publish_to_state_as": "process"
+      }
+    },
+    {
+      "node_id": "summarize_note",
+      "capability_id": "traverse-starter.summarize",
+      "capability_version": "1.1.0",
+      "input": {
+        "from_workflow_input": [
+          "title",
+          "tags",
+          "noteType",
+          "suggestedNextAction",
+          "status"
+        ]
+      },
+      "output": {
+        "to_workflow_state": [],
+        "publish_to_state_as": "summarize"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "edge_id": "validate_to_process",
+      "from": "validate_note",
+      "to": "process_note",
+      "trigger": "direct"
+    },
+    {
+      "edge_id": "process_to_summarize",
+      "from": "process_note",
+      "to": "summarize_note",
+      "trigger": "direct"
+    }
+  ],
+  "start_node": "validate_note",
+  "terminal_nodes": [
+    "summarize_note"
+  ],
+  "output_projection": [
+    "validate",
+    "process",
+    "summarize"
+  ],
+  "tags": [
+    "registry-consumer",
+    "golden-path",
+    "reference-app"
+  ],
+  "governing_spec": "054-public-scope-registry-ref"
+}

--- a/scripts/ci/repository_checks.sh
+++ b/scripts/ci/repository_checks.sh
@@ -312,6 +312,11 @@ grep -q "cargo run -p traverse-cli-rs -- bundle register" docs/getting-started.m
 grep -q "cargo run -p traverse-cli-rs -- expedition execute" docs/getting-started.md
 grep -q "cargo run -p traverse-cli-rs -- trace inspect" docs/getting-started.md
 grep -q "bash scripts/ci/expedition_golden_path.sh" docs/getting-started.md
+grep -q "examples/applications/registry-consumer/README.md" docs/getting-started.md
+grep -q '"registry_ref"' examples/applications/registry-consumer/components/validate/component.manifest.json
+grep -q '"registry_ref"' examples/applications/registry-consumer/components/process/component.manifest.json
+grep -q '"registry_ref"' examples/applications/registry-consumer/components/summarize/component.manifest.json
+! grep -R -q -E '"(contract_path|wasm_binary_path)"' examples/applications/registry-consumer/components
 grep -q "docs/troubleshooting.md" quickstart.md
 grep -q "docs/troubleshooting.md" docs/tutorial-index.md
 grep -q "Repository Checks" docs/troubleshooting.md


### PR DESCRIPTION
## Summary

- add a golden application whose three components resolve published Traverse Starter capabilities exclusively through `registry_ref`
- add stable CLI regressions for missing sync and deprecated-only ranges
- link the sample from Getting Started and enforce its registry-only shape in repository checks

## Governing Spec

- `054-public-scope-registry-ref`
- `055-registry-sync`
- `004-spec-alignment-gate`
- `070-runtime-event-sink-boundary`

## Project Item

- Closes #869
- https://github.com/orgs/traverse-framework/projects/1/

## What Changed

- Contracts changed: none
- Runtime behavior changed: none; CLI regression coverage locks existing fail-closed behavior
- Compatibility impact: additive example, documentation, and tests only
- ADR needed or linked: no architectural decision required

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing
- [x] Core coverage preserved
- [x] Required validation gates passing

Commands:

- `cargo test -p traverse-cli-rs registry_ -- --nocapture`
- synced public `registry sync`, `app validate`, and `app register` against the golden app
- `bash scripts/ci/repository_checks.sh`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_TARGET_DIR=/private/tmp/traverse-issue-869-target RUST_TEST_THREADS=1 BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body /private/tmp/traverse-issue-869-pr-body.md`

## Notes

The golden app pins active Traverse Starter `1.1.0` records and excludes deprecated `1.0.x` records. The existing local-path Traverse Starter smoke remains unchanged.

Made with [Cursor](https://cursor.com)