### PR TITLE
Inventory published capabilities for ECCA event-product compliance

### DIFF
--- a/contracts/examples/expedition/events/conditions-summary-assessed/contract.json
+++ b/contracts/examples/expedition/events/conditions-summary-assessed/contract.json
@@ -64,7 +64,12 @@
       "version": "1.0.0"
     }
   ],
-  "subscribers": [],
+  "subscribers": [
+    {
+      "capability_id": "expedition.planning.validate-team-readiness",
+      "version": "1.0.0"
+    }
+  ],
   "policies": [
     {
       "id": "manual-approval-required"

--- a/contracts/examples/expedition/events/expedition-intent-interpreted/contract.json
+++ b/contracts/examples/expedition/events/expedition-intent-interpreted/contract.json
@@ -71,7 +71,12 @@
       "version": "1.0.0"
     }
   ],
-  "subscribers": [],
+  "subscribers": [
+    {
+      "capability_id": "expedition.planning.assess-conditions-summary",
+      "version": "1.0.0"
+    }
+  ],
   "policies": [
     {
       "id": "manual-approval-required"

--- a/contracts/examples/expedition/events/expedition-objective-captured/contract.json
+++ b/contracts/examples/expedition/events/expedition-objective-captured/contract.json
@@ -88,7 +88,12 @@
       "version": "1.0.0"
     }
   ],
-  "subscribers": [],
+  "subscribers": [
+    {
+      "capability_id": "expedition.planning.interpret-expedition-intent",
+      "version": "1.0.0"
+    }
+  ],
   "policies": [
     {
       "id": "manual-approval-required"

--- a/contracts/examples/expedition/events/expedition-plan-assembled/contract.json
+++ b/contracts/examples/expedition/events/expedition-plan-assembled/contract.json
@@ -77,6 +77,10 @@
     {
       "capability_id": "expedition.planning.assemble-expedition-plan",
       "version": "1.0.0"
+    },
+    {
+      "capability_id": "expedition.planning.plan-expedition",
+      "version": "1.0.0"
     }
   ],
   "subscribers": [],

--- a/contracts/examples/expedition/events/team-readiness-validated/contract.json
+++ b/contracts/examples/expedition/events/team-readiness-validated/contract.json
@@ -64,7 +64,12 @@
       "version": "1.0.0"
     }
   ],
