### PR TITLE
feat(runtime): migrate local datastore v1 to v2

### DIFF
--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -611,9 +611,6 @@ impl DataStore for LocalFileDataStore {
             Some(LOCAL_DATA_STORE_V2_FORMAT) => decode_v2_envelope(value)?,
             _ => return Err(integrity_error("unknown_format_version")),
         };
-        if envelope.format != LOCAL_DATA_STORE_FORMAT {
-            return Err(integrity_error("unknown_format_version"));
-        }
         match envelope.classification {
             LocalDataClassification::Public => {
                 let record = envelope
@@ -2266,6 +2263,43 @@ mod tests {
             thread::sleep(Duration::from_millis(10));
         }
         false
+    }
+
+    #[test]
+    fn v2_envelope_rejects_tampering_unknown_fields_and_invalid_inner_format() {
+        let private = LocalDataStoreEnvelope {
+            format: LOCAL_DATA_STORE_FORMAT.to_string(),
+            classification: LocalDataClassification::Private,
+            digest: "sha256:opaque".to_string(),
+            record: None,
+            record_key: Some("record".to_string()),
+            key_id: Some("host-key".to_string()),
+            nonce: Some("000000000000000000000000".to_string()),
+            ciphertext: Some("00000000000000000000000000000000".to_string()),
+            retained_at: None,
+        };
+        let wrapped = v2_envelope(private).expect("wrap private payload");
+        assert_eq!(wrapped.encryption_disclosure, "host_managed_opaque");
+
+        let mut tampered = serde_json::to_value(&wrapped).expect("json");
+        tampered["payload_integrity"] = Value::String("sha256:bad".to_string());
+        assert!(decode_v2_envelope(tampered).is_err());
+
+        let mut payload_tampered = serde_json::to_value(&wrapped).expect("json");
+        payload_tampered["payload_integrity"] = Value::String("sha256:bad".to_string());
+        payload_tampered["integrity"]["content_digest"] = Value::String("sha256:bad".to_string());
+        assert!(decode_v2_envelope(payload_tampered).is_err());
+
+        let mut unknown = serde_json::to_value(&wrapped).expect("json");
+        unknown["format_version"] = json!(99);
+        assert!(decode_v2_envelope(unknown).is_err());
+
+        let mut invalid_inner = wrapped;
+        invalid_inner.payload.format = "unknown/9".to_string();
+        let bytes = serde_json::to_vec(&invalid_inner.payload).expect("payload");
+        invalid_inner.payload_integrity = digest_bytes(&bytes);
+        invalid_inner.integrity.content_digest = invalid_inner.payload_integrity.clone();
+        assert!(decode_v2_envelope(serde_json::to_value(invalid_inner).expect("json")).is_err());
     }
 
     fn stateful_contract(state_schema: Option<Value>) -> CapabilityContract {

--- a/crates/traverse-runtime/src/data_store.rs
+++ b/crates/traverse-runtime/src/data_store.rs
@@ -11,8 +11,9 @@ mod coordinator;
 mod maintenance;
 pub use coordinator::{DataStoreCoordinator, DataStoreCoordinatorError};
 pub use maintenance::{
-    BackupManifest, BackupRecordIndexEntry, DataStoreMaintenance, LocalFileDataStoreMaintenance,
-    MaintenanceError, MaintenanceErrorCode, MaintenanceEvidence, RetentionPolicy,
+    BackupManifest, BackupRecordIndexEntry, DataStoreMaintenance, DataStoreMigration,
+    LocalFileDataStoreMaintenance, MaintenanceError, MaintenanceErrorCode, MaintenanceEvidence,
+    MigrationError, MigrationErrorCode, MigrationReport, RetentionPolicy,
 };
 
 #[cfg(feature = "datastore-encryption")]
@@ -36,6 +37,9 @@ use zeroize::Zeroizing;
 /// than the earlier generic `DataStore` surface that supplied its merge helper.
 const DATA_STORE_SPEC: &str = "089-datastore-synchronization";
 const LOCAL_DATA_STORE_FORMAT: &str = "local-datastore/1";
+const LOCAL_DATA_STORE_V2_FORMAT: &str = "local-datastore/2";
+const LOCAL_DATA_STORE_V2_FORMAT_VERSION: u32 = 2;
+const LOCAL_DATA_STORE_V2_SCHEMA_VERSION: u32 = 1;
 const LOCAL_DATA_STORE_LOCK_FILE: &str = ".traverse-datastore.lock";
 const HEXADECIMAL_DIGITS: &[u8; 16] = b"0123456789abcdef";
 
@@ -124,6 +128,74 @@ struct LocalDataStoreEnvelope {
     /// Absent on legacy envelopes; age prune treats missing stamps as retained.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     retained_at: Option<String>,
+}
+
+/// Version-two wrapper keeps the durable payload self-identifying and
+/// independently integrity-protected. The payload remains opaque to callers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct LocalDataStoreV2Envelope {
+    format: String,
+    format_version: u32,
+    schema_version: u32,
+    payload_integrity: String,
+    integrity: LocalDataStoreIntegrity,
+    encryption_disclosure: String,
+    payload: LocalDataStoreEnvelope,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct LocalDataStoreIntegrity {
+    algorithm: String,
+    content_digest: String,
+}
+
+fn v2_envelope(
+    payload: LocalDataStoreEnvelope,
+) -> Result<LocalDataStoreV2Envelope, DataStoreError> {
+    let payload_bytes = serde_json::to_vec(&payload)
+        .map_err(|error| serialization_error("serialize v2 data store payload", &error))?;
+    let payload_integrity = digest_bytes(&payload_bytes);
+    Ok(LocalDataStoreV2Envelope {
+        format: LOCAL_DATA_STORE_V2_FORMAT.to_string(),
+        format_version: LOCAL_DATA_STORE_V2_FORMAT_VERSION,
+        schema_version: LOCAL_DATA_STORE_V2_SCHEMA_VERSION,
+        integrity: LocalDataStoreIntegrity {
+            algorithm: "sha256".to_string(),
+            content_digest: payload_integrity.clone(),
+        },
+        payload_integrity,
+        encryption_disclosure: match payload.classification {
+            LocalDataClassification::Public => "not_enabled".to_string(),
+            LocalDataClassification::Private => "host_managed_opaque".to_string(),
+        },
+        payload,
+    })
+}
+
+fn decode_v2_envelope(value: Value) -> Result<LocalDataStoreEnvelope, DataStoreError> {
+    let envelope: LocalDataStoreV2Envelope =
+        serde_json::from_value(value).map_err(|_| integrity_error("malformed_envelope"))?;
+    if envelope.format != LOCAL_DATA_STORE_V2_FORMAT
+        || envelope.format_version != LOCAL_DATA_STORE_V2_FORMAT_VERSION
+        || envelope.schema_version != LOCAL_DATA_STORE_V2_SCHEMA_VERSION
+        || envelope.integrity.algorithm != "sha256"
+        || envelope.integrity.content_digest != envelope.payload_integrity
+        || !matches!(
+            envelope.encryption_disclosure.as_str(),
+            "not_enabled" | "host_managed_opaque"
+        )
+    {
+        return Err(integrity_error("unknown_format_version"));
+    }
+    let payload_bytes = serde_json::to_vec(&envelope.payload)
+        .map_err(|error| serialization_error("serialize v2 payload for verification", &error))?;
+    if digest_bytes(&payload_bytes) != envelope.payload_integrity {
+        return Err(integrity_error("digest_mismatch"));
+    }
+    if envelope.payload.format != LOCAL_DATA_STORE_FORMAT {
+        return Err(integrity_error("unknown_format_version"));
+    }
+    Ok(envelope.payload)
 }
 
 /// Stable, secret-free key-provider failure codes.
@@ -532,8 +604,13 @@ impl DataStore for LocalFileDataStore {
         if value.get("format").is_none() {
             return Err(integrity_error("legacy_unverified"));
         }
-        let envelope: LocalDataStoreEnvelope =
-            serde_json::from_value(value).map_err(|_| integrity_error("malformed_envelope"))?;
+        let envelope: LocalDataStoreEnvelope = match value.get("format").and_then(Value::as_str) {
+            Some(LOCAL_DATA_STORE_FORMAT) => {
+                serde_json::from_value(value).map_err(|_| integrity_error("malformed_envelope"))?
+            }
+            Some(LOCAL_DATA_STORE_V2_FORMAT) => decode_v2_envelope(value)?,
+            _ => return Err(integrity_error("unknown_format_version")),
+        };
         if envelope.format != LOCAL_DATA_STORE_FORMAT {
             return Err(integrity_error("unknown_format_version"));
         }
@@ -561,7 +638,7 @@ impl DataStore for LocalFileDataStore {
 
     fn write(&mut self, record: StateRecord) -> Result<(), DataStoreError> {
         let path = self.path_for_key(&record.key)?;
-        self.ensure_classification_unchanged(&path)?;
+        let write_v2 = self.ensure_classification_unchanged(&path)?;
         let record_key = record.key.clone();
         let envelope = match self.classification {
             LocalDataClassification::Public => LocalDataStoreEnvelope {
@@ -577,8 +654,12 @@ impl DataStore for LocalFileDataStore {
             },
             LocalDataClassification::Private => self.encrypt_private_record(record)?,
         };
-        let text = serde_json::to_vec(&envelope)
-            .map_err(|error| serialization_error("serialize state record envelope", &error))?;
+        let text = if write_v2 {
+            serde_json::to_vec(&v2_envelope(envelope)?)
+        } else {
+            serde_json::to_vec(&envelope)
+        }
+        .map_err(|error| serialization_error("serialize state record envelope", &error))?;
         let temporary_path = self.temporary_path_for_key(&record_key);
         let write_result = (|| {
             let mut temporary_file = File::create(&temporary_path)
@@ -750,13 +831,20 @@ impl LocalFileDataStore {
         })
     }
 
-    fn ensure_classification_unchanged(&self, path: &PathBuf) -> Result<(), DataStoreError> {
+    fn ensure_classification_unchanged(&self, path: &PathBuf) -> Result<bool, DataStoreError> {
         if !path.exists() {
-            return Ok(());
+            return Ok(false);
         }
         let bytes = fs::read(path).map_err(|error| io_error("read existing envelope", &error))?;
-        let envelope: LocalDataStoreEnvelope =
+        let value: Value =
             serde_json::from_slice(&bytes).map_err(|_| integrity_error("malformed_envelope"))?;
+        let write_v2 =
+            value.get("format").and_then(Value::as_str) == Some(LOCAL_DATA_STORE_V2_FORMAT);
+        let envelope = if write_v2 {
+            decode_v2_envelope(value)?
+        } else {
+            serde_json::from_value(value).map_err(|_| integrity_error("malformed_envelope"))?
+        };
         if envelope.format != LOCAL_DATA_STORE_FORMAT {
             return Err(integrity_error("unknown_format_version"));
         }
@@ -767,8 +855,12 @@ impl LocalFileDataStore {
                 json!({ "reason": "delete_before_reclassifying" }),
             ));
         }
-        Ok(())
+        Ok(write_v2)
     }
+}
+
+fn digest_bytes(bytes: &[u8]) -> String {
+    format!("sha256:{}", hex_encode(&Sha256::digest(bytes)))
 }
 
 fn digest_for_record(record: &StateRecord) -> Result<String, DataStoreError> {

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -2100,12 +2100,25 @@ mod tests {
         );
         drop(maintenance);
 
-        let reader =
+        let mut reader =
             LocalFileDataStore::with_classification(&root, LocalDataClassification::Public)
                 .expect("v2 reader");
         assert_eq!(
             reader.read("k00").expect("read").expect("record").key,
             "k00"
+        );
+        reader
+            .write(StateRecord {
+                key: "k00".to_string(),
+                value: json!({ "n": 99 }),
+                lamport_clock: 99,
+                writer_id: "host".to_string(),
+            })
+            .expect("v2-preserving write");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&fs::read(root.join("k00.json")).expect("v2 rewrite"))
+                .expect("v2 json")["format"],
+            LOCAL_DATA_STORE_V2_FORMAT
         );
         drop(reader);
 
@@ -2161,6 +2174,43 @@ mod tests {
             fs::read(root.join("k00.json")).expect("source preserved"),
             before
         );
+    }
+
+    #[test]
+    fn migration_error_mapping_is_stable_and_secret_free() {
+        let maintenance = MaintenanceError {
+            code: MaintenanceErrorCode::MaintenanceIoFailed,
+            message: "internal path must not escape".to_string(),
+            details: json!({ "path": "/secret" }),
+        };
+        let io = std::io::Error::other("internal path must not escape");
+        let data_store = DataStoreError {
+            code: DataStoreErrorCode::IoFailure,
+            message: "internal path must not escape".to_string(),
+            details: json!({ "path": "/secret" }),
+        };
+        let mapped = [
+            map_migration_source_error(maintenance.clone()),
+            map_migration_backup_error(maintenance.clone()),
+            map_migration_write_io(io),
+            map_migration_write_data_store(data_store),
+            map_migration_verification_error(maintenance.clone()),
+            map_migration_commit_io(std::io::Error::other("internal")),
+            map_migration_commit_error(maintenance),
+        ];
+        let expected = [
+            MigrationErrorCode::SourceInvalid,
+            MigrationErrorCode::BackupFailed,
+            MigrationErrorCode::WriteFailed,
+            MigrationErrorCode::WriteFailed,
+            MigrationErrorCode::VerificationFailed,
+            MigrationErrorCode::CommitFailed,
+            MigrationErrorCode::CommitFailed,
+        ];
+        for (error, code) in mapped.into_iter().zip(expected) {
+            assert_eq!(error.code, code);
+            assert!(!error.details.to_string().contains("secret"));
+        }
     }
 
     fn write_zip(parent: &Path, members: &[(&str, &[u8])]) -> PathBuf {

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -2297,6 +2297,14 @@ mod tests {
         assert_eq!(error.details["reason"], "missing_verified_backup_digest");
     }
 
+    #[derive(Debug)]
+    struct Boom;
+    impl Serialize for Boom {
+        fn serialize<S: serde::Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
+            Err(serde::ser::Error::custom("boom"))
+        }
+    }
+
     #[test]
     fn migration_serialize_and_abandon_helpers_are_covered() {
         let parse_error = serde_json::from_str::<Value>("{").expect_err("invalid json");
@@ -2304,13 +2312,6 @@ mod tests {
         assert_eq!(write_failed.code, MigrationErrorCode::WriteFailed);
         assert_eq!(write_failed.details["reason"], "serialize_candidate");
 
-        #[derive(Debug)]
-        struct Boom;
-        impl Serialize for Boom {
-            fn serialize<S: serde::Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
-                Err(serde::ser::Error::custom("boom"))
-            }
-        }
         let boom = json_to_vec(&Boom).expect_err("custom serialize failure");
         assert_eq!(
             map_envelope_serialize_error(boom).code,

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -471,7 +471,7 @@ impl DataStoreMigration for LocalFileDataStoreMaintenance {
         File::create(candidate_root.join(LOCAL_DATA_STORE_LOCK_FILE))
             .map_err(map_migration_write_io)?;
 
-        let candidate = (|| -> Result<(), MigrationError> {
+        (|| -> Result<(), MigrationError> {
             for key in &keys {
                 let source = self
                     .read_envelope(key)
@@ -482,30 +482,10 @@ impl DataStoreMigration for LocalFileDataStoreMaintenance {
                     .map_err(map_migration_write_io)?;
             }
             verify_v2_store_root(&candidate_root).map_err(map_migration_verification_error)
-        })();
-        if let Err(error) = candidate {
-            let _ = fs::remove_dir_all(&candidate_root);
-            return Err(error);
-        }
+        })()
+        .map_err(|error| abandon_failed_candidate(&candidate_root, error))?;
 
-        let _ = self.lock_file.unlock();
-        if let Err(error) = fs::rename(&self.root, &previous_root) {
-            let _ = self.reacquire_lock();
-            let _ = fs::remove_dir_all(&candidate_root);
-            return Err(map_migration_commit_io(error));
-        }
-        if let Err(error) = fs::rename(&candidate_root, &self.root) {
-            let _ = fs::rename(&previous_root, &self.root);
-            let _ = self.reacquire_lock();
-            return Err(map_migration_commit_io(error));
-        }
-        if let Err(error) = self.reacquire_lock() {
-            let _ = fs::rename(&self.root, &candidate_root);
-            let _ = fs::rename(&previous_root, &self.root);
-            let _ = self.reacquire_lock();
-            return Err(map_migration_commit_error(error));
-        }
-        let _ = fs::remove_dir_all(&previous_root);
+        commit_migrated_store_root(self, &candidate_root, &previous_root)?;
 
         Ok(MigrationReport {
             governing_spec: MIGRATION_SPEC.to_string(),
@@ -533,11 +513,23 @@ fn verify_v2_store_root(root: &Path) -> Result<(), MaintenanceError> {
         let value: Value =
             serde_json::from_slice(&bytes).map_err(|_| malformed_envelope_error())?;
         let envelope = decode_v2_envelope(value).map_err(map_data_store_error)?;
-        parse_envelope_bytes(
-            &serde_json::to_vec(&envelope).map_err(|_| malformed_envelope_error())?,
-        )?;
+        parse_envelope_bytes(&serialize_envelope_for_verify(&envelope)?)?;
     }
     Ok(())
+}
+
+fn serialize_envelope_for_verify(
+    envelope: &LocalDataStoreEnvelope,
+) -> Result<Vec<u8>, MaintenanceError> {
+    json_to_vec(envelope).map_err(map_envelope_serialize_error)
+}
+
+fn map_envelope_serialize_error(_: serde_json::Error) -> MaintenanceError {
+    malformed_envelope_error()
+}
+
+fn json_to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>, serde_json::Error> {
+    serde_json::to_vec(value)
 }
 
 fn verified_backup_digest(digest: Option<String>) -> Result<String, MigrationError> {
@@ -553,13 +545,85 @@ fn verified_backup_digest(digest: Option<String>) -> Result<String, MigrationErr
 fn serialize_v2_candidate(
     envelope: &super::LocalDataStoreV2Envelope,
 ) -> Result<Vec<u8>, MigrationError> {
-    serde_json::to_vec(envelope).map_err(|_| {
-        migration_error(
-            MigrationErrorCode::WriteFailed,
-            "datastore_write_failed",
-            "serialize_candidate",
-        )
-    })
+    json_to_vec(envelope).map_err(map_serialize_candidate_error)
+}
+
+fn map_serialize_candidate_error(_: serde_json::Error) -> MigrationError {
+    migration_error(
+        MigrationErrorCode::WriteFailed,
+        "datastore_write_failed",
+        "serialize_candidate",
+    )
+}
+
+fn abandon_failed_candidate(candidate_root: &Path, error: MigrationError) -> MigrationError {
+    let _ = fs::remove_dir_all(candidate_root);
+    error
+}
+
+fn commit_migrated_store_root(
+    maintenance: &mut LocalFileDataStoreMaintenance,
+    candidate_root: &Path,
+    previous_root: &Path,
+) -> Result<(), MigrationError> {
+    let _ = maintenance.lock_file.unlock();
+    move_live_aside_for_migration(maintenance, previous_root, candidate_root)?;
+    install_migrated_candidate(maintenance, candidate_root, previous_root)?;
+    reacquire_migrated_lock(maintenance, candidate_root, previous_root)?;
+    let _ = fs::remove_dir_all(previous_root);
+    Ok(())
+}
+
+fn move_live_aside_for_migration(
+    maintenance: &mut LocalFileDataStoreMaintenance,
+    previous_root: &Path,
+    candidate_root: &Path,
+) -> Result<(), MigrationError> {
+    fs::rename(&maintenance.root, previous_root)
+        .map_err(|error| abort_migration_before_aside(maintenance, candidate_root, error))
+}
+
+fn install_migrated_candidate(
+    maintenance: &mut LocalFileDataStoreMaintenance,
+    candidate_root: &Path,
+    previous_root: &Path,
+) -> Result<(), MigrationError> {
+    fs::rename(candidate_root, &maintenance.root)
+        .map_err(|error| abort_migration_after_aside(maintenance, previous_root, error))
+}
+
+fn abort_migration_before_aside(
+    maintenance: &mut LocalFileDataStoreMaintenance,
+    candidate_root: &Path,
+    error: std::io::Error,
+) -> MigrationError {
+    let _ = maintenance.reacquire_lock();
+    let _ = fs::remove_dir_all(candidate_root);
+    map_migration_commit_io(error)
+}
+
+fn abort_migration_after_aside(
+    maintenance: &mut LocalFileDataStoreMaintenance,
+    previous_root: &Path,
+    error: std::io::Error,
+) -> MigrationError {
+    let _ = fs::rename(previous_root, &maintenance.root);
+    let _ = maintenance.reacquire_lock();
+    map_migration_commit_io(error)
+}
+
+fn reacquire_migrated_lock(
+    maintenance: &mut LocalFileDataStoreMaintenance,
+    candidate_root: &Path,
+    previous_root: &Path,
+) -> Result<(), MigrationError> {
+    if let Err(error) = maintenance.reacquire_lock() {
+        let _ = fs::rename(&maintenance.root, candidate_root);
+        let _ = fs::rename(previous_root, &maintenance.root);
+        let _ = maintenance.reacquire_lock();
+        return Err(map_migration_commit_error(error));
+    }
+    Ok(())
 }
 
 fn migration_error(code: MigrationErrorCode, message: &str, reason: &str) -> MigrationError {
@@ -2231,6 +2295,152 @@ mod tests {
         assert_eq!(error.code, MigrationErrorCode::BackupFailed);
         assert_eq!(error.message, "datastore_backup_failed");
         assert_eq!(error.details["reason"], "missing_verified_backup_digest");
+    }
+
+    #[test]
+    fn migration_serialize_and_abandon_helpers_are_covered() {
+        let parse_error = serde_json::from_str::<Value>("{").expect_err("invalid json");
+        let write_failed = map_serialize_candidate_error(parse_error);
+        assert_eq!(write_failed.code, MigrationErrorCode::WriteFailed);
+        assert_eq!(write_failed.details["reason"], "serialize_candidate");
+
+        #[derive(Debug)]
+        struct Boom;
+        impl Serialize for Boom {
+            fn serialize<S: serde::Serializer>(
+                &self,
+                _serializer: S,
+            ) -> Result<S::Ok, S::Error> {
+                Err(serde::ser::Error::custom("boom"))
+            }
+        }
+        let boom = json_to_vec(&Boom).expect_err("custom serialize failure");
+        assert_eq!(
+            map_envelope_serialize_error(boom).code,
+            MaintenanceErrorCode::RestoreVerifyFailed
+        );
+        assert!(json_to_vec(&Boom)
+            .map_err(map_serialize_candidate_error)
+            .is_err());
+
+        let candidate = temp_root("abandon-candidate").join("work");
+        fs::create_dir_all(&candidate).expect("candidate");
+        fs::write(candidate.join("marker.json"), b"{}").expect("marker");
+        let abandoned = abandon_failed_candidate(
+            &candidate,
+            migration_error(
+                MigrationErrorCode::VerificationFailed,
+                "datastore_verification_failed",
+                "candidate_verification_failed",
+            ),
+        );
+        assert_eq!(abandoned.code, MigrationErrorCode::VerificationFailed);
+        assert!(!candidate.exists());
+    }
+
+    #[test]
+    fn migration_commit_rename_failures_preserve_live_store() {
+        let as_of = "2026-08-05T00:00:00Z";
+        let root = temp_root("mig-commit-aside");
+        drop(seed_store(&root, 1, None));
+        let before = fs::read(root.join("k00.json")).expect("source");
+        let parent = root.parent().expect("parent");
+        let suffix = restore_work_suffix(&root, as_of);
+        let candidate_root = parent.join(format!(".traverse-datastore-migration-{suffix}"));
+        let previous_root = parent.join(format!(".traverse-datastore-pre-v2-{suffix}"));
+        let _ = fs::remove_dir_all(&candidate_root);
+        let _ = fs::remove_file(&previous_root);
+        let _ = fs::remove_dir_all(&previous_root);
+        fs::create_dir_all(&candidate_root).expect("candidate");
+        fs::write(candidate_root.join(LOCAL_DATA_STORE_LOCK_FILE), b"").expect("lock");
+        fs::write(&previous_root, b"block aside").expect("occupy previous");
+
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let failed =
+            commit_migrated_store_root(&mut maintenance, &candidate_root, &previous_root)
+                .expect_err("aside must fail");
+        assert_eq!(failed.code, MigrationErrorCode::CommitFailed);
+        assert_eq!(
+            fs::read(root.join("k00.json")).expect("live preserved"),
+            before
+        );
+        assert!(!candidate_root.exists());
+        let _ = fs::remove_file(&previous_root);
+    }
+
+    #[test]
+    fn migration_commit_install_failure_restores_previous_root() {
+        let as_of = "2026-08-05T00:00:00Z";
+        let root = temp_root("mig-commit-install");
+        drop(seed_store(&root, 1, None));
+        let before = fs::read(root.join("k00.json")).expect("source");
+        let parent = root.parent().expect("parent");
+        let suffix = restore_work_suffix(&root, as_of);
+        let candidate_root = parent.join(format!(".traverse-datastore-migration-{suffix}"));
+        let previous_root = parent.join(format!(".traverse-datastore-pre-v2-{suffix}"));
+        let _ = fs::remove_dir_all(&candidate_root);
+        let _ = fs::remove_dir_all(&previous_root);
+        fs::create_dir_all(&candidate_root).expect("candidate");
+        fs::write(candidate_root.join(LOCAL_DATA_STORE_LOCK_FILE), b"").expect("lock");
+
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let _ = maintenance.lock_file.unlock();
+        fs::rename(&root, &previous_root).expect("aside");
+        fs::write(&root, b"block install").expect("occupy root");
+
+        let failed =
+            install_migrated_candidate(&mut maintenance, &candidate_root, &previous_root)
+                .expect_err("install must fail");
+        assert_eq!(failed.code, MigrationErrorCode::CommitFailed);
+        assert_eq!(
+            fs::read(previous_root.join("k00.json")).expect("aside preserved"),
+            before
+        );
+        assert!(candidate_root.exists());
+        let _ = fs::remove_file(&root);
+        let _ = fs::rename(&previous_root, &root);
+        let _ = fs::remove_dir_all(&candidate_root);
+    }
+
+    #[test]
+    fn migration_reacquire_failure_rolls_back_committed_swap() {
+        let as_of = "2026-08-05T00:00:00Z";
+        let root = temp_root("mig-reacquire");
+        drop(seed_store(&root, 1, None));
+        let before = fs::read(root.join("k00.json")).expect("source");
+        let parent = root.parent().expect("parent");
+        let suffix = restore_work_suffix(&root, as_of);
+        let candidate_root = parent.join(format!(".traverse-datastore-migration-{suffix}"));
+        let previous_root = parent.join(format!(".traverse-datastore-pre-v2-{suffix}"));
+        let _ = fs::remove_dir_all(&candidate_root);
+        let _ = fs::remove_dir_all(&previous_root);
+        fs::create_dir_all(&candidate_root).expect("candidate");
+        fs::write(candidate_root.join(LOCAL_DATA_STORE_LOCK_FILE), b"").expect("candidate lock");
+        fs::write(candidate_root.join("k00.json"), br#"{"format":"candidate"}"#).expect("cand");
+
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let _ = maintenance.lock_file.unlock();
+        fs::rename(&root, &previous_root).expect("aside");
+        fs::rename(&candidate_root, &root).expect("install");
+
+        let blocker = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(root.join(LOCAL_DATA_STORE_LOCK_FILE))
+            .expect("blocker");
+        blocker.try_lock().expect("hold lock");
+
+        let failed =
+            reacquire_migrated_lock(&mut maintenance, &candidate_root, &previous_root)
+                .expect_err("reacquire must fail while blocked");
+        assert_eq!(failed.code, MigrationErrorCode::CommitFailed);
+        drop(blocker);
+        assert_eq!(
+            fs::read(root.join("k00.json")).expect("rolled back"),
+            before
+        );
+        let _ = fs::remove_dir_all(&candidate_root);
+        let _ = fs::remove_dir_all(&previous_root);
     }
 
     fn write_zip(parent: &Path, members: &[(&str, &[u8])]) -> PathBuf {

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -3,9 +3,10 @@
 //! Governed by spec `083-datastore-retention-backup` / ADR-0021.
 
 use super::{
-    DataStoreError, LOCAL_DATA_STORE_FORMAT, LOCAL_DATA_STORE_LOCK_FILE, LocalDataClassification,
-    LocalDataStoreEnvelope, digest_for_private_envelope, digest_for_record, hex_decode, lock_error,
-    validate_key,
+    DataStoreError, LOCAL_DATA_STORE_FORMAT, LOCAL_DATA_STORE_LOCK_FILE,
+    LOCAL_DATA_STORE_V2_FORMAT, LocalDataClassification, LocalDataStoreEnvelope,
+    decode_v2_envelope, digest_for_private_envelope, digest_for_record, hex_decode, lock_error,
+    v2_envelope, validate_key,
 };
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
@@ -20,6 +21,7 @@ use zip::read::ZipArchive;
 use zip::write::SimpleFileOptions;
 
 const MAINTENANCE_SPEC: &str = "083-datastore-retention-backup";
+const MIGRATION_SPEC: &str = "092-datastore-v2-migration-ownership";
 const BACKUP_MANIFEST_VERSION: &str = "1";
 const BACKUP_MANIFEST_MEMBER: &str = "manifest.json";
 const BACKUP_RECORDS_PREFIX: &str = "records/";
@@ -49,6 +51,54 @@ pub struct MaintenanceError {
     pub code: MaintenanceErrorCode,
     pub message: String,
     pub details: Value,
+}
+
+/// Stable, secret-free failure codes for an explicit host-owned v1-to-v2 migration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MigrationErrorCode {
+    TransitionUnsupported,
+    SourceInvalid,
+    BackupFailed,
+    WriteFailed,
+    VerificationFailed,
+    CommitFailed,
+    RestoreFailed,
+    OwnerLocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationError {
+    pub code: MigrationErrorCode,
+    pub message: String,
+    pub details: Value,
+}
+
+/// Safe evidence returned to the owning host; it never contains paths, keys, or values.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationReport {
+    pub governing_spec: String,
+    pub source_format: String,
+    pub target_format: String,
+    pub record_count: u64,
+    pub backup_content_digest: String,
+    pub outcome: String,
+}
+
+/// Host-explicit format-migration port. Generic runtime and CLI paths never call it.
+pub trait DataStoreMigration {
+    /// Migrates a verified v1 root to v2 only after a host-directed backup and
+    /// complete candidate verification have succeeded.
+    ///
+    /// # Errors
+    ///
+    /// Returns a stable, secret-free [`MigrationError`] when the source,
+    /// backup, candidate, ownership lock, or atomic commit cannot be verified.
+    fn migrate_v1_to_v2(
+        &mut self,
+        backup_destination: &Path,
+        as_of: &str,
+    ) -> Result<MigrationReport, MigrationError>;
 }
 
 /// Secret-free maintenance evidence (FR-009).
@@ -386,6 +436,182 @@ impl DataStoreMaintenance for LocalFileDataStoreMaintenance {
             failure_reason: None,
         })
     }
+}
+
+impl DataStoreMigration for LocalFileDataStoreMaintenance {
+    fn migrate_v1_to_v2(
+        &mut self,
+        backup_destination: &Path,
+        as_of: &str,
+    ) -> Result<MigrationReport, MigrationError> {
+        parse_as_of(as_of).map_err(map_migration_source_error)?;
+        let keys = self
+            .list_record_keys()
+            .map_err(map_migration_source_error)?;
+
+        // Validate every committed source envelope before any backup artifact or
+        // candidate representation is written.
+        for key in &keys {
+            self.read_envelope(key)
+                .map_err(map_migration_source_error)?;
+        }
+
+        let backup = self
+            .backup(backup_destination, as_of)
+            .map_err(map_migration_backup_error)?;
+        let backup_digest = backup
+            .archive_content_digest
+            .ok_or_else(|| MigrationError {
+                code: MigrationErrorCode::BackupFailed,
+                message: "datastore_backup_failed".to_string(),
+                details: json!({ "reason": "missing_verified_backup_digest" }),
+            })?;
+
+        let parent = restore_parent(&self.root).map_err(map_migration_commit_error)?;
+        let suffix = restore_work_suffix(&self.root, as_of);
+        let candidate_root = parent.join(format!(".traverse-datastore-migration-{suffix}"));
+        let previous_root = parent.join(format!(".traverse-datastore-pre-v2-{suffix}"));
+        let _ = fs::remove_dir_all(&candidate_root);
+        let _ = fs::remove_dir_all(&previous_root);
+        fs::create_dir_all(&candidate_root).map_err(map_migration_write_io)?;
+        File::create(candidate_root.join(LOCAL_DATA_STORE_LOCK_FILE))
+            .map_err(map_migration_write_io)?;
+
+        let candidate = (|| -> Result<(), MigrationError> {
+            for key in &keys {
+                let source = self
+                    .read_envelope(key)
+                    .map_err(map_migration_source_error)?;
+                let v2 = v2_envelope(source).map_err(map_migration_write_data_store)?;
+                let bytes = serde_json::to_vec(&v2).map_err(|_| MigrationError {
+                    code: MigrationErrorCode::WriteFailed,
+                    message: "datastore_write_failed".to_string(),
+                    details: json!({ "reason": "serialize_candidate" }),
+                })?;
+                fs::write(candidate_root.join(format!("{key}.json")), bytes)
+                    .map_err(map_migration_write_io)?;
+            }
+            verify_v2_store_root(&candidate_root).map_err(map_migration_verification_error)
+        })();
+        if let Err(error) = candidate {
+            let _ = fs::remove_dir_all(&candidate_root);
+            return Err(error);
+        }
+
+        let _ = self.lock_file.unlock();
+        if let Err(error) = fs::rename(&self.root, &previous_root) {
+            let _ = self.reacquire_lock();
+            let _ = fs::remove_dir_all(&candidate_root);
+            return Err(map_migration_commit_io(error));
+        }
+        if let Err(error) = fs::rename(&candidate_root, &self.root) {
+            let _ = fs::rename(&previous_root, &self.root);
+            let _ = self.reacquire_lock();
+            return Err(map_migration_commit_io(error));
+        }
+        if let Err(error) = self.reacquire_lock() {
+            let _ = fs::rename(&self.root, &candidate_root);
+            let _ = fs::rename(&previous_root, &self.root);
+            let _ = self.reacquire_lock();
+            return Err(map_migration_commit_error(error));
+        }
+        let _ = fs::remove_dir_all(&previous_root);
+
+        Ok(MigrationReport {
+            governing_spec: MIGRATION_SPEC.to_string(),
+            source_format: LOCAL_DATA_STORE_FORMAT.to_string(),
+            target_format: LOCAL_DATA_STORE_V2_FORMAT.to_string(),
+            record_count: keys.len() as u64,
+            backup_content_digest: backup_digest,
+            outcome: "datastore_migration_committed".to_string(),
+        })
+    }
+}
+
+fn verify_v2_store_root(root: &Path) -> Result<(), MaintenanceError> {
+    for entry in
+        fs::read_dir(root).map_err(|error| maintenance_io("list migration candidate", &error))?
+    {
+        let entry =
+            entry.map_err(|error| maintenance_io("read migration candidate entry", &error))?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes =
+            fs::read(path).map_err(|error| maintenance_io("read migration candidate", &error))?;
+        let value: Value =
+            serde_json::from_slice(&bytes).map_err(|_| malformed_envelope_error())?;
+        let envelope = decode_v2_envelope(value).map_err(map_data_store_error)?;
+        parse_envelope_bytes(
+            &serde_json::to_vec(&envelope).map_err(|_| malformed_envelope_error())?,
+        )?;
+    }
+    Ok(())
+}
+
+fn migration_error(code: MigrationErrorCode, message: &str, reason: &str) -> MigrationError {
+    MigrationError {
+        code,
+        message: message.to_string(),
+        details: json!({ "reason": reason }),
+    }
+}
+
+fn map_migration_source_error(_: MaintenanceError) -> MigrationError {
+    migration_error(
+        MigrationErrorCode::SourceInvalid,
+        "datastore_source_invalid",
+        "source_validation_failed",
+    )
+}
+
+fn map_migration_backup_error(_: MaintenanceError) -> MigrationError {
+    migration_error(
+        MigrationErrorCode::BackupFailed,
+        "datastore_backup_failed",
+        "backup_verification_failed",
+    )
+}
+
+fn map_migration_write_io(_: std::io::Error) -> MigrationError {
+    migration_error(
+        MigrationErrorCode::WriteFailed,
+        "datastore_write_failed",
+        "candidate_write_failed",
+    )
+}
+
+fn map_migration_write_data_store(_: DataStoreError) -> MigrationError {
+    migration_error(
+        MigrationErrorCode::WriteFailed,
+        "datastore_write_failed",
+        "candidate_serialization_failed",
+    )
+}
+
+fn map_migration_verification_error(_: MaintenanceError) -> MigrationError {
+    migration_error(
+        MigrationErrorCode::VerificationFailed,
+        "datastore_verification_failed",
+        "candidate_verification_failed",
+    )
+}
+
+fn map_migration_commit_io(_: std::io::Error) -> MigrationError {
+    migration_error(
+        MigrationErrorCode::CommitFailed,
+        "datastore_commit_failed",
+        "atomic_commit_failed",
+    )
+}
+
+fn map_migration_commit_error(_: MaintenanceError) -> MigrationError {
+    migration_error(
+        MigrationErrorCode::CommitFailed,
+        "datastore_commit_failed",
+        "atomic_commit_failed",
+    )
 }
 
 fn select_prune_victims(
@@ -1847,6 +2073,94 @@ mod tests {
         let missing = materialize_archive_to_root(&missing_member, &root).expect_err("missing");
         assert_eq!(missing.code, MaintenanceErrorCode::BackupVerifyFailed);
         assert_eq!(missing.details["reason"], "missing_member");
+    }
+
+    #[test]
+    fn explicit_v1_to_v2_migration_is_verified_and_restore_remains_explicit() {
+        let root = temp_root("v2-migration-success");
+        drop(seed_store(&root, 2, None));
+        let archive = root
+            .parent()
+            .expect("parent")
+            .join(format!("migration-{}.zip", Uuid::new_v4()));
+
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let report = maintenance
+            .migrate_v1_to_v2(&archive, "2026-08-05T00:00:00Z")
+            .expect("migration");
+        assert_eq!(report.governing_spec, MIGRATION_SPEC);
+        assert_eq!(report.source_format, LOCAL_DATA_STORE_FORMAT);
+        assert_eq!(report.target_format, LOCAL_DATA_STORE_V2_FORMAT);
+        assert_eq!(report.record_count, 2);
+        assert!(report.backup_content_digest.starts_with("sha256:"));
+        assert_eq!(
+            serde_json::from_slice::<Value>(&fs::read(root.join("k00.json")).expect("v2 file"))
+                .expect("v2 json")["format"],
+            LOCAL_DATA_STORE_V2_FORMAT
+        );
+        drop(maintenance);
+
+        let reader =
+            LocalFileDataStore::with_classification(&root, LocalDataClassification::Public)
+                .expect("v2 reader");
+        assert_eq!(
+            reader.read("k00").expect("read").expect("record").key,
+            "k00"
+        );
+        drop(reader);
+
+        let mut restore = LocalFileDataStoreMaintenance::open(&root).expect("restore maintenance");
+        restore
+            .restore(&archive, "2026-08-05T00:01:00Z")
+            .expect("explicit restore");
+        drop(restore);
+        let restored =
+            serde_json::from_slice::<Value>(&fs::read(root.join("k00.json")).expect("v1 file"))
+                .expect("v1 json");
+        assert_eq!(restored["format"], LOCAL_DATA_STORE_FORMAT);
+    }
+
+    #[test]
+    fn migration_rejects_unknown_source_without_backup_or_rewrite() {
+        let root = temp_root("v2-migration-unknown");
+        fs::write(root.join("k00.json"), br#"{"format":"unknown/9"}"#).expect("source");
+        let original = fs::read(root.join("k00.json")).expect("original");
+        let archive = root
+            .parent()
+            .expect("parent")
+            .join(format!("migration-unknown-{}.zip", Uuid::new_v4()));
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let error = maintenance
+            .migrate_v1_to_v2(&archive, "2026-08-05T00:00:00Z")
+            .expect_err("unknown source must fail closed");
+        assert_eq!(error.code, MigrationErrorCode::SourceInvalid);
+        assert_eq!(error.message, "datastore_source_invalid");
+        assert_eq!(
+            fs::read(root.join("k00.json")).expect("source preserved"),
+            original
+        );
+        assert!(!archive.exists());
+    }
+
+    #[test]
+    fn corrupt_restore_backup_preserves_the_committed_store() {
+        let root = temp_root("v2-migration-corrupt-backup");
+        drop(seed_store(&root, 1, None));
+        let before = fs::read(root.join("k00.json")).expect("source");
+        let corrupt = root
+            .parent()
+            .expect("parent")
+            .join(format!("migration-corrupt-{}.zip", Uuid::new_v4()));
+        fs::write(&corrupt, b"not a verified backup").expect("corrupt archive");
+        let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
+        let error = maintenance
+            .restore(&corrupt, "2026-08-05T00:00:00Z")
+            .expect_err("corrupt archive");
+        assert_eq!(error.code, MaintenanceErrorCode::BackupVerifyFailed);
+        assert_eq!(
+            fs::read(root.join("k00.json")).expect("source preserved"),
+            before
+        );
     }
 
     fn write_zip(parent: &Path, members: &[(&str, &[u8])]) -> PathBuf {

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -459,13 +459,7 @@ impl DataStoreMigration for LocalFileDataStoreMaintenance {
         let backup = self
             .backup(backup_destination, as_of)
             .map_err(map_migration_backup_error)?;
-        let backup_digest = backup
-            .archive_content_digest
-            .ok_or_else(|| MigrationError {
-                code: MigrationErrorCode::BackupFailed,
-                message: "datastore_backup_failed".to_string(),
-                details: json!({ "reason": "missing_verified_backup_digest" }),
-            })?;
+        let backup_digest = verified_backup_digest(backup.archive_content_digest)?;
 
         let parent = restore_parent(&self.root).map_err(map_migration_commit_error)?;
         let suffix = restore_work_suffix(&self.root, as_of);
@@ -483,11 +477,7 @@ impl DataStoreMigration for LocalFileDataStoreMaintenance {
                     .read_envelope(key)
                     .map_err(map_migration_source_error)?;
                 let v2 = v2_envelope(source).map_err(map_migration_write_data_store)?;
-                let bytes = serde_json::to_vec(&v2).map_err(|_| MigrationError {
-                    code: MigrationErrorCode::WriteFailed,
-                    message: "datastore_write_failed".to_string(),
-                    details: json!({ "reason": "serialize_candidate" }),
-                })?;
+                let bytes = serialize_v2_candidate(&v2)?;
                 fs::write(candidate_root.join(format!("{key}.json")), bytes)
                     .map_err(map_migration_write_io)?;
             }
@@ -548,6 +538,28 @@ fn verify_v2_store_root(root: &Path) -> Result<(), MaintenanceError> {
         )?;
     }
     Ok(())
+}
+
+fn verified_backup_digest(digest: Option<String>) -> Result<String, MigrationError> {
+    digest.ok_or_else(|| {
+        migration_error(
+            MigrationErrorCode::BackupFailed,
+            "datastore_backup_failed",
+            "missing_verified_backup_digest",
+        )
+    })
+}
+
+fn serialize_v2_candidate(
+    envelope: &super::LocalDataStoreV2Envelope,
+) -> Result<Vec<u8>, MigrationError> {
+    serde_json::to_vec(envelope).map_err(|_| {
+        migration_error(
+            MigrationErrorCode::WriteFailed,
+            "datastore_write_failed",
+            "serialize_candidate",
+        )
+    })
 }
 
 fn migration_error(code: MigrationErrorCode, message: &str, reason: &str) -> MigrationError {
@@ -2211,6 +2223,14 @@ mod tests {
             assert_eq!(error.code, code);
             assert!(!error.details.to_string().contains("secret"));
         }
+    }
+
+    #[test]
+    fn migration_requires_verified_backup_digest() {
+        let error = verified_backup_digest(None).expect_err("digest is required");
+        assert_eq!(error.code, MigrationErrorCode::BackupFailed);
+        assert_eq!(error.message, "datastore_backup_failed");
+        assert_eq!(error.details["reason"], "missing_verified_backup_digest");
     }
 
     fn write_zip(parent: &Path, members: &[(&str, &[u8])]) -> PathBuf {

--- a/crates/traverse-runtime/src/data_store_maintenance.rs
+++ b/crates/traverse-runtime/src/data_store_maintenance.rs
@@ -2307,10 +2307,7 @@ mod tests {
         #[derive(Debug)]
         struct Boom;
         impl Serialize for Boom {
-            fn serialize<S: serde::Serializer>(
-                &self,
-                _serializer: S,
-            ) -> Result<S::Ok, S::Error> {
+            fn serialize<S: serde::Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
                 Err(serde::ser::Error::custom("boom"))
             }
         }
@@ -2319,9 +2316,11 @@ mod tests {
             map_envelope_serialize_error(boom).code,
             MaintenanceErrorCode::RestoreVerifyFailed
         );
-        assert!(json_to_vec(&Boom)
-            .map_err(map_serialize_candidate_error)
-            .is_err());
+        assert!(
+            json_to_vec(&Boom)
+                .map_err(map_serialize_candidate_error)
+                .is_err()
+        );
 
         let candidate = temp_root("abandon-candidate").join("work");
         fs::create_dir_all(&candidate).expect("candidate");
@@ -2356,9 +2355,8 @@ mod tests {
         fs::write(&previous_root, b"block aside").expect("occupy previous");
 
         let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
-        let failed =
-            commit_migrated_store_root(&mut maintenance, &candidate_root, &previous_root)
-                .expect_err("aside must fail");
+        let failed = commit_migrated_store_root(&mut maintenance, &candidate_root, &previous_root)
+            .expect_err("aside must fail");
         assert_eq!(failed.code, MigrationErrorCode::CommitFailed);
         assert_eq!(
             fs::read(root.join("k00.json")).expect("live preserved"),
@@ -2388,9 +2386,8 @@ mod tests {
         fs::rename(&root, &previous_root).expect("aside");
         fs::write(&root, b"block install").expect("occupy root");
 
-        let failed =
-            install_migrated_candidate(&mut maintenance, &candidate_root, &previous_root)
-                .expect_err("install must fail");
+        let failed = install_migrated_candidate(&mut maintenance, &candidate_root, &previous_root)
+            .expect_err("install must fail");
         assert_eq!(failed.code, MigrationErrorCode::CommitFailed);
         assert_eq!(
             fs::read(previous_root.join("k00.json")).expect("aside preserved"),
@@ -2416,7 +2413,11 @@ mod tests {
         let _ = fs::remove_dir_all(&previous_root);
         fs::create_dir_all(&candidate_root).expect("candidate");
         fs::write(candidate_root.join(LOCAL_DATA_STORE_LOCK_FILE), b"").expect("candidate lock");
-        fs::write(candidate_root.join("k00.json"), br#"{"format":"candidate"}"#).expect("cand");
+        fs::write(
+            candidate_root.join("k00.json"),
+            br#"{"format":"candidate"}"#,
+        )
+        .expect("cand");
 
         let mut maintenance = LocalFileDataStoreMaintenance::open(&root).expect("maintenance");
         let _ = maintenance.lock_file.unlock();
@@ -2430,9 +2431,8 @@ mod tests {
             .expect("blocker");
         blocker.try_lock().expect("hold lock");
 
-        let failed =
-            reacquire_migrated_lock(&mut maintenance, &candidate_root, &previous_root)
-                .expect_err("reacquire must fail while blocked");
+        let failed = reacquire_migrated_lock(&mut maintenance, &candidate_root, &previous_root)
+            .expect_err("reacquire must fail while blocked");
         assert_eq!(failed.code, MigrationErrorCode::CommitFailed);
         drop(blocker);
         assert_eq!(


### PR DESCRIPTION
## Summary

Implements the explicit host-owned `local-datastore/1` to `local-datastore/2` transition with a verified backup, complete candidate verification, and atomic commit.

## Governing Spec

- `082-datastore-format-migration`
- `092-datastore-v2-migration-ownership`

## Project Item

Closes #873.

## Definition of Done

- [x] Host-explicit migrator creates a verified backup before commit.
- [x] Failed validation and corrupt restore evidence preserve committed data.
- [x] Unknown source formats fail closed with stable errors.
- [x] V2 envelopes carry explicit version and integrity metadata.

## Validation

- `cargo test -p traverse-runtime`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/issue873-pr-body.md`
