### PR TITLE
feat(runtime): add governed event delivery evidence

### DIFF
--- a/crates/traverse-runtime/examples/journal_operational_limits.rs
+++ b/crates/traverse-runtime/examples/journal_operational_limits.rs
@@ -113,6 +113,10 @@ fn fixture_event(index: usize, payload_bytes: usize) -> TraverseEvent {
         owner: "traverse-runtime".to_string(),
         version: "1.0.0".to_string(),
         lifecycle_status: LifecycleStatus::Active,
+        deduplication_id: Some(format!("journal-benchmark-{index:08}")),
+        ordering_scope: Some(format!("benchmark-{}", index % 32)),
+        correlation_id: Some(format!("benchmark-{index:08}")),
+        causation_id: Some("benchmark-command".to_string()),
         subject_id: Some(format!("benchmark-subject-{}", index % 32)),
         actor_id: None,
     }

--- a/crates/traverse-runtime/src/events/broker.rs
+++ b/crates/traverse-runtime/src/events/broker.rs
@@ -77,6 +77,7 @@ struct BrokerState {
     validation_evidence: Vec<EventValidationEvidence>,
     quarantine_records: Vec<EventQuarantineRecord>,
     observed_lineage: Vec<EventLineageRecord>,
+    telemetry: Vec<EventTelemetryRecord>,
     metrics: EventRuntimeMetrics,
 }
 
@@ -102,6 +103,28 @@ pub struct EventLineageRecord {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EventQuarantineRecord {
     pub evidence: EventValidationEvidence,
+}
+
+/// Portable, OpenTelemetry-compatible event boundary evidence.
+///
+/// Host adapters can map this stable, payload-free shape to their chosen
+/// OpenTelemetry SDK. The in-process broker retains it for deterministic
+/// conformance tests and never exports an event payload or subject identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventTelemetryRecord {
+    pub operation: &'static str,
+    pub outcome: &'static str,
+    pub contract_id: String,
+    pub contract_version: String,
+    pub event_id: String,
+    pub deduplication_id: Option<String>,
+    pub ordering_scope: Option<String>,
+    pub correlation_id: Option<String>,
+    pub causation_id: Option<String>,
+    pub consumer_id: Option<String>,
+    pub cursor: Option<EventCursor>,
+    pub retry_count: u32,
+    pub latency_ms: u64,
 }
 
 /// Counter snapshot for OpenTelemetry-compatible event runtime evidence.
@@ -218,6 +241,15 @@ impl InProcessBroker {
             .unwrap_or_default()
     }
 