-  "subscribers": [],
+  "subscribers": [
+    {
+      "capability_id": "expedition.planning.assemble-expedition-plan",
+      "version": "1.0.0"
+    }
+  ],
   "policies": [
     {
       "id": "manual-approval-required"

--- a/contracts/governance/ecca-capability-inventory.json
+++ b/contracts/governance/ecca-capability-inventory.json
@@ -1,0 +1,127 @@
+{
+  "kind": "ecca_capability_inventory",
+  "schema_version": "1.0.0",
+  "governing_spec": "534-ecca-event-products@1.0.0",
+  "governing_issue": "traverse-framework/traverse#899",
+  "generated_at": "2026-07-30T00:00:00Z",
+  "capabilities": [
+    {
+      "capability_id": "doc-approval.analyze",
+      "version": "1.0.0",
+      "path": "contracts/examples/doc-approval/capabilities/analyze/contract.json",
+      "classification": "no-event-required",
+      "evidence": "side_effects=[memory_only]; no emits; result returns directly to the caller with no asynchronous domain fact broadcast to independent consumers."
+    },
+    {
+      "capability_id": "doc-approval.recommend",
+      "version": "1.0.0",
+      "path": "contracts/examples/doc-approval/capabilities/recommend/contract.json",
+      "classification": "no-event-required",
+      "evidence": "side_effects=[memory_only]; no emits; result returns directly to the caller with no asynchronous domain fact broadcast to independent consumers."
+    },
+    {
+      "capability_id": "hello.world.say-hello",
+      "version": "1.0.0",
+      "path": "contracts/examples/hello-world/capabilities/say-hello/contract.json",
+      "classification": "no-event-required",
+      "evidence": "side_effects=[memory_only]; no emits; trivial synchronous response with no externally meaningful asynchronous effect."
+    },
+    {
+      "capability_id": "meeting-notes.process",
+      "version": "1.0.0",
+      "path": "contracts/examples/meeting-notes/capabilities/process/contract.json",
+      "classification": "no-event-required",
+      "evidence": "side_effects=[memory_only]; no emits; result returns directly to the caller with no asynchronous domain fact broadcast to independent consumers."
+    },
+    {
+      "capability_id": "traverse-starter.pipeline",
+      "version": "1.0.0",
+      "path": "contracts/examples/traverse-starter/capabilities/pipeline/contract.json",
+      "classification": "no-event-required",
+      "evidence": "side_effects=[state_change] only, no event_emission side effect and no emits; state_change is capability-local persisted state via the runtime DataStore with no declared consumers, so no domain fact is broadcast."
+    },
+    {
+      "capability_id": "traverse-starter.process",
+      "version": "1.0.0",
+      "path": "contracts/examples/traverse-starter/capabilities/process/contract.json",
+      "classification": "no-event-required",
+      "evidence": "side_effects=[memory_only]; no emits; result returns directly to the caller with no asynchronous domain fact broadcast to independent consumers."
+    },
+    {
+      "capability_id": "traverse-starter.summarize",
+      "version": "1.0.0",
+      "path": "contracts/examples/traverse-starter/capabilities/summarize/contract.json",
+      "classification": "no-event-required",
+      "evidence": "side_effects=[memory_only]; no emits; result returns directly to the caller with no asynchronous domain fact broadcast to independent consumers."
+    },
+    {
+      "capability_id": "traverse-starter.validate",
+      "version": "1.0.0",
+      "path": "contracts/examples/traverse-starter/capabilities/validate/contract.json",
+      "classification": "no-event-required",
+      "evidence": "side_effects=[memory_only]; no emits; result returns directly to the caller with no asynchronous domain fact broadcast to independent consumers."
+    },
+    {
+      "capability_id": "traverse.inference.generate",
+      "version": "1.0.0",
+      "path": "contracts/inference/traverse.inference.generate/contract.json",
+      "classification": "no-event-required",
+      "evidence": "side_effects=[external_call]; no emits; the model-provider call is a synchronous request/response returned directly to the caller, not an asynchronous domain fact broadcast to independent consumers."
+    },
+    {
+      "capability_id": "expedition.planning.capture-expedition-objective",
+      "version": "1.0.0",
+      "path": "contracts/examples/expedition/capabilities/capture-expedition-objective/contract.json",
+      "classification": "governed-event-declared",
+      "governed_events": ["expedition.planning.expedition-objective-captured"],
+      "evidence": "side_effects includes event_emission; declared emits matches the published expedition-objective-captured event contract, which lists this capability as a publisher."
+    },
+    {
+      "capability_id": "expedition.planning.interpret-expedition-intent",
+      "version": "1.0.0",
+      "path": "contracts/examples/expedition/capabilities/interpret-expedition-intent/contract.json",
+      "classification": "governed-event-declared",
+      "governed_events": ["expedition.planning.expedition-intent-interpreted"],
+      "evidence": "side_effects includes event_emission; declared emits matches the published expedition-intent-interpreted event contract, which lists this capability as a publisher."
+    },
+    {
+      "capability_id": "expedition.planning.assess-conditions-summary",
+      "version": "1.0.0",
+      "path": "contracts/examples/expedition/capabilities/assess-conditions-summary/contract.json",
+      "classification": "governed-event-declared",
+      "governed_events": ["expedition.planning.conditions-summary-assessed"],
+      "evidence": "side_effects includes event_emission; declared emits matches the published conditions-summary-assessed event contract, which lists this capability as a publisher."
+    },
+    {
+      "capability_id": "expedition.planning.validate-team-readiness",
+      "version": "1.0.0",
+      "path": "contracts/examples/expedition/capabilities/validate-team-readiness/contract.json",
+      "classification": "governed-event-declared",
+      "governed_events": ["expedition.planning.team-readiness-validated"],
+      "evidence": "side_effects includes event_emission; declared emits matches the published team-readiness-validated event contract, which lists this capability as a publisher."
+    },
+    {
+      "capability_id": "expedition.planning.assemble-expedition-plan",
+      "version": "1.0.0",
+      "path": "contracts/examples/expedition/capabilities/assemble-expedition-plan/contract.json",
+      "classification": "governed-event-declared",
+      "governed_events": ["expedition.planning.expedition-plan-assembled"],
+      "evidence": "side_effects includes event_emission; declared emits matches the published expedition-plan-assembled event contract, which lists this capability as a publisher."
+    },
+    {
+      "capability_id": "expedition.planning.plan-expedition",
+      "version": "1.0.0",
+      "path": "contracts/examples/expedition/capabilities/plan-expedition/contract.json",
+      "classification": "governed-event-declared",
+      "governed_events": ["expedition.planning.expedition-plan-assembled"],
+      "evidence": "Composite workflow capability whose terminal step re-emits expedition-plan-assembled; side_effects includes event_emission and this capability is now declared as a second publisher on the expedition-plan-assembled event contract, closing a prior declared/observed producer gap found during this inventory."
+    }
+  ],
+  "excluded": [
+    {
+      "kind": "connector_contract",
+      "reason": "Connectors (traverse.http, traverse.fs.read, traverse.env) are resource adapters, not capabilities, per the constitution's capability-first boundary principle. They are out of scope for the ECCA existing-catalog migration in FR-020.",
+      "ids": ["traverse.http", "traverse.fs.read", "traverse.env"]
+    }
+  ]
+}

--- a/crates/traverse-contracts/tests/ecca_capability_inventory.rs
+++ b/crates/traverse-contracts/tests/ecca_capability_inventory.rs
@@ -1,0 +1,222 @@
+//! Regression test for the ECCA existing-catalog migration (spec 534-ecca-event-products, FR-020).
+//!
+//! Governed by traverse-framework/traverse#899. Fails the build when a published
+//! capability contract has no inventory classification, or when a capability that
+//! declares `event_emission`/`emits` does not have a matching, validator-parseable
+//! event contract that lists it as a publisher (and, where a `consumes` reference
+//! exists, an upstream event contract that lists it as a subscriber).
+
+use std::{collections::BTreeMap, fs, path::Path, path::PathBuf};
+
+use serde_json::Value;
+use traverse_contracts::{SideEffectKind, parse_contract, parse_event_contract};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+/// Recursively collect every `contract.json` file under `dir`.
+fn find_contract_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+    for entry in fs::read_dir(dir).map_err(|error| format!("{}: {error}", dir.display()))? {
+        let entry = entry.map_err(|error| format!("{error}"))?;
+        let path = entry.path();
+        if path.is_dir() {
+            find_contract_files(&path, out)?;
+        } else if path.file_name().and_then(|name| name.to_str()) == Some("contract.json") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn read_json(path: &Path) -> Result<Value, String> {
+    let contents =
+        fs::read_to_string(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    serde_json::from_str(&contents).map_err(|error| format!("{}: {error}", path.display()))
+}
+
+fn find_event_contract_path(root: &Path, event_id: &str) -> Result<PathBuf, String> {
+    let mut candidates = Vec::new();
+    find_contract_files(&root.join("contracts/examples"), &mut candidates)?;
+    candidates
+        .into_iter()
+        .find(|path| {
+            read_json(path)
+                .ok()
+                .and_then(|value| {
+                    let is_event = value.get("kind")?.as_str()? == "event_contract";
+                    let id = value.get("id")?.as_str()?;
+                    Some(is_event && id == event_id)
+                })
+                .unwrap_or(false)
+        })
+        .ok_or_else(|| format!("no event contract file found for event id '{event_id}'"))
+}
+
+fn assert_declared_publisher(
+    root: &Path,
+    capability_id: &str,
+    event_id: &str,
+) -> Result<(), String> {
+    let event_path = find_event_contract_path(root, event_id)?;
+    let event_json = fs::read_to_string(&event_path)
+        .map_err(|error| format!("{}: {error}", event_path.display()))?;
+    let event_contract = parse_event_contract(&event_json)
+        .map_err(|error| format!("{}: {error:?}", event_path.display()))?;
+
+    if !event_contract
+        .publishers
+        .iter()
+        .any(|publisher| publisher.capability_id == capability_id)
+    {
+        return Err(format!(
+            "'{capability_id}' emits '{event_id}' but is not declared as a publisher on that \
+             event contract at {}",
+            event_path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn assert_declared_subscriber(
+    root: &Path,
+    capability_id: &str,
+    event_id: &str,
+) -> Result<(), String> {
+    let event_path = find_event_contract_path(root, event_id)?;
+    let event_json = fs::read_to_string(&event_path)
+        .map_err(|error| format!("{}: {error}", event_path.display()))?;
+    let event_contract = parse_event_contract(&event_json)
+        .map_err(|error| format!("{}: {error:?}", event_path.display()))?;
+
+    if !event_contract
+        .subscribers
+        .iter()
+        .any(|subscriber| subscriber.capability_id == capability_id)
+    {
+        return Err(format!(
+            "'{capability_id}' consumes '{event_id}' but is not declared as a subscriber on \
+             that event contract at {}",
+            event_path.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Checks one published capability against its manifest entry. Returns `Err` describing the
+/// first FR-020 violation found.
+fn check_capability(root: &Path, id: &str, path: &Path, entry: &Value) -> Result<(), String> {
+    let classification = entry
+        .get("classification")
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("manifest entry for '{id}' missing classification"))?;
+
+    let contract_json =
+        fs::read_to_string(path).map_err(|error| format!("{}: {error}", path.display()))?;
+    let contract =
+        parse_contract(&contract_json).map_err(|error| format!("{}: {error:?}", path.display()))?;
+
+    let declares_event_emission = contract
+        .side_effects
+        .iter()
+        .any(|effect| matches!(effect.kind, SideEffectKind::EventEmission));
+    let has_emits = !contract.emits.is_empty();
+
+    if !declares_event_emission && !has_emits {
+        if classification != "no-event-required" {
+            return Err(format!(
+                "'{id}' has no event_emission side effect and no emits, so it must be \
+                 classified 'no-event-required', not '{classification}'"
+            ));
+        }
+        let evidence = entry.get("evidence").and_then(Value::as_str).unwrap_or("");
+        if evidence.trim().is_empty() {
+            return Err(format!(
+                "'{id}' is classified no-event-required but has no documented evidence"
+            ));
+        }
+        return Ok(());
+    }
+
+    if classification != "governed-event-declared" {
+        return Err(format!(
+            "'{id}' declares event_emission/emits but is classified '{classification}'"
+        ));
+    }
+    if !(declares_event_emission && has_emits) {
+        return Err(format!(
+            "'{id}' must declare both an event_emission side effect and a non-empty emits \
+             list to be classified governed-event-declared"
+        ));
+    }
+
+    for event_ref in &contract.emits {
+        assert_declared_publisher(root, id, &event_ref.event_id)?;
+    }
+    for consumed in &contract.consumes {
+        assert_declared_subscriber(root, id, &consumed.event_id)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn every_published_capability_has_an_inventory_classification() -> Result<(), String> {
+    let root = repo_root();
+
+    let mut contract_files = Vec::new();
+    find_contract_files(&root.join("contracts/examples"), &mut contract_files)?;
+    find_contract_files(&root.join("contracts/inference"), &mut contract_files)?;
+
+    let published_capabilities: BTreeMap<String, PathBuf> = contract_files
+        .into_iter()
+        .filter_map(|path| {
+            let value = read_json(&path).ok()?;
+            if value.get("kind")?.as_str()? != "capability_contract" {
+                return None;
+            }
+            let id = value.get("id")?.as_str()?.to_string();
+            Some((id, path))
+        })
+        .collect();
+
+    let manifest = read_json(&root.join("contracts/governance/ecca-capability-inventory.json"))?;
+    let manifest_entries = manifest
+        .get("capabilities")
+        .and_then(Value::as_array)
+        .ok_or("manifest missing capabilities array")?;
+
+    let mut manifest_ids: BTreeMap<String, &Value> = BTreeMap::new();
+    for entry in manifest_entries {
+        let id = entry
+            .get("capability_id")
+            .and_then(Value::as_str)
+            .ok_or("manifest entry missing capability_id")?
+            .to_string();
+        manifest_ids.insert(id, entry);
+    }
+
+    for id in published_capabilities.keys() {
+        if !manifest_ids.contains_key(id) {
+            return Err(format!(
+                "published capability '{id}' has no ECCA inventory classification in \
+                 contracts/governance/ecca-capability-inventory.json; FR-020 requires a \
+                 validator-backed classification before its next publication"
+            ));
+        }
+    }
+    for id in manifest_ids.keys() {
+        if !published_capabilities.contains_key(id) {
+            return Err(format!(
+                "ECCA inventory manifest references '{id}' but no such published capability \
+                 contract exists on disk; remove the stale entry"
+            ));
+        }
+    }
+
+    for (id, path) in &published_capabilities {
+        let entry = manifest_ids[id];
+        check_capability(&root, id, path, entry)?;
+    }
+
+    Ok(())
+}

--- a/specs/534-ecca-event-products/capability-migration-report.md
+++ b/specs/534-ecca-event-products/capability-migration-report.md
@@ -1,0 +1,116 @@
+# ECCA Existing-Catalog Migration Report
+
+**Governing spec**: `534-ecca-event-products@1.0.0` (FR-020)
+**Governing issue**: traverse-framework/traverse#899
+**Machine-readable source of truth**: `contracts/governance/ecca-capability-inventory.json`
+**Mechanically checked by**: `crates/traverse-contracts/tests/ecca_capability_inventory.rs`
+
+## Scope
+
+Every currently published `capability_contract` under `contracts/examples/` and
+`contracts/inference/` received a validator-backed classification before its
+next publication, per FR-020. `connector_contract` entries under
+`contracts/connectors/` are out of scope: connectors are resource adapters,
+not capabilities, under the constitution's capability-first boundary
+principle (Principle I).
+
+## Outcome summary
+
+| Outcome | Count |
+| --- | --- |
+| Compliant — governed event product already declared | 6 |
+| No event required (documented evidence) | 9 |
+| Blocked | 0 |
+| Exception-free | 15 |
+| **Total published capabilities** | **15** |
+
+No artificial event was created to satisfy a quota. Every `no-event-required`
+classification is backed by a `side_effects`/`emits` inspection recorded in
+the inventory manifest, consistent with QG-004 and the FR-020 non-goal.
+
+## No-event-required capabilities (9)
+
+All nine have `side_effects` containing only `memory_only`, `state_change`, or
+`external_call`, and an empty `emits` list — i.e. their result returns
+directly to the caller (or is written to their own capability-local state)
+with no domain fact broadcast to independent consumers:
+
+- `doc-approval.analyze`
+- `doc-approval.recommend`
+- `hello.world.say-hello`
+- `meeting-notes.process`
+- `traverse-starter.pipeline`
+- `traverse-starter.process`
+- `traverse-starter.summarize`
+- `traverse-starter.validate`
+- `traverse.inference.generate`
+
+## Governed-event-declared capabilities (6)
+
+All six declare `side_effects: [event_emission]` and a non-empty `emits`
+referencing one of the five published expedition-domain event contracts under
+`contracts/examples/expedition/events/`:
+
+- `expedition.planning.capture-expedition-objective` → `expedition-objective-captured`
+- `expedition.planning.interpret-expedition-intent` → `expedition-intent-interpreted`
+- `expedition.planning.assess-conditions-summary` → `conditions-summary-assessed`
+- `expedition.planning.validate-team-readiness` → `team-readiness-validated`
+- `expedition.planning.assemble-expedition-plan` → `expedition-plan-assembled`
+- `expedition.planning.plan-expedition` → `expedition-plan-assembled` (second producer)
+
+## Declared/observed drift found and closed during this inventory
+
+Building the inventory surfaced two categories of drift between capability
+declarations and the event contracts' `publishers`/`subscribers` records
+(the exact drift class FR-016 requires the catalog to be able to show). Both
+were closed as part of this migration, using only the existing capability and
+event contract schema fields — no new ECCA descriptor fields were introduced,
+since the descriptor/schema work itself belongs to #896 and #897:
+
+1. **Undeclared second producer**: `expedition.planning.plan-expedition` is a
+   composite workflow capability whose terminal step re-emits
+   `expedition-plan-assembled` (see its `side_effects`, `emits`, and
+   `dependencies` fields), but the event contract's `publishers` list
+   contained only `assemble-expedition-plan`. Fixed by adding
+   `plan-expedition` as a second publisher.
+2. **Missing subscriber declarations**: four capabilities (`assess-conditions-summary`,
+   `interpret-expedition-intent`, `validate-team-readiness`,
+   `assemble-expedition-plan`) declare a `consumes` reference to another
+   capability's event, but the corresponding event contract's `subscribers`
+   list was empty. Fixed by adding the matching subscriber entry to each of
+   the four upstream event contracts (`expedition-intent-interpreted`,
+   `expedition-objective-captured`, `conditions-summary-assessed`,
+   `team-readiness-validated`).
+
+## What is explicitly deferred, and why
+
+Per ADR-0028 ("the first implementation is deliberately incremental") and to
+avoid duplicating #896 (registry catalog and capability discovery) and #897
+(runtime validation, lineage, and conformance), this migration does not:
+
+- Add the new ECCA-only descriptor fields (CloudEvents-explicit
+  source/subject/time mapping, `exposure` class, per-field controlled data
+  classification, retention/deprecation) to the five existing event
+  contracts. Those fields are introduced by #896/#897's schema work; adding
+  them here ahead of that landing would risk conflicting field definitions.
+- Implement runtime enforcement that rejects republication of a
+  non-compliant capability (FR-011/FR-013). That requires the ECCA validator
+  built in #897, which has not landed yet.
+- Add OpenTelemetry lineage evidence (FR-019); that is runtime instrumentation
+  scoped to #897.
+
+The regression test added in this change enforces the part of FR-020 that is
+independent of that future work: every published capability must have an
+inventory entry, and every capability declaring `event_emission`/`emits` must
+have a validator-parseable event contract that lists it as a publisher (and,
+where a `consumes` reference exists, the upstream event must list it as a
+subscriber). A capability added later without an inventory entry, or an
+undeclared producer/consumer relationship, fails this test.
+
+## Maintainer review note
+
+No capability's classification was changed to `governed-event-declared` by
+fabricating an event; every `governed-event-declared` entry already had a
+side-effect and `emits` declaration in its checked-in contract prior to this
+inventory. This report only makes existing, self-declared relationships
+mechanically checkable and closes the drift listed above.


### PR DESCRIPTION
## Governing Spec

- `534-ecca-event-products`

Version 1.0.0, FR-020 "Existing Catalog Migration". Extends `003-event-contracts`, `018-event-driven-composition`. Approved via #895 / ADR-0028.

## Project Item

Closes traverse-framework/traverse#899 (org Project 1 item, tracked under the ECCA event-product epic #894).

## Summary

Closes #899. Inventories every currently published capability contract (15 total, under `contracts/examples/` and `contracts/inference/`) and records a validator-backed classification for each, per FR-020:

- **9 classified `no-event-required`**, with documented `side_effects`/`emits` evidence: `doc-approval.analyze`, `doc-approval.recommend`, `hello.world.say-hello`, `meeting-notes.process`, `traverse-starter.pipeline`, `traverse-starter.process`, `traverse-starter.summarize`, `traverse-starter.validate`, `traverse.inference.generate`.
- **6 classified `governed-event-declared`**: the six expedition-planning capabilities that already declare `event_emission` side effects and `emits` referencing one of the five published expedition-domain event contracts.

No artificial event was created to satisfy a quota (QG-004), consistent with the FR-020 non-goal.

## Drift found and closed

Building the inventory surfaced two categories of drift between capability declarations and event contracts' `publishers`/`subscribers` records (the exact drift FR-016 requires the catalog to show):

1. `expedition.planning.plan-expedition` (a composite workflow capability) re-emits `expedition-plan-assembled` in its terminal step but was missing from that event's `publishers` list — added as a second publisher.
2. Four capabilities declare a `consumes` reference to an upstream event whose `subscribers` list was empty — added the matching subscriber entry to each of the four event contracts (`expedition-intent-interpreted`, `expedition-objective-captured`, `conditions-summary-assessed`, `team-readiness-validated`).

## What's deferred, and why

Per ADR-0028 ("the first implementation is deliberately incremental") and to avoid duplicating #896 (registry catalog) and #897 (runtime validation/lineage), this PR does not add the new ECCA-only descriptor fields (CloudEvents-explicit mapping, `exposure` class, per-field data classification, retention/deprecation) or runtime republish enforcement — that schema/runtime work belongs to #896/#897, which haven't landed yet. Full rationale is in the migration report.

## Changes

- `contracts/governance/ecca-capability-inventory.json` — machine-readable inventory manifest (source of truth for the regression test).
- `specs/534-ecca-event-products/capability-migration-report.md` — migration report per FR-020.
- `crates/traverse-contracts/tests/ecca_capability_inventory.rs` — new regression test: fails the build for any capability contract with no inventory entry, or any undeclared producer/consumer relationship.
- 5 event contract JSON files — added the missing publisher/subscriber declarations described above.

## Validation

- `cargo test -p traverse-contracts` — 35 tests pass (34 existing + 1 new), no regressions.
- `cargo build --workspace` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `bash scripts/ci/spec_alignment_check.sh` — run locally against this PR body.

## Non-goals honored

Did not force a domain event from any capability with no externally meaningful asynchronous effect (9 capabilities), and did not fabricate a domain event to satisfy a quota.
