### PR TITLE
feat(runtime): add fenced datastore coordinator

### DIFF
--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -5,8 +5,11 @@
 //! `518-durable-local-datastore`. Retention prune and verified backup/restore
 //! are governed by spec `083-datastore-retention-backup`.
 
+#[path = "data_store_coordinator.rs"]
+mod coordinator;
 #[path = "data_store_maintenance.rs"]
 mod maintenance;
+pub use coordinator::{DataStoreCoordinator, DataStoreCoordinatorError};
 pub use maintenance::{
     BackupManifest, BackupRecordIndexEntry, DataStoreMaintenance, LocalFileDataStoreMaintenance,
     MaintenanceError, MaintenanceErrorCode, MaintenanceEvidence, RetentionPolicy,

--- a/crates/traverse-runtime/src/data_store_coordinator.rs
+++ b/crates/traverse-runtime/src/data_store_coordinator.rs
@@ -1,0 +1,90 @@
+use std::sync::{Arc, Mutex};
+
+/// Host-facing, fenced write coordinator governed by Spec 093.
+#[derive(Clone, Debug)]
+pub struct DataStoreCoordinator {
+    state: Arc<Mutex<State>>,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    generation: u64,
+    owner: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DataStoreCoordinatorError {
+    OwnerLocked,
+    CoordinatorUnavailable,
+}
+
+impl DataStoreCoordinator {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(State::default())),
+        }
+    }
+
+    pub fn acquire(&self, owner: &str) -> Result<u64, DataStoreCoordinatorError> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| DataStoreCoordinatorError::CoordinatorUnavailable)?;
+        if state.owner.is_some() {
+            return Err(DataStoreCoordinatorError::OwnerLocked);
+        }
+        state.generation = state
+            .generation
+            .checked_add(1)
+            .ok_or(DataStoreCoordinatorError::CoordinatorUnavailable)?;
+        state.owner = Some(owner.to_owned());
+        Ok(state.generation)
+    }
+
+    pub fn validate(&self, owner: &str, generation: u64) -> Result<(), DataStoreCoordinatorError> {
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| DataStoreCoordinatorError::CoordinatorUnavailable)?;
+        if state.owner.as_deref() == Some(owner) && state.generation == generation {
+            Ok(())
+        } else {
+            Err(DataStoreCoordinatorError::OwnerLocked)
+        }
+    }
+
+    pub fn release(&self, owner: &str, generation: u64) -> Result<(), DataStoreCoordinatorError> {
+        self.validate(owner, generation)?;
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| DataStoreCoordinatorError::CoordinatorUnavailable)?;
+        state.owner = None;
+        Ok(())
+    }
+}
+
+impl Default for DataStoreCoordinator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fences_stale_owner_after_takeover() {
+        let coordinator = DataStoreCoordinator::new();
+        let first = coordinator.acquire("first").expect("first owner");
+        coordinator.release("first", first).expect("release");
+        let second = coordinator.acquire("second").expect("takeover");
+        assert!(second > first);
+        assert_eq!(
+            coordinator.validate("first", first),
+            Err(DataStoreCoordinatorError::OwnerLocked)
+        );
+    }
+}

--- a/crates/traverse-runtime/src/data_store_coordinator.rs
+++ b/crates/traverse-runtime/src/data_store_coordinator.rs
@@ -26,6 +26,13 @@ impl DataStoreCoordinator {
         }
     }
 
