### PR TITLE
docs(governance): amend eventing specs to v1.1.0 for happy/unhappy-path coverage

### DIFF
--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1673,3 +1673,67 @@ All three get an ADR + spec pair: transport (Decision 47), capability ABI
 Six specs total to author across the near-term and north-star batches (one
 near-term SSE spec, three north-star ADR+spec pairs), each producing its
 own "author the spec" ticket ahead of its "implement" ticket.
+
+## Decision 52: Amend Specs 096–099 to v1.1.0 to Close Happy/Unhappy-Path Gaps Found Before Implementation
+
+- **Date**: 2026-08-06
+- **Status**: Accepted
+- **Governing specs**: `096-runtime-event-sse-transport`, `097-websocket-grpc-event-transport`, `098-capability-event-host-abi`, `099-workflow-event-broker-unification` (all amended v1.0.0 -> v1.1.0)
+- **Related issues**: `#963`–`#973`
+- **Origin**: Pre-implementation audit requested by the user ("make sure we have all the tickets... specs and ADRs defined and approved... identify happy and unhappy paths") before any of the eventing-sequence tickets began implementation.
+
+### Context
+
+A systematic pass through the four specs merged in PR #974, checking each
+against a happy/unhappy-path checklist (success, auth failure, malformed
+input, dependency-unavailable, concurrency/replay edge cases), found seven
+requirement gaps that were genuinely undefined behavior — not just missing
+illustrative Acceptance Scenarios for already-stated requirements. Left
+unresolved, each implementer would have had to invent the behavior ad hoc:
+
+- `096`: no defined response for a malformed/expired `Last-Event-ID`
+  (despite `EventBroker` already having typed `InvalidCursor`/`CursorExpired`
+  errors for exactly this), and no defined response for an internal
+  `EventBroker` failure during poll.
+- `097`: FR-008 only covered failures *before* a stream starts, leaving
+  mid-stream broker failure undefined; no reconnect/resume story for a
+  dropped WebSocket connection; no bound on malformed/oversized incoming
+  client messages.
+- `098`: no requirement for memory-bounds validation at the WASM guest/host
+  boundary for the new host function, despite the guest supplying the
+  payload pointer/length the host reads.
+- `099`: FR-007 only covered "event type not registered" — `EventBroker`
+  being unreachable at subscription-registration time was a distinct,
+  undefined failure mode.
+
+Per `.specify/memory/constitution.md` and `approved-specs.json`
+(`"immutable": true`), none of these four specs could be edited in place;
+closing the gaps required a formal, versioned amendment, following the
+precedent already established in `traverse-framework/registry`'s own
+`016-ecca-event-product-adoption` spec (v1.0.0 -> v2.0.0 -> v2.1.0, each
+amendment explicitly owner-approved and logged).
+
+### Decision
+
+Amend all four specs to v1.1.0, adding one new FR (two for `097`, none
+removed or changed) per gap, each proposing a resolution grounded in a
+pattern already established elsewhere in this codebase rather than a novel
+design (typed `EventError` variants -> structured HTTP status codes;
+`browser_adapter.rs`'s existing bounded-input constants; `traverse-swift-host`'s
+existing WASM-boundary bounds-checking discipline). No existing FR text
+changed in any of the four specs — this is purely additive.
+
+### Alternatives Considered
+
+- Defer explicitly and let each ticket's implementer propose the exact
+  behavior during implementation, reviewed in PR rather than pre-specified —
+  this was offered as the deferral option but not chosen; the user chose to
+  close the gaps now, before implementation starts.
+
+### Outcome
+
+`specs/governance/approved-specs.json` updated to `"version": "1.1.0"` for
+all four spec ids. Each spec file carries an `## Amendment` note (matching
+the registry repo's own amendment-note convention) documenting what changed
+and why. Tracked for codification in a follow-up PR alongside the DoD
+strengthening pass on issues `#963`–`#973`.

--- a/specs/964-runtime-event-sse-transport/spec.md
+++ b/specs/964-runtime-event-sse-transport/spec.md
@@ -2,8 +2,20 @@
 
 **Status**: Approved
 **Canonical governing ID**: `096-runtime-event-sse-transport`
+**Version**: 1.1.0
 **Extends**: `207-event-broker`, `534-ecca-event-products`
 **Input**: Issue #964; `/brainstorm` session recorded as Decision 45 in `docs/decision-log.md`.
+
+**Amendment (2026-08-06, v1.0.0 -> v1.1.0)**: A pre-implementation happy/unhappy-path
+audit found this spec left two failure modes undefined — a malformed or expired
+`Last-Event-ID`, and an internal `EventBroker` error during subscribe/poll — even
+though `EventBroker` already carries typed errors for both (`EventError::InvalidCursor`,
+`EventError::CursorExpired`). Leaving these undefined would have left the implementer
+to invent the HTTP response shape ad hoc. FR-009 and FR-010 below close both gaps.
+No existing FR text changed. Approved by the repo owner the same day this gap was
+raised, no separate `/brainstorm` needed since the fix pattern (typed error ->
+structured HTTP response) is already established practice in this codebase, not a new
+architecture decision.
 
 ## Purpose
 
@@ -68,6 +80,19 @@ issue #966).
   stable indefinitely: `097-websocket-grpc-event-transport` (issue #966)
   is expected to retire this SSE endpoint outright once WebSocket ships
   (Decision 47), not run alongside it as a permanent fallback.
+- **FR-009** (v1.1.0): A malformed `Last-Event-ID` (fails `EventBroker`'s cursor
+  parsing, surfaced as `EventError::InvalidCursor`) MUST return `400 Bad
+  Request` with a `problem+json` body identifying the malformed value. An
+  expired cursor (outside the active retention window, surfaced as
+  `EventError::CursorExpired`) MUST return `410 Gone` with the oldest
+  available cursor included in the response body. Neither case MUST silently
+  fall back to a full replay from the start of the retention window.
+- **FR-010** (v1.1.0): An internal `EventBroker` error during subscribe or
+  poll (for example, a poisoned lock or other non-cursor failure) MUST
+  return `503 Service Unavailable` with a `problem+json` body. The
+  connection MUST NOT be silently dropped without a terminal error response
+  — the client must be able to distinguish "no new events" from "the
+  broker failed."
 
 ## Acceptance Scenarios
 
@@ -87,6 +112,15 @@ issue #966).
 5. Given the migration has landed, when `crates/traverse-cli/src/http_api.rs`
    is inspected, then no `AppStateEventRecord` type or references to it
    remain.
+6. Given a client sends a malformed `Last-Event-ID`, when the request is
+   served, then the response is `400` with a `problem+json` body — not a
+   silent restart from the beginning of the stream.
+7. Given a client sends an expired `Last-Event-ID` (older than the active
+   retention window), when the request is served, then the response is
+   `410 Gone` with the oldest available cursor in the body.
+8. Given `EventBroker` fails internally during a poll, when the failure
+   occurs, then the client receives a `503` `problem+json` response rather
+   than a connection that appears to hang.
 
 ## Out of Scope
 

--- a/specs/966-websocket-grpc-event-transport/spec.md
+++ b/specs/966-websocket-grpc-event-transport/spec.md
@@ -2,8 +2,17 @@
 
 **Status**: Approved
 **Canonical governing ID**: `097-websocket-grpc-event-transport`
+**Version**: 1.1.0
 **Extends**: `013-browser-runtime-subscription`, `207-event-broker`, `534-ecca-event-products`
 **Input**: Issue #966; ADR-0034; `/brainstorm` session recorded as Decision 47 in `docs/decision-log.md`.
+
+**Amendment (2026-08-06, v1.0.0 -> v1.1.0)**: A pre-implementation happy/unhappy-path
+audit found three undefined failure modes: FR-008 only covered failures *before* a
+stream starts, leaving mid-stream broker failure undefined; there was no reconnect/
+resume story despite real WebSocket connections dropping routinely; and there was no
+bound on malformed or oversized client-sent messages. FR-009, FR-010, and FR-011 below
+close these. No existing FR text changed. Approved by the repo owner the same day this
+gap was raised.
 
 ## Purpose
 
@@ -62,6 +71,23 @@ issues #967 WebSocket and #968 gRPC).
   machine-readable error before any partial event stream begins, matching
   `013`'s existing `invalid_request`/`not_found` error-message pattern
   rather than a raw protocol-level error.
+- **FR-009** (v1.1.0): If `EventBroker` becomes unavailable *after* a
+  WebSocket or gRPC stream has already started delivering events, the
+  connection MUST be closed with a structured close frame (WebSocket) or
+  trailer/status (gRPC) identifying the failure — never a silent hang or a
+  bare TCP reset the client cannot distinguish from "no new events."
+- **FR-010** (v1.1.0): A WebSocket client reconnecting after a dropped
+  connection MUST be able to resume its subscription by supplying the
+  last-seen `EventCursor`, resolved the same way `096`'s FR-003 resolves
+  `Last-Event-ID` for SSE (including `096`'s FR-009 malformed/expired-cursor
+  behavior, `400`/`410`, applied at the WebSocket handshake instead of an
+  HTTP request).
+- **FR-011** (v1.1.0): The WebSocket server MUST enforce a maximum incoming
+  message size and MUST reject a malformed frame with a structured close
+  code rather than crashing the connection handler or silently ignoring it
+  — consistent with this codebase's existing bounded-input discipline
+  (`MAX_REQUEST_HEADER_BYTES`/`MAX_REQUEST_BODY_BYTES` in
+  `crates/traverse-cli/src/browser_adapter.rs`).
 
 ## Acceptance Scenarios
 
@@ -83,6 +109,15 @@ issues #967 WebSocket and #968 gRPC).
 5. Given WebSocket has shipped, when `crates/traverse-cli/src/http_api.rs`
    is inspected, then the SSE app-events endpoint from `096` no longer
    exists.
+6. Given an open WebSocket stream, when `EventBroker` fails internally mid-
+   stream, then the connection is closed with a structured close frame
+   identifying the failure, not a silent hang.
+7. Given a WebSocket client reconnects with a last-seen `EventCursor` after
+   an unplanned disconnect, when the connection re-establishes, then
+   delivery resumes from that cursor without gaps or duplicates.
+8. Given a client sends an oversized or malformed WebSocket frame, when the
+   server receives it, then the connection is rejected with a structured
+   close code rather than crashing the handler.
 
 ## Out of Scope
 

--- a/specs/969-capability-event-host-abi/spec.md
+++ b/specs/969-capability-event-host-abi/spec.md
@@ -2,8 +2,17 @@
 
 **Status**: Approved
 **Canonical governing ID**: `098-capability-event-host-abi`
+**Version**: 1.1.0
 **Extends**: `002-capability-contracts`, `003-event-contracts`, `207-event-broker`
 **Input**: Issue #969; ADR-0035; `/brainstorm` session recorded as Decisions 48–49 in `docs/decision-log.md`.
+
+**Amendment (2026-08-06, v1.0.0 -> v1.1.0)**: A pre-implementation happy/unhappy-path
+audit found no requirement governing memory-bounds safety at the WASM guest/host
+boundary for the new host function — a real gap, since the guest supplies the
+payload pointer/length the host reads. FR-008 below closes it, matching this
+codebase's existing bounded-limits discipline elsewhere at the WASM boundary
+(`traverse-swift-host`). No existing FR text changed. Approved by the repo owner the
+same day this gap was raised.
 
 ## Purpose
 
@@ -58,6 +67,12 @@ implementation or fixture migration (tracked separately as issue #970).
   documented in the same location as the existing native-bridge ABI
   whitelist, so the full set of host-callable functions for a given ABI
   version remains discoverable in one place.
+- **FR-008** (v1.1.0): The host implementation MUST validate the guest-
+  supplied payload's memory bounds (pointer + length within the guest's
+  linear memory) and enforce a maximum payload size before deserializing
+  it. A malformed or oversized payload MUST be rejected by returning an
+  error code to the guest — the host MUST NOT panic, trap, or read past
+  guest memory bounds.
 
 ## Acceptance Scenarios
 
@@ -76,6 +91,10 @@ implementation or fixture migration (tracked separately as issue #970).
    capability fixture or test relies on an `emitted_events` field inside a
    capability's JSON output, and `PlacementRouter`'s post-hoc violation
    check for undeclared emissions no longer exists.
+5. Given a capability calls the host function with an oversized or
+   out-of-bounds payload pointer, when the call is made, then the host
+   returns an error to the guest without panicking, trapping, or reading
+   outside the guest's linear memory.
 
 ## Out of Scope
 

--- a/specs/971-workflow-event-broker-unification/spec.md
+++ b/specs/971-workflow-event-broker-unification/spec.md
@@ -2,8 +2,16 @@
 
 **Status**: Approved
 **Canonical governing ID**: `099-workflow-event-broker-unification`
+**Version**: 1.1.0
 **Extends**: `018-event-driven-composition`, `207-event-broker`
 **Input**: Issue #971; ADR-0036; `/brainstorm` session recorded as Decision 50 in `docs/decision-log.md`.
+
+**Amendment (2026-08-06, v1.0.0 -> v1.1.0)**: A pre-implementation happy/unhappy-path
+audit found FR-007 only covered "event type not registered in the catalog" — it left
+`EventBroker` being unreachable/unavailable at the moment a workflow tries to register
+a waiting-edge subscription undefined, a distinct failure mode from an unregistered
+type. FR-008 below closes it. No existing FR text changed. Approved by the repo owner
+the same day this gap was raised.
 
 ## Purpose
 
@@ -54,6 +62,11 @@ does not include the implementation itself (tracked separately as issue
   example, an unregistered event type in `EventBroker`'s catalog) MUST
   surface a stable, machine-readable error rather than silently never
   waking.
+- **FR-008** (v1.1.0): If `EventBroker` is unreachable or internally failing
+  at the moment a workflow attempts to register a waiting-edge subscription
+  (distinct from FR-007's "event type not registered" case), the workflow
+  execution MUST surface a stable, retryable error rather than silently
+  never waking or crashing the execution.
 
 ## Acceptance Scenarios
 
@@ -71,6 +84,10 @@ does not include the implementation itself (tracked separately as issue
    identifies the `EventBroker` subscription and cursor responsible for the
    advancement, in addition to `018`'s existing event-match/predicate/
    edge-selection evidence.
+5. Given `EventBroker` is unreachable when a workflow attempts to register a
+   waiting-edge subscription, when the attempt is made, then a stable,
+   retryable error is surfaced and the workflow does not crash or hang
+   silently.
 
 ## Out of Scope
 

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1247,7 +1247,7 @@
     },
     {
       "id": "096-runtime-event-sse-transport",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "approved",
       "immutable": true,
       "path": "specs/964-runtime-event-sse-transport/spec.md",
@@ -1259,7 +1259,7 @@
     },
     {
       "id": "097-websocket-grpc-event-transport",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "approved",
       "immutable": true,
       "path": "specs/966-websocket-grpc-event-transport/spec.md",
@@ -1272,7 +1272,7 @@
     },
     {
       "id": "098-capability-event-host-abi",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "approved",
       "immutable": true,
       "path": "specs/969-capability-event-host-abi/spec.md",
@@ -1287,7 +1287,7 @@
     },
     {
       "id": "099-workflow-event-broker-unification",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "status": "approved",
       "immutable": true,
       "path": "specs/971-workflow-event-broker-unification/spec.md",


### PR DESCRIPTION
## Summary

Amends the 4 eventing specs merged in #974 (096/097/098/099) from v1.0.0 to
v1.1.0, closing 7 requirement gaps found by a pre-implementation happy/
unhappy-path audit. See `docs/decision-log.md` Decision 52 for full context
and each spec's own `## Amendment` note for what changed. No existing FR
text changed in any spec — purely additive (2 new FRs on `096`, 3 on `097`,
1 each on `098`/`099`).

This is documentation/governance only — no implementation code changes.

## Governing Spec

- `096-runtime-event-sse-transport`
- `097-websocket-grpc-event-transport`
- `098-capability-event-host-abi`
- `099-workflow-event-broker-unification`
- `070-runtime-event-sink-boundary`
- `004-spec-alignment-gate`

## Project Item

Relates to #963, #965, #967, #968, #970, #972 (DoD on each already updated
to reference the new FRs).

## Definition of Done

- [x] Specs amended to v1.1.0, registry entries updated.
- [x] Decision-log entry (52) cites the accepted decision and alternatives
      considered.

## Validation

- `jq empty specs/governance/approved-specs.json`
- `git diff --check`
