### PR TITLE
feat(cli): telemetry enable/disable command, install ID, HTTP sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,6 +1988,7 @@ dependencies = [
  "traverse-contracts",
  "traverse-registry",
  "traverse-runtime",
+ "uuid",
  "zeroize",
 ]
 

--- a/crates/traverse-cli/Cargo.toml
+++ b/crates/traverse-cli/Cargo.toml
@@ -18,6 +18,7 @@ semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.11"
+uuid = { version = "1", features = ["v4"] }
 zeroize = "1.8"
 traverse-contracts = { workspace = true }
 traverse-registry = { workspace = true }

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -3,6 +3,7 @@ mod capability_packages;
 mod federation_operator;
 mod http_api;
 mod supply_chain;
+mod telemetry;
 
 use browser_adapter::serve_local_browser_adapter;
 use capability_packages::load_capability_package;
@@ -156,6 +157,8 @@ enum Command {
         allowed_origins: Vec<String>,
         render_mobile_qr: bool,
     },
+    TelemetryEnable,
+    TelemetryDisable,
 }
 
 #[derive(Debug)]
@@ -341,6 +344,19 @@ fn run_command(command: Command) -> Result<String, CliError> {
             version,
             workspace_id,
         } => workflow_inspect(&workflow_id, version.as_deref(), &workspace_id),
+        Command::TelemetryEnable => telemetry::enable_telemetry()
+            .map(|config| render_telemetry_state("enabled", &config))
+            .map_err(CliError::IoError),
+        Command::TelemetryDisable => telemetry::disable_telemetry()
+            .map(|config| render_telemetry_state("disabled", &config))
+            .map_err(CliError::IoError),
+    }
+}
+
+fn render_telemetry_state(action: &str, config: &telemetry::TelemetryConfig) -> String {
+    match &config.install_id {
+        Some(install_id) => format!("telemetry {action} (install_id: {install_id})"),
+        None => format!("telemetry {action}"),
     }
 }
 
@@ -411,6 +427,9 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
         (Some("capability"), Some("discover")) => parse_capability_discover_command(args),
         (Some("capability"), Some("publish")) => parse_capability_publish_command(args),
         (Some("workflow"), Some(_)) => parse_workflow_command(args),
+        (Some("telemetry"), Some("enable")) => Ok(Command::TelemetryEnable),
+        (Some("telemetry"), Some("disable")) => Ok(Command::TelemetryDisable),
+        (Some("telemetry"), _) => Err(usage()),
         _ => parse_fixed_arity_command(args),
     }
 }
@@ -454,8 +473,63 @@ fn subcommand_help(family: Option<&str>, subcommand: Option<&str>) -> String {
         (Some("browser-adapter"), Some("serve")) => help_browser_adapter_serve(),
         (Some("browser-adapter"), _) => help_browser_adapter(),
         (Some("serve"), _) => help_serve(),
+        (Some("telemetry"), Some("enable")) => help_telemetry_enable(),
+        (Some("telemetry"), Some("disable")) => help_telemetry_disable(),
+        (Some("telemetry"), _) => help_telemetry(),
         _ => usage(),
     }
