### PR TITLE
chore(runtime): adopt ECCA registry interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "traverse-registry"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c89f4a562a8a59f49b1da036caa571cbd3b9c033826030d99d7254a8cd2bedb"
+checksum = "37a63c63e14f554e870799a03276af14b61949b430ad42fc31012e227bce77e8"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.8.1"
 
 [workspace.dependencies]
 traverse-contracts = { path = "crates/traverse-contracts", version = "0.8.1" }
-traverse-registry = { version = "=0.9.1" }
+traverse-registry = { version = "=0.11.0" }
 traverse-runtime = { path = "crates/traverse-runtime", version = "0.8.1" }
 
 # The published registry crate pins the current contracts release.  During


### PR DESCRIPTION
## Summary

Update the Traverse workspace to consume `traverse-registry` 0.11.0, the Spec
534-correct ECCA descriptor and conformance interface.

## Governing Spec

- `534-ecca-event-products`
- ADR-0028

## Project Item

- Traverse #897

## Definition of Done

- [x] Runtime conformance work builds against the published ECCA registry interface.
- [x] Existing runtime event behavior remains validated against the upgraded dependency.

## Validation

- `cargo check -p traverse-runtime`
- `cargo test -p traverse-runtime --lib events:: --no-fail-fast`
- Repository local preflight against `origin/main`
