### PR TITLE
docs(governance): reconcile approved spec headers

### DIFF
--- a/specs/001-foundation-v0-1/spec.md
+++ b/specs/001-foundation-v0-1/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `001-foundation-v0-1`  
 **Created**: 2026-03-26  
-**Status**: Draft  
+**Status**: Approved
 **Input**: User description: "Foundation v0.1 for a Rust + WASM portable capability runtime with contracts, registries, event-driven communication, graph-based workflows, structured traces, and a React browser demo."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/002-capability-contracts/spec.md
+++ b/specs/002-capability-contracts/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `002-capability-contracts`  
 **Created**: 2026-03-26  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Existing Traverse foundation specification, data model, constitution, and project source material derived from UMA, ECCA, and C-DAD.
 
 ## Purpose

--- a/specs/003-event-contracts/spec.md
+++ b/specs/003-event-contracts/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `003-event-contracts`  
 **Created**: 2026-03-26  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Existing Traverse foundation specification, constitution, planning artifacts, and source material already reviewed from ECCA, C-DAD, UMA, and UMA Chapter 13.
 
 ## Purpose

--- a/specs/004-spec-alignment-gate/spec.md
+++ b/specs/004-spec-alignment-gate/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `004-spec-alignment-gate`  
 **Created**: 2026-03-27  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Existing Traverse foundation specification, constitution, quality standards, and issue `#7` for deterministic spec-alignment enforcement.
 
 ## Purpose

--- a/specs/005-capability-registry/spec.md
+++ b/specs/005-capability-registry/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `005-capability-registry`  
 **Created**: 2026-03-27  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Existing Traverse foundation specification, capability contract and event contract slices, spec-alignment governance, and the registry design decisions agreed during the planning session.
 
 ## Purpose

--- a/specs/006-runtime-request-execution/spec.md
+++ b/specs/006-runtime-request-execution/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `006-runtime-request-execution`  
 **Created**: 2026-03-27  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Foundation runtime slice for `traverse-runtime`, covering request schema, deterministic local execution, ambiguity behavior, runtime state transitions, and trace output.
 
 ## Purpose

--- a/specs/007-workflow-registry-traversal/spec.md
+++ b/specs/007-workflow-registry-traversal/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `007-workflow-registry-traversal`  
 **Created**: 2026-03-27  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Foundation workflow slice for deterministic workflow registration, workflow metadata, and runtime traversal over registered capabilities and event edges.
 
 ## Purpose

--- a/specs/008-expedition-example-domain/spec.md
+++ b/specs/008-expedition-example-domain/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `008-expedition-example-domain`  
 **Created**: 2026-03-27  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Issue `#30`, existing Traverse foundation specs, and the agreed product direction for the first real example domain and canonical workflow.
 
 ## Purpose

--- a/specs/009-expedition-example-artifacts/spec.md
+++ b/specs/009-expedition-example-artifacts/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `009-expedition-example-artifacts`  
 **Created**: 2026-03-27  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Issue `#33`, the approved expedition example domain, capability contract rules, event contract rules, and workflow registry rules.
 
 ## Purpose

--- a/specs/010-runtime-state-machine/spec.md
+++ b/specs/010-runtime-state-machine/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `010-runtime-state-machine`  
 **Created**: 2026-03-30  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Dedicated runtime-governance slice for the Traverse runtime state machine, including state values, transition rules, emitted state-event semantics, and terminal behavior.
 
 ## Purpose

--- a/specs/011-event-registry/spec.md
+++ b/specs/011-event-registry/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `011-event-registry`  
 **Created**: 2026-03-30  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Dedicated registry slice for governed event contract publication, storage, lookup, indexing, and compatibility-aware discovery.
 
 ## Purpose

--- a/specs/013-browser-runtime-subscription/spec.md
+++ b/specs/013-browser-runtime-subscription/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `013-browser-runtime-subscription`  
 **Created**: 2026-03-31  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Dedicated governing slice for the browser-facing runtime subscription surface that streams runtime lifecycle, state, trace, and terminal result messages to UI consumers.
 
 ## Purpose

