### PR TITLE
spec(088): opt-in runtime usage telemetry, decision 42, ADR-0030

### DIFF
--- a/docs/adr/0030-runtime-usage-telemetry.md
+++ b/docs/adr/0030-runtime-usage-telemetry.md
@@ -1,0 +1,77 @@
+# ADR-0030: Opt-In Runtime Usage Telemetry Behind a Provider-Neutral Port
+
+- Status: Accepted
+- Date: 2026-08-04
+- Governing spec: `536-runtime-usage-telemetry` / `088-runtime-usage-telemetry`
+- Decision evidence: `docs/decision-log.md` Decision 42, originating in
+  `traverse-framework/registry`'s Decision 47 (registry#134)
+- Extends: ADR-0029 (provider-neutral port precedent)
+
+## Context
+
+There is no signal today for whether a published capability is actually
+resolved or executed by real consumers, only whether it exists in the
+registry index. `traverse-framework/registry` brainstormed the policy for a
+maintainer-facing adoption signal (registry decision 47) and handed off the
+architecture to this repo, since the only components that can observe
+resolve/execute events — `traverse-cli` and the shared `traverse-contracts`
+port surface — live here. `crates/traverse-registry`, where resolution
+itself happens, was extracted to `traverse-framework/registry` (Spec 051)
+and cannot take on a concrete network/telemetry dependency without breaking
+its own portability and that repo's inherited-governance boundary
+(`013-inherited-registry-governance` FR-002).
+
+## Decision
+
+Add a `UsageTelemetrySink` port trait to `traverse-contracts`, with a no-op
+default — the same provider-neutral-port pattern ADR-0029 established for
+hosted DataStore transport. `traverse-cli` owns the only real
+implementation: a persistent, prompt-free opt-in config command, a locally
+generated anonymous install ID, and an HTTPS client to a purpose-built
+hosted product-analytics collector (e.g. PostHog). `crates/traverse-registry`
+calls the port at its resolution call site (contract defined here as FR-008;
+the actual call site is `traverse-framework/registry`'s own governed change,
+tracked as that repo's Spec 015) but never links against the concrete
+adapter, network code, or opt-in state — it only ever sees the trait, and by
+default the no-op implementation.
+
+Consent is opt-in and off by default, with no interactive prompts anywhere.
+Every event carries exactly four fields (event type, `namespace/id@version`,
+timestamp, anonymous install ID) — no CLI version, OS, hostname, or IP.
+Sends are fire-and-forget with a short timeout; any failure is swallowed
+completely so telemetry can never add latency or a new failure mode to a
+real command.
+
+## Consequences
+
+- Capability adoption/orphan visibility becomes possible for the first time,
+  without any component gaining a hard telemetry dependency.
+- `crates/traverse-registry` stays portable and fully testable offline; the
+  no-op default means today's behavior is unchanged until `traverse-cli`
+  wires the real adapter and a user opts in.
+- Two repos must coordinate a release sequence: this repo publishes the
+  trait in `traverse-contracts` first, `traverse-framework/registry` bumps
+  its pinned dependency and adds the resolve-side call, then this repo bumps
+  its own `traverse-registry` dependency to pick it up.
+- Adoption of the telemetry itself will likely be low precisely because it
+  is opt-in with no prompts — accepted deliberately, matching this
+  ecosystem's existing no-consent-UI posture (registry decision 45) rather
+  than trading it away for higher data volume.
+
+## Alternatives Considered
+
+- Opt-out by default: rejected — a materially bigger trust decision than
+  anything else in either repo's history, requiring real disclosure/consent
+  design neither repo has built.
+- Reuse registry's existing Plausible website-analytics account: rejected —
+  Plausible's event/property model is website-pageview-shaped, a weaker fit
+  for arbitrary CLI event properties than a tool built for anonymous
+  distinct-ID-plus-custom-event tracking.
+- Self-hosted collector (e.g. a Cloudflare Worker): rejected — first piece
+  of maintained backend infrastructure either repo would own, a bigger
+  operational shift than this feature's value justifies today.
+- Instrumenting `crates/traverse-registry` directly with a concrete HTTP
+  client: rejected — would break that crate's portability/offline
+  testability and cross the inherited-governance boundary from
+  `013-inherited-registry-governance` FR-002 without a dedicated spec in its
+  own repo.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1178,3 +1178,60 @@ maintenance are unsupported in v1.
 
 Unlocks Spec 085 approval path for web permanence without blocking on crypto
 or zip-backup parity.
+
+## Decision 42: Opt-In, Anonymous Runtime Usage Telemetry Behind a Provider-Neutral Port
+
+- **Date**: 2026-08-04
+- **Status**: Accepted
+- **Governing spec**: `088-runtime-usage-telemetry` (`specs/536-runtime-usage-telemetry`)
+- **Related ADR**: ADR-0030
+- **Related Project 1**: Runtime usage telemetry for capability resolve/execute
+- **Origin**: `traverse-framework/registry`'s `docs/decision-log.md` Decision 47
+  (registry `/brainstorm`, closing registry#134), handed off here per that
+  entry's own execution boundary since the actual instrumentation touches
+  `traverse-cli` and the shared `traverse-contracts` port, both owned by this
+  repo (`crates/traverse-registry`, where capability *resolution* actually
+  happens, was extracted to `traverse-framework/registry` by Spec 051 and is
+  governed there under its own `013-inherited-registry-governance`/FR-002 —
+  this decision does not re-litigate that boundary).
+
+### Decision
+
+Runtime usage telemetry answers "is a published capability actually being
+resolved/executed," distinct from this repo's OTel integrated-observability
+work (Spec 029, operator-facing traces/logs/metrics for a single deployment).
+It is a separate, deliberately minimal, opt-in-only signal reported to the
+Traverse maintainers, not an operator-facing signal.
+
+- Two counters, not one: a `resolve` event (registry version lookup) and an
+  `execute` event (`capability execute`/`serve`, actual WASM invocation),
+  tracked per exact `namespace/id@version`.
+- **Opt-in, off by default.** No prompts, ever. A persistent CLI config
+  command (`traverse-cli telemetry enable`/`disable`) is the only way to turn
+  it on.
+- Each event carries `namespace/id@version`, event type, timestamp, and an
+  anonymous random install ID (a UUID generated once locally on first
+  opt-in) — enough to distinguish one automated pipeline from many distinct
+  users, nothing that identifies a real person or machine.
+- Collected by a purpose-built hosted product-analytics tool (e.g. PostHog),
+  not this repo's website-analytics account (a different, cookie-based-web
+  shaped tool) and not new self-hosted infrastructure.
+- Sent fire-and-forget with a short timeout; any failure is swallowed
+  silently and must never delay or fail the real CLI command it's attached
+  to.
+- Architecturally: a `UsageTelemetrySink` port trait lives in
+  `traverse-contracts` (the existing pattern for provider-neutral ports, see
+  ADR-0029's transport-port precedent) with a no-op default. `traverse-cli`
+  owns the only real adapter (config, install ID, PostHog HTTP client).
+  `crates/traverse-registry` (external, `traverse-framework/registry`-owned)
+  calls the port at its resolution call site but never depends on the
+  concrete adapter, network code, or opt-in state directly — that keeps the
+  registry crate portable and testable without a live collector, matching
+  how the hosted-transport port (Spec 087) keeps DataStore sync provider-blind.
+
+### Outcome
+
+Unlocks Spec 088 approval path. `crates/traverse-registry`'s own resolve-side
+hook is out of this repo's governance — tracked as its own spec
+(`traverse-framework/registry`'s Spec 015) and ticket in that repo's Project 3,
+sequenced behind this repo publishing the new `traverse-contracts` trait.

--- a/specs/536-runtime-usage-telemetry/spec.md
+++ b/specs/536-runtime-usage-telemetry/spec.md
@@ -127,12 +127,12 @@ Out of scope (tracked elsewhere or deliberately deferred):
 
 ## Implementation Tickets
 
-- Traverse #925 — add `UsageTelemetrySink` port trait to `traverse-contracts`
-- Traverse #926 — `traverse-cli`: `telemetry enable`/`disable` command,
+- Traverse #927 — add `UsageTelemetrySink` port trait to `traverse-contracts`
+- Traverse #928 — `traverse-cli`: `telemetry enable`/`disable` command,
   install ID, PostHog adapter
-- Traverse #927 — `traverse-cli`: emit `execute` event from `capability
+- Traverse #929 — `traverse-cli`: emit `execute` event from `capability
   execute`/`serve`
-- Traverse #928 — `traverse-cli`: bump `traverse-registry` dependency once
+- Traverse #930 — `traverse-cli`: bump `traverse-registry` dependency once
   registry's resolve-hook (registry Spec 015) ships
-- `traverse-framework/registry`#144 — `crates/traverse-registry`: emit
+- `traverse-framework/registry`#145 — `crates/traverse-registry`: emit
   `resolve` event via the port (registry Spec 015, that repo's Project 3)

--- a/specs/536-runtime-usage-telemetry/spec.md
+++ b/specs/536-runtime-usage-telemetry/spec.md
@@ -1,0 +1,138 @@
+# Feature Specification: Opt-In Runtime Usage Telemetry for Published Capabilities
+
+**Status**: Approved
+**Canonical governing ID**: `088-runtime-usage-telemetry`
+**Extends**: `087-hosted-datastore-transport` (provider-neutral port precedent), `029-integrated-observability` (distinguished from, not superseded by — see Scope)
+**Decision evidence**: `docs/decision-log.md` Decision 42, itself handed off from `traverse-framework/registry`'s `docs/decision-log.md` Decision 47 (registry `/brainstorm`, closing registry#134)
+
+## Purpose
+
+Define an opt-in, anonymous signal for how often a published capability is
+actually **resolved** (a registry version lookup) and **executed** (a real
+WASM invocation via `capability execute`/`serve`), reported to the Traverse
+maintainers so capability adoption and unused/orphaned capabilities become
+visible.
+
+This is deliberately not the same concern as Spec 029 (Integrated
+Observability): Spec 029 is an operator-facing OTel signal scoped to a single
+deployment, always under that deployment's own control and export
+configuration. This spec defines a maintainer-facing, cross-deployment
+adoption signal, sent only when a user explicitly opts in, to a fixed
+maintainer-owned collector, not a configurable OTLP endpoint. The two systems
+share no code path and neither depends on the other.
+
+## Scope
+
+In scope:
+
+- a provider-neutral `UsageTelemetrySink` port in `traverse-contracts`, with a
+  no-op default
+- a `traverse-cli` adapter: persistent opt-in/opt-out config command, a
+  locally generated anonymous install ID, and a hosted product-analytics
+  collector client (e.g. PostHog)
+- an `execute` event emitted from `traverse-cli`'s `capability execute`/
+  `serve` command path
+- the contract that `crates/traverse-registry`'s resolution path calls the
+  port for a `resolve` event on every successful resolution
+
+Out of scope (tracked elsewhere or deliberately deferred):
+
+- the actual `resolve`-event call site inside `crates/traverse-registry` —
+  that crate was extracted to, and is now governed by,
+  `traverse-framework/registry` (Spec 051 extraction; `013-inherited-registry-governance`
+  FR-002 requires any new behavior there to go through a new spec in that
+  repo, not this one). See `traverse-framework/registry`'s Spec 015.
+- any public-facing display of usage counts (registry decision 47: admin-only
+  dashboard for now)
+- richer diagnostic payloads (CLI version, OS, etc.) beyond the fields in
+  FR-004
+- a self-hosted collector or new backend infrastructure of any kind
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: A `UsageTelemetrySink` trait MUST be added to `traverse-contracts`,
+  exposing a method to record a usage event (event type `resolve` or
+  `execute`, a capability reference `namespace/id@version`, and a timestamp).
+  A no-op implementation MUST be the default so that no caller (including
+  `crates/traverse-registry`) takes on a network or configuration dependency
+  merely by calling the port.
+- **FR-002**: `traverse-cli` MUST provide a persistent local opt-in mechanism
+  (`traverse-cli telemetry enable` / `telemetry disable`), off by default.
+  Enabling telemetry MUST NOT display any interactive prompt at any other
+  time; there MUST be no env-var-only or first-run-prompt path to enabling
+  it.
+- **FR-003**: On first successful `telemetry enable`, `traverse-cli` MUST
+  generate a random UUID once and persist it in local CLI config as the
+  install ID. This ID MUST NOT be derived from or combined with any
+  machine-identifying, network-identifying, or personally-identifying value.
+- **FR-004**: Every event `traverse-cli`'s real `UsageTelemetrySink`
+  implementation sends MUST contain exactly: event type (`resolve` or
+  `execute`), `namespace/id@version`, an event timestamp, and the install ID
+  from FR-003. It MUST NOT contain CLI version, OS, hostname, IP address, or
+  any other field.
+- **FR-005**: `traverse-cli`'s real sink implementation MUST send each event
+  to a purpose-built hosted product-analytics collector (e.g. PostHog) over
+  HTTPS, fire-and-forget, with a short send timeout (target: 1-2 seconds).
+  Any failure (timeout, DNS failure, non-2xx response, or collector
+  unavailability) MUST be swallowed completely: it MUST NOT delay, retry
+  synchronously, fail, or log — even in verbose/debug output — the CLI
+  command the event is attached to.
+- **FR-006**: `traverse-cli` MUST emit an `execute` event through the sink
+  each time `capability execute`/`serve` completes a real WASM invocation,
+  only when telemetry is enabled (FR-002).
+- **FR-007**: When telemetry is disabled (the default), `traverse-cli` MUST
+  wire the no-op `UsageTelemetrySink` (FR-001) so that no network call of any
+  kind related to this spec ever occurs.
+- **FR-008**: `crates/traverse-registry`'s resolution path MUST accept an
+  optional, caller-supplied `UsageTelemetrySink` and, on a successful
+  version resolution, MUST invoke it with a `resolve` event carrying the
+  resolved `namespace/id@version`. A failed resolution MUST NOT emit an
+  event. This requirement defines the contract `traverse-cli` and
+  `crates/traverse-registry` (as of `traverse-framework/registry` Spec 015)
+  must both satisfy; it does not itself change `crates/traverse-registry`'s
+  code (out of this repo's governance, see Scope).
+
+## Acceptance Scenarios
+
+1. Given a fresh `traverse-cli` install with telemetry never enabled, when
+   `registry sync` or `capability execute` runs, then no network call to any
+   telemetry collector occurs.
+2. Given a user runs `traverse-cli telemetry enable`, when they run it again
+   on the same machine, then the same install ID persists (it is not
+   regenerated) and no interactive prompt is ever shown.
+3. Given telemetry is enabled and a capability executes successfully via
+   `capability execute`, when the event is sent, then it contains exactly
+   the four fields in FR-004 and no others.
+4. Given telemetry is enabled and the collector is unreachable, when
+   `capability execute` runs, then the command completes with its normal
+   exit code and output, unaffected by the telemetry failure.
+5. Given telemetry is disabled, when any command that could emit a usage
+   event runs, then the no-op sink is used and no collector code path
+   executes at all.
+
+## Quality Gates
+
+- **QG-001**: A unit test MUST prove the no-op `UsageTelemetrySink` is wired
+  whenever telemetry is disabled, with no HTTP client constructed.
+- **QG-002**: A unit test MUST prove the real sink's payload contains exactly
+  the FR-004 field set (no accidental extra fields) for both `resolve` and
+  `execute` event types.
+- **QG-003**: A test MUST simulate collector timeout/failure and assert the
+  invoking command's exit code and output are unaffected.
+- **QG-004**: A test MUST prove the install ID persists across repeated CLI
+  invocations after `telemetry enable` and is a v4 UUID with no embedded
+  machine-identifying data.
+
+## Implementation Tickets
+
+- Traverse #925 — add `UsageTelemetrySink` port trait to `traverse-contracts`
+- Traverse #926 — `traverse-cli`: `telemetry enable`/`disable` command,
+  install ID, PostHog adapter
+- Traverse #927 — `traverse-cli`: emit `execute` event from `capability
+  execute`/`serve`
+- Traverse #928 — `traverse-cli`: bump `traverse-registry` dependency once
+  registry's resolve-hook (registry Spec 015) ships
+- `traverse-framework/registry`#144 — `crates/traverse-registry`: emit
+  `resolve` event via the port (registry Spec 015, that repo's Project 3)

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1132,6 +1132,19 @@
         "docs/adr/0029-hosted-datastore-transport.md",
         "specs/535-hosted-datastore-transport/"
       ]
+    },
+    {
+      "id": "088-runtime-usage-telemetry",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/536-runtime-usage-telemetry/spec.md",
+      "governs": [
+        "crates/traverse-contracts/",
+        "crates/traverse-cli/",
+        "docs/adr/0030-runtime-usage-telemetry.md",
+        "specs/536-runtime-usage-telemetry/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Codifies `traverse-framework/registry`'s decision 47 (that repo's `/brainstorm`, closing registry#134) as a real Traverse spec: opt-in-only runtime usage telemetry for capability `resolve`/`execute` events. Adds `docs/decision-log.md` Decision 42, `specs/536-runtime-usage-telemetry/spec.md` (canonical `088-runtime-usage-telemetry`), `docs/adr/0030-runtime-usage-telemetry.md`, and registers the spec as approved in `specs/governance/approved-specs.json`.

Architecture: a `UsageTelemetrySink` port trait in `traverse-contracts` (no-op default, same provider-neutral-port pattern as ADR-0029's hosted transport), with `traverse-cli` owning the only real adapter (opt-in config command, anonymous install ID, PostHog HTTP client). `crates/traverse-registry` (extracted to, and governed by, `traverse-framework/registry`) calls the port at its resolve call site under a contract this spec defines (FR-008), but that repo's own actual code change is tracked as its own spec there (Spec 015), per `013-inherited-registry-governance` FR-002 — not this repo's governance to claim.

Prose/governance only in this PR — no Rust code changes. Implementation is tracked as four separate tickets (traverse-contracts port, CLI command + PostHog adapter, execute-event wiring, dependency bump) plus one ticket in the registry repo for the resolve-side hook.

## Governing Spec

- 065-sigstore-bundle-verification
- 088-runtime-usage-telemetry

## Project Item

Closes #924 (design-proposal issue this PR codifies as a real spec)

## What Changed

- Contracts changed: none in this PR (spec only; `UsageTelemetrySink` trait itself is a separate implementation ticket)
- Runtime behavior changed: none
- Compatibility impact: none
- ADR needed or linked: ADR-0030 (this PR)

## Validation

- [x] Spec alignment checked (`BASE_SHA=origin/main HEAD_SHA=HEAD scripts/ci/spec_alignment_check.sh` run locally, passed)
- [x] Contract alignment checked (no contracts touched)
- [ ] Tests updated and passing (no code in this PR)
- [x] Core coverage preserved (no code in this PR)
- [ ] Required validation gates passing (pending CI)

## Notes

`crates/traverse-registry`'s own resolve-hook implementation is explicitly out of scope for this repo per `013-inherited-registry-governance` FR-002 — see `traverse-framework/registry`'s own Spec 015 and its Project 3 ticket.
