### PR TITLE
docs(governance): govern WASI stdio FFI boundary

### DIFF
--- a/docs/adr/0031-governed-wasi-stdio-ffi-boundary.md
+++ b/docs/adr/0031-governed-wasi-stdio-ffi-boundary.md
@@ -1,0 +1,53 @@
+# ADR-0031: Retain a Governed WASI Stdio FFI Boundary
+
+- Status: Accepted
+- Date: 2026-08-04
+- Governing spec: `090-governed-wasi-stdio-ffi`
+- Owner: Traverse maintainers
+- Review by: 2026-11-04
+
+## Context
+
+Traverse #921 must replace the expedition guest's static fixture behavior with
+real, input-driven logic. On `wasm32-wasip1`, Rust's normal `std::io` path
+introduces `wasi_snapshot_preview1::environ_get`, which is not in the existing
+Host ABI v1 whitelist. Direct stdio calls require Rust `unsafe`, while the
+workspace correctly denies unsafe code by default.
+
+## Decision
+
+Keep the workspace deny-by-default policy. Permit exactly one additional,
+guest-local exception: `crates/traverse-expedition-wasm/src/wasi_stdio.rs`.
+It may use direct FFI only for `wasi_snapshot_preview1::fd_read`, `fd_write`,
+and `proc_exit`.
+
+The module is limited to bounded stdin/stdout/status translation. It may not
+perform pointer work outside its reviewed helpers, import any other WASI or
+Traverse host function, access environment/filesystem/network/clock/random
+state, spawn processes, use mutable globals, or expose a general-purpose FFI
+API. Business logic remains in safe Rust outside the module. The source and
+compiled import boundaries are CI-enforced.
+
+## Consequences
+
+- #921 can provide portable JSON request/response execution without adding
+  ambient environment authority or changing Host ABI v1.
+- Reviewers have a finite source and import set to audit.
+- The exception is not reusable by another guest. A second guest or any new
+  import requires a successor ADR, spec amendment, owner, review date, and
+  security review.
+
+## Alternatives Considered
+
+- Add `environ_get` to Host ABI v1: rejected because it expands ambient
+  authority solely to accommodate the Rust standard-library I/O path.
+- Build a shared safe host-I/O abstraction first: deferred because it creates
+  a larger public surface than the expedition capability requires.
+- Permit unsafe code workspace-wide: rejected because it removes the
+  auditable, capability-specific boundary.
+
+## Removal Criteria
+
+Remove this exception when a reviewed safe guest-I/O abstraction can preserve
+the same bounded, ABI-v1-compatible behavior without direct FFI. Removal must
+delete the module allowance and tighten the CI allowlist in the same change.

--- a/scripts/ci/scoped_unsafe_boundary_check.sh
+++ b/scripts/ci/scoped_unsafe_boundary_check.sh
@@ -2,7 +2,9 @@
 
 set -euo pipefail
 
-readonly approved_boundary="crates/traverse-swift-host/src/lib.rs"
+readonly swift_boundary="crates/traverse-swift-host/src/lib.rs"
+readonly expedition_boundary="crates/traverse-expedition-wasm/src/wasi_stdio.rs"
+readonly expedition_root="crates/traverse-expedition-wasm/src/main.rs"
 
 if ! grep -Fqx 'unsafe_code = "deny"' Cargo.toml; then
   echo "Workspace unsafe-code lint must remain set to deny." >&2
@@ -13,8 +15,8 @@ opt_outs=()
 while IFS= read -r path; do
   opt_outs+=("${path}")
 done < <(grep -RIlF --include='*.rs' '#![allow(unsafe_code)]' crates || true)
-if [[ "${#opt_outs[@]}" -ne 1 || "${opt_outs[0]:-}" != "${approved_boundary}" ]]; then
-  echo "Only ${approved_boundary} may opt out of the workspace unsafe-code lint." >&2
+if [[ "${#opt_outs[@]}" -ne 1 || "${opt_outs[0]:-}" != "${swift_boundary}" ]]; then
+  echo "Only ${swift_boundary} may use a crate-level unsafe-code opt-out." >&2
   exit 1
 fi
 
@@ -22,9 +24,40 @@ unsafe_files=()
 while IFS= read -r path; do
   unsafe_files+=("${path}")
 done < <(grep -RIl --include='*.rs' -E '#\[unsafe\(|unsafe[[:space:]]*(\{|fn|impl|trait|extern)' crates || true)