--- a/specs/017-ai-agent-packaging/spec.md
+++ b/specs/017-ai-agent-packaging/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `017-ai-agent-packaging`  
 **Created**: 2026-04-01  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Issue `#49`, the approved runtime, workflow, event, and MCP-adjacent foundation slices, plus the MVP need for real governed WASM-backed AI agents.
 
 ## Purpose

--- a/specs/018-event-driven-composition/spec.md
+++ b/specs/018-event-driven-composition/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `018-event-driven-composition`  
 **Created**: 2026-03-30  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Issue `#36`, the approved foundation, event-contract, and workflow-traversal slices, plus the agreed decisions for governed event-driven workflow progression.
 
 ## Purpose

--- a/specs/019-downstream-consumer-contract/spec.md
+++ b/specs/019-downstream-consumer-contract/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `019-downstream-consumer-contract`  
 **Created**: 2026-04-03  
-**Status**: Draft  
+**Status**: Approved
 **Input**: The agreed Traverse architecture for `youaskm3`, where Traverse provides the runtime and MCP substrate while the downstream app owns UI, product UX, and presentation behavior.
 
 ## Purpose

--- a/specs/023-browser-hosted-mcp-consumer-model/spec.md
+++ b/specs/023-browser-hosted-mcp-consumer-model/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `codex/issue-174-browser-hosted-mcp-consumer-model`  
 **Created**: 2026-04-07  
-**Status**: Draft  
+**Status**: Approved
 **Input**: Issue `#174`, the approved downstream consumer contract, the local browser adapter transport slice, the dedicated Traverse MCP server model, and the need for one governed browser-hosted consumption model for apps like `youaskm3`.
 
 ## Purpose

--- a/specs/029-integrated-observability/spec.md
+++ b/specs/029-integrated-observability/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `029-integrated-observability`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Observability layer for `traverse-runtime` and `traverse-mcp`, covering OpenTelemetry signal export, W3C Trace Context propagation, attribute naming conventions, and deterministic test-mode identifiers.
 
 ## Purpose

--- a/specs/030-security-identity-model/spec.md
+++ b/specs/030-security-identity-model/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `030-security-identity-model`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Identity and signing layer for `traverse-runtime`, `traverse-contracts`, and `traverse-cli`, covering caller identity propagation, artifact signature verification, OIDC-style JWT handling, and safe identity derivation.
 
 ## Purpose

--- a/specs/031-supply-chain-hardening/spec.md
+++ b/specs/031-supply-chain-hardening/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `031-supply-chain-hardening`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Supply chain security layer for `scripts/ci/`, `.github/workflows/`, and `Cargo.toml`, covering SBOM generation, reproducible builds, SLSA provenance, artifact checksum verification, and nightly supply-chain CI checks.
 
 ## Purpose

--- a/specs/032-universal-data-access/spec.md
+++ b/specs/032-universal-data-access/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `032-universal-data-access`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Offline-first state access layer for capabilities running across browser, edge, and cloud environments, covering the `DataStore` trait, schema validation, deterministic conflict resolution, and sync lifecycle.
 
 ## Purpose

--- a/specs/036-event-subscription-replay/spec.md
+++ b/specs/036-event-subscription-replay/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `036-event-subscription-replay`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Event delivery model for Traverse covering at-least-once subscription, cursor-based replay, bounded buffer retention, backpressure handling, and browser adapter compatibility. Unblocks GitHub issues #308 and #312.
 
 ## Purpose

--- a/specs/038-wasi-host-insulation/spec.md
+++ b/specs/038-wasi-host-insulation/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `038-wasi-host-insulation`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Stable host-function boundary for WASM modules compiled for Traverse, insulating module authors from WASI churn and establishing an independently versioned Traverse Host ABI. Governs `crates/traverse-runtime/` and `Cargo.toml`. Unblocks GitHub issue #330.
 
 ## Purpose

