### PR TITLE
feat(contracts): add UsageTelemetrySink port trait

### DIFF
--- a/crates/traverse-contracts/src/lib.rs
+++ b/crates/traverse-contracts/src/lib.rs
@@ -5,7 +5,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeSet, HashSet};
 
+pub mod usage_telemetry;
 pub mod violations;
+pub use usage_telemetry::{NoOpUsageTelemetrySink, UsageEvent, UsageEventKind, UsageTelemetrySink};
 pub use violations::ViolationRecord;
 
 const CAPABILITY_CONTRACT_KIND: &str = "capability_contract";

--- a/crates/traverse-contracts/src/usage_telemetry.rs
+++ b/crates/traverse-contracts/src/usage_telemetry.rs
@@ -1,0 +1,113 @@
+//! Provider-neutral usage-telemetry port (spec `088-runtime-usage-telemetry`
+//! FR-001). No caller of [`UsageTelemetrySink`] takes on a network or
+//! configuration dependency merely by calling it: [`NoOpUsageTelemetrySink`]
+//! is the default and performs no I/O of any kind.
+
+/// Which kind of usage event occurred (spec 088 FR-001).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UsageEventKind {
+    /// A registry version lookup resolved successfully.
+    Resolve,
+    /// A capability was executed via a real WASM invocation.
+    Execute,
+}
+
+/// One usage-telemetry event: exactly the capability-identifying fields
+/// spec 088 FR-004 permits (the install ID, also required by FR-004, is
+/// attached by the caller's concrete sink implementation, not this port).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UsageEvent {
+    /// Which kind of event occurred.
+    pub kind: UsageEventKind,
+    /// The capability reference, formatted as `namespace/id@version`.
+    pub capability_ref: String,
+    /// Event timestamp (ISO 8601).
+    pub timestamp: String,
+}
+
+/// Provider-neutral port for recording usage-telemetry events.
+///
+/// Implementations MUST NOT block or fail the caller on downstream failure:
+/// per FR-005, any collector failure (timeout, DNS, non-2xx) must be
+/// swallowed entirely by the concrete sink, never surfaced through `record`.
+pub trait UsageTelemetrySink: Send + Sync {
+    /// Records one usage event.
+    fn record(&self, event: UsageEvent);
+}
+
+/// Default [`UsageTelemetrySink`]: performs no I/O of any kind (FR-001,
+/// FR-007). Wired whenever telemetry is disabled or unconfigured, so no
+/// caller (including `crates/traverse-registry`) takes on a network or
+/// configuration dependency merely by holding a sink.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoOpUsageTelemetrySink;
+
+impl UsageTelemetrySink for NoOpUsageTelemetrySink {
+    fn record(&self, _event: UsageEvent) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_op_sink_records_without_side_effects() {
+        let sink = NoOpUsageTelemetrySink;
+        sink.record(UsageEvent {
+            kind: UsageEventKind::Resolve,
+            capability_ref: "hello.world/say-hello@1.0.0".to_string(),
+            timestamp: "2026-08-04T00:00:00Z".to_string(),
+        });
+        sink.record(UsageEvent {
+            kind: UsageEventKind::Execute,
+            capability_ref: "hello.world/say-hello@1.0.0".to_string(),
+            timestamp: "2026-08-04T00:00:00Z".to_string(),
+        });
+    }
+
+    #[test]
+    #[allow(clippy::clone_on_copy, clippy::default_constructed_unit_structs)]
+    fn no_op_sink_default_clone_and_debug_are_stable() {
+        let sink = NoOpUsageTelemetrySink::default();
+        let cloned = sink.clone();
+        assert_eq!(format!("{sink:?}"), format!("{cloned:?}"));
+        assert_eq!(format!("{sink:?}"), "NoOpUsageTelemetrySink");
+    }
+
+    #[test]
+    fn no_op_sink_is_usable_as_a_trait_object() {
+        let sink: Box<dyn UsageTelemetrySink> = Box::new(NoOpUsageTelemetrySink);
+        sink.record(UsageEvent {
+            kind: UsageEventKind::Resolve,
+            capability_ref: "a.b/c@1.0.0".to_string(),
+            timestamp: "t".to_string(),
+        });
+    }
+
+    #[test]
+    fn usage_event_kind_equality_and_debug() {
+        assert_eq!(UsageEventKind::Resolve, UsageEventKind::Resolve);
+        assert_ne!(UsageEventKind::Resolve, UsageEventKind::Execute);
+        assert_eq!(format!("{:?}", UsageEventKind::Resolve), "Resolve");
+        assert_eq!(format!("{:?}", UsageEventKind::Execute), "Execute");
+        assert_eq!(UsageEventKind::Execute.clone(), UsageEventKind::Execute);
+    }
+
+    #[test]
+    fn usage_event_equality_clone_and_debug() {
+        let event = UsageEvent {
+            kind: UsageEventKind::Resolve,
+            capability_ref: "a.b/c@1.0.0".to_string(),
+            timestamp: "t".to_string(),
+        };
+        let cloned = event.clone();
+        assert_eq!(event, cloned);
+        assert!(format!("{event:?}").contains("Resolve"));
+
+        let different = UsageEvent {
+            kind: UsageEventKind::Execute,
+            ..event.clone()
+        };
+        assert_ne!(event, different);
+    }
+}


### PR DESCRIPTION
## Project Item

Closes traverse-framework/traverse#927.

## Governing Spec

- `088-runtime-usage-telemetry`

## Summary

Adds the provider-neutral `UsageTelemetrySink` port to `traverse-contracts`, required by spec 088 FR-001: a trait for recording a usage event (`resolve`/`execute`, a `namespace/id@version` capability reference, and a timestamp), plus `NoOpUsageTelemetrySink`, a no-op default. No caller — including `crates/traverse-registry` (external, `traverse-framework/registry`) — takes on a network or configuration dependency merely by holding a sink, since the default implementation performs no I/O of any kind.

This is the shared boundary both `traverse-cli` (issues #928/#929, this repo) and the externally-owned `traverse-registry` crate (Spec 015 there) call into. Same provider-neutral port pattern ADR-0029 established for hosted DataStore transport.

## Out of scope (tracked in follow-on tickets per the spec)

- The real `traverse-cli` sink implementation, `telemetry enable`/`disable` command, install ID generation, and PostHog adapter (#928).
- Emitting the `execute` event from `capability execute`/`serve` (#929).
- Bumping `traverse-cli`'s `traverse-registry` dependency once the registry's resolve-hook ships (#930).
- The actual `resolve`-event call site inside `crates/traverse-registry` (`traverse-framework/registry`#145, out of this repo's governance per Spec 051 extraction).

Per the ticket's own Definition of Done, I did not bump the crate version in this PR: nothing outside this crate consumes the new trait yet (that starts with #928), so there's no real publish/pin need yet, and bumping the shared workspace version for a not-yet-consumed addition seemed premature. Happy to bump it now if that's the preferred convention — let me know.

## Validation

- `cargo test -p traverse-contracts` — 39 passed, 0 failed (up from 34; 5 new tests)
- `cargo clippy -p traverse-contracts --all-targets -- -D warnings` and `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build --workspace` — clean
- `bash scripts/ci/coverage_gate.sh` (after `cargo llvm-cov clean --workspace` to clear stale profile data from unrelated earlier work) — traverse-contracts 100.00% (895/895 lines); full gate passes for every crate
- No `unsafe`/`unwrap`/`expect`/`panic`/`todo` introduced
- `bash scripts/ci/spec_alignment_check.sh` run locally against this PR body