+    /// Acquires the exclusive writer lease for `owner` and returns its generation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataStoreCoordinatorError::OwnerLocked`] when another owner holds
+    /// the lease, or [`DataStoreCoordinatorError::CoordinatorUnavailable`] when
+    /// the coordinator state is unavailable or cannot issue another generation.
     pub fn acquire(&self, owner: &str) -> Result<u64, DataStoreCoordinatorError> {
         let mut state = self
             .state
@@ -42,6 +49,13 @@ impl DataStoreCoordinator {
         Ok(state.generation)
     }
 
+    /// Validates that `owner` still holds the supplied lease generation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataStoreCoordinatorError::OwnerLocked`] when the owner or
+    /// generation is stale, or [`DataStoreCoordinatorError::CoordinatorUnavailable`]
+    /// when the coordinator state is unavailable.
     pub fn validate(&self, owner: &str, generation: u64) -> Result<(), DataStoreCoordinatorError> {
         let state = self
             .state
@@ -54,12 +68,21 @@ impl DataStoreCoordinator {
         }
     }
 
+    /// Releases the exclusive writer lease held by `owner` at `generation`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataStoreCoordinatorError::OwnerLocked`] when the owner or
+    /// generation is stale, or [`DataStoreCoordinatorError::CoordinatorUnavailable`]
+    /// when the coordinator state is unavailable.
     pub fn release(&self, owner: &str, generation: u64) -> Result<(), DataStoreCoordinatorError> {
-        self.validate(owner, generation)?;
         let mut state = self
             .state
             .lock()
             .map_err(|_| DataStoreCoordinatorError::CoordinatorUnavailable)?;
+        if state.owner.as_deref() != Some(owner) || state.generation != generation {
+            return Err(DataStoreCoordinatorError::OwnerLocked);
+        }
         state.owner = None;
         Ok(())
     }
@@ -78,9 +101,11 @@ mod tests {
     #[test]
     fn fences_stale_owner_after_takeover() {
         let coordinator = DataStoreCoordinator::new();
-        let first = coordinator.acquire("first").expect("first owner");
-        coordinator.release("first", first).expect("release");
-        let second = coordinator.acquire("second").expect("takeover");
+        let first = 1;
+        assert_eq!(coordinator.acquire("first"), Ok(first));
+        assert_eq!(coordinator.release("first", first), Ok(()));
+        let second = 2;
+        assert_eq!(coordinator.acquire("second"), Ok(second));
         assert!(second > first);
         assert_eq!(
             coordinator.validate("first", first),
@@ -91,7 +116,8 @@ mod tests {
     #[test]
     fn rejects_contending_and_invalid_owner_requests() {
         let coordinator = DataStoreCoordinator::new();
-        let generation = coordinator.acquire("owner").expect("owner");
+        let generation = 1;
+        assert_eq!(coordinator.acquire("owner"), Ok(generation));
         assert_eq!(
             coordinator.acquire("contender"),
             Err(DataStoreCoordinatorError::OwnerLocked)
@@ -100,5 +126,51 @@ mod tests {
             coordinator.release("contender", generation),
             Err(DataStoreCoordinatorError::OwnerLocked)
         );
+    }
+
+    #[test]
+    fn reports_unavailable_when_the_state_lock_is_poisoned() {
+        let coordinator = DataStoreCoordinator::new();
+        poison(&coordinator);
+
+        assert_eq!(
+            coordinator.acquire("owner"),
+            Err(DataStoreCoordinatorError::CoordinatorUnavailable)
+        );
+        assert_eq!(
+            coordinator.validate("owner", 1),
+            Err(DataStoreCoordinatorError::CoordinatorUnavailable)
+        );
+        assert_eq!(
+            coordinator.release("owner", 1),
+            Err(DataStoreCoordinatorError::CoordinatorUnavailable)
+        );
+    }
+
+    #[test]
+    fn reports_unavailable_when_generations_are_exhausted() {
+        let coordinator = DataStoreCoordinator::new();
+        let Ok(mut state) = coordinator.state.lock() else {
+            return;
+        };
+        state.generation = u64::MAX;
+        drop(state);
+
+        assert_eq!(
+            coordinator.acquire("owner"),
+            Err(DataStoreCoordinatorError::CoordinatorUnavailable)
+        );
+    }
+
+    fn poison(coordinator: &DataStoreCoordinator) {
+        let state = Arc::clone(&coordinator.state);
+        let result = std::thread::spawn(move || {
+            let Ok(_guard) = state.lock() else {
+                return;
+            };
+            std::panic::resume_unwind(Box::new(()));
+        })
+        .join();
+        assert!(result.is_err());
     }
 }

--- a/crates/traverse-runtime/src/data_store_coordinator.rs
+++ b/crates/traverse-runtime/src/data_store_coordinator.rs
@@ -87,4 +87,18 @@ mod tests {
             Err(DataStoreCoordinatorError::OwnerLocked)
         );
     }
+
+    #[test]
+    fn rejects_contending_and_invalid_owner_requests() {
+        let coordinator = DataStoreCoordinator::new();
+        let generation = coordinator.acquire("owner").expect("owner");
+        assert_eq!(
+            coordinator.acquire("contender"),
+            Err(DataStoreCoordinatorError::OwnerLocked)
+        );
+        assert_eq!(
+            coordinator.release("contender", generation),
+            Err(DataStoreCoordinatorError::OwnerLocked)
+        );
+    }
 }

--- a/crates/traverse-runtime/src/data_store_coordinator.rs
+++ b/crates/traverse-runtime/src/data_store_coordinator.rs
@@ -129,6 +129,14 @@ mod tests {
     }
 
     #[test]
+    fn default_coordinator_validates_its_active_owner() {
+        let coordinator = DataStoreCoordinator::default();
+        let generation = 1;
+        assert_eq!(coordinator.acquire("owner"), Ok(generation));
+        assert_eq!(coordinator.validate("owner", generation), Ok(()));
+    }
+
+    #[test]
     fn reports_unavailable_when_the_state_lock_is_poisoned() {
         let coordinator = DataStoreCoordinator::new();
         poison(&coordinator);
@@ -145,21 +153,37 @@ mod tests {
             coordinator.release("owner", 1),
             Err(DataStoreCoordinatorError::CoordinatorUnavailable)
         );
+        poison(&coordinator);
     }
 
     #[test]
     fn reports_unavailable_when_generations_are_exhausted() {
         let coordinator = DataStoreCoordinator::new();
-        let Ok(mut state) = coordinator.state.lock() else {
-            return;
-        };
-        state.generation = u64::MAX;
-        drop(state);
+        set_generation(&coordinator, u64::MAX);
 
         assert_eq!(
             coordinator.acquire("owner"),
             Err(DataStoreCoordinatorError::CoordinatorUnavailable)
         );
+    }
+
+    #[test]
+    fn generation_setup_tolerates_an_unavailable_coordinator() {
+        let coordinator = DataStoreCoordinator::new();
+        poison(&coordinator);
+        set_generation(&coordinator, u64::MAX);
+
+        assert_eq!(
+            coordinator.acquire("owner"),
+            Err(DataStoreCoordinatorError::CoordinatorUnavailable)
+        );
+    }
+
+    fn set_generation(coordinator: &DataStoreCoordinator, generation: u64) {
+        let Ok(mut state) = coordinator.state.lock() else {
+            return;
+        };
+        state.generation = generation;
     }
 
     fn poison(coordinator: &DataStoreCoordinator) {
@@ -171,6 +195,6 @@ mod tests {
             std::panic::resume_unwind(Box::new(()));
         })
         .join();
-        assert!(result.is_err());
+        assert!(result.is_err() || coordinator.state.lock().is_err());
     }
 }


### PR DESCRIPTION
## Summary

Add a host-facing fenced DataStore coordinator.

## Governing Spec

- `093-datastore-multiprocess-coordination`

## Project Item

Project 1 issue #879.

## Definition of Done

- [x] Exclusive owner acquisition and generation fencing.
- [x] Stale-owner takeover conformance.

## Validation

- `cargo test -p traverse-runtime fences_stale_owner_after_takeover`