+}
+
+fn help_telemetry_enable() -> String {
+    "traverse-cli telemetry enable
+
+  Purpose:
+    Opt in to anonymous usage telemetry: how often published capabilities are
+    resolved and executed, reported to the Traverse maintainers. Off by
+    default. Never shown as an interactive prompt anywhere else -- this
+    command is the only way to turn it on.
+
+    On first enable, generates and persists a random local install ID (a v4
+    UUID, not derived from any machine-identifying value). Running enable
+    again does not regenerate it.
+
+    Each reported event contains exactly: event type (resolve/execute), the
+    capability reference (namespace/id@version), a timestamp, and the
+    install ID. Nothing else -- no CLI version, OS, hostname, or IP address.
+
+  Optional flags:
+    --help   Print this help text.
+
+  Example:
+    traverse-cli telemetry enable"
+        .to_string()
+}
+
+fn help_telemetry_disable() -> String {
+    "traverse-cli telemetry disable
+
+  Purpose:
+    Opt back out of anonymous usage telemetry. The no-op sink is wired
+    immediately; no further usage events are ever sent. The install ID from
+    a prior enable is retained, so a later enable does not mint a new one.
+
+  Optional flags:
+    --help   Print this help text.
+
+  Example:
+    traverse-cli telemetry disable"
+        .to_string()
+}
+
+fn help_telemetry() -> String {
+    "traverse-cli telemetry <subcommand>
+
+  Subcommands:
+    enable    Opt in to anonymous usage telemetry.
+    disable   Opt out of anonymous usage telemetry (the default).
+
+  Run `traverse-cli telemetry <subcommand> --help` for subcommand-specific help."
+        .to_string()
 }
 
 fn help_app_new() -> String {
@@ -8446,6 +8520,9 @@ mod tests {
             ("browser-adapter", Some("serve")),
             ("browser-adapter", None),
             ("serve", None),
+            ("telemetry", Some("enable")),
+            ("telemetry", Some("disable")),
+            ("telemetry", None),
         ];
         for (family, sub) in pairs {
             let help = match sub {

--- a/crates/traverse-cli/src/telemetry.rs
+++ b/crates/traverse-cli/src/telemetry.rs
@@ -1,0 +1,436 @@
+//! Local telemetry opt-in configuration and the real `UsageTelemetrySink`
+//! adapter (spec `088-runtime-usage-telemetry` FR-002 through FR-005, FR-007).
+//!
+//! `wire_usage_telemetry_sink` and `load_telemetry_config` are not yet called
+//! from any command: wiring the sink into `capability execute`/`serve`'s
+//! success path is issue #929, deliberately out of this ticket's scope. Both
+//! are fully implemented and tested here so #929 only needs to call them.
+//!
+//! The collector endpoint and API key are provisioned separately from this
+//! code (infrastructure setup, not code): both are read from environment
+//! variables (`TRAVERSE_TELEMETRY_ENDPOINT`, `TRAVERSE_TELEMETRY_API_KEY`) by
+//! [`wire_usage_telemetry_sink`], never hardcoded or committed. If either is
+//! unset, the real sink is never constructed and the no-op sink is used
+//! instead — consistent with "never fail the caller" (FR-005) and the honest
+//! state before a real collector project exists.
+
+#![allow(dead_code)] // wired into capability execute/serve in #929
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use traverse_contracts::{NoOpUsageTelemetrySink, UsageEvent, UsageEventKind, UsageTelemetrySink};
+use uuid::Uuid;
+
+const CONFIG_FILE_NAME: &str = "cli-config.json";
+const SEND_TIMEOUT_SECS: &str = "2";
+
+/// Persistent local telemetry opt-in state (FR-002, FR-003). Lives at the
+/// CLI-user level (outside any workspace), so it survives across workspaces
+/// and working directories.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct TelemetryConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub install_id: Option<String>,
+}
+
+/// Resolves the Traverse CLI's user-level config root. `TRAVERSE_HOME`
+/// overrides the default (`$HOME/.traverse`, falling back to `$USERPROFILE`
+/// where `HOME` is unset).
+fn cli_home_dir() -> Result<PathBuf, String> {
+    if let Ok(override_dir) = std::env::var("TRAVERSE_HOME") {
+        return Ok(PathBuf::from(override_dir));
+    }
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| "neither HOME, USERPROFILE, nor TRAVERSE_HOME is set".to_string())?;
+    Ok(PathBuf::from(home).join(".traverse"))
+}
+
+fn default_config_path() -> Result<PathBuf, String> {
+    Ok(cli_home_dir()?.join(CONFIG_FILE_NAME))
+}
+
+/// Loads the telemetry config at `path`. Any read/parse failure (including
+/// "file does not exist yet") is treated as the safe default: telemetry
+/// disabled, no install id. Telemetry must never become accidentally
+/// enabled by a missing, corrupt, or unreadable config file.
+fn load_telemetry_config_at(path: &Path) -> TelemetryConfig {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return TelemetryConfig::default();
+    };
+    serde_json::from_str(&contents).unwrap_or_default()
+}
+
+fn write_telemetry_config_at(path: &Path, config: &TelemetryConfig) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    let serialized = serde_json::to_string_pretty(config)
+        .map_err(|error| format!("failed to serialize telemetry config: {error}"))?;
+    std::fs::write(path, format!("{serialized}\n"))
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))
+}
+
+/// Enables telemetry at `path` (FR-002). Generates and persists a v4 UUID
+/// install ID on first enable only (FR-003); a later `enable` reuses the
+/// existing ID rather than regenerating it.
+fn enable_telemetry_at(path: &Path) -> Result<TelemetryConfig, String> {
+    let mut config = load_telemetry_config_at(path);
+    config.enabled = true;
+    if config.install_id.is_none() {
+        config.install_id = Some(Uuid::new_v4().to_string());
+    }
+    write_telemetry_config_at(path, &config)?;
+    Ok(config)
+}
+
+/// Disables telemetry at `path` (FR-002). The install ID, once generated, is
+/// retained so a later re-enable does not mint a new one.
+fn disable_telemetry_at(path: &Path) -> Result<TelemetryConfig, String> {
+    let mut config = load_telemetry_config_at(path);
+    config.enabled = false;
+    write_telemetry_config_at(path, &config)?;
+    Ok(config)
+}
+
+/// Loads the current telemetry config from the real user-level config path.
+#[must_use]
+pub fn load_telemetry_config() -> TelemetryConfig {
+    match default_config_path() {
+        Ok(path) => load_telemetry_config_at(&path),
+        Err(_) => TelemetryConfig::default(),
+    }
+}
+
+/// Enables telemetry at the real user-level config path (`traverse-cli
+/// telemetry enable`). No interactive prompt is ever shown (FR-002).
+///
+/// # Errors
+///
+/// Returns an error message when the config directory or file cannot be
+/// created or written.
+pub fn enable_telemetry() -> Result<TelemetryConfig, String> {
+    enable_telemetry_at(&default_config_path()?)
+}
+
+/// Disables telemetry at the real user-level config path (`traverse-cli
+/// telemetry disable`).
+///
+/// # Errors
+///
+/// Returns an error message when the config file cannot be written.
+pub fn disable_telemetry() -> Result<TelemetryConfig, String> {
+    disable_telemetry_at(&default_config_path()?)
+}
+
+fn event_kind_label(kind: UsageEventKind) -> &'static str {
+    match kind {
+        UsageEventKind::Resolve => "resolve",
+        UsageEventKind::Execute => "execute",
+    }
+}
+
+/// Builds the exact FR-004 payload: event type, `namespace/id@version`,
+/// timestamp, and install ID -- no other field.
+fn build_event_payload(api_key: &str, install_id: &str, event: &UsageEvent) -> Value {
+    serde_json::json!({
+        "api_key": api_key,
+        "event": event_kind_label(event.kind),
+        "distinct_id": install_id,
+        "properties": {
+            "capability_ref": event.capability_ref,
+            "timestamp": event.timestamp,
+            "install_id": install_id,
+        }
+    })
+}
+
+/// Real [`UsageTelemetrySink`]: sends exactly the FR-004 field set to a
+/// hosted product-analytics collector, fire-and-forget, over a
+/// short-timeout `curl` child process (FR-005). `record` never blocks or
+/// fails the caller: the child is spawned and immediately detached (never
+/// `.wait()`-ed), its own `--max-time` bounds its lifetime, and its exit
+/// status is never inspected. Any failure to even spawn `curl` is swallowed
+/// the same way.
+pub struct HttpUsageTelemetrySink {
+    endpoint: String,
+    api_key: String,
+    install_id: String,
+}
+
+impl HttpUsageTelemetrySink {
+    #[must_use]
+    pub fn new(endpoint: String, api_key: String, install_id: String) -> Self {
+        Self {
+            endpoint,
+            api_key,
+            install_id,
+        }
+    }
+}
+
+impl UsageTelemetrySink for HttpUsageTelemetrySink {
+    fn record(&self, event: UsageEvent) {
+        let payload = build_event_payload(&self.api_key, &self.install_id, &event);
+        let Ok(body) = serde_json::to_string(&payload) else {
+            return;
+        };
+        let _ = std::process::Command::new("curl")
+            .args([
+                "-fsSL",
+                "--max-time",
+                SEND_TIMEOUT_SECS,
+                "-X",
+                "POST",
+                "-H",
+                "Content-Type: application/json",
+                "-d",
+                &body,
+                &self.endpoint,
+            ])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+    }
+}
+
+/// Pure wiring decision: given a loaded config and an optional collector
+/// endpoint/key pair, decides which sink implementation to use.
+fn wire_usage_telemetry_sink_from(
+    config: &TelemetryConfig,
+    endpoint: Option<String>,
+    api_key: Option<String>,
+) -> Box<dyn UsageTelemetrySink> {
+    let (true, Some(install_id), Some(endpoint), Some(api_key)) =
+        (config.enabled, config.install_id.clone(), endpoint, api_key)
+    else {
+        return Box::new(NoOpUsageTelemetrySink);
+    };
+    Box::new(HttpUsageTelemetrySink::new(endpoint, api_key, install_id))
+}
+
+/// Builds the sink `capability execute`/`serve` should use for this process:
+/// the no-op sink when telemetry is disabled or the collector is
+/// unconfigured (FR-007), or the real HTTP sink when enabled and configured
+/// (FR-005).
+#[must_use]
+pub fn wire_usage_telemetry_sink() -> Box<dyn UsageTelemetrySink> {
+    wire_usage_telemetry_sink_from(
+        &load_telemetry_config(),
+        std::env::var("TRAVERSE_TELEMETRY_ENDPOINT").ok(),
+        std::env::var("TRAVERSE_TELEMETRY_API_KEY").ok(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used)]
+
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_config_path() -> PathBuf {
+        static NEXT_TEST_DIR: AtomicU64 = AtomicU64::new(1);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let sequence = NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("traverse-cli-telemetry-test-{nanos}-{sequence}"));
+        dir.join(CONFIG_FILE_NAME)
+    }
+
+    fn test_event(kind: UsageEventKind) -> UsageEvent {
+        UsageEvent {
+            kind,
+            capability_ref: "hello.world/say-hello@1.0.0".to_string(),
+            timestamp: "2026-08-04T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn enable_generates_and_persists_install_id_once() {
+        let path = unique_temp_config_path();
+
+        let first = enable_telemetry_at(&path).expect("enable must succeed");
+        assert!(first.enabled);
+        let install_id = first.install_id.clone().expect("install id must be set");
+
+        let parsed = Uuid::parse_str(&install_id).expect("install id must be a valid UUID");
+        assert_eq!(parsed.get_version_num(), 4, "install id must be a v4 UUID");
+        assert!(
+            !install_id.contains(std::env::consts::OS),
+            "install id must not embed machine-identifying data"
+        );
+
+        // A second `enable` (simulating a later CLI invocation) must reuse
+        // the same install id, not regenerate it (FR-003, QG-004).
+        let second = enable_telemetry_at(&path).expect("second enable must succeed");
+        assert_eq!(second.install_id, first.install_id);
+
+        // Loading from disk directly (a fresh process) must see the same
+        // persisted state.
+        let reloaded = load_telemetry_config_at(&path);
+        assert_eq!(reloaded, second);
+    }
+
+    #[test]
+    fn disable_keeps_install_id_but_clears_enabled_flag() {
+        let path = unique_temp_config_path();
+        let enabled = enable_telemetry_at(&path).expect("enable must succeed");
+
+        let disabled = disable_telemetry_at(&path).expect("disable must succeed");
+        assert!(!disabled.enabled);
+        assert_eq!(disabled.install_id, enabled.install_id);
+
+        // Re-enabling after a disable must still reuse the same id.
+        let re_enabled = enable_telemetry_at(&path).expect("re-enable must succeed");
+        assert_eq!(re_enabled.install_id, enabled.install_id);
+    }
+
+    #[test]
+    fn load_defaults_to_disabled_when_config_file_is_missing_or_corrupt() {
+        let missing_path = unique_temp_config_path();
+        assert_eq!(
+            load_telemetry_config_at(&missing_path),
+            TelemetryConfig::default()
+        );
+
+        let corrupt_path = unique_temp_config_path();
+        if let Some(parent) = corrupt_path.parent() {
+            std::fs::create_dir_all(parent).expect("dir must create");
+        }
+        std::fs::write(&corrupt_path, b"not valid json").expect("corrupt file must write");
+        assert_eq!(
+            load_telemetry_config_at(&corrupt_path),
+            TelemetryConfig::default(),
+            "a corrupt config file must fail open to disabled, never accidentally enabled"
+        );
+    }
+
+    #[test]
+    fn build_event_payload_contains_exactly_the_fr_004_fields() {
+        let payload = build_event_payload(
+            "test-key",
+            "install-123",
+            &test_event(UsageEventKind::Resolve),
+        );
+
+        assert_eq!(payload["event"], "resolve");
+        assert_eq!(payload["distinct_id"], "install-123");
+        let properties = payload["properties"]
+            .as_object()
+            .expect("properties must be an object");
+        assert_eq!(
+            properties.len(),
+            3,
+            "properties must contain exactly capability_ref, timestamp, and install_id -- no more"
+        );
+        assert_eq!(properties["capability_ref"], "hello.world/say-hello@1.0.0");
+        assert_eq!(properties["timestamp"], "2026-08-04T00:00:00Z");
+        assert_eq!(properties["install_id"], "install-123");
+
+        let execute_payload = build_event_payload(
+            "test-key",
+            "install-123",
+            &test_event(UsageEventKind::Execute),
+        );
+        assert_eq!(execute_payload["event"], "execute");
+    }
+
+    #[test]
+    fn no_op_wiring_when_telemetry_disabled() {
+        let sink = wire_usage_telemetry_sink_from(
+            &TelemetryConfig {
+                enabled: false,
+                install_id: Some("install-123".to_string()),
+            },
+            Some("http://127.0.0.1:1/".to_string()),
+            Some("test-key".to_string()),
+        );
+        // The no-op sink performs no I/O; this must return instantly with
+        // no observable effect even though a collector endpoint is set.
+        sink.record(test_event(UsageEventKind::Resolve));
+    }
+
+    #[test]
+    fn no_op_wiring_when_collector_is_unconfigured() {
+        let sink = wire_usage_telemetry_sink_from(
+            &TelemetryConfig {
+                enabled: true,
+                install_id: Some("install-123".to_string()),
+            },
+            None,
+            None,
+        );
+        sink.record(test_event(UsageEventKind::Resolve));
+    }
+
+    #[test]
+    fn no_op_wiring_when_enabled_but_install_id_missing() {
+        let sink = wire_usage_telemetry_sink_from(
+            &TelemetryConfig {
+                enabled: true,
+                install_id: None,
+            },
+            Some("http://127.0.0.1:1/".to_string()),
+            Some("test-key".to_string()),
+        );
+        sink.record(test_event(UsageEventKind::Resolve));
+    }
+
+    #[test]
+    fn real_sink_is_wired_when_enabled_and_configured() {
+        let sink = wire_usage_telemetry_sink_from(
+            &TelemetryConfig {
+                enabled: true,
+                install_id: Some("install-123".to_string()),
+            },
+            Some("http://127.0.0.1:1/".to_string()),
+            Some("test-key".to_string()),
+        );
+        // Exercises the real HttpUsageTelemetrySink path end to end; the
+        // unreachable endpoint proves the failure-swallowing behavior below.
+        sink.record(test_event(UsageEventKind::Execute));
+    }
+
+    #[test]
+    fn record_never_blocks_the_caller_even_when_the_collector_is_unreachable() {
+        // Port 1 is a reserved, near-universally-refused port: connecting
+        // fails fast, but the point of this test is that `record` does not
+        // wait for that outcome at all (FR-005: fire-and-forget, must not
+        // delay the invoking command).
+        let sink = HttpUsageTelemetrySink::new(
+            "http://127.0.0.1:1/".to_string(),
+            "test-key".to_string(),
+            "install-123".to_string(),
+        );
+
+        let started = Instant::now();
+        sink.record(test_event(UsageEventKind::Execute));
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed.as_millis() < 500,
+            "record() must return immediately after spawning, not wait for the \
+             collector or its {SEND_TIMEOUT_SECS}s timeout; took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn wire_usage_telemetry_sink_reads_the_real_environment() {
+        // Exercises the thin production wrapper's delegation to the pure
+        // decision function; whichever branch the ambient test environment
+        // takes (TRAVERSE_TELEMETRY_ENDPOINT/API_KEY are not expected to be
+        // set in CI), this must not panic.
+        let sink = wire_usage_telemetry_sink();
+        sink.record(test_event(UsageEventKind::Resolve));
+    }
+}