-if [[ "${#unsafe_files[@]}" -ne 1 || "${unsafe_files[0]:-}" != "${approved_boundary}" ]]; then
-  echo "Unsafe syntax is permitted only in ${approved_boundary}." >&2
-  exit 1
+for path in "${unsafe_files[@]}"; do
+  if [[ "${path}" != "${swift_boundary}" && "${path}" != "${expedition_boundary}" ]]; then
+    echo "Unsafe syntax is permitted only in ${swift_boundary} or ${expedition_boundary}." >&2
+    exit 1
+  fi
+done
+
+if [[ -f "${expedition_boundary}" ]]; then
+  if ! grep -Fqx '#[allow(unsafe_code)]' "${expedition_root}"; then
+    echo "The expedition guest must scope its unsafe-code allowance to wasi_stdio." >&2
+    exit 1
+  fi
+  if [[ "$(grep -Fc 'mod wasi_stdio;' "${expedition_root}")" -ne 1 ]]; then
+    echo "The expedition guest must expose exactly one wasi_stdio module." >&2
+    exit 1
+  fi
+  if [[ "$(grep -Fc 'wasi_snapshot_preview1' "${expedition_boundary}")" -ne 1 ]]; then
+    echo "The expedition boundary must import exactly one WASI Preview 1 module." >&2
+    exit 1
+  fi
+  for symbol in fd_read fd_write proc_exit; do
+    if [[ "$(grep -Ec "fn ${symbol}\\(" "${expedition_boundary}")" -ne 1 ]]; then
+      echo "Missing or duplicate audited WASI symbol: ${symbol}" >&2
+      exit 1
+    fi
+  done
+  if [[ "$(grep -Ec '^[[:space:]]*(pub[[:space:]]+)?unsafe[[:space:]]+extern[[:space:]]+"C"' "${expedition_boundary}")" -ne 1 ]]; then
+    echo "The expedition boundary must contain exactly one audited unsafe extern block." >&2
+    exit 1
+  fi
+  if grep -Eq 'environ_get|path_|fd_(open|close|seek|sync)|random_get|clock_|sock_|proc_raise' "${expedition_boundary}"; then
+    echo "The expedition boundary imports a forbidden WASI capability." >&2
+    exit 1
+  fi
 fi
 
 exports=(
@@ -35,12 +68,12 @@ exports=(
   traverse_swift_host_status_message
 )
 for symbol in "${exports[@]}"; do
-  if [[ "$(grep -Fc "fn ${symbol}" "${approved_boundary}")" -ne 1 ]]; then
+  if [[ "$(grep -Fc "fn ${symbol}" "${swift_boundary}")" -ne 1 ]]; then
     echo "Missing or duplicate audited C-ABI symbol: ${symbol}" >&2
     exit 1
   fi
 done
-if [[ "$(grep -Fc '#[unsafe(no_mangle)]' "${approved_boundary}")" -ne 5 ]]; then
+if [[ "$(grep -Fc '#[unsafe(no_mangle)]' "${swift_boundary}")" -ne 5 ]]; then
   echo "The audited Swift host must expose exactly five production C-ABI symbols." >&2
   exit 1
 fi

--- a/specs/537-governed-wasi-stdio-ffi/spec.md
+++ b/specs/537-governed-wasi-stdio-ffi/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Governed WASI Stdio FFI Boundary
+
+**Status**: Approved
+**Canonical governing ID**: `090-governed-wasi-stdio-ffi`
+**Extends**: `038-wasi-host-insulation` (without changing Host ABI v1) and
+`001-foundation-v0-1` (workspace safety policy)
+**Decision evidence**: Traverse #921 decision record, 2026-08-04
+
+## Purpose
+
+Define the single guest-side Rust FFI exception needed for the expedition
+WASM capability to consume JSON from WASI stdin, emit JSON to WASI stdout, and
+return a deterministic process status. The exception is an implementation
+boundary, not a new host capability or an expansion of Traverse Host ABI v1.
+
+## Scope
+
+In scope:
+
+- one audited module at `crates/traverse-expedition-wasm/src/wasi_stdio.rs`;
+- direct WASI Preview 1 imports of exactly `fd_read`, `fd_write`, and
+  `proc_exit` from `wasi_snapshot_preview1`;
+- a narrow lint exception that applies only to that module;
+- deterministic CI checks of the Rust source boundary and compiled artifact
+  import whitelist;
+- ADR-0031's owner, review date, removal criteria, and security constraints.
+
+Out of scope:
+
+- adding `environ_get` or any other import to Traverse Host ABI v1;
+- filesystem, environment, network, clock, random, socket, process-spawn, or
+  host-defined capability access;
+- a reusable generic unsafe-WASI crate or a workspace-wide unsafe exception;
+- changing the host executor's existing ABI whitelist.
+
+## Requirements
+
+- **FR-001**: The workspace-level `unsafe_code = "deny"` lint MUST remain
+  unchanged.
+- **FR-002**: Only `crates/traverse-swift-host/src/lib.rs` and the expedition
+  guest's `wasi_stdio.rs` module MAY contain unsafe syntax. The Swift boundary
+  remains governed by ADR-0013/ADR-0015; this spec does not broaden it.
+- **FR-003**: The expedition crate MUST scope its `unsafe_code` allowance to
+  the `wasi_stdio` module only. No crate-wide guest opt-out is permitted.
+- **FR-004**: The guest module MUST import exactly `fd_read`, `fd_write`, and
+  `proc_exit` from `wasi_snapshot_preview1`; it MUST import no other WASI or
+  host function.
+- **FR-005**: `fd_read` MAY be used only to receive the bounded JSON request
+  through stdin (file descriptor 0), `fd_write` only to emit the bounded JSON
+  result/error through stdout (file descriptor 1), and `proc_exit` only to
+  report the final bounded status.
+- **FR-006**: All pointer, length, and I/O-result conversion must be contained
+  in `wasi_stdio.rs`; business logic, JSON domain serialization, and capability
+  dispatch MUST remain safe Rust outside that module.
+- **FR-007**: Any nonzero WASI errno, oversized request/response, malformed
+  input, or short write MUST become a deterministic, bounded capability error;
+  it MUST NOT invoke undefined behavior, panic, or ambient fallback.
+- **FR-008**: `scripts/ci/scoped_unsafe_boundary_check.sh` MUST fail when the
+  workspace lint changes, unsafe syntax appears outside the two approved
+  boundaries, the guest module lacks its local allowance, or its import set
+  differs from FR-004.
+- **FR-009**: Built expedition artifacts MUST continue to pass the existing
+  Host ABI import whitelist verification. `environ_get` is explicitly denied.
+
+## Acceptance Scenarios
+
+1. Given a valid JSON request on stdin, when the expedition guest runs, then
+   it reads only fd 0, emits one bounded JSON response only on fd 1, and exits
+   deterministically.
+2. Given a source change that adds `environ_get`, a filesystem import, or an
+   unsafe block outside `wasi_stdio.rs`, when the scoped-boundary check runs,
+   then CI fails and identifies the boundary violation.
+3. Given a compiled expedition artifact, when Host ABI verification runs, then
+   it accepts only the three declared Preview 1 stdio/process imports and
+   rejects every other import before execution.
+4. Given a malformed or too-large request, when the guest runs, then it emits
+   the governed error response or exit status without a panic or host access.
+
+## Quality Gates
+
+- **QG-001**: The scoped unsafe-boundary script must run in required Rust CI.
+- **QG-002**: Focused unit tests cover each errno/short-I/O/size-limit branch
+  in the safe wrapper exposed by `wasi_stdio.rs`.
+- **QG-003**: An integration test invokes the built guest through
+  `WasmExecutor` and validates its artifact imports and stdin/stdout behavior.
+- **QG-004**: `bash scripts/ci/spec_alignment_check.sh` and Host ABI artifact
+  verification pass with this spec declared in the implementation PR.
+
+## Compatibility and Removal
+
+This is a source-level exception only. It does not version or alter Host ABI
+v1. A future safe WASI guest-I/O abstraction may replace this module only via a
+successor immutable spec and ADR. Until then, changes to its import set,
+pointer handling, or scope require a successor ADR and explicit review.
+
+## Implementation Tickets
+
+- Traverse #936 — establish this governing spec, ADR, and CI policy.
+- Traverse #921 — implement the input-driven expedition guest under this
+  boundary after #936 merges.

--- a/specs/README.md
+++ b/specs/README.md
@@ -29,6 +29,7 @@ Traverse uses split, focused governing specs instead of one giant spec file. Thi
 | Event delivery, replay, and missed-event recovery | `036-event-subscription-replay` |
 | Semver range matching and compatible version selection | `037-semver-range-resolution` |
 | WASI and host ABI insulation from standards churn | `038-wasi-host-insulation` |
+| Audited guest-side WASI stdin/stdout FFI exception | `090-governed-wasi-stdio-ffi` |
 | Connector/plugin model and third-party integrations | `039-connector-plugin-architecture` |
 | Contractual enforcement gates and fail-fast validation | `040-contractual-enforcement-gate` |
 | Programmatic workflow building and composition | `041-workflow-composition-api` |

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1170,6 +1170,19 @@
         "docs/adr/0027-datastore-synchronization.md",
         "specs/533-datastore-synchronization/"
       ]
+    },
+    {
+      "id": "090-governed-wasi-stdio-ffi",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/537-governed-wasi-stdio-ffi/spec.md",
+      "governs": [
+        "crates/traverse-expedition-wasm/",
+        "scripts/ci/scoped_unsafe_boundary_check.sh",
+        "docs/adr/0031-governed-wasi-stdio-ffi-boundary.md",
+        "specs/537-governed-wasi-stdio-ffi/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Governs the approved expedition guest WASI stdio FFI exception with an immutable spec, successor ADR, and CI boundary enforcement.

Closes #936

## Governing Spec

- `090-governed-wasi-stdio-ffi`
- `004-spec-alignment-gate`

## Project Item

- Project 1 issue: #936
- Consumer: #921

## Validation

- `bash scripts/ci/scoped_unsafe_boundary_check.sh`
- `BASE_SHA=origin/main bash scripts/ci/spec_alignment_check.sh .pr-body-936.md`
- `bash scripts/ci/repository_checks.sh`
- `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body .pr-body-936.md`