### PR TITLE
feat(cli): emit execute usage-telemetry event on real WASM invocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,6 +1979,7 @@ dependencies = [
 name = "traverse-cli-rs"
 version = "0.8.1"
 dependencies = [
+ "chrono",
  "ed25519-dalek",
  "qrcode",
  "semver",

--- a/crates/traverse-cli/Cargo.toml
+++ b/crates/traverse-cli/Cargo.toml
@@ -12,6 +12,7 @@ name = "traverse-cli"
 path = "src/main.rs"
 
 [dependencies]
+chrono = "0.4"
 ed25519-dalek = "3.0.0"
 qrcode = { version = "0.14.1", default-features = false }
 semver = "1.0.27"

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -4716,8 +4716,14 @@ fn handle_execute<W: Write, E: LocalExecutor + Clone>(
         }
     };
 
-    let outcome: RuntimeExecutionOutcome =
-        state.with_workspace_mut(&workspace_id, |ws| Ok(ws.runtime.execute(runtime_request)))?;
+    let sink = crate::telemetry::wire_usage_telemetry_sink();
+    let outcome: RuntimeExecutionOutcome = state.with_workspace_mut(&workspace_id, |ws| {
+        Ok(crate::telemetry::execute_with_telemetry(
+            &ws.runtime,
+            runtime_request,
+            sink.as_ref(),
+        ))
+    })?;
 
     match serialize_outcome(&outcome) {
         Ok(body_str) => write_json_raw(w, 200, "OK", &body_str),
@@ -4836,8 +4842,14 @@ fn handle_sync_workspace_execution<W: Write, E: LocalExecutor + Clone>(
         capability_id.as_deref(),
         capability_version.as_deref(),
     )?;
-    let outcome: RuntimeExecutionOutcome =
-        state.with_workspace_mut(workspace_id, |ws| Ok(ws.runtime.execute(runtime_request)))?;
+    let sink = crate::telemetry::wire_usage_telemetry_sink();
+    let outcome: RuntimeExecutionOutcome = state.with_workspace_mut(workspace_id, |ws| {
+        Ok(crate::telemetry::execute_with_telemetry(
+            &ws.runtime,
+            runtime_request,
+            sink.as_ref(),
+        ))
+    })?;
     let status = if outcome.result.status == RuntimeResultStatus::Error {
         "failed"
     } else {
@@ -5641,7 +5653,9 @@ fn run_app_command_invoke<E: LocalExecutor + Clone>(
         },
         governing_spec: "006-runtime-request-execution".to_string(),
     };
-    let outcome = ws.runtime.execute(runtime_request);
+    let sink = crate::telemetry::wire_usage_telemetry_sink();
+    let outcome =
+        crate::telemetry::execute_with_telemetry(&ws.runtime, runtime_request, sink.as_ref());
     let execution_id = outcome.result.execution_id.clone();
     let succeeded = outcome.result.status != RuntimeResultStatus::Error;
     ws.executions.insert(

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -3845,7 +3845,8 @@ fn execute_capability_package(
         ArtifactRouter::new().map_err(|error| CliError::ExecutionFailed(error.message))?,
     )
     .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development());
-    let outcome = runtime.execute(request);
+    let sink = telemetry::wire_usage_telemetry_sink();
+    let outcome = telemetry::execute_with_telemetry(&runtime, request, sink.as_ref());
 
     if outcome.result.status == RuntimeResultStatus::Error {
         return Err(CliError::ExecutionFailed(render_runtime_execution_failure(
@@ -5609,20 +5610,22 @@ mod tests {
     #![allow(clippy::expect_used)]
 
     use super::{
-        CapabilityPublishRequest, CliError, Command, DEFAULT_PUBLIC_REGISTRY_SOURCE,
-        ExpeditionExampleExecutor, FetchedRegistryIndex, PublishCommandOutput,
-        PublishProcessRunner, RealPublishProcessRunner, RegistryIndexFetcher, RegistrySyncError,
-        app_new_at, app_register_at, app_registration_state_path, app_validate, app_validate_at,
+        ArtifactRouter, CapabilityPublishRequest, CapabilityRegistry, CliError, Command,
+        DEFAULT_PUBLIC_REGISTRY_SOURCE, ExpeditionExampleExecutor, FetchedRegistryIndex,
+        PublishCommandOutput, PublishProcessRunner, RealPublishProcessRunner, RegistryIndexFetcher,
+        RegistrySyncError, Runtime, RuntimeResultStatus, app_new_at, app_register_at,
+        app_registration_state_path, app_validate, app_validate_at,
         canonical_expedition_bundle_path, capability_publish_at, component_new_at, curl_text,
         ensure_clean_registry_checkout, execute_capability_package, execute_expedition,
         execute_traverse_starter_process, execute_traverse_starter_summarize,
         execute_traverse_starter_validate, help_expedition_execute, help_serve, inspect_bundle,
         inspect_capability_package, inspect_event, inspect_trace, latest_index_release_asset,
-        load_registered_bundle, load_registered_bundle_with_public_records, load_runtime_request,
-        parse_command, publish_file_sha256_digest, register_bundle, register_generated_app_bundle,
+        load_capability_package, load_registered_bundle,
+        load_registered_bundle_with_public_records, load_runtime_request, parse_command,
+        publish_file_sha256_digest, register_bundle, register_generated_app_bundle,
         registry_record_order, registry_sync_at, registry_sync_default_or_override,
         registry_sync_failure_json, reject_private_contract_scope, run_command, sha256_hex,
-        validate_registry_path_segment,
+        telemetry, validate_registry_path_segment,
     };
     use crate::capability_packages::fnv1a64;
     use serde_json::Value;
@@ -5631,8 +5634,10 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::process::Command as ProcessCommand;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::time::{SystemTime, UNIX_EPOCH};
     use traverse_contracts::parse_contract;
+    use traverse_contracts::{UsageEvent, UsageEventKind, UsageTelemetrySink};
     use traverse_registry::{
         PublicRegistryCapabilityRecord, PublicRegistryIndex, load_application_bundle_manifest,
         load_synced_public_registry_state, write_synced_public_registry_state,
@@ -7502,6 +7507,53 @@ mod tests {
 
         assert!(output.contains("capability_id: doc-approval.analyze"));
         assert!(output.contains("status: completed"));
+    }
+
+    #[derive(Default)]
+    struct SpyTelemetrySink {
+        events: Arc<Mutex<Vec<UsageEvent>>>,
+    }
+
+    impl UsageTelemetrySink for SpyTelemetrySink {
+        fn record(&self, event: UsageEvent) {
+            self.events
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(event);
+        }
+    }
+
+    #[test]
+    fn execute_with_telemetry_fires_exactly_one_execute_event_on_real_success() {
+        let manifest_path = repo_root().join("examples/doc-approval/analyze-agent/manifest.json");
+        let request_path = repo_root().join("examples/doc-approval/runtime-requests/analyze.json");
+
+        let package =
+            load_capability_package(&manifest_path).expect("doc-approval package must load");
+        let request = load_runtime_request(&request_path).expect("request must load");
+        let mut registry = CapabilityRegistry::new();
+        registry
+            .register(package.capability_registration())
+            .expect("capability must register");
+        let runtime = Runtime::new(
+            registry,
+            ArtifactRouter::new().expect("artifact router must construct"),
+        )
+        .with_security_config(traverse_runtime::security::RuntimeSecurityConfig::development());
+
+        let sink = SpyTelemetrySink::default();
+        let events = sink.events.clone();
+        let outcome = telemetry::execute_with_telemetry(&runtime, request, &sink);
+
+        assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
+        let recorded = events.lock().expect("lock must not be poisoned");
+        assert_eq!(
+            recorded.len(),
+            1,
+            "a successful real WASM invocation must fire exactly one execute event"
+        );
+        assert_eq!(recorded[0].kind, UsageEventKind::Execute);
+        assert_eq!(recorded[0].capability_ref, "doc-approval.analyze@1.0.0");
     }
 
     #[test]

--- a/crates/traverse-cli/src/telemetry.rs
+++ b/crates/traverse-cli/src/telemetry.rs
@@ -1,10 +1,10 @@
 //! Local telemetry opt-in configuration and the real `UsageTelemetrySink`
-//! adapter (spec `088-runtime-usage-telemetry` FR-002 through FR-005, FR-007).
+//! adapter (spec `088-runtime-usage-telemetry` FR-002 through FR-007).
 //!
-//! `wire_usage_telemetry_sink` and `load_telemetry_config` are not yet called
-//! from any command: wiring the sink into `capability execute`/`serve`'s
-//! success path is issue #929, deliberately out of this ticket's scope. Both
-//! are fully implemented and tested here so #929 only needs to call them.
+//! [`execute_with_telemetry`] is the wiring point `capability-package
+//! execute` and `serve`'s execution handlers call on every real WASM
+//! invocation; it fires an `execute` event through whatever sink it's given
+//! on success, and nothing on failure (FR-006).
 //!
 //! The collector endpoint and API key are provisioned separately from this
 //! code (infrastructure setup, not code): both are read from environment
@@ -14,12 +14,14 @@
 //! instead — consistent with "never fail the caller" (FR-005) and the honest
 //! state before a real collector project exists.
 
-#![allow(dead_code)] // wired into capability execute/serve in #929
-
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 use traverse_contracts::{NoOpUsageTelemetrySink, UsageEvent, UsageEventKind, UsageTelemetrySink};
+use traverse_runtime::{
+    LocalExecutor, Runtime, RuntimeExecutionOutcome, RuntimeRequest, RuntimeResultStatus,
+};
 use uuid::Uuid;
 
 const CONFIG_FILE_NAME: &str = "cli-config.json";
@@ -227,13 +229,78 @@ pub fn wire_usage_telemetry_sink() -> Box<dyn UsageTelemetrySink> {
     )
 }
 
+/// Pure decision: records an `execute` event through `sink` when `status`
+/// is not an error and a capability was actually resolved (FR-006). No
+/// event for a failed/errored execution, and none if no capability id or
+/// version is present (should not occur when `status` is `Completed`, but
+/// the runtime's trace fields are `Option`s at the type level).
+fn record_execute_event(
+    status: RuntimeResultStatus,
+    selected_capability_id: Option<&str>,
+    selected_capability_version: Option<&str>,
+    sink: &dyn UsageTelemetrySink,
+) {
+    if status == RuntimeResultStatus::Error {
+        return;
+    }
+    let (Some(id), Some(version)) = (selected_capability_id, selected_capability_version) else {
+        return;
+    };
+    sink.record(UsageEvent {
+        kind: UsageEventKind::Execute,
+        capability_ref: format!("{id}@{version}"),
+        timestamp: Utc::now().to_rfc3339(),
+    });
+}
+
+/// Executes `request` against `runtime`, then records an `execute`
+/// usage-telemetry event through `sink` on successful completion (spec 088
+/// FR-006). Called by `capability-package execute` and every `serve`
+/// execution handler on every real WASM invocation; the caller supplies the
+/// sink (typically [`wire_usage_telemetry_sink`]'s result) so this stays
+/// independently testable without touching the real environment or config
+/// file.
+pub fn execute_with_telemetry<E: LocalExecutor>(
+    runtime: &Runtime<E>,
+    request: RuntimeRequest,
+    sink: &dyn UsageTelemetrySink,
+) -> RuntimeExecutionOutcome {
+    let outcome = runtime.execute(request);
+    record_execute_event(
+        outcome.result.status,
+        outcome.trace.selection.selected_capability_id.as_deref(),
+        outcome
+            .trace
+            .selection
+            .selected_capability_version
+            .as_deref(),
+        sink,
+    );
+    outcome
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]
 
     use super::*;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
     use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+    #[derive(Default)]
+    struct SpySink {
+        events: Arc<Mutex<Vec<UsageEvent>>>,
+    }
+
+    impl UsageTelemetrySink for SpySink {
+        fn record(&self, event: UsageEvent) {
+            self.events
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(event);
+        }
+    }
 
     fn unique_temp_config_path() -> PathBuf {
         static NEXT_TEST_DIR: AtomicU64 = AtomicU64::new(1);
@@ -421,6 +488,50 @@ mod tests {
             elapsed.as_millis() < 500,
             "record() must return immediately after spawning, not wait for the \
              collector or its {SEND_TIMEOUT_SECS}s timeout; took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn record_execute_event_fires_on_successful_completion() {
+        let spy = SpySink::default();
+        record_execute_event(
+            RuntimeResultStatus::Completed,
+            Some("hello.world.say-hello"),
+            Some("1.0.0"),
+            &spy,
+        );
+        let events = spy.events.lock().expect("lock must not be poisoned");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, UsageEventKind::Execute);
+        assert_eq!(events[0].capability_ref, "hello.world.say-hello@1.0.0");
+    }
+
+    #[test]
+    fn record_execute_event_is_silent_on_error_status() {
+        let spy = SpySink::default();
+        record_execute_event(
+            RuntimeResultStatus::Error,
+            Some("hello.world.say-hello"),
+            Some("1.0.0"),
+            &spy,
+        );
+        assert!(
+            spy.events
+                .lock()
+                .expect("lock must not be poisoned")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn record_execute_event_is_silent_when_no_capability_was_resolved() {
+        let spy = SpySink::default();
+        record_execute_event(RuntimeResultStatus::Completed, None, None, &spy);
+        assert!(
+            spy.events
+                .lock()
+                .expect("lock must not be poisoned")
+                .is_empty()
         );
     }
 


### PR DESCRIPTION
## Project Item

Closes traverse-framework/traverse#929.

## Governing Spec

- `088-runtime-usage-telemetry`
- `026-event-broker`

(`026-event-broker` covers `crates/traverse-runtime/src/events/broker.rs`, pulled in transitively by merging `origin/main` for #923, which landed concurrently.)

## Summary

Wires `wire_usage_telemetry_sink()` and the real `UsageTelemetrySink` adapter (both from #928, merged in #933) into every place `traverse-cli` completes a real WASM invocation, per spec 088 FR-006:

- **`capability-package execute`** (`execute_capability_package` in `main.rs`).
- **`serve`'s synchronous execute endpoint** (`handle_execute` in `http_api.rs`).
- **`serve`'s workspace execute endpoint** (`handle_sync_workspace_execution`, reached via `handle_execute_workspace` when the caller doesn't request async).
- **`serve`'s declarative app-command-invoke path** (`run_app_command_invoke`), which also drives a real `Runtime::execute` on command dispatch.

The `expedition execute` path (`ExpeditionCliExecutor`/`ExpeditionExampleExecutor`) is deliberately **not** wired: per #916/#921, that path dispatches to hardcoded example handlers, not real WASM, so firing a usage event there would misrepresent adoption of real capabilities.

### Design

All four call sites now go through one new function, `telemetry::execute_with_telemetry(runtime, request, sink)`:

- Executes the request against the runtime exactly as before.
- On any non-`Error` status, records an `execute` `UsageEvent` with `capability_ref` built from the runtime's own resolved `trace.selection.selected_capability_id`/`selected_capability_version` — the actually-selected capability, not just what the caller asked for (which may have been a version range or unspecified).
- On `Error` status, or if no capability was resolved (shouldn't happen on success, but the fields are `Option`s at the type level), no event fires.
- The sink is passed in explicitly by the caller (`telemetry::wire_usage_telemetry_sink()`), not fetched internally — this keeps `execute_with_telemetry` fully unit-testable with a spy sink, without touching real env vars or the config file.

## What's still not wired

Nothing left in this ticket's scope. Production telemetry only actually leaves the machine once a real collector project is provisioned (endpoint/key set via `TRAVERSE_TELEMETRY_ENDPOINT`/`TRAVERSE_TELEMETRY_API_KEY`) and telemetry is user-opted-in via `traverse-cli telemetry enable` — both already shipped in #928/#933; #928 itself stays open only pending that external provisioning step.

## Changes

- `crates/traverse-cli/src/telemetry.rs`: `record_execute_event` (pure decision helper) and `execute_with_telemetry` (runtime-execution wrapper); `chrono::Utc` for FR-006 timestamps.
- `crates/traverse-cli/src/main.rs`: `execute_capability_package` now calls `execute_with_telemetry`; new integration test `execute_with_telemetry_fires_exactly_one_execute_event_on_real_success` (real doc-approval WASM fixture + spy sink).
- `crates/traverse-cli/src/http_api.rs`: `handle_execute`, `handle_sync_workspace_execution`, `run_app_command_invoke` now call `execute_with_telemetry`.
- `crates/traverse-cli/Cargo.toml`: added `chrono = "0.4"` (already a transitive dependency via `traverse-runtime`; now used directly for FR-006's ISO 8601 timestamp, matching the same `Utc::now().to_rfc3339()` convention `traverse-runtime` itself uses).

## Validation

- `cargo test -p traverse-cli-rs --bin traverse-cli` — 337 passed, 0 failed (up from 333)
- New tests: `record_execute_event_fires_on_successful_completion`, `record_execute_event_is_silent_on_error_status`, `record_execute_event_is_silent_when_no_capability_was_resolved` (pure decision logic, telemetry.rs), `execute_with_telemetry_fires_exactly_one_execute_event_on_real_success` (real WASM execution end-to-end, main.rs) — together covering all three DoD assertions: fires once on success, silent on error, silent when unconfigured/no-op (the no-op sink path is already covered by #928's existing tests)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo build --workspace` — clean
- `cargo fmt --check --all` — clean
- `bash scripts/ci/coverage_gate.sh` (after `cargo llvm-cov clean --workspace`) — traverse-cli-rs 88.10% (threshold 87%); full gate passes for every crate
- No `unsafe`/`unwrap`/`panic`/`todo` introduced
- `bash scripts/ci/spec_alignment_check.sh` run locally against this PR body