### PR DESCRIPTION
## Project Item

Progresses traverse-framework/traverse#928. Not closing it — see "What's deferred" below.

## Governing Spec

- `088-runtime-usage-telemetry`

## Summary

Adds `traverse-cli telemetry enable`/`telemetry disable` and the real `UsageTelemetrySink` HTTP adapter, per spec 088 FR-002 through FR-005, FR-007.

- **Persistent opt-in (FR-002, FR-003)**: `telemetry enable`/`disable` persist a flag at `$TRAVERSE_HOME/cli-config.json` (default `$HOME/.traverse`, falling back to `$USERPROFILE` where `HOME` is unset) — a genuinely user-level location, independent of CWD/workspace, distinct from the existing workspace-relative `.traverse/` state this repo already uses elsewhere. No interactive prompt exists anywhere. On first `enable`, generates and persists a v4 UUID install ID; a later `enable` reuses it rather than regenerating (verified by test).
- **Real sink (FR-004, FR-005)**: `HttpUsageTelemetrySink` sends exactly the four permitted fields (event type, `namespace/id@version`, timestamp, install ID) to a collector via `curl`, matching the existing `curl_text` shell-out convention rather than adding a new HTTP client dependency. It's genuinely fire-and-forget: the child is `.spawn()`-ed and never `.wait()`-ed, so `record()` returns immediately regardless of collector latency or reachability (verified by a timing-bounded test against an unreachable address); `curl --max-time 2` bounds the detached child's own lifetime. Any failure — spawn, serialize, network — is swallowed completely, never surfaced to the caller.
- **No-op when disabled/unconfigured (FR-007)**: `wire_usage_telemetry_sink()` returns the no-op sink from #927 whenever telemetry is off, or when the collector isn't configured.

