### PR TITLE
docs(governance): define no-std WASI guest profile

### DIFF
--- a/docs/adr/0032-no-std-wasi-guest-profile.md
+++ b/docs/adr/0032-no-std-wasi-guest-profile.md
@@ -1,0 +1,33 @@
+# ADR-0032: Adopt a No-Std WASI Guest Profile for Expedition Execution
+
+- Status: Accepted
+- Date: 2026-08-04
+- Governing spec: `091-no-std-wasi-guest-profile`
+- Owner: Traverse maintainers
+- Review by: 2026-11-04
+
+## Context
+
+The audited FFI exception in ADR-0031 correctly limits application I/O to
+`fd_read`, `fd_write`, and `proc_exit`. Compiled evidence nevertheless showed
+that Rust `std` startup imports `environ_get`, which ABI v1 denies before guest
+logic begins.
+
+## Decision
+
+Use a guest-local `no_std` plus `alloc` profile for the expedition component.
+The guest owns a bounded allocator and deterministic panic/termination path.
+It retains only the three ADR-0031 WASI imports. No Host ABI v1 change is made.
+
+## Consequences
+
+The expedition guest can remain least-authority compatible, but its allocator,
+panic behavior, memory limit, and artifact import evidence are now mandatory
+review and test subjects. A reusable no-std runtime or any further import needs
+a successor ADR and security review.
+
+## Alternatives Considered
+
+- Add `environ_get`: rejected; it broadens ambient authority.
+- Keep `std` and accept import validation failure: rejected; it cannot execute.
+- Build a shared guest framework: deferred; it expands scope beyond #921.

--- a/specs/538-no-std-wasi-guest-profile/spec.md
+++ b/specs/538-no-std-wasi-guest-profile/spec.md
@@ -1,0 +1,63 @@
+# Feature Specification: No-Std WASI Guest Profile
+
+**Status**: Approved
+**Canonical governing ID**: `091-no-std-wasi-guest-profile`
+**Extends**: `090-governed-wasi-stdio-ffi`
+**Decision evidence**: Traverse #921 decision record, 2026-08-04
+
+## Purpose
+
+Define the no-`std` guest profile required for the expedition WASM component.
+Normal Rust `std` startup imports `wasi_snapshot_preview1::environ_get`, which
+Host ABI v1 deliberately denies. This profile removes that import without
+expanding the Host ABI or weakening the audited FFI boundary.
+
+## Requirements
+
+- **FR-001**: `traverse-expedition-wasm` MUST compile for `wasm32-wasip1`
+  with `#![no_std]` and `extern crate alloc`; it MUST NOT link Rust `std`.
+- **FR-002**: The guest MUST supply an explicitly reviewed allocator and panic
+  strategy. Allocation failure, panic, malformed input, and size-limit failure
+  MUST terminate deterministically through the governed status path.
+- **FR-003**: Dynamic allocation MUST be bounded by a documented guest memory
+  limit; business input and output each remain bounded by Spec 090's I/O
+  limits.
+- **FR-004**: The compiled guest MUST import exactly
+  `wasi_snapshot_preview1::{fd_read,fd_write,proc_exit}` and no other WASI or
+  host symbol. `environ_get` remains forbidden.
+- **FR-005**: The allocator, panic handler, and startup code MUST be guest
+  local; they MUST NOT create a reusable host API, ambient authority, or new
+  public runtime surface.
+- **FR-006**: The existing source boundary check and artifact ABI verifier
+  MUST be required validation for every change to the guest profile.
+
+## Acceptance Scenarios
+
+1. Given the built expedition guest, when ABI verification runs, then the
+   artifact contains only the three allowed Preview 1 imports.
+2. Given a valid bounded JSON request on stdin, when the guest executes via
+   `WasmExecutor`, then it produces the contract-valid output without `std` or
+   environment access.
+3. Given an oversized request, allocation failure, or panic, when the guest
+   executes, then it returns a deterministic bounded error/status without a
+   trap that can crash the host.
+
+## Quality Gates
+
+- **QG-001**: A compile-time check rejects a guest build that links `std` or
+  imports `environ_get`.
+- **QG-002**: Focused tests cover allocator exhaustion, panic handling, I/O
+  errno/short write, and malformed input behavior.
+- **QG-003**: The end-to-end CLI/ArtifactRouter/WasmExecutor path runs the
+  compiled guest and captures its trace evidence.
+
+## Out of Scope
+
+- Any Host ABI v1 addition, including `environ_get`.
+- A shared allocator crate or a general no-`std` framework.
+- Filesystem, environment, network, clock, random, or process-spawn access.
+
+## Implementation Tickets
+
+- Traverse #940 — establish this profile and ADR.
+- Traverse #921 — migrate the expedition guest and prove the real artifact.

--- a/specs/README.md
+++ b/specs/README.md
@@ -30,6 +30,7 @@ Traverse uses split, focused governing specs instead of one giant spec file. Thi
 | Semver range matching and compatible version selection | `037-semver-range-resolution` |
 | WASI and host ABI insulation from standards churn | `038-wasi-host-insulation` |
 | Audited guest-side WASI stdin/stdout FFI exception | `090-governed-wasi-stdio-ffi` |
+| No-std guest profile for ABI-v1-compatible WASI execution | `091-no-std-wasi-guest-profile` |
 | Connector/plugin model and third-party integrations | `039-connector-plugin-architecture` |
 | Contractual enforcement gates and fail-fast validation | `040-contractual-enforcement-gate` |
 | Programmatic workflow building and composition | `041-workflow-composition-api` |

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1183,6 +1183,18 @@
         "docs/adr/0031-governed-wasi-stdio-ffi-boundary.md",
         "specs/537-governed-wasi-stdio-ffi/"
       ]
+    },
+    {
+      "id": "091-no-std-wasi-guest-profile",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/538-no-std-wasi-guest-profile/spec.md",
+      "governs": [
+        "crates/traverse-expedition-wasm/",
+        "docs/adr/0032-no-std-wasi-guest-profile.md",
+        "specs/538-no-std-wasi-guest-profile/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Defines the approved no-`std` WASI guest profile required to keep #921 compatible with Host ABI v1 without authorizing `environ_get`.

Closes #940

## Governing Spec

- `091-no-std-wasi-guest-profile`
- `004-spec-alignment-gate`

## Project Item

- Project 1 issue: #940
- Consumer: #921

## Validation

- `bash scripts/ci/scoped_unsafe_boundary_check.sh`
- `git diff --check`