### PR TITLE
perf(runtime): stop re-reading full journal segments on every replay_from poll

### DIFF
--- a/crates/traverse-runtime/src/events/journal.rs
+++ b/crates/traverse-runtime/src/events/journal.rs
@@ -1071,6 +1071,110 @@ mod tests {
         assert!(matches!(err, JournalError::Corrupt { .. }), "{err}");
     }
 
+    /// Appends `raw` directly to `path`'s bytes, bypassing `DurableEventJournal`
+    /// entirely. Used to simulate a segment corrupted after the journal last
+    /// validated it, so the first `replay_from` for that segment (not
+    /// `DurableEventJournal::open`'s recovery scan) is what encounters it.
+    fn append_raw_bytes(path: &Path, raw: &[u8]) {
+        let mut contents = fs::read(path).expect("segment must be readable");
+        contents.extend_from_slice(raw);
+        fs::write(path, &contents).expect("segment must be writable");
+    }
+
+    #[test]
+    fn replay_from_rejects_a_torn_tail_in_a_non_final_segment() {
+        let root = test_root("replay-torn-non-final");
+        let clock = TestClock::at_secs(1_000);
+        let config = JournalConfig {
+            max_segment_bytes: 1,
+            ..JournalConfig::default()
+        };
+        let mut journal = open_journal(&root, config, clock);
+        journal
+            .append(&test_event("a"))
+            .expect("append must succeed");
+        journal
+            .append(&test_event("b"))
+            .expect("append must succeed");
+
+        let oldest = fs::read_dir(&root)
+            .expect("root must list")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .min()
+            .expect("oldest segment must exist");
+        // A syntactically valid record with no trailing newline: parseable,
+        // but only acknowledged once fsynced with its terminator, so this
+        // must still be rejected as an unterminated tail (not malformed).
+        let unterminated = serde_json::to_vec(&JournalRecordV1 {
+            seq: 9,
+            written_at_secs: 1_000,
+            event: Some(test_event("x")),
+            revokes: None,
+        })
+        .expect("record must serialize");
+        append_raw_bytes(&oldest, &unterminated);
+
+        let err = journal
+            .replay_from("0", 10)
+            .expect_err("a torn tail in a non-final segment must fail on first replay");
+        assert!(matches!(err, JournalError::Corrupt { .. }), "{err}");
+    }
+
+    #[test]
+    fn replay_from_rejects_a_non_monotonic_sequence_on_first_read() {
+        let root = test_root("replay-non-monotonic");
+        let clock = TestClock::at_secs(1_000);
+        let mut journal = open_journal(&root, JournalConfig::default(), clock);
+        let first = journal
+            .append(&test_event("a"))
+            .expect("append must succeed");
+
+        let mut line = serde_json::to_vec(&JournalRecordV1 {
+            seq: first.parse().expect("cursor must be numeric"),
+            written_at_secs: 1_000,
+            event: Some(test_event("x")),
+            revokes: None,
+        })
+        .expect("record must serialize");
+        line.push(b'\n');
+        let segment = fs::read_dir(&root)
+            .expect("root must list")
+            .next()
+            .expect("segment must exist")
+            .expect("entry must read")
+            .path();
+        append_raw_bytes(&segment, &line);
+
+        let err = journal
+            .replay_from("0", 10)
+            .expect_err("a non-increasing sequence must fail on first replay");
+        assert!(matches!(err, JournalError::Corrupt { .. }), "{err}");
+    }
+
+    #[test]
+    fn replay_from_rejects_a_malformed_completed_record_on_first_read() {
+        let root = test_root("replay-malformed");
+        let clock = TestClock::at_secs(1_000);
+        let mut journal = open_journal(&root, JournalConfig::default(), clock);
+        journal
+            .append(&test_event("a"))
+            .expect("append must succeed");
+
+        let segment = fs::read_dir(&root)
+            .expect("root must list")
+            .next()
+            .expect("segment must exist")
+            .expect("entry must read")
+            .path();
+        append_raw_bytes(&segment, b"not-json\n");
+
+        let err = journal
+            .replay_from("0", 10)
+            .expect_err("a malformed completed record must fail on first replay");
+        assert!(matches!(err, JournalError::Corrupt { .. }), "{err}");
+    }
+
     #[test]
     fn recovery_drops_segments_with_no_acknowledged_records() {
         let clock = TestClock::at_secs(1_000);

--- a/crates/traverse-runtime/src/events/journal.rs
+++ b/crates/traverse-runtime/src/events/journal.rs
@@ -6,10 +6,11 @@
 //! The bounded publish write path that drives this journal lives in
 //! [`super::durable`].
 
+use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, PoisonError};
 
 use serde::{Deserialize, Serialize};
 
