### PR TITLE
docs(governance): approve S3-compatible remote DataStore profile

### DIFF
--- a/docs/adr/0029-s3-compatible-remote-datastore.md
+++ b/docs/adr/0029-s3-compatible-remote-datastore.md
@@ -1,7 +1,7 @@
 # ADR-0029: Constrain the Remote DataStore Adapter to an S3-Compatible Profile
 
-**Status:** Proposed  
-**Governing draft:** `535-s3-compatible-remote-datastore`  
+**Status:** Accepted  
+**Governing spec:** `095-s3-compatible-remote-datastore`  
 **Extends:** ADR-0024
 
 ## Decision

--- a/specs/535-s3-compatible-remote-datastore/spec.md
+++ b/specs/535-s3-compatible-remote-datastore/spec.md
@@ -1,6 +1,7 @@
 # Feature Specification: S3-Compatible Remote DataStore Adapter
 
-**Status**: Draft — requires maintainer approval before #886 implementation.
+**Status**: Approved
+**Canonical governing ID**: `095-s3-compatible-remote-datastore`
 **Extends**: `530-remote-key-value-datastore`, `518-durable-local-datastore`,
 `519-embedder-owned-datastore-integration`
 **Input**: Issue #892.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1232,6 +1232,18 @@
         "docs/adr/0024-remote-key-value-datastore-contract.md",
         "specs/530-remote-key-value-datastore/"
       ]
+    },
+    {
+      "id": "095-s3-compatible-remote-datastore",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/535-s3-compatible-remote-datastore/spec.md",
+      "governs": [
+        "crates/traverse-runtime/",
+        "docs/adr/0029-s3-compatible-remote-datastore.md",
+        "specs/535-s3-compatible-remote-datastore/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Approve the S3-compatible remote DataStore adapter profile (Spec 535 / ADR-0029), the provider-specific constraint that gates #886 implementation. Decision-log alignment confirmed against #892's recorded "Approved decisions" (S3-compatible + MinIO conformance target, conditional writes with opaque version tokens, host-provisioned tenant prefix and least-privilege credentials, no hidden retries, Traverse SHA-256 digest with ETag as concurrency token only) — the spec text matches that record exactly.

## Governing Spec

- `095-s3-compatible-remote-datastore`
- `004-spec-alignment-gate`

## Project Item

Issue #892 (governing profile); unblocks #886.

## Definition of Done

- [x] Spec, ADR, and immutable registry entry are present.

## Validation

- `jq empty specs/governance/approved-specs.json`
- `git diff --check`
