### PR TITLE
feat: add IndexedDB DataStore backend

### DIFF
--- a/packages/web/TraverseEmbedder/README.md
+++ b/packages/web/TraverseEmbedder/README.md
@@ -86,6 +86,38 @@ embedder.submit("my-app.process", { note: "hello" });
 embedder.shutdown();
 ```
 
+## IndexedDB DataStore
+
+`IndexedDbDataStore` is the browser backend for the existing host-owned
+DataStore port (Spec `085-datastore-indexeddb`). The embedding application
+must supply an origin-scoped database name and owns its lifecycle, retention,
+backup, and deletion policy. Traverse does not choose a default database.
+
+```ts
+import { IndexedDbDataStore } from "traverse-embedder-web";
+
+const store = await IndexedDbDataStore.open({
+  databaseName: "my-app-state",
+  classification: "public",
+});
+await store.write({
+  key: "draft",
+  value: { status: "ready" },
+  lamport_clock: 1,
+  writer_id: "browser-host",
+});
+const draft = await store.read("draft");
+store.close();
+```
+
+The adapter holds an exclusive Web Lock for its lifetime. A contender receives
+`store_locked`; a browser without Web Locks receives `locking_unsupported`.
+Public records use the same `local-datastore/1` SHA-256 integrity envelope as
+the native backend. Quota and persistence failures are typed and writes are
+never silently dropped. Private operations fail with `key_provider_required`,
+and `prune`, `backup`, and `restore` fail with `unsupported`; IndexedDB v1 does
+not store private plaintext or provide maintenance archives.
+
 ## Error mapping
 
 Boundary failures use stable `EmbedderErrorCode` values —

--- a/packages/web/TraverseEmbedder/package.json
+++ b/packages/web/TraverseEmbedder/package.json
@@ -23,10 +23,11 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs tests/registryCache.test.mjs"
+    "test": "npm run build && node --test tests/embedder.test.mjs tests/bundleEmbedder.test.mjs tests/registryCache.test.mjs tests/indexedDbDataStore.test.mjs"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",
+    "fake-indexeddb": "^6.2.5",
     "typescript": "^5.6.0",
     "wabt": "^1.0.39"
   }

--- a/packages/web/TraverseEmbedder/src/index.ts
+++ b/packages/web/TraverseEmbedder/src/index.ts
@@ -85,6 +85,15 @@ export type {
   VerifiedRegistryDependency,
 } from "./registryCache.js";
 
+export { IndexedDbDataStore, IndexedDbDataStoreError } from "./indexedDbDataStore.js";
+export type {
+  DataClassification,
+  IndexedDbDataStoreConfig,
+  IndexedDbDataStoreErrorCode,
+  IndexedDbDataStoreOperation,
+  StateRecord,
+} from "./indexedDbDataStore.js";
+
 export {
   HOST_ABI_V1_WHITELIST,
   SUPPORTED_HOST_ABI_VERSION,

--- a/packages/web/TraverseEmbedder/src/indexedDbDataStore.ts
+++ b/packages/web/TraverseEmbedder/src/indexedDbDataStore.ts
@@ -1,0 +1,541 @@
+import type { JsonValue } from "./types.js";
+
+const DATA_STORE_FORMAT = "local-datastore/1";
+const DATABASE_VERSION = 1;
+const RECORDS_OBJECT_STORE = "records";
+const LOCK_NAME_PREFIX = "traverse-datastore:";
+
+export type DataClassification = "public" | "private";
+
+export interface StateRecord {
+  readonly key: string;
+  readonly value: JsonValue;
+  readonly lamport_clock: number;
+  readonly writer_id: string;
+}
+
+export type IndexedDbDataStoreErrorCode =
+  | "invalid_key"
+  | "integrity_check_failed"
+  | "key_provider_required"
+  | "store_locked"
+  | "locking_unsupported"
+  | "quota_exceeded"
+  | "persistence_unavailable"
+  | "backend_failed"
+  | "unsupported";
+
+export type IndexedDbDataStoreOperation =
+  | "open"
+  | "read"
+  | "write"
+  | "delete"
+  | "prune"
+  | "backup"
+  | "restore";
+
+/** A stable, secret-free browser DataStore failure (Spec 085 FR-005/FR-007). */
+export class IndexedDbDataStoreError extends Error {
+  readonly code: IndexedDbDataStoreErrorCode;
+  readonly operation: IndexedDbDataStoreOperation;
+  readonly reason: string;
+
+  constructor(
+    code: IndexedDbDataStoreErrorCode,
+    operation: IndexedDbDataStoreOperation,
+    reason: string,
+  ) {
+    super(code);
+    this.name = "IndexedDbDataStoreError";
+    this.code = code;
+    this.operation = operation;
+    this.reason = reason;
+  }
+}
+
+export interface IndexedDbDataStoreConfig {
+  /**
+   * Host-selected, origin-scoped IndexedDB name. Traverse never derives or
+   * supplies a global default name.
+   */
+  readonly databaseName: string;
+  /** Fixed classification for this store. Private operations fail closed. */
+  readonly classification: DataClassification;
+  /** Browser globals may be injected by a conformance harness. */
+  readonly indexedDB?: IDBFactory | null;
+  /** Browser Web Locks may be injected by a conformance harness. */
+  readonly locks?: WebLockManager | null;
+}
+
+interface WebLock {
+  readonly name: string;
+  readonly mode: "exclusive" | "shared";
+}
+
+interface WebLockManager {
+  request<T>(
+    name: string,
+    options: { readonly mode: "exclusive"; readonly ifAvailable: true },
+    callback: (lock: WebLock | null) => Promise<T>,
+  ): Promise<T>;
+}
+
+interface PublicEnvelope {
+  readonly format: typeof DATA_STORE_FORMAT;
+  readonly classification: "public";
+  readonly digest: string;
+  readonly record: StateRecord;
+}
+
+function dataStoreError(
+  code: IndexedDbDataStoreErrorCode,
+  operation: IndexedDbDataStoreOperation,
+  reason: string,
+): IndexedDbDataStoreError {
+  return new IndexedDbDataStoreError(code, operation, reason);
+}
+
+function defaultIndexedDb(): IDBFactory | undefined {
+  return globalThis.indexedDB;
+}
+
+function defaultLocks(): WebLockManager | undefined {
+  const browserNavigator = globalThis.navigator as
+    | (Navigator & { readonly locks?: WebLockManager })
+    | undefined;
+  return browserNavigator?.locks;
+}
+
+function validateDatabaseName(databaseName: string): void {
+  if (databaseName.trim().length === 0) {
+    throw dataStoreError("persistence_unavailable", "open", "invalid_database_name");
+  }
+}
+
+function validateKey(key: string, operation: "read" | "write" | "delete"): void {
+  if (!/^[A-Za-z0-9_-]+$/.test(key)) {
+    throw dataStoreError("invalid_key", operation, "invalid_state_key");
+  }
+}
+
+function validateRecord(record: StateRecord): void {
+  validateKey(record.key, "write");
+  if (
+    !Number.isSafeInteger(record.lamport_clock) ||
+    record.lamport_clock < 0 ||
+    record.writer_id.length === 0 ||
+    !isJsonValue(record.value)
+  ) {
+    throw dataStoreError("backend_failed", "write", "invalid_state_record");
+  }
+}
+
+function privateUnsupported(
+  operation: "read" | "write" | "delete",
+): IndexedDbDataStoreError {
+  return dataStoreError("key_provider_required", operation, "private_record");
+}
+
+function mapDomFailure(
+  operation: "open" | "read" | "write" | "delete",
+  failure: unknown,
+): IndexedDbDataStoreError {
+  if (failure instanceof IndexedDbDataStoreError) {
+    return failure;
+  }
+  const name =
+    typeof failure === "object" &&
+    failure !== null &&
+    "name" in failure &&
+    typeof failure.name === "string"
+      ? failure.name
+      : "";
+  if (name === "QuotaExceededError") {
+    return dataStoreError("quota_exceeded", operation, "storage_quota_exceeded");
+  }
+  if (
+    name === "SecurityError" ||
+    name === "InvalidStateError" ||
+    name === "NotSupportedError" ||
+    name === "UnknownError"
+  ) {
+    return dataStoreError(
+      "persistence_unavailable",
+      operation,
+      "indexeddb_unavailable",
+    );
+  }
+  return dataStoreError("backend_failed", operation, "indexeddb_operation_failed");
+}
+
+function sortedJsonValue(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map(sortedJsonValue);
+  }
+  if (typeof value === "object" && value !== null) {
+    const sorted: { [key: string]: JsonValue } = {};
+    for (const key of Object.keys(value).sort()) {
+      const child = value[key];
+      if (child !== undefined) {
+        sorted[key] = sortedJsonValue(child);
+      }
+    }
+    return sorted;
+  }
+  return value;
+}
+
+function canonicalRecord(record: StateRecord): string {
+  return JSON.stringify({
+    key: record.key,
+    value: sortedJsonValue(record.value),
+    lamport_clock: record.lamport_clock,
+    writer_id: record.writer_id,
+  });
+}
+
+async function digestForRecord(
+  record: StateRecord,
+  operation: "read" | "write",
+): Promise<string> {
+  if (globalThis.crypto?.subtle === undefined) {
+    throw dataStoreError("backend_failed", operation, "digest_unavailable");
+  }
+  let digest: ArrayBuffer;
+  try {
+    digest = await globalThis.crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(canonicalRecord(record)),
+    );
+  } catch {
+    throw dataStoreError("backend_failed", operation, "digest_failed");
+  }
+  const hexadecimal = Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+  return `sha256:${hexadecimal}`;
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  return isJsonValueInner(value, new WeakSet<object>());
+}
+
+function isJsonValueInner(
+  value: unknown,
+  ancestors: WeakSet<object>,
+): value is JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    if (ancestors.has(value)) {
+      return false;
+    }
+    ancestors.add(value);
+    const valid = value.every((child) => isJsonValueInner(child, ancestors));
+    ancestors.delete(value);
+    return valid;
+  }
+  if (
+    typeof value === "object" &&
+    (Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null)
+  ) {
+    if (ancestors.has(value)) {
+      return false;
+    }
+    ancestors.add(value);
+    const valid = Object.values(value).every((child) =>
+      isJsonValueInner(child, ancestors),
+    );
+    ancestors.delete(value);
+    return valid;
+  }
+  return false;
+}
+
+function parseEnvelope(value: unknown, requestedKey: string): PublicEnvelope {
+  if (typeof value !== "object" || value === null) {
+    throw dataStoreError("integrity_check_failed", "read", "malformed_envelope");
+  }
+  const envelope = value as Partial<PublicEnvelope>;
+  if (envelope.format !== DATA_STORE_FORMAT) {
+    throw dataStoreError(
+      "integrity_check_failed",
+      "read",
+      envelope.format === undefined ? "legacy_unverified" : "unknown_format_version",
+    );
+  }
+  if (envelope.classification !== "public") {
+    throw dataStoreError("key_provider_required", "read", "private_record");
+  }
+  if (
+    "record_key" in envelope ||
+    "key_id" in envelope ||
+    "nonce" in envelope ||
+    "ciphertext" in envelope
+  ) {
+    throw dataStoreError("integrity_check_failed", "read", "malformed_envelope");
+  }
+  const record = envelope.record as Partial<StateRecord> | undefined;
+  if (
+    record === undefined ||
+    typeof record.key !== "string" ||
+    record.key !== requestedKey ||
+    typeof record.writer_id !== "string" ||
+    record.writer_id.length === 0 ||
+    typeof record.lamport_clock !== "number" ||
+    !Number.isSafeInteger(record.lamport_clock) ||
+    record.lamport_clock < 0 ||
+    !isJsonValue(record.value) ||
+    typeof envelope.digest !== "string"
+  ) {
+    throw dataStoreError("integrity_check_failed", "read", "malformed_envelope");
+  }
+  return envelope as PublicEnvelope;
+}
+
+function openDatabase(factory: IDBFactory, databaseName: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    let rejected = false;
+    let request: IDBOpenDBRequest;
+    try {
+      request = factory.open(databaseName, DATABASE_VERSION);
+    } catch (error) {
+      reject(mapDomFailure("open", error));
+      return;
+    }
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(RECORDS_OBJECT_STORE)) {
+        request.result.createObjectStore(RECORDS_OBJECT_STORE);
+      }
+    };
+    request.onerror = () => {
+      rejected = true;
+      reject(mapDomFailure("open", request.error));
+    };
+    request.onblocked = () => {
+      rejected = true;
+      reject(dataStoreError("persistence_unavailable", "open", "upgrade_blocked"));
+    };
+    request.onsuccess = () => {
+      if (rejected) {
+        request.result.close();
+        return;
+      }
+      if (!request.result.objectStoreNames.contains(RECORDS_OBJECT_STORE)) {
+        request.result.close();
+        reject(dataStoreError("backend_failed", "open", "records_store_missing"));
+        return;
+      }
+      resolve(request.result);
+    };
+  });
+}
+
+/**
+ * Host-owned IndexedDB implementation of the DataStore public-record port.
+ *
+ * Opening holds one origin-scoped exclusive Web Lock until `close()`. The
+ * adapter exposes no fallback lock and never persists private plaintext.
+ */
+export class IndexedDbDataStore {
+  readonly databaseName: string;
+  readonly classification: DataClassification;
+
+  private readonly database: IDBDatabase;
+  private releaseLock: (() => void) | undefined;
+  private lockRequest: Promise<void> | undefined;
+  private closed = false;
+
+  private constructor(
+    databaseName: string,
+    classification: DataClassification,
+    database: IDBDatabase,
+    releaseLock: () => void,
+    lockRequest: Promise<void>,
+  ) {
+    this.databaseName = databaseName;
+    this.classification = classification;
+    this.database = database;
+    this.releaseLock = releaseLock;
+    this.lockRequest = lockRequest;
+  }
+
+  static async open(config: IndexedDbDataStoreConfig): Promise<IndexedDbDataStore> {
+    validateDatabaseName(config.databaseName);
+    const factory =
+      config.indexedDB === undefined ? defaultIndexedDb() : config.indexedDB;
+    if (factory === undefined || factory === null) {
+      throw dataStoreError(
+        "persistence_unavailable",
+        "open",
+        "indexeddb_unavailable",
+      );
+    }
+    const locks = config.locks === undefined ? defaultLocks() : config.locks;
+    if (locks === undefined || locks === null) {
+      throw dataStoreError("locking_unsupported", "open", "web_locks_unavailable");
+    }
+
+    let signalAcquired: (() => void) | undefined;
+    let signalRejected: ((error: IndexedDbDataStoreError) => void) | undefined;
+    const acquired = new Promise<void>((resolve, reject) => {
+      signalAcquired = resolve;
+      signalRejected = reject;
+    });
+    let releaseLock: () => void = () => undefined;
+    const held = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    let lockRequest: Promise<void>;
+    try {
+      lockRequest = locks
+        .request(
+          `${LOCK_NAME_PREFIX}${config.databaseName}`,
+          { mode: "exclusive", ifAvailable: true },
+          async (lock) => {
+            if (lock === null) {
+              signalRejected?.(
+                dataStoreError("store_locked", "open", "exclusive_owner_active"),
+              );
+              return;
+            }
+            signalAcquired?.();
+            await held;
+          },
+        )
+        .catch(() => {
+          signalRejected?.(
+            dataStoreError("locking_unsupported", "open", "web_locks_failed"),
+          );
+        });
+    } catch {
+      throw dataStoreError("locking_unsupported", "open", "web_locks_failed");
+    }
+
+    await acquired;
+    try {
+      const database = await openDatabase(factory, config.databaseName);
+      return new IndexedDbDataStore(
+        config.databaseName,
+        config.classification,
+        database,
+        releaseLock,
+        lockRequest,
+      );
+    } catch (error) {
+      releaseLock();
+      await lockRequest;
+      throw error;
+    }
+  }
+
+  async read(key: string): Promise<StateRecord | null> {
+    this.ensureOpen("read");
+    validateKey(key, "read");
+    if (this.classification === "private") {
+      throw privateUnsupported("read");
+    }
+    const stored = await this.request("read", "readonly", (store) => store.get(key));
+    if (stored === undefined) {
+      return null;
+    }
+    const envelope = parseEnvelope(stored, key);
+    const expectedDigest = await digestForRecord(envelope.record, "read");
+    if (envelope.digest !== expectedDigest) {
+      throw dataStoreError("integrity_check_failed", "read", "digest_mismatch");
+    }
+    return envelope.record;
+  }
+
+  async write(record: StateRecord): Promise<void> {
+    this.ensureOpen("write");
+    validateRecord(record);
+    if (this.classification === "private") {
+      throw privateUnsupported("write");
+    }
+    const envelope: PublicEnvelope = {
+      format: DATA_STORE_FORMAT,
+      classification: "public",
+      digest: await digestForRecord(record, "write"),
+      record,
+    };
+    await this.request("write", "readwrite", (store) => store.put(envelope, record.key));
+  }
+
+  async delete(key: string): Promise<void> {
+    this.ensureOpen("delete");
+    validateKey(key, "delete");
+    if (this.classification === "private") {
+      throw privateUnsupported("delete");
+    }
+    await this.request("delete", "readwrite", (store) => store.delete(key));
+  }
+
+  async prune(): Promise<never> {
+    throw dataStoreError("unsupported", "prune", "maintenance_unsupported");
+  }
+
+  async backup(): Promise<never> {
+    throw dataStoreError("unsupported", "backup", "maintenance_unsupported");
+  }
+
+  async restore(): Promise<never> {
+    throw dataStoreError("unsupported", "restore", "maintenance_unsupported");
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.database.close();
+    this.releaseLock?.();
+    this.releaseLock = undefined;
+    this.lockRequest = undefined;
+  }
+
+  private ensureOpen(operation: "read" | "write" | "delete"): void {
+    if (this.closed) {
+      throw dataStoreError("backend_failed", operation, "store_closed");
+    }
+  }
+
+  private request(
+    operation: "read" | "write" | "delete",
+    mode: IDBTransactionMode,
+    createRequest: (store: IDBObjectStore) => IDBRequest,
+  ): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      let transaction: IDBTransaction;
+      let request: IDBRequest;
+      try {
+        transaction = this.database.transaction(RECORDS_OBJECT_STORE, mode);
+        request = createRequest(transaction.objectStore(RECORDS_OBJECT_STORE));
+      } catch (error) {
+        reject(mapDomFailure(operation, error));
+        return;
+      }
+      let result: unknown;
+      request.onsuccess = () => {
+        result = request.result;
+      };
+      request.onerror = () => {
+        reject(mapDomFailure(operation, request.error));
+      };
+      transaction.oncomplete = () => resolve(result);
+      transaction.onerror = () => {
+        reject(mapDomFailure(operation, transaction.error ?? request.error));
+      };
+      transaction.onabort = () => {
+        reject(mapDomFailure(operation, transaction.error ?? request.error));
+      };
+    });
+  }
+}

--- a/packages/web/TraverseEmbedder/tests/indexedDbDataStore.test.mjs
+++ b/packages/web/TraverseEmbedder/tests/indexedDbDataStore.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  IDBFactory,
+  IDBObjectStore,
+} from "fake-indexeddb";
+import {
+  IndexedDbDataStore,
+  IndexedDbDataStoreError,
+} from "../dist/index.js";
+
+class ConformanceLockManager {
+  #held = new Set();
+
+  async request(name, _options, callback) {
+    if (this.#held.has(name)) {
+      return callback(null);
+    }
+    this.#held.add(name);
+    try {
+      return await callback({ name, mode: "exclusive" });
+    } finally {
+      this.#held.delete(name);
+    }
+  }
+}
+
+function config(databaseName, overrides = {}) {
+  return {
+    databaseName,
+    classification: "public",
+    indexedDB: overrides.indexedDB ?? new IDBFactory(),
+    locks: overrides.locks ?? new ConformanceLockManager(),
+  };
+}
+
+function record(value = { status: "ready" }) {
+  return {
+    key: "draft",
+    value,
+    lamport_clock: 1,
+    writer_id: "writer-a",
+  };
+}
+
+function isCode(code, reason) {
+  return (error) =>
+    error instanceof IndexedDbDataStoreError &&
+    error.code === code &&
+    (reason === undefined || error.reason === reason);
+}
+
+async function mutateRecord(factory, databaseName, mutate) {
+  const database = await new Promise((resolve, reject) => {
+    const request = factory.open(databaseName, 1);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+  });
+  await new Promise((resolve, reject) => {
+    const transaction = database.transaction("records", "readwrite");
+    const store = transaction.objectStore("records");
+    const get = store.get("draft");
+    get.onerror = () => reject(get.error);
+    get.onsuccess = () => store.put(mutate(get.result), "draft");
+    transaction.onerror = () => reject(transaction.error);
+    transaction.oncomplete = resolve;
+  });
+  database.close();
+}
+
+test("browser conformance: public records persist across reopen", async () => {
+  const factory = new IDBFactory();
+  const locks = new ConformanceLockManager();
+  const first = await IndexedDbDataStore.open(
+    config("public-reopen", { indexedDB: factory, locks }),
+  );
+  await first.write(record());
+  assert.deepEqual(await first.read("draft"), record());
+  first.close();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const reopened = await IndexedDbDataStore.open(
+    config("public-reopen", { indexedDB: factory, locks }),
+  );
+  assert.deepEqual(await reopened.read("draft"), record());
+  await reopened.delete("draft");
+  assert.equal(await reopened.read("draft"), null);
+  reopened.close();
+});
+
+test("browser conformance: a same-origin contender receives store_locked", async () => {
+  const factory = new IDBFactory();
+  const locks = new ConformanceLockManager();
+  const owner = await IndexedDbDataStore.open(
+    config("exclusive-owner", { indexedDB: factory, locks }),
+  );
+  await assert.rejects(
+    () =>
+      IndexedDbDataStore.open(
+        config("exclusive-owner", { indexedDB: factory, locks }),
+      ),
+    isCode("store_locked", "exclusive_owner_active"),
+  );
+  owner.close();
+});
+
+test("browser conformance: missing Web Locks fails closed", async () => {
+  await assert.rejects(
+    () =>
+      IndexedDbDataStore.open({
+        databaseName: "no-locks",
+        classification: "public",
+        indexedDB: new IDBFactory(),
+        locks: null,
+      }),
+    isCode("locking_unsupported", "web_locks_unavailable"),
+  );
+});
+
+test("browser conformance: unavailable persistence has a stable typed error", async () => {
+  await assert.rejects(
+    () =>
+      IndexedDbDataStore.open({
+        databaseName: "no-indexeddb",
+        classification: "public",
+        indexedDB: null,
+        locks: new ConformanceLockManager(),
+      }),
+    isCode("persistence_unavailable", "indexeddb_unavailable"),
+  );
+});
+
+test("browser conformance: tampered public data fails integrity verification", async () => {
+  const factory = new IDBFactory();
+  const locks = new ConformanceLockManager();
+  const store = await IndexedDbDataStore.open(
+    config("integrity", { indexedDB: factory, locks }),
+  );
+  await store.write(record());
+  store.close();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await mutateRecord(factory, "integrity", (envelope) => ({
+    ...envelope,
+    record: record({ status: "tampered" }),
+  }));
+
+  const reopened = await IndexedDbDataStore.open(
+    config("integrity", { indexedDB: factory, locks }),
+  );
+  await assert.rejects(
+    () => reopened.read("draft"),
+    isCode("integrity_check_failed", "digest_mismatch"),
+  );
+  reopened.close();
+});
+
+test("browser conformance: private operations fail without storing plaintext", async () => {
+  const factory = new IDBFactory();
+  const store = await IndexedDbDataStore.open({
+    ...config("private-fail-closed", { indexedDB: factory }),
+    classification: "private",
+  });
+  await assert.rejects(() => store.write(record("secret")), isCode("key_provider_required"));
+  await assert.rejects(() => store.read("draft"), isCode("key_provider_required"));
+  await assert.rejects(() => store.delete("draft"), isCode("key_provider_required"));
+  store.close();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const publicView = await IndexedDbDataStore.open(
+    config("private-fail-closed", { indexedDB: factory }),
+  );
+  assert.equal(await publicView.read("draft"), null);
+  publicView.close();
+});
+
+test("browser conformance: quota failures are typed and never silently succeed", async () => {
+  const store = await IndexedDbDataStore.open(config("quota"));
+  const originalPut = IDBObjectStore.prototype.put;
+  IDBObjectStore.prototype.put = function quotaFailure() {
+    throw new DOMException("test-only quota detail", "QuotaExceededError");
+  };
+  try {
+    await assert.rejects(() => store.write(record()), isCode("quota_exceeded"));
+  } finally {
+    IDBObjectStore.prototype.put = originalPut;
+    store.close();
+  }
+});
+
+test("browser conformance: maintenance is explicitly unsupported", async () => {
+  const store = await IndexedDbDataStore.open(config("maintenance"));
+  await assert.rejects(() => store.prune(), isCode("unsupported"));
+  await assert.rejects(() => store.backup(), isCode("unsupported"));
+  await assert.rejects(() => store.restore(), isCode("unsupported"));
+  store.close();
+});


### PR DESCRIPTION
## Summary
- Add a host-owned IndexedDB backend for public DataStore read, write, and delete.
- Hold exclusive ownership with Web Locks and expose stable quota, persistence, locking, and integrity failures.
- Fail closed for private records and maintenance, with browser API conformance coverage.

## Governing Spec
- `085-datastore-indexeddb`

## Project Item
- Closes #870
- Project 1 item `PVTI_lADOEbiBt84Bbyp1zg0RNAE`

## Definition of Done
- [x] Same-port public DataStore CRUD over IndexedDB
- [x] Exclusive Web Locks ownership with `store_locked` / `locking_unsupported`
- [x] Typed quota and persistence failures with no silent writes
- [x] Private and maintenance operations fail closed
- [x] Browser API conformance tests

## Validation
- `npm test` in `packages/web/TraverseEmbedder`
- `CARGO_TARGET_DIR=/tmp/t870 BASE_SHA=$(git rev-parse origin/main) bash scripts/ci/local_preflight.sh --pr-body .pr-body-870.md`