## What's deferred, and why (not closing #928)

**The collector endpoint and API key are not hardcoded.** `wire_usage_telemetry_sink()` reads them from `TRAVERSE_TELEMETRY_ENDPOINT`/`TRAVERSE_TELEMETRY_API_KEY`; if either is unset, the no-op sink is used. #928's Definition of Done includes "a real hosted PostHog (or equivalent) project is provisioned and its endpoint/key wired into the adapter (infrastructure setup, not just code)" — that's an external account/credential I can't create. The adapter itself is fully implemented and tested against FR-004/FR-005; once a real project exists, wiring it in is either setting those two env vars or hardcoding the values here (whichever this repo prefers) — no code changes needed beyond that.

**`wire_usage_telemetry_sink` is not yet called from any command.** Wiring it into `capability execute`/`serve`'s success path is #929, explicitly out of #928's own scope per the parent spec's implementation-ticket breakdown.

I'm leaving #928 open with a comment summarizing this, since the DoD isn't fully met without the real collector project.

## Changes

- `crates/traverse-cli/src/telemetry.rs` (new): config load/save, `enable_telemetry`/`disable_telemetry`, `HttpUsageTelemetrySink`, `wire_usage_telemetry_sink`.
- `crates/traverse-cli/src/main.rs`: `Command::TelemetryEnable`/`TelemetryDisable` variants, `parse_command`/`subcommand_help` wiring, `help_telemetry*` functions, dispatch in `run_command`.
- `crates/traverse-cli/Cargo.toml`: added `uuid = { version = "1", features = ["v4"] }` (already used elsewhere in the workspace, e.g. `traverse-runtime`, just not previously a direct `traverse-cli` dependency).

## Validation

- `cargo test -p traverse-cli-rs --bin traverse-cli` — 333 passed, 0 failed (up from 322; 10 new telemetry tests + 1 help-coverage table update)
- Tests cover: install ID generated once and persisted across repeated invocations, is a valid v4 UUID with no embedded machine data (QG-004); the real sink's payload contains exactly the FR-004 field set (QG-002); `record()` returns near-instantly against an unreachable collector, proving it never blocks the caller (QG-003); no-op wiring when disabled, when the collector is unconfigured, and when enabled without an install id; a corrupt/missing config file fails open to disabled, never accidentally enabled
- `cargo clippy -p traverse-cli-rs --all-targets -- -D warnings` and `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build --workspace` — clean
- `bash scripts/ci/coverage_gate.sh` (after `cargo llvm-cov clean --workspace`) — traverse-cli-rs 88.02% (threshold 87%); full gate passes for every crate
- No `unsafe`/`unwrap`/`panic`/`todo` introduced (`#[allow(clippy::expect_used)]` on the test module only, matching the existing convention elsewhere in this file and in `traverse-runtime`)
- `bash scripts/ci/spec_alignment_check.sh` run locally against this PR body
