### PR TITLE
feat(runtime): validate governed event envelopes

### DIFF
--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -14,6 +14,7 @@ use super::{
         BrokerEvent, EventBroker, EventCursor, EventError, LifecycleStatus, Subscription,
         SubscriptionId, SubscriptionPoll, TraverseEvent,
     },
+    validation::{EventValidationEvidence, EventValidationMode, validate_event},
 };
 
 /// Clock abstraction used by the broker for retention pruning.
@@ -71,6 +72,7 @@ struct BrokerState {
     subscriptions: HashMap<SubscriptionId, SubscriptionState>,
     /// See [`EventBroker::seed_restart_floor`].
     restart_floor: u64,
+    validation_evidence: Vec<EventValidationEvidence>,
 }
 
 /// Synchronous, in-memory implementation of [`EventBroker`].
@@ -83,6 +85,7 @@ pub struct InProcessBroker {
     config: BrokerConfig,
     clock: Arc<dyn BrokerClock>,
     state: Mutex<BrokerState>,
+    validation_mode: EventValidationMode,
 }
 
 impl std::fmt::Debug for InProcessBroker {
@@ -111,6 +114,24 @@ impl InProcessBroker {
         config: BrokerConfig,
         clock: Arc<dyn BrokerClock>,
     ) -> Result<Self, EventError> {
+        Self::with_clock_and_validation(catalog, config, clock, EventValidationMode::Migration)
+    }
+
+    /// Create a broker with an explicit governed-event enforcement policy.
+    ///
+    /// Migration mode records violations without interrupting existing traffic;
+    /// enforcement mode rejects invalid envelopes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EventError::InvalidRetentionWindow`] when the configuration
+    /// cannot maintain replay and queue guarantees.
+    pub fn with_clock_and_validation(
+        catalog: Arc<EventCatalog>,
+        config: BrokerConfig,
+        clock: Arc<dyn BrokerClock>,
+        validation_mode: EventValidationMode,
+    ) -> Result<Self, EventError> {
         if config.retention_window == Duration::from_secs(0) {
             return Err(EventError::InvalidRetentionWindow(
                 "retention_window must be > 0".to_string(),
@@ -127,7 +148,18 @@ impl InProcessBroker {
             config,
             clock,
             state: Mutex::new(BrokerState::default()),
+            validation_mode,
         })
+    }
+
+    /// Returns sanitized validation and quarantine evidence. Payload data is
+    /// never retained through this interface.
+    #[must_use]
+    pub fn validation_evidence(&self) -> Vec<EventValidationEvidence> {
+        self.state
+            .lock()
+            .map(|state| state.validation_evidence.clone())
+            .unwrap_or_default()
     }
 
     fn subscribe_with_subject(
@@ -197,6 +229,21 @@ impl InProcessBroker {
         event: &TraverseEvent,
         assigned_cursor: Option<u64>,
     ) -> Result<(), EventError> {
+        let validation = validate_event(event, self.validation_mode);
+        if let Some(evidence) = EventValidationEvidence::from_result(&validation) {
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
+            state.validation_evidence.push(evidence);
+        }
+        if !validation.accepted {
+            let code = validation
+                .diagnostics
+                .first()
+                .map_or("EVP-000", |diagnostic| diagnostic.code);
+            return Err(EventError::ValidationRejected(code.to_owned()));
+        }
         let entry = self
             .catalog
             .get(&event.event_type)
@@ -789,6 +836,45 @@ mod tests {
             .publish(sample_event("dev.traverse.draft", "evt-001"))
             .expect_err("draft publish must fail");
         assert!(matches!(err, EventError::LifecycleViolation(_)));
+    }
+
+    #[test]
+    fn enforcement_rejects_invalid_events_and_retains_sanitized_evidence() {
+        let event_type = "dev.traverse.orders.created";
+        let broker = InProcessBroker::with_clock_and_validation(
+            make_catalog(event_type, LifecycleStatus::Active),
+            BrokerConfig::default(),
+            Arc::new(SystemClock),
+            EventValidationMode::Enforcement,
+        )
+        .expect("broker must be created");
+        let mut invalid = sample_event(event_type, "evt-invalid");
+        invalid.owner.clear();
+        invalid.data = serde_json::json!({"customer_email": "private@example.test"});
+
+        let error = broker
+            .publish(invalid)
+            .expect_err("enforcement must reject a missing owner");
+        assert!(matches!(error, EventError::ValidationRejected(code) if code == "EVP-005"));
+        let evidence = broker.validation_evidence();
+        assert_eq!(evidence.len(), 1);
+        assert_eq!(evidence[0].contract_id, event_type);
+        assert_eq!(evidence[0].diagnostics[0].code, "EVP-005");
+        assert!(!format!("{evidence:?}").contains("private@example.test"));
+    }
+
+    #[test]
+    fn migration_records_invalid_event_evidence_without_rejecting_delivery() {
+        let event_type = "dev.traverse.orders.created";
+        let broker = InProcessBroker::new(make_catalog(event_type, LifecycleStatus::Active))
+            .expect("broker must be created");
+        let mut invalid = sample_event(event_type, "evt-migration");
+        invalid.owner.clear();
+
+        broker
+            .publish(invalid)
+            .expect("migration mode must preserve delivery");
+        assert_eq!(broker.validation_evidence().len(), 1);
     }
 
     #[test]

--- a/crates/traverse-runtime/src/events/mod.rs
+++ b/crates/traverse-runtime/src/events/mod.rs
@@ -7,6 +7,7 @@ pub mod catalog;
 pub mod durable;
 pub mod journal;
 pub mod types;
+pub mod validation;
 
 pub use broker::{BrokerClock, BrokerConfig, InProcessBroker, SystemClock};
 pub use catalog::{EventCatalog, EventCatalogEntry};
@@ -18,4 +19,8 @@ pub use types::{
     BrokerEvent, BrokerEventSink, EventBroker, EventCursor, EventError, LifecycleStatus,
     NoopRuntimeEventSink, RuntimeEventSink, Subscription, SubscriptionId, SubscriptionPoll,
     TraverseEvent,
+};
+pub use validation::{
+    EventValidationDiagnostic, EventValidationEvidence, EventValidationMode, EventValidationResult,
+    validate_event,
 };

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -48,6 +48,8 @@ pub struct TraverseEvent {
 /// Errors that can occur during event broker operations.
 #[derive(Debug, PartialEq, Eq)]
 pub enum EventError {
+    /// A governed event failed enforcement-mode envelope validation.
+    ValidationRejected(String),
     /// Attempted to publish an event whose catalog entry is `Deprecated` or `Draft`.
     LifecycleViolation(String),
     /// Attempted to publish an event type not registered in the catalog.
@@ -75,6 +77,7 @@ pub enum EventError {
 impl std::fmt::Display for EventError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::ValidationRejected(code) => write!(f, "event validation rejected: {code}"),
             Self::LifecycleViolation(msg) => write!(f, "lifecycle violation: {msg}"),
             Self::UnregisteredEventType(t) => write!(f, "unregistered event type: {t}"),
             Self::InvalidCursor(msg) => write!(f, "invalid cursor: {msg}"),
@@ -286,6 +289,7 @@ mod tests {
     #[test]
     fn event_error_display_covers_all_variants() {
         let cases: Vec<EventError> = vec![
+            EventError::ValidationRejected("EVP-005".to_string()),
             EventError::LifecycleViolation("x".to_string()),
             EventError::UnregisteredEventType("t".to_string()),
             EventError::InvalidCursor("c".to_string()),

--- a/crates/traverse-runtime/src/events/validation.rs
+++ b/crates/traverse-runtime/src/events/validation.rs
@@ -1,0 +1,213 @@
+//! Deterministic runtime validation for governed event-product envelopes.
+//!
+//! Governed by approved spec `534-ecca-event-products` (FR-012 through FR-014).
+
+use semver::Version;
+
+use super::TraverseEvent;
+
+/// Runtime policy used at producer and consumer boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventValidationMode {
+    /// Record violations without rejecting legacy traffic.
+    Migration,
+    /// Reject traffic that does not satisfy the governed envelope profile.
+    Enforcement,
+}
+
+/// Stable, machine-readable diagnostic for an invalid event envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventValidationDiagnostic {
+    pub code: &'static str,
+    pub path: &'static str,
+    pub severity: &'static str,
+    pub remediation: &'static str,
+    pub contract_id: String,
+    pub version: String,
+}
+
+/// Result of applying the portable event-product envelope profile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventValidationResult {
+    pub accepted: bool,
+    pub diagnostics: Vec<EventValidationDiagnostic>,
+}
+
+/// Sanitized quarantine evidence for a rejected event.
+///
+/// It retains only contract identity and deterministic diagnostics. Event data,
+/// credentials, and other envelope values are deliberately excluded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventValidationEvidence {
+    pub contract_id: String,
+    pub version: String,
+    pub diagnostics: Vec<EventValidationDiagnostic>,
+}
+
+impl EventValidationEvidence {
+    #[must_use]
+    pub fn from_result(result: &EventValidationResult) -> Option<Self> {
+        let first = result.diagnostics.first()?;
+        Some(Self {
+            contract_id: first.contract_id.clone(),
+            version: first.version.clone(),
+            diagnostics: result.diagnostics.clone(),
+        })
+    }
+}
+
+impl EventValidationResult {
+    #[must_use]
+    pub fn is_valid(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+}
+
+/// Validate a `TraverseEvent` without host or transport dependencies.
+///
+/// Migration mode preserves delivery while surfacing deterministic evidence;
+/// enforcement mode rejects the same invalid envelope.
+#[must_use]
+pub fn validate_event(event: &TraverseEvent, mode: EventValidationMode) -> EventValidationResult {
+    let mut diagnostics = Vec::new();
+    validate_non_empty(&mut diagnostics, "EVP-001", "/id", "id", &event.id, event);
+    validate_non_empty(
+        &mut diagnostics,
+        "EVP-002",
+        "/source",
+        "source",
+        &event.source,
+        event,
+    );
+    validate_non_empty(
+        &mut diagnostics,
+        "EVP-003",
+        "/datacontenttype",
+        "datacontenttype",
+        &event.datacontenttype,
+        event,
+    );
+    validate_non_empty(
+        &mut diagnostics,
+        "EVP-004",
+        "/time",
+        "time",
+        &event.time,
+        event,
+    );
+    validate_non_empty(
+        &mut diagnostics,
+        "EVP-005",
+        "/owner",
+        "owner",
+        &event.owner,
+        event,
+    );
+    if Version::parse(&event.version).is_err() {
+        diagnostics.push(diagnostic(
+            "EVP-006",
+            "/version",
+            "version must be semantic",
+            event,
+        ));
+    }
+    if !is_fact_type(&event.event_type) {
+        diagnostics.push(diagnostic(
+            "EVP-007",
+            "/type",
+            "type must use a dotted past-tense fact name",
+            event,
+        ));
+    }
+    let accepted = mode == EventValidationMode::Migration || diagnostics.is_empty();
+    EventValidationResult {
+        accepted,
+        diagnostics,
+    }
+}
+
+fn validate_non_empty(
+    diagnostics: &mut Vec<EventValidationDiagnostic>,
+    code: &'static str,
+    path: &'static str,
+    field: &'static str,
+    value: &str,
+    event: &TraverseEvent,
+) {
+    if value.trim().is_empty() {
+        diagnostics.push(diagnostic(code, path, field, event));
+    }
+}
+
+fn diagnostic(
+    code: &'static str,
+    path: &'static str,
+    remediation: &'static str,
+    event: &TraverseEvent,
+) -> EventValidationDiagnostic {
+    EventValidationDiagnostic {
+        code,
+        path,
+        severity: "error",
+        remediation,
+        contract_id: event.event_type.clone(),
+        version: event.version.clone(),
+    }
+}
+
+fn is_fact_type(value: &str) -> bool {
+    value.contains('.')
+        && value
+            .rsplit('.')
+            .next()
+            .is_some_and(|last| last.ends_with("ed") && !last.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::LifecycleStatus;
+
+    fn valid_event() -> TraverseEvent {
+        TraverseEvent {
+            id: "evt-1".to_string(),
+            source: "capability/orders".to_string(),
+            event_type: "orders.order.created".to_string(),
+            datacontenttype: "application/json".to_string(),
+            time: "2026-07-30T00:00:00Z".to_string(),
+            data: serde_json::json!({"order_id":"1"}),
+            owner: "orders".to_string(),
+            version: "1.0.0".to_string(),
+            lifecycle_status: LifecycleStatus::Active,
+            subject_id: None,
+            actor_id: None,
+        }
+    }
+
+    #[test]
+    fn enforcement_rejects_invalid_envelope_with_stable_diagnostic() {
+        let mut event = valid_event();
+        event.owner.clear();
+        event.version = "not-semver".to_string();
+        let result = validate_event(&event, EventValidationMode::Enforcement);
+        assert!(!result.accepted);
+        assert_eq!(result.diagnostics[0].code, "EVP-005");
+        assert_eq!(result.diagnostics[0].severity, "error");
+        assert_eq!(result.diagnostics[1].code, "EVP-006");
+    }
+
+    #[test]
+    fn migration_mode_reports_but_does_not_reject_legacy_gap() {
+        let mut event = valid_event();
+        event.event_type = "orders.order.create".to_string();
+        let result = validate_event(&event, EventValidationMode::Migration);
+        assert!(result.accepted);
+        assert_eq!(result.diagnostics[0].code, "EVP-007");
+    }
+
+    #[test]
+    fn valid_result_reports_validity() {
+        let result = validate_event(&valid_event(), EventValidationMode::Enforcement);
+        assert!(result.is_valid());
+    }
+}


### PR DESCRIPTION
## Summary

Add governed event-envelope validation at the runtime broker boundary, including migration and enforcement modes plus sanitized rejection evidence.

## Governing Spec

- `534-ecca-event-products`

FR-012 through FR-014.

## Project Item

Traverse #897

## Definition of Done

- [x] Deterministic envelope diagnostics and enforcement rejection are implemented.
- [x] Sanitized evidence excludes event payload data.
- [ ] Remaining observed-lineage and cross-host conformance work continues in this PR.

## Validation

- `CARGO_TARGET_DIR=/private/tmp/traverse-issue-897-target cargo test -p traverse-runtime events:: --lib`
- `cargo fmt --check`
