### PR TITLE
docs(governance): approve remote key-value DataStore contract

### DIFF
--- a/docs/adr/0024-remote-key-value-datastore-contract.md
+++ b/docs/adr/0024-remote-key-value-datastore-contract.md
@@ -1,7 +1,7 @@
 # ADR-0024: Keep Remote DataStore Provider-Neutral and Host-Owned
 
-- Status: Proposed
-- Governing draft: `530-remote-key-value-datastore`
+- Status: Accepted
+- Governing spec: `094-remote-key-value-datastore`
 - Extends: ADR-0018 and ADR-0019
 
 ## Decision

--- a/specs/530-remote-key-value-datastore/spec.md
+++ b/specs/530-remote-key-value-datastore/spec.md
@@ -2,7 +2,8 @@
 
 **Feature Branch**: `codex/issue-874-remote-datastore-contract`
 **Created**: 2026-07-29
-**Status**: Draft — requires maintainer approval before any adapter implementation.
+**Status**: Approved
+**Canonical governing ID**: `094-remote-key-value-datastore`
 **Input**: Issue #874; extends Specs 518 and 519.
 
 ## Purpose

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1220,6 +1220,18 @@
         "docs/adr/0033-datastore-multiprocess-coordination.md",
         "specs/539-datastore-multiprocess-coordination/"
       ]
+    },
+    {
+      "id": "094-remote-key-value-datastore",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/530-remote-key-value-datastore/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "docs/adr/0024-remote-key-value-datastore-contract.md",
+        "specs/530-remote-key-value-datastore/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Approve the provider-neutral remote key-value DataStore contract (Spec 530 / ADR-0024). Enrico confirmed approval in chat; the decision-log-backed governing artifacts (Spec 530, ADR-0024) reflect the already-recorded design decisions in #874.

## Governing Spec

- `094-remote-key-value-datastore`
- `004-spec-alignment-gate`

## Project Item

Issue #874 (governing contract); unblocks #886.

## Definition of Done

- [x] Spec, ADR, and immutable registry entry are present.

## Validation

- `jq empty specs/governance/approved-specs.json`
- `git diff --check`
