### PR TITLE
docs(governance): approve eventing-architecture specs and ADRs

### DIFF
--- a/docs/adr/0034-websocket-grpc-event-transport.md
+++ b/docs/adr/0034-websocket-grpc-event-transport.md
@@ -1,0 +1,60 @@
+# ADR-0034: Adopt WebSocket and gRPC as the Governed Runtime Event Transport, Replacing SSE
+
+- Status: Accepted
+- Governing spec: `097-websocket-grpc-event-transport`
+
+## Context
+
+`534-ecca-event-products` deliberately scopes out "selecting a broker vendor
+or transport topology," leaving how a governed domain event reaches an
+external client (browser, mobile, or another runtime) undecided. A
+repo-wide dependency search found no WebSocket or gRPC dependency anywhere
+in the workspace (no `tonic`/`prost`, no websocket library); the only
+transport in the codebase is SSE, and it currently reads from an ungoverned
+type (closed by `096-runtime-event-sse-transport`, issue #964), not
+`EventBroker`. Traverse has no production users or production capabilities
+yet (Decision 48, `docs/decision-log.md`), so this decision is not
+constrained by an existing client base.
+
+## Decision
+
+Traverse adopts WebSocket and gRPC together as the governed event transport,
+both reading from the same `EventBroker`/`TraverseEvent` source, and both
+decided in the same increment rather than sequenced as primary/secondary —
+UMA's own reference architecture treats them as peers a client selects
+between per platform and workload (WebSocket via browser-native APIs or
+libraries such as Starscream/OkHttp; gRPC via `grpc-swift`/`grpc-java` for
+mobile clients that need structured, typed contracts and lower battery
+overhead). SSE is retired outright once WebSocket ships — it does not
+remain as a permanent parallel transport, consistent with Decision 48's
+no-back-compat-tax principle.
+
+## Consequences
+
+The workspace takes on a new dependency for WebSocket handling and for gRPC
+(`tonic`/`prost` or equivalent), plus `.proto` contract authorship and
+versioning for the event service. Connection lifecycle, auth-over-socket,
+and message framing must all be designed (governed by the spec this ADR
+pairs with) rather than reusing the existing HTTP request/response and SSE
+patterns. The SSE endpoint built under `096-runtime-event-sse-transport`
+is explicitly transitional: its removal is in scope for whichever ticket
+implements WebSocket (issue #967), not a separate cleanup task.
+`browser_adapter.rs`'s eventual disposition (issue #973) is blocked on this
+transport existing, since its governed message contract (`013`) doesn't yet
+have a production transport to run on.
+
+## Alternatives Considered
+
+- Keep SSE as a permanent fallback alongside WebSocket — rejected. Traverse
+  has no installed base to protect, and permanently maintaining two
+  transports for one source of truth adds surface area for a compatibility
+  constraint that doesn't exist.
+- WebSocket only, defer gRPC until a concrete native/mobile client exists —
+  this was the recommended option going into the decision, but was not
+  chosen; the user opted to decide both together rather than speculatively
+  defer gRPC, accepting the larger upfront design cost.
+- Decide no transport now, leave it an open "TBD" — rejected. UMA's model
+  and Traverse's own capability contracts (`emits`/`consumes`,
+  `service_type: Subscribable`) already assume governed events reach a live
+  client somewhere; leaving the transport permanently undecided leaves that
+  assumption unfulfillable.

--- a/docs/adr/0035-capability-event-host-abi.md
+++ b/docs/adr/0035-capability-event-host-abi.md
@@ -1,0 +1,67 @@
+# ADR-0035: Replace the Output-JSON Event Convention With an Imperative WASM Host ABI
+
+- Status: Accepted
+- Governing spec: `098-capability-event-host-abi`
+
+## Context
+
+No WASM host-function ABI exists for a capability to imperatively publish or
+subscribe to events during execution — confirmed by searching
+`traverse-native-bridge`, `crates/traverse-runtime/src/executor/wasm.rs`, and
+`crates/traverse-runtime/src/executor/native.rs` for any such import (zero
+hits). The unrelated guest-exported `traverse_next_event` function
+(`071-native-runtime-wasm-bridge`) is part of the native embedder-bridge
+lifecycle ABI for hosting the runtime orchestrator in Swift/Kotlin/.NET
+shells; it is not a mechanism for WASM business capabilities to emit domain
+events and this ADR does not touch it.
+
+Instead, a capability declares an `emitted_events` array inside its own JSON
+output. `PlacementRouter` Step 3.5 validates this array *after* execution
+completes, checking each declared event against the contract's `emits` list
+and rejecting undeclared emissions as a `ContractViolation`
+(`undeclared_event_emission`). This is the piece of the runtime furthest
+from UMA's reference model, where a microservice calls the runtime's
+abstraction layer directly to dispatch an event
+(`this.eventDispatcher.dispatch(...)`, UMA white paper §5.1.2.2) rather than
+describing events as a side channel in its return value.
+
+Traverse has no production users or production capabilities today
+(`docs/decision-log.md` Decision 48).
+
+## Decision
+
+Introduce a new WASM host-function import capabilities call imperatively to
+emit an event during execution, and **breaking-replace** the output-JSON
+`emitted_events` convention with it rather than keeping both. The host
+function validates the emitted event against the contract's `emits` list
+synchronously, at call time — an undeclared emission is rejected as it
+happens, not discovered after the capability has already finished running.
+This follows directly from Decision 48: with no production capabilities
+depending on the current convention, there is no cost to replacing it
+outright, and a single canonical path avoids permanently maintaining two
+ways to emit an event plus the post-hoc violation-detection complexity in
+`PlacementRouter` Step 3.5.
+
+## Consequences
+
+Every existing `Subscribable` capability fixture and test that relies on the
+output-JSON convention must be migrated to call the new host function
+instead (tracked as issue #970). `PlacementRouter`'s Step 3.5 post-hoc
+violation check is removed once the host-side synchronous check exists,
+since it becomes dead code. The capability host ABI gains a new versioned
+surface that must be documented and whitelisted the same way the existing
+`traverse_*` bridge functions are (`host_abi_whitelist` in
+`crates/traverse-runtime/src/executor/wasm.rs`). No migration or
+deprecation window is provided, consistent with Decision 48 — this is a
+point-in-time replacement, not a phased rollout.
+
+## Alternatives Considered
+
+- Additive/optional host function alongside the existing output-JSON
+  convention — rejected. The user explicitly chose breaking replacement per
+  Decision 48, to avoid two permanent paths to the same outcome.
+- Leave the output-JSON convention as-is and only add host-side synchronous
+  validation on top of it — rejected as a half-measure: it would keep the
+  declarative convention that diverges furthest from UMA's imperative model
+  while adding complexity, without capturing the actual benefit (a real
+  imperative ABI) of doing this work at all.

--- a/docs/adr/0036-workflow-event-broker-unification.md
+++ b/docs/adr/0036-workflow-event-broker-unification.md
@@ -1,0 +1,63 @@
+# ADR-0036: Unify Workflow Event-Driven Edges With `EventBroker`
+
+- Status: Accepted
+- Governing spec: `099-workflow-event-broker-unification`
+
+## Context
+
+`018-event-driven-composition` deliberately scoped workflow event-driven
+edges to advance "without introducing external brokers, event-created
+executions, direct-capability waiting semantics" — a considered design
+choice, not a placeholder. In the current implementation
+(`workflows.rs::evaluate_event_driven_edges`), a waiting workflow edge can
+only advance from an event extracted from the *same* workflow execution's
+own node output (`emitted_events(output: &Value)` reads an `emitted_events`
+array out of a capability's JSON output). There is no connection to
+`EventBroker`, no cross-workflow delivery, no cross-process delivery, and
+no durability — the whole mechanism is a synchronous, in-memory pattern
+match scoped to one execution.
+
+This is a third, separate event mechanism in Traverse alongside `EventBroker`
+and the capability output-JSON convention being replaced by
+`098-capability-event-host-abi` (issue #969). Traverse has no production
+workflows depending on `018`'s current scope cut today
+(`docs/decision-log.md` Decision 48).
+
+## Decision
+
+Unify workflow event-driven edge advancement with the real `EventBroker`.
+A waiting edge subscribes to `EventBroker` the same way any other consumer
+does, so it can advance from an event published by another workflow,
+another capability, or an external publisher — not only from the same
+execution's own node output. This reverses `018`'s explicit scope cut,
+justified by Decision 48 (no back-compat tax pre-production) and by this
+being the one place in the runtime where UMA's cross-system event-driven
+composition model was structurally impossible under the prior design.
+`018`'s existing deterministic multi-workflow wake ordering and
+exact-once-per-edge consumption guarantees are preserved, now enforced
+against a real broker instead of a single synchronous evaluation pass.
+
+## Consequences
+
+Workflow execution gains a dependency on `EventBroker`'s delivery and
+durability characteristics — a waiting edge's advancement now depends on
+broker availability, not just in-process state. `EventDrivenEvaluationOutcome`
+and its trace evidence must be extended to record which broker subscription
+and cursor produced the wake-up, so the existing explainability guarantees
+from `018` (dedicated wake-up decision evidence) survive the change.
+Cross-workflow and cross-process wake ordering must be proven deterministic
+under the broker's own delivery model, not assumed from the old single-pass
+implementation.
+
+## Alternatives Considered
+
+- Keep `018`'s synchronous, single-execution-scoped model as deliberately
+  separate — this was the recommended option going into the decision
+  (workflow-edge advancement is arguably simpler without cross-process
+  delivery/ordering/durability concerns), but the user chose unification,
+  citing that it's the one remaining place event-driven composition can't
+  cross a workflow or process boundary, which is core to UMA's model and to
+  what capability authors will expect once `098`'s imperative ABI exists.
+- Introduce a fourth, purpose-built broker just for workflow-edge wake-ups —
+  rejected: this would recreate the exact fragmentation this whole
+  brainstorm session exists to close.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1302,3 +1302,374 @@ values are absent, and #929's execute-path wiring (#934) already shipped
 against the same port. Whenever the user creates the PostHog project and
 hands over its endpoint/key, the remaining work is a one-line hardcode into
 `telemetry.rs` plus a PR — no further design decisions.
+
+## Decision 44: Wire `PlacementRouter` Into the Live Execution Path Is Not a New Decision — It's an Unimplemented Approved Requirement
+
+- **Date**: 2026-08-05
+- **Status**: Accepted
+- **Governing spec**: `210-runtime-placement-router` (already approved; FR-006, Assumptions)
+- **Related issues**: `#963`
+- **Origin**: `/brainstorm` session closing the eventing-architecture gap analysis (UMA white paper comparison)
+
+### Context
+
+A full read of the UMA white paper's eventing model (capability↔runtime,
+runtime↔runtime, runtime↔UI) against the current codebase found that
+`PlacementRouter::execute` — which evaluates placement, selects an executor,
+writes trace entries, and (Step 5) publishes a `Subscribable` capability's
+declared `emitted_events` to `EventBroker` — is fully built and tested
+(`router/mod.rs`, `router_tests.rs`, `expedition_wasm_tests.rs`,
+`thread_pool_integration.rs`) but never constructed or called from the live
+`Runtime::execute` path in `traverse-runtime/src/lib.rs`. That path instead
+only emits one hardcoded system lifecycle event
+(`RUNTIME_EXECUTION_EVENT_TYPE`) per run via `emit_execution_lifecycle_event`
+— no capability-declared business event ever reaches `EventBroker` in
+production today.
+
+Before treating this as an open brainstorm question, `210-runtime-placement-router`
+was checked directly: **FR-006** already states *"PlacementRouter is the
+single public entry point for all capability execution in traverse-runtime,"*
+and its Assumptions section already states *"PlacementRouter replaces any
+ad-hoc execution wiring currently in traverse-runtime."*
+
+### Decision
+
+This is not a design decision to brainstorm — it is a gap between an already
+Approved, immutable spec and the current implementation. It goes straight to
+a ticket ("wire `PlacementRouter` into `Runtime::execute`, retire the
+ad-hoc lifecycle-only emission path") with no new spec, ADR, or brainstorm
+question required.
+
+### Alternatives Considered
+
+None — the governing spec already forecloses alternatives (single entry
+point, replaces ad-hoc wiring).
+
+### Outcome
+
+Filed as the first, prerequisite ticket in the eventing sequence. Every
+other decision in this session assumes this lands first, since it's what
+makes `EventBroker` carry real capability events instead of only lifecycle
+telemetry.
+
+## Decision 45: Governance Vehicle for the Runtime-Event-to-Transport Gap Is New, Narrow Specs — Not a `534` Addendum
+
+- **Date**: 2026-08-05
+- **Status**: Accepted
+- **Governing specs**: extends `207-event-broker`, `534-ecca-event-products`
+- **Related issues**: `#964`, `#965`
+- **Origin**: `/brainstorm` session, question 1
+
+### Context
+
+`534-ecca-event-products` (approved 2026-07-29, the newest eventing spec)
+explicitly scopes in "runtime behavior" and "host adapters" as still-open
+work — which is exactly where "how does a domain event reach a UI
+transport" belongs. But `.specify/memory/constitution.md` and
+`approved-specs.json` (`"immutable": true` on every entry) both state specs
+are treated as immutable once approved for implementation, so `534` cannot
+be edited in place. The real choice was between one new combined spec
+covering the whole bridge, or several narrow specs matching this repo's
+existing convention (every other spec here — `003`, `013`, `018`, `207`,
+`534`, etc. — is single-purpose).
+
+### Decision
+
+Close the gap with separate, narrow specs per concern rather than one
+combined spec: one spec for "production SSE reads from `EventBroker`"
+(extends `207` + `534`), and downstream north-star specs (below) for
+transport and capability ABI, each extending their own governing chain.
+
+### Alternatives Considered
+
+- Edit `534` in place — rejected, specs are immutable once approved.
+- One combined spec covering SSE migration + `browser_adapter.rs` fate +
+  transport — rejected, couples a "must do" (governed plumbing) to a
+  "policy call" (dev-tool disposition) and has no precedent in this repo's
+  spec granularity.
+
+### Outcome
+
+Unlocks the SSE-migration spec as its own ticket, independent of the
+`browser_adapter.rs` and transport decisions below.
+
+## Decision 46: Keep `browser_adapter.rs` As-Is for Now; Track Its Eventual Merge as a North-Star Item
+
+- **Date**: 2026-08-05
+- **Status**: Accepted
+- **Governing specs**: `013-browser-runtime-subscription`, `019-local-browser-adapter-transport` (unchanged)
+- **Related issues**: `#973`
+- **Origin**: `/brainstorm` session, question 2
+
+### Context
+
+`browser_adapter.rs` (`traverse-cli browser-adapter serve`) is a standalone,
+single-connection, local-dev-only server implementing spec `013`'s governed
+browser-subscription message contract, replaying one hardcoded canonical
+outcome. It is not the production HTTP API server and is not backed by
+`EventBroker`. Three options existed: retire it, merge it into the
+production HTTP API (making spec `013`'s ordered message contract real in
+production), or leave it unchanged.
+
+### Decision
+
+Leave it unchanged for now — it doesn't block the SSE-on-`EventBroker`
+migration. The user explicitly flagged that this should not be forgotten:
+merging it into the production server (so spec `013`'s ordered
+`subscription_established → state → trace → terminal_result →
+stream_completed` contract becomes real, `EventBroker`-backed production
+behavior) is tracked as a north-star ticket, gated on the WebSocket
+transport (Decision 47) shipping first.
+
+### Alternatives Considered
+
+- Retire it entirely — rejected for now: loses a low-friction local-testing
+  workflow with no replacement ready yet.
+- Merge into production HTTP API now — rejected for now: the production
+  endpoint doesn't yet implement spec `013`'s ordered message contract;
+  doing this before the transport decision (Decision 47) would mean
+  redoing it once WebSocket lands anyway.
+
+### Outcome
+
+No ticket for `browser_adapter.rs` in the near-term batch. One north-star
+ticket filed: "revisit merging `browser_adapter.rs` into the production
+HTTP API," explicitly blocked on the WebSocket transport ticket.
+
+## Decision 47: North-Star Runtime Event Transport Is WebSocket + gRPC, Decided Now, Replacing SSE
+
+- **Date**: 2026-08-05
+- **Status**: Accepted
+- **Governing specs**: new ADR + spec (to be authored), extends `013-browser-runtime-subscription`, `207-event-broker`, `534-ecca-event-products`
+- **Related issues**: `#966`, `#967`, `#968`
+- **Origin**: `/brainstorm` session, questions 3–6
+
+### Context
+
+`534-ecca-event-products` explicitly scopes out "selecting a broker vendor
+or transport topology" — meaning no existing spec picks a wire protocol for
+runtime→UI (or cross-boundary runtime→runtime) event delivery. A repo-wide
+search found zero WebSocket or gRPC dependencies (no `tonic`/`prost`,
+no websocket library) anywhere in the workspace; only SSE exists, and only
+on the ungoverned `AppStateEventRecord` channel. The UMA white paper
+(§4.4.2) treats WebSocket and gRPC as the common event-management interface,
+with SSE framed only as a comparison option, not the target state.
+
+Four sub-questions were resolved in sequence:
+
+1. **Decide now vs. defer**: decide now, rather than leaving it an open
+   "TBD" — UMA is unambiguous here and Traverse already has real capability
+   contracts declaring publishers/subscribers with nowhere governed for
+   those events to reach a live client.
+2. **Relationship to the near-term SSE work**: WebSocket replaces SSE
+   outright once it ships (not "SSE stays as a fallback") — one transport,
+   one code path, matching the "no back-compat tax while pre-production"
+   principle established in Decision 48.
+3. **Sequencing**: still migrate the existing SSE endpoint onto
+   `EventBroker` first (Decision 45's spec), then replace it with WebSocket
+   later — the SSE step is small, bounded, and already scoped; it proves
+   "`EventBroker` actually reaches a transport" before taking on WebSocket's
+   larger lift (server framework, connection lifecycle, auth-over-socket).
+4. **gRPC scope**: decide gRPC now too, alongside WebSocket, rather than
+   deferring it — per UMA's own guidance (§4.3 Platform Considerations),
+   WebSocket and gRPC are peers a client picks between per platform/workload
+   (`Starscream`/`OkHttp` for WebSocket, `grpc-swift`/`grpc-java` for gRPC on
+   mobile), not a primary/secondary pair, so scoping only one now would
+   under-specify the interface UMA actually describes.
+
+### Decision
+
+Author an ADR + spec (Decision 50) committing to WebSocket and gRPC as the
+governed runtime-event transport pair, both reading from the same
+`EventBroker`/`TraverseEvent` source, replacing the SSE endpoint outright
+once shipped. Implementation is staged: SSE-on-`EventBroker` ships first
+(Decision 45), WebSocket and gRPC ship after, each retiring their
+predecessor rather than running in parallel indefinitely.
+
+### Alternatives Considered
+
+- Defer the transport choice entirely — rejected, UMA and the existing
+  capability contracts already assume this exists.
+- WebSocket only, gRPC deferred until a native/mobile client exists —
+  rejected: the user chose to decide both together rather than
+  speculatively defer gRPC.
+- Keep SSE as a permanent fallback alongside WebSocket — rejected in favor
+  of a clean replacement, consistent with the pre-production fix-fast
+  principle (Decision 48).
+
+### Outcome
+
+Two north-star tickets: author the transport ADR+spec, then implement
+WebSocket (retiring SSE) and gRPC. Both are downstream of the near-term
+SSE-on-`EventBroker` ticket (Decision 45), not blocking it.
+
+## Decision 48: No Backward-Compatibility Tax While Traverse Has No Production Users — General Principle
+
+- **Date**: 2026-08-05
+- **Status**: Accepted
+- **Governing specs**: none (cross-cutting principle, applies to governance choices generally, not one spec)
+- **Related issues**: none yet
+- **Origin**: `/brainstorm` session, stated by the user when resolving the capability-ABI compatibility question (Decision 49)
+
+### Context
+
+Deciding whether the north-star capability-side event ABI should be
+additive (alongside the existing "declare events in output JSON"
+convention) or a breaking replacement of it raised a broader question: how
+much should any current Traverse design decision weigh compatibility with
+existing capabilities, contracts, or runtime behavior, given there are no
+production users or production capabilities yet.
+
+### Decision
+
+**General rule for now**: prefer fixing the architecture correctly over
+preserving compatibility with pre-production code, contracts, or
+conventions. This is not scoped to the capability ABI alone — it applies to
+future governance decisions in this repo until stated otherwise (e.g. once
+real external users or production capabilities exist, this default should
+be revisited).
+
+### Alternatives Considered
+
+- Default to additive/backward-compatible changes as a standing rule —
+  rejected by the user: there is no installed base to protect yet, and
+  compatibility shims add permanent surface area for a constraint that
+  doesn't currently exist.
+
+### Outcome
+
+Directly determined Decision 49 (breaking ABI replacement) and Decision 47
+(WebSocket replaces SSE outright rather than SSE staying a fallback).
+Should be cited by name in future brainstorms/ADRs where a
+compatibility-vs-correctness fork comes up, until the user says otherwise.
+
+## Decision 49: Capability-Side WASM Host ABI Is a Breaking Replacement of the Output-JSON Event Convention
+
+- **Date**: 2026-08-05
+- **Status**: Accepted
+- **Governing specs**: new ADR + spec (to be authored), extends `002-capability-contracts`, `003-event-contracts`, `207-event-broker`
+- **Related issues**: `#969`, `#970`
+- **Origin**: `/brainstorm` session, question 6
+
+### Context
+
+No WASM host-function ABI exists today for a capability to imperatively
+publish or subscribe to events (confirmed: zero hits across
+`traverse-native-bridge`, `executor/wasm.rs`, `executor/native.rs`).
+Capabilities instead declare an `emitted_events` array inside their own JSON
+output, which `PlacementRouter` Step 3.5 validates *after* execution
+completes against the contract's `emits` list, rejecting undeclared
+emissions as a `ContractViolation`. This is the piece furthest from UMA's
+model, where a microservice calls the runtime's abstraction layer directly
+(e.g. `this.eventDispatcher.dispatch(...)`, §5.1.2.2).
+
+### Decision
+
+The north-star ABI is a **breaking replacement**, not an additive option:
+capabilities will be required to call a new host function to emit events
+imperatively; the output-JSON declaration convention is deprecated and
+removed rather than kept as a second supported path. This follows directly
+from Decision 48 (no back-compat tax pre-production) — with no production
+capabilities depending on the current convention, there's no cost to
+replacing it outright, and a single canonical path avoids permanently
+maintaining two ways to do the same thing plus the post-hoc violation-check
+complexity (the host function can reject an undeclared event synchronously
+at call time instead of after the fact).
+
+### Alternatives Considered
+
+- Additive/optional host function alongside the existing convention —
+  rejected per Decision 48; would create permanent dual-path complexity for
+  a compatibility constraint that doesn't exist yet.
+
+### Outcome
+
+Two north-star tickets: author the capability-ABI ADR+spec, then implement
+the host function (native-bridge + WASM executor + contract validation
+changes) and migrate existing capability fixtures/tests off the
+output-JSON convention.
+
+## Decision 50: Unify Workflow Event-Driven Edges With `EventBroker`, Superseding `018`'s No-External-Broker Scope Cut
+
+- **Date**: 2026-08-05
+- **Status**: Accepted
+- **Governing specs**: new ADR + spec (to be authored), extends `018-event-driven-composition`, `207-event-broker`
+- **Related issues**: `#971`, `#972`
+- **Origin**: `/brainstorm` session, question 7
+
+### Context
+
+Spec `018-event-driven-composition` deliberately scoped workflow
+event-driven edges to avoid "external brokers, event-created executions,
+direct-capability waiting semantics" — a considered design choice, not a
+placeholder. In the current implementation
+(`workflows.rs::evaluate_event_driven_edges`), a waiting workflow edge can
+only advance from an event extracted from the *same* workflow execution's
+own node output — no cross-workflow, cross-process, or durable delivery,
+and no connection to `EventBroker` at all. This is a third, separate
+event mechanism alongside the broker and the (soon-to-be-replaced) ABI
+convention.
+
+### Decision
+
+Unify workflow-edge advancement with the real `EventBroker`, so a waiting
+edge can advance from any governed event — including ones from other
+workflows, other capabilities, or external publishers — not just events
+declared in the same execution's own output. This reverses `018`'s explicit
+scope cut, justified by Decision 48 (no back-compat tax pre-production) and
+by this being the one place in the runtime where UMA's cross-system
+event-driven composition model was structurally impossible under the
+current design.
+
+### Alternatives Considered
+
+- Keep `018`'s synchronous, single-execution-scoped model as deliberately
+  separate — rejected: while it was a legitimate scope cut at the time
+  (avoids delivery/ordering/durability concerns), it's the one remaining
+  place event-driven composition can't cross a workflow or process
+  boundary, which is core to UMA's model and to what capability authors
+  will expect once the ABI (Decision 49) exists.
+
+### Outcome
+
+Two north-star tickets: author the workflow-edge-unification ADR+spec,
+then implement cross-workflow/cross-process event-driven edge advancement
+via `EventBroker`.
+
+## Decision 51: ADR + Spec Pairing for All Three North-Star Decisions
+
+- **Date**: 2026-08-05
+- **Status**: Accepted
+- **Governing specs**: n/a (meta-decision about how Decisions 47, 49, and 50 get formalized)
+- **Related issues**: none yet
+- **Origin**: `/brainstorm` session, question 8
+
+### Context
+
+This repo pairs an ADR with a spec for major technology/pattern pivots
+(ADR-0001 + `001-foundation-v0-1`; ADR-0024 + `530-remote-key-value-datastore`;
+ADR-0029 + `535-s3-compatible-remote-datastore`; ADR-0033 +
+`539-datastore-multiprocess-coordination`). The question was whether all
+three north-star decisions (transport, capability ABI, workflow-edge
+unification) warrant that pairing, or only the two that introduce genuinely
+new technology/patterns (transport, ABI), with workflow-edge unification
+covered by a spec alone since it applies an already-ADR'd pattern
+(`EventBroker`, governed by `207`/`534`) somewhere it wasn't used yet.
+
+### Decision
+
+All three get an ADR + spec pair: transport (Decision 47), capability ABI
+(Decision 49), and workflow-edge unification (Decision 50).
+
+### Alternatives Considered
+
+- ADR+spec for transport and ABI only, spec-alone for workflow-edge
+  unification — this was the recommended option (workflow-edge unification
+  arguably just extends an existing pattern rather than introducing a new
+  one), but the user chose full ADR+spec coverage for all three instead.
+
+### Outcome
+
+Six specs total to author across the near-term and north-star batches (one
+near-term SSE spec, three north-star ADR+spec pairs), each producing its
+own "author the spec" ticket ahead of its "implement" ticket.

--- a/specs/964-runtime-event-sse-transport/spec.md
+++ b/specs/964-runtime-event-sse-transport/spec.md
@@ -1,0 +1,99 @@
+# Feature Specification: Production SSE Transport Backed by EventBroker
+
+**Status**: Approved
+**Canonical governing ID**: `096-runtime-event-sse-transport`
+**Extends**: `207-event-broker`, `534-ecca-event-products`
+**Input**: Issue #964; `/brainstorm` session recorded as Decision 45 in `docs/decision-log.md`.
+
+## Purpose
+
+Make the production HTTP API's app-events SSE endpoint
+(`/v1/workspaces/{workspace_id}/apps/{app_id}/events`, `handle_app_events` in
+`crates/traverse-cli/src/http_api.rs`) a governed consumer of `EventBroker`,
+replacing the ungoverned `AppStateEventRecord` type it streams today.
+`AppStateEventRecord` carries no relationship to `TraverseEvent`, event
+contracts, or `EventBroker` lifecycle/ownership metadata — it is the one
+production-facing surface in Traverse that emits events with no governance
+attached to them at all. This spec closes that gap without picking a wire
+protocol (transport topology stays out of scope, per `534`'s own boundary);
+it governs what the existing SSE endpoint reads from, not a new endpoint or a
+new protocol.
+
+## Capability Boundary
+
+This endpoint is a read-only, workspace-scoped view over events already
+published to `EventBroker` for capabilities executing in that workspace. It
+does not publish events, does not expose the broker's full catalog across
+workspace boundaries, and does not introduce delivery guarantees beyond what
+`EventBroker`/`DurableBroker` already provide. It is not the browser
+subscription surface governed by `013-browser-runtime-subscription` (that
+surface's ordered message contract — `subscription_established → state →
+trace → terminal_result → stream_completed` — is out of scope here; see
+issue #973) and it does not select or introduce a new transport (WebSocket
+and gRPC are governed separately by `097-websocket-grpc-event-transport`,
+issue #966).
+
+## Requirements
+
+- **FR-001**: `handle_app_events` MUST source its SSE stream from
+  `EventBroker`/`TraverseEvent` (via `Subscription`/`SubscriptionPoll`/
+  `EventCursor`), not from `AppStateEventRecord`. `AppStateEventRecord` and
+  its population call sites MUST be removed once this migration lands — it
+  is not kept as a parallel or dual-emit path (per Decision 48, no
+  back-compat tax while there are no production consumers).
+- **FR-002**: Each SSE `data:` payload MUST serialize the full `TraverseEvent`
+  CloudEvents envelope (`id`, `source`, `event_type`, `datacontenttype`,
+  `time`, `data`) plus its governance metadata (`owner`, `version`,
+  `lifecycle_status`), not a reshaped or partial projection.
+- **FR-003**: The endpoint MUST continue to support replay via the
+  `Last-Event-ID` request header, resolved against `EventBroker`'s existing
+  cursor semantics (`EventCursor`, `subscribe`/`subscribe_for_subject`,
+  `poll`) rather than a bespoke replay mechanism.
+- **FR-004**: The endpoint MUST remain workspace- and app-scoped: a
+  subscriber for `{workspace_id}/{app_id}` MUST only receive events whose
+  `source` and/or `subject_id` resolve to that workspace/app pairing.
+  Cross-workspace event leakage through this endpoint is a spec violation.
+- **FR-005**: Existing authorization (`SCOPE_RUNTIME_EVENTS_READ`, loopback
+  and bearer-token modes) MUST be preserved unchanged by this migration.
+- **FR-006**: The signals currently carried only by `AppStateEventRecord`
+  (`state_changed`, `capability_result`, session-lifecycle events,
+  command-dispatch events) MUST each be mapped onto a registered
+  `EventCatalog` entry with an explicit owner, version, and lifecycle
+  status — they MUST NOT be dropped silently, and MUST NOT bypass catalog
+  registration as an informal "system event" carve-out.
+- **FR-007**: When no events are available for a subscriber, the endpoint
+  MUST continue to emit a heartbeat message so long-lived connections are
+  not mistaken for a dead stream.
+- **FR-008**: This spec does not require this endpoint's design to remain
+  stable indefinitely: `097-websocket-grpc-event-transport` (issue #966)
+  is expected to retire this SSE endpoint outright once WebSocket ships
+  (Decision 47), not run alongside it as a permanent fallback.
+
+## Acceptance Scenarios
+
+1. Given a `Subscribable` capability whose declared event has been published
+   to `EventBroker` (per issue #963's `PlacementRouter` wiring), when a
+   client opens `GET /v1/workspaces/{workspace_id}/apps/{app_id}/events`,
+   then the response is an SSE stream whose `data:` payloads are full
+   `TraverseEvent` envelopes for that workspace/app.
+2. Given a client reconnects with a `Last-Event-ID` header, when the request
+   is served, then only events with a cursor after that id are replayed,
+   using `EventBroker`'s own cursor resolution.
+3. Given an event published for workspace A, when a client subscribed to
+   workspace B's endpoint polls, then that event is never delivered.
+4. Given no new events are available, when the connection is held open,
+   then a heartbeat message is emitted rather than the connection appearing
+   silent or dead.
+5. Given the migration has landed, when `crates/traverse-cli/src/http_api.rs`
+   is inspected, then no `AppStateEventRecord` type or references to it
+   remain.
+
+## Out of Scope
+
+- Selecting or implementing WebSocket or gRPC transport (governed by
+  `097-websocket-grpc-event-transport`, issue #966).
+- The browser-subscription ordered message contract and its production
+  exposure (`013-browser-runtime-subscription`; tracked separately as issue
+  #973, currently deferred).
+- Any change to `EventBroker`'s internal delivery, durability, or lifecycle
+  semantics — this spec only governs what already reads from it.

--- a/specs/966-websocket-grpc-event-transport/spec.md
+++ b/specs/966-websocket-grpc-event-transport/spec.md
@@ -1,0 +1,95 @@
+# Feature Specification: WebSocket and gRPC Event Transport
+
+**Status**: Approved
+**Canonical governing ID**: `097-websocket-grpc-event-transport`
+**Extends**: `013-browser-runtime-subscription`, `207-event-broker`, `534-ecca-event-products`
+**Input**: Issue #966; ADR-0034; `/brainstorm` session recorded as Decision 47 in `docs/decision-log.md`.
+
+## Purpose
+
+Define the governed WebSocket and gRPC interfaces through which an external
+client — browser, mobile, or another runtime instance — receives events
+published to `EventBroker`, replacing the SSE endpoint governed by
+`096-runtime-event-sse-transport` (issue #964) once implemented. Both
+transports read from the same `TraverseEvent` source and carry the same
+CloudEvents-shaped envelope; neither is a lower-priority fallback for the
+other. This spec also defines how `013-browser-runtime-subscription`'s
+ordered browser message contract (`subscription_established → state →
+trace → terminal_result → stream_completed`) maps onto the WebSocket
+transport, since `013` explicitly excludes transport protocols from its own
+scope.
+
+## Capability Boundary
+
+This spec governs the wire interface and connection/session lifecycle for
+both transports. It does not govern `EventBroker`'s internal delivery,
+durability, or catalog semantics (those stay governed by `207`), does not
+re-litigate whether SSE should remain a fallback (ADR-0034 already decided
+no), and does not include the actual implementation (tracked separately as
+issues #967 WebSocket and #968 gRPC).
+
+## Requirements
+
+- **FR-001**: A WebSocket connection MUST require the same authorization
+  scope semantics as the SSE endpoint it replaces (equivalent to
+  `SCOPE_RUNTIME_EVENTS_READ`), asserted during the connection handshake,
+  not per-message.
+- **FR-002**: Once authorized, a client MUST be able to subscribe to one or
+  more event types (or the browser-subscription ordered stream for one
+  `request_id`/`execution_id`, per `013`) over the same connection, mapping
+  onto `EventBroker::subscribe`/`subscribe_for_subject`.
+- **FR-003**: Every message delivered over WebSocket MUST carry the full
+  `TraverseEvent` CloudEvents envelope plus governance metadata, matching
+  `096`'s FR-002 requirement for the SSE transport it replaces.
+- **FR-004**: When a WebSocket connection is used for the browser
+  subscription contract (`013`), message ordering MUST preserve `013`'s
+  existing guarantees: `subscription_established` first, all governed
+  runtime state events in order, then the terminal result, then
+  `stream_completed` last.
+- **FR-005**: The gRPC service MUST define `.proto` message types whose
+  fields are a 1:1 mapping of `TraverseEvent`'s CloudEvents fields
+  (`specversion`, `id`, `source`, `type`, `time`, `data`, and the governance
+  metadata envelope), matching UMA's reference `EventService` shape
+  (`SendEvent`, `StreamEvents`) as a starting point, not a binding
+  requirement to match it exactly.
+- **FR-006**: gRPC connections MUST use TLS for transport encryption; token-
+  based client authentication (matching the WebSocket authorization model in
+  FR-001) MUST be enforced before any event is streamed.
+- **FR-007**: Once WebSocket ships, the SSE endpoint governed by `096` MUST
+  be removed, not kept running in parallel (ADR-0034).
+- **FR-008**: A connection or stream failure (auth rejection, malformed
+  subscription request, broker unavailability) MUST return a structured,
+  machine-readable error before any partial event stream begins, matching
+  `013`'s existing `invalid_request`/`not_found` error-message pattern
+  rather than a raw protocol-level error.
+
+## Acceptance Scenarios
+
+1. Given an authorized WebSocket client subscribes to an event type, when
+   `EventBroker` publishes a matching event, then the client receives the
+   full `TraverseEvent` envelope over the open connection.
+2. Given a WebSocket client opens a browser-subscription stream for one
+   `execution_id`, when the stream completes, then the message sequence is
+   `subscription_established`, governed state events in order,
+   `terminal_result`, `stream_completed` — matching `013`'s ordering
+   guarantees.
+3. Given a gRPC client calls `StreamEvents`, when events are published,
+   then each streamed message deserializes into the same logical
+   `TraverseEvent` fields a WebSocket client would receive for the same
+   event.
+4. Given an unauthorized connection attempt on either transport, when the
+   handshake completes, then the connection is rejected with a structured
+   error before any event data is sent.
+5. Given WebSocket has shipped, when `crates/traverse-cli/src/http_api.rs`
+   is inspected, then the SSE app-events endpoint from `096` no longer
+   exists.
+
+## Out of Scope
+
+- Re-deciding whether SSE should remain a fallback (settled by ADR-0034).
+- `EventBroker`'s internal delivery/durability semantics (governed by
+  `207`).
+- `browser_adapter.rs`'s disposition (tracked separately as issue #973,
+  blocked on this spec's implementation landing).
+- Client SDK implementations for any specific platform (iOS, Android, web
+  framework) — this spec governs the server-side interface only.

--- a/specs/969-capability-event-host-abi/spec.md
+++ b/specs/969-capability-event-host-abi/spec.md
@@ -1,0 +1,90 @@
+# Feature Specification: Capability-Side WASM Host ABI for Event Publish/Subscribe
+
+**Status**: Approved
+**Canonical governing ID**: `098-capability-event-host-abi`
+**Extends**: `002-capability-contracts`, `003-event-contracts`, `207-event-broker`
+**Input**: Issue #969; ADR-0035; `/brainstorm` session recorded as Decisions 48–49 in `docs/decision-log.md`.
+
+## Purpose
+
+Define a WASM host-function ABI that lets a capability imperatively publish
+an event during execution, and remove the output-JSON `emitted_events`
+convention it replaces. Today a capability declares emitted events inside
+its own JSON output, checked post-execution by `PlacementRouter` Step 3.5
+against the contract's `emits` list. This spec moves that check to the
+point of emission and gives capability authors a real, imperative
+publish/subscribe surface, matching UMA's reference model (§5.1.2.2,
+`eventDispatcher.dispatch(...)`).
+
+## Capability Boundary
+
+This spec governs the host-function ABI surface (import signatures, calling
+convention, synchronous validation behavior) and the removal of the
+output-JSON convention it replaces. It is unrelated to and does not modify
+`071-native-runtime-wasm-bridge`'s guest-exported `traverse_next_event`
+function, which is part of the native embedder-bridge lifecycle ABI, not a
+business-event mechanism. It does not change `EventBroker`'s internal
+delivery or catalog semantics (`207`), and it does not include the actual
+implementation or fixture migration (tracked separately as issue #970).
+
+## Requirements
+
+- **FR-001**: A new host-function import (versioned and whitelisted the same
+  way as existing `traverse_*` bridge functions in
+  `host_abi_whitelist`/`HOST_ABI_V1_WHITELIST`) MUST let a WASM capability
+  publish a `TraverseEvent`-shaped payload during its own execution.
+- **FR-002**: The host implementation of this function MUST validate the
+  emitted event's `event_type`/`version` against the calling capability's
+  contract `emits` list **synchronously, at call time**. An undeclared
+  emission MUST be rejected immediately (returning an error to the guest),
+  not discovered after execution completes.
+- **FR-003**: A capability whose `service_type` is not `Subscribable` MUST
+  be rejected by this host function at call time — only `Subscribable`
+  capabilities may emit events, matching the existing constraint enforced
+  by `PlacementRouter` Step 3.5 today.
+- **FR-004**: The output-JSON `emitted_events` convention (a capability
+  declaring events inside its JSON output, validated post-execution) MUST
+  be removed once this ABI exists — not kept as a second supported path
+  (ADR-0035; Decision 48, no back-compat tax pre-production).
+- **FR-005**: `PlacementRouter` Step 3.5's post-hoc `undeclared_event_emission`
+  violation check MUST be removed once the host-side synchronous check
+  (FR-002) supersedes it. `PlacementRouter` Step 5 (publish to `EventBroker`)
+  continues to run for events accepted via this ABI.
+- **FR-006**: All existing `Subscribable` capability fixtures and tests
+  relying on the output-JSON convention MUST be migrated to call this ABI
+  instead, with no fixture left on the old convention once this spec's
+  implementation lands.
+- **FR-007**: The host function signature and its whitelist entry MUST be
+  documented in the same location as the existing native-bridge ABI
+  whitelist, so the full set of host-callable functions for a given ABI
+  version remains discoverable in one place.
+
+## Acceptance Scenarios
+
+1. Given a `Subscribable` capability whose contract declares `emits:
+   [{event_id: "x", version: "1.0.0"}]`, when it calls the new host function
+   with a matching event, then the event is accepted and later published to
+   `EventBroker` by `PlacementRouter` Step 5.
+2. Given the same capability calls the host function with an undeclared
+   event type, when the call is made, then it is rejected synchronously,
+   before execution completes — not discovered afterward as a trace
+   violation.
+3. Given a capability whose `service_type` is `Stateless`, when it calls the
+   event-emit host function, then the call is rejected regardless of
+   payload.
+4. Given the migration is complete, when the codebase is inspected, then no
+   capability fixture or test relies on an `emitted_events` field inside a
+   capability's JSON output, and `PlacementRouter`'s post-hoc violation
+   check for undeclared emissions no longer exists.
+
+## Out of Scope
+
+- Any change to `071-native-runtime-wasm-bridge`'s `traverse_next_event` or
+  other native-bridge lifecycle functions.
+- A subscribe-side host function for a capability to receive events
+  pushed to it mid-execution — this spec covers publish only; a
+  subscribe-side ABI, if needed, is separate future work.
+- `EventBroker`'s internal delivery/durability semantics (governed by
+  `207`).
+- Workflow event-driven edges consuming from this ABI's output (governed
+  separately by `099-workflow-event-broker-unification`, issue #971).

--- a/specs/971-workflow-event-broker-unification/spec.md
+++ b/specs/971-workflow-event-broker-unification/spec.md
@@ -1,0 +1,80 @@
+# Feature Specification: Unify Workflow Event-Driven Edges With EventBroker
+
+**Status**: Approved
+**Canonical governing ID**: `099-workflow-event-broker-unification`
+**Extends**: `018-event-driven-composition`, `207-event-broker`
+**Input**: Issue #971; ADR-0036; `/brainstorm` session recorded as Decision 50 in `docs/decision-log.md`.
+
+## Purpose
+
+Let a waiting workflow event-driven edge advance from any event published to
+`EventBroker` — including events from other workflow executions, other
+capabilities, or external publishers — rather than only events declared in
+the same execution's own node output, as `018-event-driven-composition`
+currently requires. This spec supersedes `018`'s explicit "without
+introducing external brokers" scope cut while preserving its deterministic
+ordering and exact-once-consumption guarantees.
+
+## Capability Boundary
+
+This spec governs how a waiting workflow edge subscribes to and consumes
+`EventBroker` events. It does not change `EventBroker`'s own delivery or
+catalog semantics (`207`), does not change how a capability emits an event
+(governed separately by `098-capability-event-host-abi`, issue #969), and
+does not include the implementation itself (tracked separately as issue
+#972).
+
+## Requirements
+
+- **FR-001**: A workflow edge with `WorkflowEdgeTrigger::Event` MUST
+  register a subscription with `EventBroker` for its declared
+  `event_ref` (`event_id` + `version`), rather than only being evaluated
+  against the current execution's own node output.
+- **FR-002**: An event published by `EventBroker` — regardless of which
+  workflow execution, capability, or external publisher produced it — MUST
+  be eligible to advance any waiting edge whose `event_ref` and predicate
+  match, preserving `018`'s existing simple field-equality payload
+  predicate model.
+- **FR-003**: `018`'s deterministic multi-workflow wake ordering guarantee
+  MUST be preserved: when one event is eligible for more than one waiting
+  edge (across one or more workflow executions), all eligible edges MUST
+  wake in deterministic, explainable order.
+- **FR-004**: `018`'s exact-once-per-edge consumption guarantee MUST be
+  preserved: one event record MUST NOT trigger the same waiting edge more
+  than once, even when sourced from a durable/replayed broker stream.
+- **FR-005**: `EventDrivenEvaluationOutcome` and its trace evidence MUST
+  record which `EventBroker` subscription and cursor produced a given
+  wake-up decision, so the wake-up remains explainable and reconstructable
+  from trace evidence alone (preserving `018`'s explainability requirement,
+  now against a real broker rather than a single synchronous pass).
+- **FR-006**: This unification MUST NOT introduce a new top-level runtime
+  waiting state, matching `018`'s original constraint that event-driven
+  progression stays within the existing state model.
+- **FR-007**: A waiting edge whose subscription cannot be established (for
+  example, an unregistered event type in `EventBroker`'s catalog) MUST
+  surface a stable, machine-readable error rather than silently never
+  waking.
+
+## Acceptance Scenarios
+
+1. Given workflow A is waiting on an event-driven edge, when workflow B (a
+   separate execution) or a standalone capability publishes the exact
+   declared event to `EventBroker`, then workflow A's edge advances.
+2. Given two waiting edges across two different workflow executions are
+   both eligible for one published event, when the event is processed, then
+   both wake in deterministic order and each edge consumes the event
+   exactly once.
+3. Given a matching event is replayed from `EventBroker`'s durable journal
+   after a restart, when a waiting edge that already consumed that event
+   record is re-evaluated, then it does not advance a second time.
+4. Given a wake-up occurs, when trace evidence is inspected, then it
+   identifies the `EventBroker` subscription and cursor responsible for the
+   advancement, in addition to `018`'s existing event-match/predicate/
+   edge-selection evidence.
+
+## Out of Scope
+
+- Changes to how a capability emits an event (`098-capability-event-host-abi`,
+  issue #969).
+- `EventBroker`'s own delivery, durability, or catalog semantics (`207`).
+- Introducing a new top-level runtime waiting state.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1244,6 +1244,59 @@
         "docs/adr/0029-s3-compatible-remote-datastore.md",
         "specs/535-s3-compatible-remote-datastore/"
       ]
+    },
+    {
+      "id": "096-runtime-event-sse-transport",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/964-runtime-event-sse-transport/spec.md",
+      "governs": [
+        "crates/traverse-cli/src/http_api.rs",
+        "crates/traverse-runtime/src/events/",
+        "specs/964-runtime-event-sse-transport/"
+      ]
+    },
+    {
+      "id": "097-websocket-grpc-event-transport",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/966-websocket-grpc-event-transport/spec.md",
+      "governs": [
+        "crates/traverse-cli/",
+        "crates/traverse-runtime/src/events/",
+        "docs/adr/0034-websocket-grpc-event-transport.md",
+        "specs/966-websocket-grpc-event-transport/"
+      ]
+    },
+    {
+      "id": "098-capability-event-host-abi",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/969-capability-event-host-abi/spec.md",
+      "governs": [
+        "crates/traverse-native-bridge/",
+        "crates/traverse-runtime/src/executor/",
+        "crates/traverse-runtime/src/router/",
+        "crates/traverse-contracts/",
+        "docs/adr/0035-capability-event-host-abi.md",
+        "specs/969-capability-event-host-abi/"
+      ]
+    },
+    {
+      "id": "099-workflow-event-broker-unification",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/971-workflow-event-broker-unification/spec.md",
+      "governs": [
+        "crates/traverse-runtime/src/workflows.rs",
+        "crates/traverse-runtime/src/events/",
+        "docs/adr/0036-workflow-event-broker-unification.md",
+        "specs/971-workflow-event-broker-unification/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Codifies 4 new governed specs + 3 ADRs from a `/brainstorm` session that
mapped the UMA white paper's eventing model against this repo's current
implementation. See `docs/decision-log.md` Decisions 44-51 for the full
reasoning and alternatives considered for each.

- `096-runtime-event-sse-transport` — production SSE reads from
  `EventBroker`, replacing the ungoverned `AppStateEventRecord` type
  `handle_app_events` streams today.
- ADR-0034 + `097-websocket-grpc-event-transport` — WebSocket + gRPC as the
  governed north-star transport, replacing SSE once shipped.
- ADR-0035 + `098-capability-event-host-abi` — capability-side WASM host
  ABI for imperative event publish, breaking-replacing the output-JSON
  `emitted_events` convention capabilities use today.
- ADR-0036 + `099-workflow-event-broker-unification` — unify workflow
  event-driven edges (spec `018`) with `EventBroker`, superseding `018`'s
  deliberate no-external-broker scope cut.

This is documentation/governance only — no implementation code changes.
Implementation is tracked separately per spec: #965, #967, #968, #970, #972.
`070-runtime-event-sink-boundary` and `004-spec-alignment-gate` are
declared because they already govern the shared files this PR touches
(`docs/adr/`, `docs/decision-log.md`, `specs/governance/approved-specs.json`).

## Governing Spec

- `096-runtime-event-sse-transport`
- `097-websocket-grpc-event-transport`
- `098-capability-event-host-abi`
- `099-workflow-event-broker-unification`
- `070-runtime-event-sink-boundary`
- `004-spec-alignment-gate`

## Project Item

Closes #964, #966, #969, #971 (the spec/ADR-authoring tickets). Linked to
#894 (event-first capability composition gate) as its missing
"UI/catalog discovery" child slice.

## Definition of Done

- [x] Specs, ADRs, and immutable registry entries are present.
- [x] Each new spec cites an accepted `docs/decision-log.md` entry
      (Decision-Log Traceability Gate, `docs/project-management.md`).

## Validation

- `jq empty specs/governance/approved-specs.json`
- `git diff --check`