--- a/specs/039-connector-plugin-architecture/spec.md
+++ b/specs/039-connector-plugin-architecture/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `039-connector-plugin-architecture`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Plugin model that allows capabilities to declare external resource dependencies (HTTP, filesystem, environment variables) through a `ConnectorPlugin` trait and a `connector_contract.json`; connectors are registered in the Traverse registry alongside capabilities and injected at execution time. Governs `crates/traverse-contracts/` and `crates/traverse-registry/`. Unblocks GitHub issue #331.
 
 ## Purpose

--- a/specs/040-contractual-enforcement-gate/spec.md
+++ b/specs/040-contractual-enforcement-gate/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `040-contractual-enforcement-gate`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Three-layer contractual validation enforced at authoring/CI-time, registration-time, and execution-time across all governed artifact directories. Introduces the draft quarantine convention, a unified violation taxonomy, and aggregate (non-fail-fast) violation reporting. Governs `scripts/ci/`, `crates/traverse-runtime/`, `crates/traverse-contracts/`, and `specs/governance/`. Unblocks GitHub issue #332.
 
 ## Purpose

--- a/specs/041-workflow-composition-api/spec.md
+++ b/specs/041-workflow-composition-api/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `041-workflow-composition-api`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Spec slice defining the runtime and registry surface for registering, inspecting, and executing DAG-based workflows composed of capability nodes — covering JSON document format, HTTP API endpoints, CLI commands, cycle detection, and edge schema validation. Unblocks GitHub issue #309.
 
 ## Purpose

--- a/specs/042-mcp-library-surface/spec.md
+++ b/specs/042-mcp-library-surface/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `042-mcp-library-surface`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Spec slice defining the refactoring of `traverse-mcp` into a dual-surface crate: a public Rust library API callable by agents without MCP wire protocol, and a thin stdio server binary that wraps the library. Covers public function signatures, `McpToolRegistry`, semver stability guarantees, and embedding rules. Unblocks GitHub issue #310.
 
 ## Purpose

--- a/specs/043-module-dependency-management/spec.md
+++ b/specs/043-module-dependency-management/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `043-module-dependency-management`
 **Created**: 2026-04-19
-**Status**: Draft
+**Status**: Approved
 **Input**: Spec slice defining how capabilities declare, resolve, lock, and verify inter-capability dependencies within Traverse's registry and contracts model. Covers dependency declaration in contracts, registration-time resolution using semver range matching, dependency lock records, execution-time digest verification, transitive resolution up to depth 5, circular dependency detection, and workspace-scoped resolution. Unblocks GitHub issue #338.
 
 ## Purpose

--- a/specs/204-placement-constraint-evaluator/spec.md
+++ b/specs/204-placement-constraint-evaluator/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `204-placement-constraint-evaluator`
 **Spec ID**: 024
 **Created**: 2026-04-08
-**Status**: Draft
+**Status**: Approved
 **Input**: GitHub issue #204
 
 > **Governance note**: This spec governs a new deterministic evaluation subsystem inside `traverse-runtime`. It extends spec 006-runtime-request-execution by replacing the stub `local`-only placement constant with a three-tier evaluator. It depends on issue #208 landing first to add `service_type` and `permitted_targets` fields to capability contracts — no placement evaluation can be implemented against contract constraints until those fields exist.

--- a/specs/205-wasm-executor-adapter/spec.md
+++ b/specs/205-wasm-executor-adapter/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `205-wasm-executor-adapter`
 **Spec ID**: 025
 **Created**: 2026-04-08