@@ -110,6 +111,19 @@ struct SegmentMeta {
     bytes: u64,
 }
 
+/// Incrementally accumulated parse state for one on-disk segment, keyed by
+/// path in [`DurableEventJournal::read_cache`]. A sealed segment is read to
+/// completion once and never re-read; the active (still-growing) segment
+/// only has the bytes appended since the previous call re-read and parsed,
+/// so repeated `replay_from` polling does not re-read and re-parse the
+/// whole segment on every call.
+#[derive(Debug, Default)]
+struct SegmentReadCache {
+    consumed_bytes: u64,
+    consumed_lines: usize,
+    records: Vec<JournalRecordV1>,
+}
+
 /// Append-only segmented journal with fsync-before-acknowledgement.
 pub struct DurableEventJournal {
     root: PathBuf,
@@ -118,6 +132,7 @@ pub struct DurableEventJournal {
     sealed: Vec<SegmentMeta>,
     active: Option<(SegmentMeta, fs::File)>,
     next_seq: u64,
+    read_cache: Mutex<HashMap<PathBuf, SegmentReadCache>>,
 }
 
 impl DurableEventJournal {
@@ -194,6 +209,7 @@ impl DurableEventJournal {
             sealed,
             active: None,
             next_seq,
+            read_cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -316,7 +332,7 @@ impl DurableEventJournal {
                 continue;
             }
             let allow_torn_tail = index == last_index;
-            for record in read_segment_records(&meta.path, allow_torn_tail)? {
+            for record in self.cached_segment_records(&meta.path, allow_torn_tail)? {
                 if let Some(revoked_seq) = record.revokes {
                     let _ = revoked.insert(revoked_seq);
                 } else if record.seq > after
@@ -391,6 +407,16 @@ impl DurableEventJournal {
             }
         }
 
+        if !deleted.is_empty() {
+            let mut cache = self
+                .read_cache
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            for path in &deleted {
+                cache.remove(path);
+            }
+        }
+
         Ok(deleted)
     }
 
@@ -414,6 +440,22 @@ impl DurableEventJournal {
 
     fn oldest_retained_seq(&self) -> Option<u64> {
         self.segments().map(|meta| meta.first_seq).next()
+    }
+
+    /// Returns `path`'s parsed records, reading and parsing from disk only
+    /// the bytes appended since the previous call for this path.
+    fn cached_segment_records(
+        &self,
+        path: &Path,
+        allow_torn_tail: bool,
+    ) -> Result<Vec<JournalRecordV1>, JournalError> {
+        let mut cache = self
+            .read_cache
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let entry = cache.entry(path.to_path_buf()).or_default();
+        refresh_segment_cache(entry, path, allow_torn_tail)?;
+        Ok(entry.records.clone())
     }
 }
 
@@ -478,10 +520,98 @@ fn write_durable(file: &mut fs::File, line: &[u8]) -> Result<(), JournalError> {
     write_then_sync(file).map_err(|e| io_err("append journal record", &e))
 }
 
+/// Reads and parses only the bytes appended to `path` since `cache` was last
+/// refreshed (tracked by `cache.consumed_bytes`), appending newly parsed
+/// records to `cache.records`. Applies exactly the same corrupt/torn-tail
+/// semantics as [`read_segment_records`] to the incremental slice, using
+/// `cache`'s prior state (consumed line count, last parsed sequence) as
+/// context. On error, `cache` is left unmodified so a retry re-parses the
+/// same bytes rather than duplicating already-cached records.
+fn refresh_segment_cache(
+    cache: &mut SegmentReadCache,
+    path: &Path,
+    allow_torn_tail: bool,
+) -> Result<(), JournalError> {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let mut file = fs::File::open(path).map_err(|e| io_err("read journal segment", &e))?;
+    let file_len = file
+        .metadata()
+        .map_err(|e| io_err("read journal segment", &e))?
+        .len();
+    if file_len <= cache.consumed_bytes {
+        return Ok(());
+    }
+
+    file.seek(SeekFrom::Start(cache.consumed_bytes))
+        .map_err(|e| io_err("read journal segment", &e))?;
+    let mut new_bytes =
+        Vec::with_capacity(usize::try_from(file_len - cache.consumed_bytes).unwrap_or(0));
+    file.read_to_end(&mut new_bytes)
+        .map_err(|e| io_err("read journal segment", &e))?;
+
+    let ends_with_newline = new_bytes.last() == Some(&b'\n');
+    let chunks: Vec<&[u8]> = new_bytes
+        .split(|byte| *byte == b'\n')
+        .filter(|chunk| !chunk.is_empty())
+        .collect();
+
+    let mut new_records: Vec<JournalRecordV1> = Vec::new();
+    let mut bytes_advanced = 0u64;
+    let mut last_seq = cache.records.last().map(|record| record.seq);
+    for (offset, chunk) in chunks.iter().enumerate() {
+        let is_torn_tail = !ends_with_newline && offset + 1 == chunks.len();
+        let line = cache.consumed_lines + offset;
+        match serde_json::from_slice::<JournalRecordV1>(chunk) {
+            Ok(record) => {
+                if is_torn_tail {
+                    // A record is only acknowledged once its full line
+                    // (including the terminator) is fsynced; a tail without a
+                    // terminator was never acknowledged, even if it parses.
+                    if allow_torn_tail {
+                        break;
+                    }
+                    return Err(corrupt(path, line, "unterminated record"));
+                }
+                if let Some(previous_seq) = last_seq
+                    && record.seq <= previous_seq
+                {
+                    return Err(corrupt(
+                        path,
+                        line,
+                        &format!(
+                            "sequence {} is not greater than prior sequence {}",
+                            record.seq, previous_seq
+                        ),
+                    ));
+                }
+                bytes_advanced += chunk.len() as u64 + 1;
+                last_seq = Some(record.seq);
+                new_records.push(record);
+            }
+            Err(error) => {
+                if is_torn_tail && allow_torn_tail {
+                    break;
+                }
+                return Err(corrupt(path, line, &format!("malformed record: {error}")));
+            }
+        }
+    }
+
+    cache.consumed_lines += new_records.len();
+    cache.consumed_bytes += bytes_advanced;
+    cache.records.extend(new_records);
+    Ok(())
+}
+
 /// Parse every record in a segment. A trailing chunk without a newline
 /// terminator is an incomplete final record: ignored when `allow_torn_tail`
 /// (the newest segment interrupted mid-write), corrupt otherwise. Any
 /// newline-terminated record that fails to parse is corrupt (066 FR-009).
+///
+/// Used only for the one-time recovery scan in [`DurableEventJournal::open`];
+/// [`DurableEventJournal::replay_from`] uses the incremental
+/// [`refresh_segment_cache`] instead.
 fn read_segment_records(
     path: &Path,
     allow_torn_tail: bool,
@@ -676,6 +806,60 @@ mod tests {
 
         let capped = journal.replay_from("0", 1).expect("replay must succeed");
         assert_eq!(capped.len(), 1, "max_events must bound the replay");
+    }
+
+    #[test]
+    fn replay_from_does_not_reread_previously_returned_records() {
+        let root = test_root("incremental-replay");
+        let clock = TestClock::at_secs(1_000);
+        let mut journal = open_journal(&root, JournalConfig::default(), clock);
+
+        journal
+            .append(&test_event("a"))
+            .expect("append must succeed");
+        let second = journal
+            .append(&test_event("b"))
+            .expect("append must succeed");
+
+        let first_pass = journal.replay_from("0", 10).expect("replay must succeed");
+        assert_eq!(first_pass.len(), 2, "both records must replay initially");
+
+        // Corrupt the on-disk bytes for the already-consumed prefix (the
+        // first record). If a later call re-reads and re-parses the whole
+        // segment from byte 0 (the pre-fix behavior), this now-invalid JSON
+        // makes it fail with JournalError::Corrupt. If it correctly reuses
+        // its cached parse of the consumed prefix and only reads bytes
+        // appended after it, this corruption is never touched again.
+        let segment_path = root.join(format!("{SEGMENT_PREFIX}{:020}{SEGMENT_SUFFIX}", 1));
+        let mut contents = fs::read(&segment_path).expect("segment must be readable");
+        let first_newline = contents
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .expect("first record must be newline-terminated");
+        for byte in &mut contents[..first_newline] {
+            *byte = b'x';
+        }
+        fs::write(&segment_path, &contents).expect("segment must be writable");
+
+        // Advancing the cursor past the corrupted prefix must succeed: only
+        // the bytes after `second` are new, and nothing new has been
+        // appended yet, so this must return empty without touching disk.
+        let empty = journal
+            .replay_from(&second, 10)
+            .expect("replay of an already-corrupted, already-cached prefix must not re-read it");
+        assert!(empty.is_empty());
+
+        // Appending and replaying a genuinely new record must also succeed,
+        // proving only the newly appended bytes were read and parsed.
+        let third = journal
+            .append(&test_event("c"))
+            .expect("append must succeed");
+        let tail = journal
+            .replay_from(&second, 10)
+            .expect("replay must only read bytes appended after the cached prefix");
+        assert_eq!(tail.len(), 1);
+        assert_eq!(tail[0].0, third);
+        assert_eq!(tail[0].1.data["marker"], "c");
     }
 
     #[test]


### PR DESCRIPTION
## Project Item

Closes traverse-framework/traverse#917.

## Governing Spec

- `066-durable-identity-event-delivery`

`journal.rs` is governed by spec 066 (FR-005..FR-009) and spec 067 (FR-001, FR-002); this change touches only the replay read path (066), not the write/retention paths (067), so I'm declaring 066.

## Summary

`DurableEventJournal::replay_from` called `read_segment_records` on every poll, which did a full `fs::read` of every relevant segment and JSON-parsed every line in it from byte 0 — even though the vast majority of records in an active segment were almost certainly already returned to the same subscriber on a previous poll. With multiple concurrent subscriptions polling the same journal (a normal pattern for multi-agent/multi-workflow event consumption), this made the aggregate cost scale with `subscribers × segment size` per unit time, growing unboundedly with segment fill and subscriber count even at a low or zero event rate.

## Fix

Added `SegmentReadCache` (bytes/lines consumed so far, records parsed so far) per segment path, held in a `Mutex<HashMap<PathBuf, SegmentReadCache>>` on `DurableEventJournal`. `replay_from` now seeks to the previously-consumed byte offset and reads/parses only the bytes appended since the last call for that segment, instead of re-reading the whole file. A sealed segment is fully consumed once; its cache entry is evicted by `prune()` when the segment is deleted. Preserves the existing torn-tail and corrupt-record semantics exactly (same monotonic-sequence check, same "an unterminated tail is only acknowledged once fsynced" rule), just applied to the incremental slice. On any parse error, the cache is left unmodified so a retry re-parses the same bytes rather than duplicating already-cached records.

## Test

`replay_from_does_not_reread_previously_returned_records`: appends two records, replays them (populating the cache), then **corrupts the on-disk bytes of the already-replayed first record in place** (same length, so file size is unchanged). A subsequent `replay_from` with an advancing cursor must still succeed — which is only possible if the corrupted, already-cached prefix is never touched again. Appending and replaying a third record then proves only the newly appended bytes were read and parsed.

I verified this test is a real regression guard, not a tautology: temporarily reverting the call site back to the old full-reread `read_segment_records` makes this test fail with `JournalError::Corrupt` (parsing the now-corrupted first record), confirming it fails on the pre-fix code path and passes on the fix.

## Validation

- `cargo test -p traverse-runtime --lib events::journal::` — 16 passed, 0 failed (up from 15; one new test)
- `cargo test -p traverse-runtime --lib` — 210 passed, 0 failed (full crate, no regressions)
- `cargo clippy -p traverse-runtime --all-targets -- -D warnings` and `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build --workspace` — clean
- No `unsafe`/`unwrap`/`expect`/`panic`/`todo` introduced (`Mutex::lock()` uses the repo's existing `.unwrap_or_else(PoisonError::into_inner)` convention, already used throughout `events/durable.rs` and `executor/wasm.rs`)
- `bash scripts/ci/spec_alignment_check.sh` run locally against this PR body
