### PR TITLE
docs(governance): approve datastore v2 migration spec

### DIFF
--- a/specs/528-datastore-v2-migration-ownership/spec.md
+++ b/specs/528-datastore-v2-migration-ownership/spec.md
@@ -2,7 +2,8 @@
 
 **Feature Branch**: `codex/issue-848-datastore-v2-migration`
 **Created**: 2026-07-28
-**Status**: Draft — successor specification requiring maintainer approval before implementation.
+**Status**: Approved
+**Canonical governing ID**: `092-datastore-v2-migration-ownership`
 **Input**: Issue #848, Decision 38, `524-production-app-readiness`, and Spec 082.
 
 ## Purpose

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1195,6 +1195,18 @@
         "docs/adr/0032-no-std-wasi-guest-profile.md",
         "specs/538-no-std-wasi-guest-profile/"
       ]
+    },
+    {
+      "id": "092-datastore-v2-migration-ownership",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/528-datastore-v2-migration-ownership/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "crates/traverse-embedder/",
+        "specs/528-datastore-v2-migration-ownership/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Approve the existing host-owned DataStore v2 migration successor.

## Governing Spec

- `082-datastore-format-migration`

## Project Item

Issue #848; unblocks #873.

## Definition of Done

- [x] Spec 092 is registered as immutable approved governance.

## Validation

- `jq empty specs/governance/approved-specs.json`
- `git diff --check`
