### PR TITLE
docs: define durable trace audit persistence

### DIFF
--- a/docs/adr/0027-durable-trace-audit-persistence.md
+++ b/docs/adr/0027-durable-trace-audit-persistence.md
@@ -1,0 +1,27 @@
+# ADR-0027: Host-Owned Durable Trace and Audit Persistence
+
+- Status: Proposed
+- Date: 2026-07-30
+- Governing draft: `527-durable-trace-productization`
+
+## Decision
+
+Production hosts own the append-only durable trace journal root, its access
+authorization, encryption keys, tenancy mapping, retention configuration, and
+deletion authority. Traverse writes only canonical UTF-8 JSON Lines containing
+safe public trace evidence and canonical hashes; it never persists raw
+request/output payloads or private trace entries.
+
+An auditable execution succeeds only after its line is `fsync` committed.
+Startup discards only an incomplete final line and emits recovery evidence;
+earlier malformed or hash-mismatched records fail closed. Host-explicit,
+workspace-scoped retention or deletion is oldest-first and emits
+`trace_pruned` evidence.
+
+## Consequences
+
+- Restart, partial-write, corruption, retention, deletion, and private-trace
+  behavior have deterministic, testable boundaries.
+- Private trace persistence and remote journal synchronization remain separate
+  governed capabilities.
+- This ADR and its draft require maintainer approval before implementation.

--- a/specs/527-durable-trace-productization/spec.md
+++ b/specs/527-durable-trace-productization/spec.md
@@ -38,6 +38,16 @@ persists raw request or output payloads.
 - **FR-006**: Stable secret-free errors are `trace_workspace_unauthorized`,
   `trace_payload_forbidden`, `trace_retention_invalid`, `trace_export_denied`,
   and `trace_recovery_failed`.
+- **FR-007**: The host-owned journal format is canonical UTF-8 JSON Lines.
+  Each committed line contains a format version, workspace-scoped trace
+  identity, safe public evidence, and a canonical record hash; append MUST
+  `fsync` before an auditable execution succeeds. A final incomplete line is
+  discarded on startup with recovery evidence; an earlier malformed or hash
+  mismatched line fails closed as `trace_recovery_failed`.
+- **FR-008**: Deletion is host-explicit and workspace-scoped. It MUST emit
+  `trace_pruned` evidence and MUST NOT silently erase records, merge journals,
+  or delete another workspace's evidence. Private entries remain in-memory
+  only; an attempted private-payload append fails as `trace_payload_forbidden`.
 
 ## Acceptance Scenarios
 
@@ -50,6 +60,9 @@ persists raw request or output payloads.
    `trace_workspace_unauthorized` without record metadata.
 4. Given an authorized export with a redaction profile, when it completes,
    then it emits only allowed evidence and declares exclusions.
+5. Given a torn final write, when the host restarts, then it discards only that
+   final line and records recovery evidence; given earlier corruption, it fails
+   closed with `trace_recovery_failed`.
 
 ## Compatibility and Governed Files
 


### PR DESCRIPTION
## Summary

- Define durable safe trace and audit persistence boundaries for production hosts.
- Record host ownership, authorization, restart retention, and redacted evidence constraints.

## Governing Spec

- `079-durable-trace-journal`
- `065-sigstore-bundle-verification`
- `070-runtime-event-sink-boundary`

## Project Item

Closes #885.

## Definition of Done

- Durable trace/audit persistence boundary is documented without raw payload persistence.
- Host ownership, authorization, retention, and recovery evidence are specified.
- ADR records the governing decision.

## Validation

- `git diff --check`
- `bash scripts/ci/repository_checks.sh`
