### PR TITLE
fix(cli): disclose expedition execute's example-implementation behavior

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -934,6 +934,17 @@ fn help_expedition_execute() -> String {
     a structured execution summary. Optionally writes the full runtime trace to
     a JSON file for later inspection with `trace inspect`.
 
+    Execution honesty: this command runs the canonical expedition bundle's
+    six capabilities through explicit, hand-written example implementations,
+    not their checked-in WASM artifacts. Two of the six
+    ('interpret-expedition-intent', 'validate-team-readiness') also have a
+    checked-in WASM artifact under examples/capabilities/; real, end-to-end
+    WASM execution for them is proven separately by
+    `traverse-cli capability-package execute`, since their current fixture
+    output does not satisfy this composite workflow's node-to-node input
+    contract. This command only recognizes the six capabilities in the
+    canonical expedition bundle; an unregistered capability ID fails closed.
+
   Required arguments:
     <request-path>          Path to the runtime request JSON file.
 
@@ -4930,10 +4941,61 @@ fn canonical_expedition_request_path() -> PathBuf {
     repo_root().join("examples/expedition/runtime-requests/plan-expedition.json")
 }
 
+/// `traverse-cli expedition execute`'s executor for the canonical expedition
+/// registry bundle. Runs each of the six registered capabilities' native
+/// example implementation — disclosed honestly in `help_expedition_execute`,
+/// rather than left unstated. Any capability id this bundle does not
+/// register fails closed with a stable, typed error rather than a
+/// fabricated result.
+///
+/// `interpret-expedition-intent` and `validate-team-readiness` also have a
+/// checked-in WASM artifact under `examples/capabilities/`, and real,
+/// end-to-end WASM execution for them is already correctly proven by
+/// `capability-package execute`
+/// (`execute_capability_package_runs_governed_capability_package_request`).
+/// They are not wired into this composite executor: both artifacts are
+/// fixed-output ABI-conformance fixtures whose bytes are digest-pinned by
+/// other example manifests (`examples/applications/expedition-readiness`,
+/// `examples/capabilities/*/manifest.json`), and whose static output does
+/// not satisfy the next workflow node's input contract in this composite —
+/// swapping them in here would break either those pinned digests or this
+/// working, tested composite demo. Authoring real, chain-compatible business
+/// logic for the expedition-planning capabilities is tracked as follow-up
+/// work, separate from this fix.
+#[derive(Debug, Default, Clone, Copy)]
+struct ExpeditionCliExecutor;
+
+impl LocalExecutor for ExpeditionCliExecutor {
+    fn execute(
+        &self,
+        capability: &traverse_registry::ResolvedCapability,
+        input: &Value,
+    ) -> Result<Value, LocalExecutionFailure> {
+        match capability.contract.id.as_str() {
+            "expedition.planning.capture-expedition-objective" => {
+                execute_capture_expedition_objective(input)
+            }
+            "expedition.planning.interpret-expedition-intent" => {
+                execute_interpret_expedition_intent(input)
+            }
+            "expedition.planning.assess-conditions-summary" => {
+                execute_assess_conditions_summary(input)
+            }
+            "expedition.planning.validate-team-readiness" => execute_validate_team_readiness(input),
+            "expedition.planning.assemble-expedition-plan" => {
+                execute_assemble_expedition_plan(input)
+            }
+            other => Err(executor_failure(&format!(
+                "unsupported expedition example capability: {other}"
+            ))),
+        }
+    }
+}
+
 fn execute_expedition_outcome(request_path: &Path) -> Result<RuntimeExecutionOutcome, CliError> {
     let request = load_runtime_request(request_path)?;
     let registered = load_registered_bundle(&canonical_expedition_bundle_path())?;
-    let runtime = Runtime::new(registered.capability_registry, ExpeditionExampleExecutor)
+    let runtime = Runtime::new(registered.capability_registry, ExpeditionCliExecutor)
         .with_workflow_registry(registered.workflow_registry)
         .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development());
     Ok(runtime.execute(request))
@@ -5480,10 +5542,10 @@ mod tests {
         canonical_expedition_bundle_path, capability_publish_at, component_new_at, curl_text,
         ensure_clean_registry_checkout, execute_capability_package, execute_expedition,
         execute_traverse_starter_process, execute_traverse_starter_summarize,
-        execute_traverse_starter_validate, help_serve, inspect_bundle, inspect_capability_package,
-        inspect_event, inspect_trace, latest_index_release_asset, load_registered_bundle,
-        load_registered_bundle_with_public_records, load_runtime_request, parse_command,
-        publish_file_sha256_digest, register_bundle, register_generated_app_bundle,
+        execute_traverse_starter_validate, help_expedition_execute, help_serve, inspect_bundle,
+        inspect_capability_package, inspect_event, inspect_trace, latest_index_release_asset,
+        load_registered_bundle, load_registered_bundle_with_public_records, load_runtime_request,
+        parse_command, publish_file_sha256_digest, register_bundle, register_generated_app_bundle,
         registry_record_order, registry_sync_at, registry_sync_default_or_override,
         registry_sync_failure_json, reject_private_contract_scope, run_command, sha256_hex,
         validate_registry_path_segment,
@@ -7294,6 +7356,53 @@ mod tests {
         assert!(output.contains("capability_id: expedition.planning.plan-expedition"));
         assert!(output.contains("status: completed"));
         assert!(output.contains("recommended_route_style: conservative-alpine-push"));
+    }
+
+    #[test]
+    fn expedition_execute_help_discloses_execution_honesty() {
+        let help = help_expedition_execute();
+
+        assert!(
+            help.contains("example implementations"),
+            "help text must disclose that capabilities run example implementations, not WASM"
+        );
+        assert!(
+            help.contains("capability-package execute"),
+            "help text must point to the command that proves real WASM execution"
+        );
+    }
+
+    #[test]
+    fn execute_expedition_rejects_a_capability_not_in_the_canonical_bundle() {
+        let temp_dir = unique_temp_dir();
+        let path = temp_dir.join("unknown-capability-request.json");
+        fs::write(
+            &path,
+            r#"{
+  "kind": "runtime_request",
+  "schema_version": "1.0.0",
+  "request_id": "unknown-capability-request",
+  "intent": {
+    "capability_id": "expedition.planning.not-a-real-capability",
+    "capability_version": "1.0.0"
+  },
+  "input": {},
+  "lookup": {
+    "scope": "prefer_private",
+    "allow_ambiguity": false
+  },
+  "context": {
+    "requested_target": "local"
+  },
+  "governing_spec": "006-runtime-request-execution"
+}"#,
+        )
+        .expect("runtime request should write");
+
+        let error = execute_expedition(&path, None, false, false)
+            .expect_err("unregistered capability id must fail closed");
+
+        assert!(error.message().contains("runtime execution failed"));
     }
 
     #[test]


### PR DESCRIPTION
## Project Item

Progresses traverse-framework/traverse#916 — **not closing it**. See "Scope decision and what's still open" below; leaving #916 open with a summary comment.

## Governing Spec

- `001-foundation-v0-1`

## Summary

`traverse-cli expedition execute`'s help text claimed to run the canonical expedition workflow "through the Traverse runtime," without disclosing that all six registered capabilities actually run a hand-written Rust reimplementation that never touches their checked-in WASM artifact. This PR fixes that specific, literal defect: help text now honestly discloses the behavior and points to `capability-package execute`, the command that already correctly executes real WASM end to end.

## What I investigated but did not ship, and why

The issue's core ask is to route `expedition execute` through `ArtifactRouter`/`WasmExecutor` (matching `capability-package execute` and `run_serve`) for capabilities that have a real artifact. I implemented this and ran it end to end. Two capabilities in the canonical bundle — `interpret-expedition-intent` and `validate-team-readiness` — do have a checked-in WASM artifact under `examples/capabilities/`. Wiring them in surfaced two blocking problems, confirmed empirically, not hypothetically:

1. **The artifacts are fixed-output ABI-conformance fixtures**, not input-driven business logic (see `examples/capabilities/*/src/agent.rs` — each is a `#![no_std]` binary that writes one hardcoded static byte string regardless of input). Their static output does not satisfy the *next* workflow node's input JSON-schema in the canonical `plan-expedition` composite (e.g. `interpret-expedition-intent`'s static `interpreted_intent` field is `{}`, but `assess-conditions-summary`'s input schema requires `interpreted_intent.route_preferences`/`.constraints`/etc.). Routing them in breaks `execute_expedition_runs_canonical_plan_request` and two other existing, passing tests with `workflow node input does not satisfy the capability input contract`.
2. **I tried correcting the fixture content** (editing the static output to be schema-compliant) and rebuilding. That fixed the chain, but broke 10 *other*, unrelated tests: these same two `.wasm` files are shared and digest-pinned by `examples/applications/expedition-readiness/*/component.manifest.json` and `examples/capabilities/*/manifest.json`, consumed by `capability-package execute` and `app validate`/`app register`. Changing the bytes invalidates those pinned digests.

So: real WASM execution for these two capabilities is currently only safe in isolation (which `capability-package execute` already does correctly) — not inside this composite workflow, without either breaking a different, working, tested surface or breaking the working, tested `expedition execute` demo itself. I reverted the fixture edits; `git status` confirms the `.wasm` files are back to their exact checked-in bytes.

Authoring real, chain-compatible business logic for the five atomic expedition-planning capabilities (so a real WASM artifact can safely replace the hand-written function in the composite) is separate, larger content work — not a drop-in fix belonging in this PR.

## Changes

- `crates/traverse-cli/src/main.rs`: renamed the dispatcher `ExpeditionExampleExecutor` → `ExpeditionCliExecutor` (dedicated to this command; the original struct is untouched and still used by `build_in_process_api`, out of scope here) with a doc comment stating the real current state and why. Removed the three dead `traverse-starter`/`meeting-notes` match arms this command's registry never reaches (only used by `build_in_process_api`'s separate registry).
- `help_expedition_execute()`: now discloses that all six capabilities run example implementations and points to `capability-package execute` for real WASM execution.
- Two new tests: `expedition_execute_help_discloses_execution_honesty` (locks in the disclosure) and `execute_expedition_rejects_a_capability_not_in_the_canonical_bundle` (a capability id outside the canonical bundle fails closed with a typed runtime error, not a silent fabricated result).

## Recommended follow-up

I'm leaving #916 open with a comment summarizing this finding, and suggesting a new, explicitly-scoped follow-up ticket for authoring real business-logic WASM for the five atomic expedition-planning capabilities (a prerequisite for fully closing #916 without breaking the composite demo or the digest-pinned fixtures elsewhere).

## Validation

- `cargo build -p traverse-cli-rs`
- `cargo test -p traverse-cli-rs --bin traverse-cli` — 322 passed, 0 failed (up from 320; two new tests)
- `cargo clippy -p traverse-cli-rs --all-targets -- -D warnings` and `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `git status` confirms `examples/capabilities/**` is unchanged (fixture-edit investigation fully reverted)
- No `unsafe`/`unwrap`/`expect`/`panic`/`todo` introduced
- `bash scripts/ci/spec_alignment_check.sh` run locally against this PR body