-**Status**: Draft
+**Status**: Approved
 **Input**: GitHub issue #205
 
 > **Governance note**: Extends spec 006-runtime-request-execution. The `local` placement defined in spec 006 is now backed by a pluggable `CapabilityExecutor` trait with two implementations: `NativeExecutor` (existing Rust path) and `WasmExecutor` (Wasmtime-backed). This spec does not change the runtime request boundary, state machine, or trace contract — it refactors the execution layer beneath selection. The expedition example domain (#211) is the first real WASM capability and validates the WasmExecutor end-to-end.

--- a/specs/206-execution-trace-tiered/spec.md
+++ b/specs/206-execution-trace-tiered/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `206-execution-trace-tiered`
 **Spec ID**: 012
 **Created**: 2026-04-08
-**Status**: Draft
+**Status**: Approved
 **Input**: GitHub issue #206
 
 > **Governance note**: Extends spec `006-runtime-request-execution` (execution path) and is governed by `001-foundation-v0-1` for the MCP surface. PlacementDecision from spec 010 is part of the public trace tier. No raw inputs or outputs are stored in any tier.

--- a/specs/207-event-broker/spec.md
+++ b/specs/207-event-broker/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `207-event-broker`
 **Spec ID**: 026
 **Created**: 2026-04-08
-**Status**: Draft
+**Status**: Approved
 **Input**: GitHub issue #207
 
 > **Governance note**: Governed by spec `003-event-contracts` (event contract format — defines the contract schema that every published event must conform to). Extends spec `006-runtime-request-execution` (execution path that produces events). Depends on issue #208 for the `subscribable` service_type on capabilities. The EventBroker and EventCatalog live in `traverse-runtime`; the MCP surface is exposed via `traverse-mcp`. ECCA principle — events as products — mandates that ownership metadata (owner, version, lifecycle_status) is non-negotiable on every published event. No raw event data is stored in the catalog; only schema reference + governance metadata.

--- a/specs/208-service-type-taxonomy/spec.md
+++ b/specs/208-service-type-taxonomy/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `208-service-type-taxonomy`
 **Spec ID**: 014
 **Created**: 2026-04-08
-**Status**: Draft
+**Status**: Approved
 **Input**: GitHub issue #208
 
 > **Governance note**: Amends spec 002-capability-contracts. All existing contract parsing must remain backward-compatible. No runtime or CI gate changes — only traverse-contracts crate and contract files in contracts/.

--- a/specs/209-capability-discovery-mcp/spec.md
+++ b/specs/209-capability-discovery-mcp/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `209-capability-discovery-mcp`
 **Spec ID**: 015
 **Created**: 2026-04-08
-**Status**: Draft
+**Status**: Approved
 **Input**: GitHub issue #209
 
 > **Governance note**: Governed by spec 001-foundation-v0-1 (MCP surface). Depends on #206 (tiered trace), #207 (event broker + catalog), #208 (service_type fields). traverse-mcp transitions from stub to functional implementation.

--- a/specs/210-runtime-placement-router/spec.md
+++ b/specs/210-runtime-placement-router/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `210-runtime-placement-router`
 **Spec ID**: 016
 **Created**: 2026-04-08
-**Status**: Draft
+**Status**: Approved
 **Input**: GitHub issue #210
 
 > **Governance note**: Extends spec 006-runtime-request-execution. Integrates #204 (placement evaluator), #205 (executor adapter), #206 (trace), #207 (event broker). This is the final integration step for the v0.2.0 execution path.

--- a/specs/211-expedition-wasm-port/spec.md
+++ b/specs/211-expedition-wasm-port/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `211-expedition-wasm-port`
 **Spec ID**: 027
 **Created**: 2026-04-08
-**Status**: Draft
+**Status**: Approved
 **Input**: GitHub issue #211
 
 > **Governance note**: Extends spec 008-expedition-example-domain and spec 009-expedition-example-artifacts. Validates the WasmExecutor from spec 011 (#205) and PlacementRouter from spec 016 (#210) end-to-end. Depends on #205 and #210 landing first.

--- a/specs/212-schema-alignment-gate-v02/spec.md
+++ b/specs/212-schema-alignment-gate-v02/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `212-schema-alignment-gate-v02`
 **Spec ID**: 028
 **Created**: 2026-04-08
-**Status**: Draft
+**Status**: Approved
 **Input**: GitHub issue #212
 
 > **Governance note**: Amends spec 004-spec-alignment-gate. Must land last in the v0.2.0 sequence — after all other specs (010–017) are approved and merged.


### PR DESCRIPTION
## Summary

Reconcile stale approved-spec headers with the existing immutable registry.

## Governing Spec

- `004-spec-alignment-gate`
- `043-module-dependency-management`

## Project Item

Project 1 issue #943.

## Definition of Done

- [x] Approved headers match the registry.
- [x] No registry entry changed.

## Validation

- Header-to-registry consistency check.
