### PR TITLE
docs: link the live registry catalog from the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.94%2B-orange)](https://www.rust-lang.org/)
 [![Version](https://img.shields.io/badge/version-v0.8.1-blue)](https://github.com/traverse-framework/traverse/releases)
+[![Registry](https://img.shields.io/badge/registry-live%20catalog-6f42c1)](https://registry.traverse-framework.com/)
 
 Your business logic runs in the browser, on your server, and in a cloud function.
 They drift. You maintain three versions of the same behavior.
@@ -24,7 +25,7 @@ Traverse is pre-1.0 (`v0.8.1`) and evolving under spec-driven governance — eve
 - **8 crates in this repo** plus the capability registry (now its own repo, see below) — 7 of these 9 are [published on crates.io](https://crates.io/search?q=traverse-): runtime, contracts, registry, CLI, MCP server, embedder SDK, and the expedition WASM example. `traverse-native-bridge` and `traverse-swift-host` are newer, not yet published.
 - **87 approved, immutable specs** govern the runtime, contracts, registry, MCP surface, WASM execution, native embedding, and durable local storage. Full list: `jq -r '.specs[].id' specs/governance/approved-specs.json` (or see [Governance](#governance) below).
 - **100% coverage enforced on core logic**, spec-alignment and supply-chain gates on every PR, 5-platform CI matrix (Linux x86_64/aarch64, macOS x86_64/arm64, Windows x86_64).
-- **Capability registry** was extracted into its own repo, [`traverse-framework/registry`](https://github.com/traverse-framework/registry), so capabilities can be published, versioned, and consumed independently of the runtime.
+- **Capability registry** was extracted into its own repo, [`traverse-framework/registry`](https://github.com/traverse-framework/registry), so capabilities can be published, versioned, and consumed independently of the runtime. Browse what's actually published at the live catalog: **[registry.traverse-framework.com](https://registry.traverse-framework.com/)**.
 - **Reference apps** for multiple platforms (web, iOS, macOS, Android, Windows, Linux, CLI) live in [`traverse-framework/reference-apps`](https://github.com/traverse-framework/reference-apps).
 
 ### Where this is going: v1.0.0
@@ -176,7 +177,7 @@ In a separate repo:
 
 | Crate | Repo | Role |
 |---|---|---|
-| `traverse-registry` | [`traverse-framework/registry`](https://github.com/traverse-framework/registry) | Capability and event registries with deterministic traversal — extracted from this repo (spec 051) so capabilities can be published and versioned independently |
+| `traverse-registry` | [`traverse-framework/registry`](https://github.com/traverse-framework/registry) | Capability and event registries with deterministic traversal — extracted from this repo (spec 051) so capabilities can be published and versioned independently. Live catalog: [registry.traverse-framework.com](https://registry.traverse-framework.com/) |
 
 ---
 


### PR DESCRIPTION
## Project Item

Closes traverse-framework/traverse#907. Requested directly by the repo owner.

## Governing Spec

- `190-readme-rewrite`

README.md is governed by this spec per `specs/governance/approved-specs.json`.

## Summary

Adds three links to the live Traverse registry catalog (https://registry.traverse-framework.com/) so it's visible from the README landing page:

- A new badge in the top badge row.
- The "Capability registry" bullet in Current State & Roadmap now links to the live catalog alongside the `traverse-framework/registry` repo link.
- The `traverse-registry` row in the crates table now links to the live catalog.

Verified the site is live and shows real published capabilities (doc-approval, formatting, meeting-notes, traverse-starter, validation domains — 11 capabilities with coverage/version metadata) before adding the link.

## Validation

- Docs-only change; no code/contract/test surfaces touched.
- Manually verified https://registry.traverse-framework.com/ resolves and renders the live capability catalog.
- `bash scripts/ci/spec_alignment_check.sh` run locally against this PR body.