+    /// Returns deterministic, sanitized boundary telemetry for host export.
+    #[must_use]
+    pub fn telemetry(&self) -> Vec<EventTelemetryRecord> {
+        self.state
+            .lock()
+            .map(|state| state.telemetry.clone())
+            .unwrap_or_default()
+    }
+
     /// Returns a deterministic counter snapshot for event runtime evidence.
     #[must_use]
     pub fn metrics(&self) -> EventRuntimeMetrics {
@@ -312,6 +344,47 @@ impl InProcessBroker {
         self.subscribe_with_subject(event_type, from_cursor, subject_id, Some(consumer_id))
     }
 
+    fn validate_boundary(&self, event: &TraverseEvent) -> Result<(), EventError> {
+        let validation = validate_event(event, self.validation_mode);
+        let validation_outcome = if validation.is_valid() {
+            "accepted"
+        } else if validation.accepted {
+            "reported"
+        } else {
+            "rejected"
+        };
+        let evidence = EventValidationEvidence::from_result(&validation);
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
+        if let Some(evidence) = evidence {
+            state.validation_evidence.push(evidence.clone());
+            state.metrics.validation_failures = state.metrics.validation_failures.saturating_add(1);
+            if !validation.accepted {
+                state
+                    .quarantine_records
+                    .push(EventQuarantineRecord { evidence });
+                state.metrics.quarantines = state.metrics.quarantines.saturating_add(1);
+            }
+        }
+        state.telemetry.push(telemetry_record(
+            "traverse.event.validation",
+            validation_outcome,
+            event,
+            None,
+            None,
+        ));
+        if !validation.accepted {
+            let code = validation
+                .diagnostics
+                .first()
+                .map_or("EVP-000", |diagnostic| diagnostic.code);
+            return Err(EventError::ValidationRejected(code.to_owned()));
+        }
+        Ok(())
+    }
+
     /// Shared implementation for `publish` and `publish_with_cursor`.
     /// `assigned_cursor`, when given, is adopted as this event's cursor
     /// instead of self-incrementing the per-type counter (spec 066 FR-007:
@@ -324,28 +397,7 @@ impl InProcessBroker {
         event: &TraverseEvent,
         assigned_cursor: Option<u64>,
     ) -> Result<(), EventError> {
-        let validation = validate_event(event, self.validation_mode);
-        if let Some(evidence) = EventValidationEvidence::from_result(&validation) {
-            let mut state = self
-                .state
-                .lock()
-                .map_err(|_| EventError::LifecycleViolation("broker lock poisoned".to_owned()))?;
-            state.validation_evidence.push(evidence.clone());
-            state.metrics.validation_failures = state.metrics.validation_failures.saturating_add(1);
-            if !validation.accepted {
-                state
-                    .quarantine_records
-                    .push(EventQuarantineRecord { evidence });
-                state.metrics.quarantines = state.metrics.quarantines.saturating_add(1);
-            }
-        }
-        if !validation.accepted {
-            let code = validation
-                .diagnostics
-                .first()
-                .map_or("EVP-000", |diagnostic| diagnostic.code);
-            return Err(EventError::ValidationRejected(code.to_owned()));
-        }
+        self.validate_boundary(event)?;
         let entry = self
             .catalog
             .get(&event.event_type)
@@ -391,6 +443,13 @@ impl InProcessBroker {
         }
         seen.insert(event.id.clone());
         state.metrics.publications = state.metrics.publications.saturating_add(1);
+        state.telemetry.push(telemetry_record(
+            "traverse.event.publish",
+            "accepted",
+            event,
+            None,
+            None,
+        ));
 
         let next = state
             .next_cursor
@@ -679,6 +738,17 @@ impl EventBroker for InProcessBroker {
                 subscription_id: subscription.subscription_id.clone(),
                 cursor: cursor_to_string(item.cursor),
             });
+            let consumer_id = subscription
+                .consumer_id
+                .clone()
+                .unwrap_or_else(|| subscription.subscription_id.clone());
+            state.telemetry.push(telemetry_record(
+                "traverse.event.delivery",
+                "delivered",
+                &item.event,
+                Some(consumer_id),
+                Some(cursor_to_string(item.cursor)),
+            ));
             out.push(BrokerEvent {
                 cursor: cursor_to_string(item.cursor),
                 event: item.event,
@@ -733,6 +803,30 @@ impl EventBroker for InProcessBroker {
     }
 }
 
+fn telemetry_record(
+    operation: &'static str,
+    outcome: &'static str,
+    event: &TraverseEvent,
+    consumer_id: Option<String>,
+    cursor: Option<EventCursor>,
+) -> EventTelemetryRecord {
+    EventTelemetryRecord {
+        operation,
+        outcome,
+        contract_id: event.event_type.clone(),
+        contract_version: event.version.clone(),
+        event_id: event.id.clone(),
+        deduplication_id: event.deduplication_id.clone(),
+        ordering_scope: event.ordering_scope.clone(),
+        correlation_id: event.correlation_id.clone(),
+        causation_id: event.causation_id.clone(),
+        consumer_id,
+        cursor,
+        retry_count: 0,
+        latency_ms: 0,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]
@@ -779,6 +873,10 @@ mod tests {
             owner: "cap.test".to_string(),
             version: "1.0.0".to_string(),
             lifecycle_status: LifecycleStatus::Active,
+            deduplication_id: Some(id.to_string()),
+            ordering_scope: Some("test".to_string()),
+            correlation_id: Some("correlation-test".to_string()),
+            causation_id: Some("command-test".to_string()),
             subject_id: None,
             actor_id: None,
         }
@@ -995,6 +1093,21 @@ mod tests {
                 quarantines: 0,
             }
         );
+        let telemetry = broker.telemetry();
+        assert_eq!(telemetry.len(), 3);
+        assert_eq!(telemetry[0].operation, "traverse.event.validation");
+        assert_eq!(telemetry[0].outcome, "accepted");
+        assert_eq!(telemetry[1].operation, "traverse.event.publish");
+        assert_eq!(telemetry[2].operation, "traverse.event.delivery");
+        assert_eq!(
+            telemetry[2].consumer_id.as_deref(),
+            Some("capability.audit")
+        );
+        assert_eq!(telemetry[2].cursor.as_deref(), Some("1"));
+        assert_eq!(telemetry[2].contract_version, "1.2.3");
+        assert_eq!(telemetry[2].retry_count, 0);
+        assert_eq!(telemetry[2].latency_ms, 0);
+        assert!(!format!("{telemetry:?}").contains("not lineage"));
     }
 
     #[test]

--- a/crates/traverse-runtime/src/events/durable.rs
+++ b/crates/traverse-runtime/src/events/durable.rs
@@ -184,7 +184,7 @@ type Ack = Arc<(Mutex<AckState>, Condvar)>;
 
 enum WriterJob {
     Write {
-        event: TraverseEvent,
+        event: Box<TraverseEvent>,
         ack: Ack,
     },
     Revoke {
@@ -302,7 +302,7 @@ impl<B: EventBroker> EventBroker for DurableBroker<B> {
         let ack: Ack = Arc::new((Mutex::new(AckState::Pending), Condvar::new()));
         self.jobs
             .send(WriterJob::Write {
-                event: event.clone(),
+                event: Box::new(event.clone()),
                 ack: Arc::clone(&ack),
             })
             .map_err(|_| EventError::JournalWrite("journal writer is unavailable".to_string()))?;
@@ -739,6 +739,10 @@ mod tests {
             owner: "test.capability".to_string(),
             version: "1.0.0".to_string(),
             lifecycle_status: LifecycleStatus::Active,
+            deduplication_id: Some("durable-test".to_string()),
+            ordering_scope: Some("test".to_string()),
+            correlation_id: Some("correlation-test".to_string()),
+            causation_id: Some("command-test".to_string()),
             subject_id: None,
             actor_id: None,
         }

--- a/crates/traverse-runtime/src/events/journal.rs
+++ b/crates/traverse-runtime/src/events/journal.rs
@@ -727,6 +727,10 @@ mod tests {
             owner: "test.capability".to_string(),
             version: "1.0.0".to_string(),
             lifecycle_status: LifecycleStatus::Active,
+            deduplication_id: Some(marker.to_string()),
+            ordering_scope: Some("test".to_string()),
+            correlation_id: Some("correlation-test".to_string()),
+            causation_id: Some("command-test".to_string()),
             subject_id: None,
             actor_id: None,
         }

--- a/crates/traverse-runtime/src/events/mod.rs
+++ b/crates/traverse-runtime/src/events/mod.rs
@@ -11,7 +11,7 @@ pub mod validation;
 
 pub use broker::{
     BrokerClock, BrokerConfig, EventLineageRecord, EventQuarantineRecord, EventRuntimeMetrics,
-    InProcessBroker, SystemClock,
+    EventTelemetryRecord, InProcessBroker, SystemClock,
 };
 pub use catalog::{EventCatalog, EventCatalogEntry};
 pub use durable::{

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -37,6 +37,18 @@ pub struct TraverseEvent {
     pub version: String,
     /// Lifecycle status at the time the event was created.
     pub lifecycle_status: LifecycleStatus,
+    /// Stable identity consumers use to deduplicate at-least-once delivery.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deduplication_id: Option<String>,
+    /// The ordering partition declared by the event contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ordering_scope: Option<String>,
+    /// Correlates related domain events across a workflow or request.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    /// Identifies the event or command that directly caused this event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
     /// Authenticated subject that caused this event, when known.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subject_id: Option<String>,
@@ -281,6 +293,10 @@ mod tests {
             owner: "traverse-runtime".to_string(),
             version: "1.0.0".to_string(),
             lifecycle_status: LifecycleStatus::Active,
+            deduplication_id: Some("f0f83e66-4d87-4dd6-884d-0128d94f730f".to_string()),
+            ordering_scope: Some("subject_test".to_string()),
+            correlation_id: Some("correlation-test".to_string()),
+            causation_id: Some("command-test".to_string()),
             subject_id: Some("subject_test".to_string()),
             actor_id: Some("actor_test".to_string()),
         }

--- a/crates/traverse-runtime/src/events/validation.rs
+++ b/crates/traverse-runtime/src/events/validation.rs
@@ -103,6 +103,38 @@ pub fn validate_event(event: &TraverseEvent, mode: EventValidationMode) -> Event
         &event.owner,
         event,
     );
+    validate_optional_non_empty(
+        &mut diagnostics,
+        "EVP-008",
+        "/deduplicationid",
+        "deduplication identity",
+        event.deduplication_id.as_deref(),
+        event,
+    );
+    validate_optional_non_empty(
+        &mut diagnostics,
+        "EVP-009",
+        "/orderingscope",
+        "ordering scope",
+        event.ordering_scope.as_deref(),
+        event,
+    );
+    validate_optional_non_empty(
+        &mut diagnostics,
+        "EVP-010",
+        "/correlationid",
+        "correlation id",
+        event.correlation_id.as_deref(),
+        event,
+    );
+    validate_optional_non_empty(
+        &mut diagnostics,
+        "EVP-011",
+        "/causationid",
+        "causation id",
+        event.causation_id.as_deref(),
+        event,
+    );
     if Version::parse(&event.version).is_err() {
         diagnostics.push(diagnostic(
             "EVP-006",
@@ -135,6 +167,19 @@ fn validate_non_empty(
     event: &TraverseEvent,
 ) {
     if value.trim().is_empty() {
+        diagnostics.push(diagnostic(code, path, field, event));
+    }
+}
+
+fn validate_optional_non_empty(
+    diagnostics: &mut Vec<EventValidationDiagnostic>,
+    code: &'static str,
+    path: &'static str,
+    field: &'static str,
+    value: Option<&str>,
+    event: &TraverseEvent,
+) {
+    if value.is_none_or(|value| value.trim().is_empty()) {
         diagnostics.push(diagnostic(code, path, field, event));
     }
 }
@@ -179,6 +224,10 @@ mod tests {
             owner: "orders".to_string(),
             version: "1.0.0".to_string(),
             lifecycle_status: LifecycleStatus::Active,
+            deduplication_id: Some("evt-1".to_string()),
+            ordering_scope: Some("order/1".to_string()),
+            correlation_id: Some("correlation-1".to_string()),
+            causation_id: Some("command-1".to_string()),
             subject_id: None,
             actor_id: None,
         }
@@ -203,6 +252,18 @@ mod tests {
         let result = validate_event(&event, EventValidationMode::Migration);
         assert!(result.accepted);
         assert_eq!(result.diagnostics[0].code, "EVP-007");
+    }
+
+    #[test]
+    fn enforcement_rejects_missing_delivery_identity() {
+        let mut event = valid_event();
+        event.deduplication_id = None;
+
+        let result = validate_event(&event, EventValidationMode::Enforcement);
+
+        assert!(!result.accepted);
+        assert_eq!(result.diagnostics[0].code, "EVP-008");
+        assert_eq!(result.diagnostics[0].path, "/deduplicationid");
     }
 
     #[test]

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -1182,6 +1182,10 @@ where
             owner: "traverse-runtime".to_string(),
             version: SUPPORTED_SCHEMA_VERSION.to_string(),
             lifecycle_status: events::LifecycleStatus::Active,
+            deduplication_id: Some(outcome.result.execution_id.clone()),
+            ordering_scope: Some(outcome.result.request_id.clone()),
+            correlation_id: Some(outcome.result.request_id.clone()),
+            causation_id: Some(outcome.result.request_id.clone()),
             subject_id: identity.map(|identity| identity.subject_id.clone()),
             actor_id: identity.and_then(|identity| identity.actor_id.clone()),
         };

--- a/crates/traverse-runtime/tests/event_broker_tests.rs
+++ b/crates/traverse-runtime/tests/event_broker_tests.rs
@@ -29,6 +29,10 @@ fn sample_event(event_type: &str, id: &str, time: &str) -> TraverseEvent {
         owner: "cap.test".to_string(),
         version: "1.0.0".to_string(),
         lifecycle_status: LifecycleStatus::Active,
+        deduplication_id: Some(id.to_string()),
+        ordering_scope: Some("test".to_string()),
+        correlation_id: Some("correlation-test".to_string()),
+        causation_id: Some("command-test".to_string()),
         subject_id: None,
         actor_id: None,
     }

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -163,6 +163,10 @@ fn sample_event(event_type: &str) -> TraverseEvent {
         owner: "router.tests".to_string(),
         version: "1.0.0".to_string(),
         lifecycle_status: LifecycleStatus::Active,
+        deduplication_id: Some("router-test".to_string()),
+        ordering_scope: Some("test".to_string()),
+        correlation_id: Some("correlation-test".to_string()),
+        causation_id: Some("command-test".to_string()),
         subject_id: None,
         actor_id: None,
     }


### PR DESCRIPTION
## Summary

- add the required at-least-once delivery identity fields to governed event envelopes
- emit payload-free, OpenTelemetry-compatible validation, publication, and delivery evidence
- enforce the delivery identity in deterministic runtime validation and cover privacy behavior

## Governing Spec

- `534-ecca-event-products`

## Project Item

- Traverse #897

## Validation

- `cargo fmt --all --check`
- `cargo test -p traverse-runtime`

Closes no issue: this is an incremental implementation slice for #897.
