### PR TITLE
feat(cli): WebSocket app-events transport, retire SSE (#967)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -243,6 +243,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -570,6 +581,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "debugid"
@@ -961,6 +978,22 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
@@ -1487,6 +1520,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,6 +1723,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1989,6 +2044,7 @@ dependencies = [
  "traverse-contracts",
  "traverse-registry",
  "traverse-runtime",
+ "tungstenite",
  "uuid",
  "zeroize",
 ]
@@ -2086,6 +2142,22 @@ dependencies = [
  "sha2 0.11.0",
  "wasmi",
  "wat",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/traverse-cli/Cargo.toml
+++ b/crates/traverse-cli/Cargo.toml
@@ -19,6 +19,7 @@ semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.11"
+tungstenite = { version = "0.30", default-features = false, features = ["handshake"] }
 uuid = { version = "1", features = ["v4"] }
 zeroize = "1.8"
 traverse-contracts = { workspace = true }

--- a/crates/traverse-cli/src/app_events_websocket.rs
+++ b/crates/traverse-cli/src/app_events_websocket.rs
@@ -1,0 +1,664 @@
+//! WebSocket runtime event transport backed by [`EventBroker`].
+//!
+//! Governed by `097-websocket-grpc-event-transport` (issue #967) and ADR-0034.
+//! Crate choice: `tungstenite` (sync `Read + Write` WebSocket) — matches the
+//! existing std `TcpStream` HTTP server without forcing a Tokio rewrite.
+//! Features limited to `handshake` (no TLS stack pulled for local/dev TCP).
+
+use crate::app_runtime_events::{
+    AppEventsHttpError, collect_app_runtime_events, short_signal_name,
+};
+use crate::http_api::{ApiState, HttpRequest, error_envelope, write_json};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::io::Write;
+use std::net::TcpStream;
+use std::time::Duration;
+use traverse_runtime::LocalExecutor;
+use traverse_runtime::events::TraverseEvent;
+use tungstenite::Message;
+use tungstenite::handshake::derive_accept_key;
+use tungstenite::protocol::frame::coding::CloseCode;
+use tungstenite::protocol::{CloseFrame, Role, WebSocket, WebSocketConfig};
+
+/// Max inbound client WebSocket message size (FR-011).
+pub(crate) const MAX_WS_INBOUND_MESSAGE_BYTES: usize = 64 * 1024;
+/// Bounded live-poll iterations for a single connection turn in tests/dev.
+const DEFAULT_LIVE_POLL_ROUNDS: usize = 1;
+const LIVE_POLL_BATCH: usize = 64;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ClientMessage {
+    Subscribe(SubscribeRequest),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SubscribeRequest {
+    #[serde(default = "default_mode")]
+    pub(crate) mode: String,
+    #[serde(default)]
+    pub(crate) from_cursor: Option<String>,
+    #[serde(default)]
+    pub(crate) execution_id: Option<String>,
+}
+
+fn default_mode() -> String {
+    "app_events".to_string()
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ServerEventMessage<'a> {
+    #[serde(rename = "type")]
+    pub(crate) message_type: &'static str,
+    pub(crate) cursor: &'a str,
+    pub(crate) signal: &'a str,
+    pub(crate) event: &'a TraverseEvent,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StructuredCloseReason {
+    #[serde(rename = "type")]
+    message_type: &'static str,
+    traverse_code: String,
+    detail: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    oldest_available_cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_event_id: Option<String>,
+}
+
+pub(crate) fn is_websocket_upgrade(request: &HttpRequest) -> bool {
+    let upgrade = request
+        .headers
+        .get("upgrade")
+        .is_some_and(|v| v.eq_ignore_ascii_case("websocket"));
+    let connection = request.headers.get("connection").is_some_and(|v| {
+        v.split(',')
+            .any(|part| part.trim().eq_ignore_ascii_case("upgrade"))
+    });
+    let has_key = request.headers.contains_key("sec-websocket-key");
+    request.method.eq_ignore_ascii_case("GET") && upgrade && connection && has_key
+}
+
+pub(crate) fn write_sse_retired_response<W: Write>(w: &mut W) -> Result<(), String> {
+    write_json(
+        w,
+        426,
+        "Upgrade Required",
+        &error_envelope(
+            "sse_retired",
+            "SSE app-events transport has been retired; use WebSocket upgrade on this path \
+             (097-websocket-grpc-event-transport / ADR-0034)",
+        ),
+    )
+}
+
+pub(crate) fn handle_app_events_websocket<E: LocalExecutor + Clone>(
+    stream: &mut TcpStream,
+    request: &HttpRequest,
+    state: &ApiState<E>,
+    loopback: bool,
+    workspace_id: &str,
+    app_id: &str,
+    authorize: impl FnOnce(
+        &HttpRequest,
+        &ApiState<E>,
+        bool,
+        &str,
+    ) -> Result<(), (u16, &'static str, Value)>,
+) -> Result<(), String> {
+    if let Err((status, reason, body)) = authorize(request, state, loopback, workspace_id) {
+        return write_json(stream, status, reason, &body);
+    }
+
+    let mut socket = match complete_websocket_handshake(stream, request) {
+        Ok(socket) => socket,
+        Err(err) => {
+            return write_json(
+                stream,
+                400,
+                "Bad Request",
+                &error_envelope("invalid_websocket_handshake", &err),
+            );
+        }
+    };
+
+    let subscribe = match read_subscribe_message(&mut socket) {
+        Ok(subscribe) => subscribe,
+        Err(CloseSignal::Structured(frame)) => {
+            let _ = socket.close(Some(frame));
+            let _ = socket.flush();
+            return Ok(());
+        }
+        Err(CloseSignal::Io(err)) => return Err(err),
+    };
+
+    match subscribe.mode.as_str() {
+        "browser_subscription" => serve_browser_subscription(
+            &mut socket,
+            state,
+            workspace_id,
+            subscribe.execution_id.as_deref(),
+        ),
+        "app_events" => serve_app_events_subscription(
+            &mut socket,
+            state,
+            workspace_id,
+            app_id,
+            subscribe.from_cursor.as_deref(),
+        ),
+        other => {
+            let _ = socket.close(Some(structured_close(
+                CloseCode::Policy,
+                "invalid_request",
+                &format!("unsupported subscribe mode '{other}'"),
+                None,
+                None,
+            )));
+            let _ = socket.flush();
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CloseSignal {
+    Structured(CloseFrame),
+    Io(String),
+}
+
+fn complete_websocket_handshake<'a>(
+    stream: &'a mut TcpStream,
+    request: &HttpRequest,
+) -> Result<WebSocket<&'a mut TcpStream>, String> {
+    let key = request
+        .headers
+        .get("sec-websocket-key")
+        .ok_or_else(|| "missing Sec-WebSocket-Key".to_string())?;
+    let accept = derive_accept_key(key.as_bytes());
+    let response = format!(
+        "HTTP/1.1 101 Switching Protocols\r\n\
+         Upgrade: websocket\r\n\
+         Connection: Upgrade\r\n\
+         Sec-WebSocket-Accept: {accept}\r\n\
+         \r\n"
+    );
+    stream
+        .write_all(response.as_bytes())
+        .map_err(|e| format!("failed to write websocket handshake response: {e}"))?;
+    stream
+        .flush()
+        .map_err(|e| format!("failed to flush websocket handshake response: {e}"))?;
+
+    let config = WebSocketConfig::default().max_message_size(Some(MAX_WS_INBOUND_MESSAGE_BYTES));
+    Ok(WebSocket::from_raw_socket(
+        stream,
+        Role::Server,
+        Some(config),
+    ))
+}
+
+fn read_subscribe_message(
+    socket: &mut WebSocket<&mut TcpStream>,
+) -> Result<SubscribeRequest, CloseSignal> {
+    match socket.read() {
+        Ok(Message::Text(text)) => parse_subscribe_text(text.as_str()),
+        Ok(Message::Binary(bytes)) => {
+            let text = String::from_utf8(bytes.to_vec()).map_err(|_| {
+                CloseSignal::Structured(structured_close(
+                    CloseCode::Policy,
+                    "invalid_request",
+                    "subscribe message must be UTF-8 text JSON",
+                    None,
+                    None,
+                ))
+            })?;
+            parse_subscribe_text(&text)
+        }
+        Ok(Message::Close(_)) => Err(CloseSignal::Structured(structured_close(
+            CloseCode::Normal,
+            "client_closed",
+            "client closed before subscribe",
+            None,
+            None,
+        ))),
+        Ok(Message::Ping(payload)) => {
+            let _ = socket.send(Message::Pong(payload));
+            read_subscribe_message(socket)
+        }
+        Ok(other) => Err(CloseSignal::Structured(structured_close(
+            CloseCode::Policy,
+            "invalid_request",
+            &format!("expected subscribe text frame, got {other}"),
+            None,
+            None,
+        ))),
+        Err(tungstenite::Error::Capacity(_)) => Err(CloseSignal::Structured(structured_close(
+            CloseCode::Size,
+            "message_too_large",
+            &format!("inbound WebSocket message exceeds {MAX_WS_INBOUND_MESSAGE_BYTES} bytes"),
+            None,
+            None,
+        ))),
+        Err(err) => Err(CloseSignal::Io(format!(
+            "failed to read websocket subscribe message: {err}"
+        ))),
+    }
+}
+
+fn parse_subscribe_text(text: &str) -> Result<SubscribeRequest, CloseSignal> {
+    if text.len() > MAX_WS_INBOUND_MESSAGE_BYTES {
+        return Err(CloseSignal::Structured(structured_close(
+            CloseCode::Size,
+            "message_too_large",
+            &format!("inbound WebSocket message exceeds {MAX_WS_INBOUND_MESSAGE_BYTES} bytes"),
+            None,
+            None,
+        )));
+    }
+    match serde_json::from_str::<ClientMessage>(text) {
+        Ok(ClientMessage::Subscribe(subscribe)) => Ok(subscribe),
+        Err(err) => Err(CloseSignal::Structured(structured_close(
+            CloseCode::Policy,
+            "invalid_request",
+            &format!("malformed subscribe message: {err}"),
+            None,
+            None,
+        ))),
+    }
+}
+
+fn serve_app_events_subscription<E: LocalExecutor + Clone>(
+    socket: &mut WebSocket<&mut TcpStream>,
+    state: &ApiState<E>,
+    workspace_id: &str,
+    app_id: &str,
+    from_cursor: Option<&str>,
+) -> Result<(), String> {
+    let collected = state.with_workspace_mut(workspace_id, |ws| {
+        Ok::<_, String>(collect_app_runtime_events(
+            ws.runtime.event_broker().as_ref(),
+            &ws.app_event_log,
+            workspace_id,
+            app_id,
+            from_cursor,
+        ))
+    })?;
+
+    let events = match collected {
+        Ok(events) => events,
+        Err(err) => {
+            let frame = close_frame_for_app_events_error(&err);
+            let _ = socket.close(Some(frame));
+            let _ = socket.flush();
+            return Ok(());
+        }
+    };
+
+    for (cursor, event) in &events {
+        if let Err(err) = send_event_frame(socket, cursor, event) {
+            close_for_broker_failure(socket, &err);
+            return Ok(());
+        }
+    }
+
+    // Live follow: poll for newly published events (FR delivery over open connection).
+    let mut cursor = events
+        .last()
+        .map(|(cursor, _)| cursor.clone())
+        .or_else(|| from_cursor.map(str::to_string));
+    for _ in 0..DEFAULT_LIVE_POLL_ROUNDS {
+        // Non-blocking peek for client close / oversized frames between polls.
+        if let Err(signal) = drain_client_control_frames(socket) {
+            return match signal {
+                CloseSignal::Structured(frame) => {
+                    let _ = socket.close(Some(frame));
+                    let _ = socket.flush();
+                    Ok(())
+                }
+                CloseSignal::Io(err) => Err(err),
+            };
+        }
+        let collected = state.with_workspace_mut(workspace_id, |ws| {
+            Ok::<_, String>(collect_app_runtime_events(
+                ws.runtime.event_broker().as_ref(),
+                &ws.app_event_log,
+                workspace_id,
+                app_id,
+                cursor.as_deref(),
+            ))
+        })?;
+        let batch = match collected {
+            Ok(batch) => batch,
+            Err(err) => {
+                close_for_app_events_error(socket, &err);
+                return Ok(());
+            }
+        };
+        if batch.is_empty() {
+            break;
+        }
+        for (next_cursor, event) in batch.into_iter().take(LIVE_POLL_BATCH) {
+            if let Err(err) = send_event_frame(socket, &next_cursor, &event) {
+                close_for_broker_failure(socket, &err);
+                return Ok(());
+            }
+            cursor = Some(next_cursor);
+        }
+    }
+
+    let _ = socket.close(Some(structured_close(
+        CloseCode::Normal,
+        "stream_completed",
+        "app events subscription completed",
+        None,
+        None,
+    )));
+    let _ = socket.flush();
+    Ok(())
+}
+
+fn serve_browser_subscription<E: LocalExecutor + Clone>(
+    socket: &mut WebSocket<&mut TcpStream>,
+    state: &ApiState<E>,
+    workspace_id: &str,
+    execution_id: Option<&str>,
+) -> Result<(), String> {
+    let Some(execution_id) = execution_id else {
+        let _ = socket.close(Some(structured_close(
+            CloseCode::Policy,
+            "invalid_request",
+            "browser_subscription mode requires execution_id",
+            None,
+            None,
+        )));
+        let _ = socket.flush();
+        return Ok(());
+    };
+
+    let outcome = state.with_workspace_mut(workspace_id, |ws| {
+        let Some(trace) = ws.traces.get(execution_id).cloned() else {
+            return Ok(None);
+        };
+        let status = ws
+            .executions
+            .get(execution_id)
+            .is_some_and(|record| record.status.as_str() == "succeeded");
+        Ok(Some((trace, status)))
+    })?;
+
+    let Some((trace, succeeded)) = outcome else {
+        let _ = socket.close(Some(structured_close(
+            CloseCode::Policy,
+            "not_found",
+            &format!("execution '{execution_id}' was not found in workspace '{workspace_id}'"),
+            None,
+            None,
+        )));
+        let _ = socket.flush();
+        return Ok(());
+    };
+
+    let request = traverse_runtime::BrowserRuntimeSubscriptionRequest {
+        kind: "browser_runtime_subscription_request".to_string(),
+        schema_version: "1.0.0".to_string(),
+        governing_spec: "013-browser-runtime-subscription".to_string(),
+        request_id: Some(trace.request.request_id.clone()),
+        execution_id: Some(execution_id.to_string()),
+    };
+    let runtime_outcome = traverse_runtime::RuntimeExecutionOutcome {
+        result: traverse_runtime::RuntimeResult {
+            kind: "runtime_result".to_string(),
+            schema_version: "1.0.0".to_string(),
+            request_id: trace.request.request_id.clone(),
+            execution_id: execution_id.to_string(),
+            trace_ref: format!("trace_{execution_id}"),
+            status: if succeeded {
+                traverse_runtime::RuntimeResultStatus::Completed
+            } else {
+                traverse_runtime::RuntimeResultStatus::Error
+            },
+            output: None,
+            error: None,
+            warnings: Vec::new(),
+        },
+        trace,
+        state_events: Vec::new(),
+    };
+    let messages = traverse_runtime::browser_subscription_messages(&request, &runtime_outcome);
+    for message in messages {
+        let payload = serde_json::to_string(&json!({
+            "type": "browser_subscription",
+            "message": message,
+        }))
+        .map_err(|e| format!("failed to serialize browser subscription message: {e}"))?;
+        if let Err(err) = socket.send(Message::Text(payload.into())) {
+            close_for_broker_failure(socket, &err.to_string());
+            return Ok(());
+        }
+    }
+    let _ = socket.close(Some(structured_close(
+        CloseCode::Normal,
+        "stream_completed",
+        "browser subscription stream completed",
+        None,
+        None,
+    )));
+    let _ = socket.flush();
+    Ok(())
+}
+
+fn send_event_frame(
+    socket: &mut WebSocket<&mut TcpStream>,
+    cursor: &str,
+    event: &TraverseEvent,
+) -> Result<(), String> {
+    let payload = serde_json::to_string(&ServerEventMessage {
+        message_type: "event",
+        cursor,
+        signal: short_signal_name(&event.event_type),
+        event,
+    })
+    .map_err(|e| format!("failed to serialize websocket event frame: {e}"))?;
+    socket
+        .send(Message::Text(payload.into()))
+        .map_err(|e| format!("failed to send websocket event frame: {e}"))
+}
+
+fn drain_client_control_frames(socket: &mut WebSocket<&mut TcpStream>) -> Result<(), CloseSignal> {
+    // Best-effort non-blocking drain using a short read timeout.
+    let stream = socket.get_mut();
+    let previous = stream.read_timeout().unwrap_or(None);
+    if stream
+        .set_read_timeout(Some(Duration::from_millis(1)))
+        .is_err()
+    {
+        return Ok(());
+    }
+    let result = match socket.read() {
+        Ok(Message::Ping(payload)) => {
+            let _ = socket.send(Message::Pong(payload));
+            Ok(())
+        }
+        Ok(Message::Close(_)) => Err(CloseSignal::Structured(structured_close(
+            CloseCode::Normal,
+            "client_closed",
+            "client closed the subscription",
+            None,
+            None,
+        ))),
+        Ok(Message::Text(_) | Message::Binary(_)) => {
+            Err(CloseSignal::Structured(structured_close(
+                CloseCode::Policy,
+                "invalid_request",
+                "unexpected client data frame after subscribe",
+                None,
+                None,
+            )))
+        }
+        Err(tungstenite::Error::Capacity(_)) => Err(CloseSignal::Structured(structured_close(
+            CloseCode::Size,
+            "message_too_large",
+            &format!("inbound WebSocket message exceeds {MAX_WS_INBOUND_MESSAGE_BYTES} bytes"),
+            None,
+            None,
+        ))),
+        // Idle / control frames / transient IO: keep the subscription open.
+        Ok(Message::Pong(_) | Message::Frame(_)) | Err(_) => Ok(()),
+    };
+    let _ = socket.get_mut().set_read_timeout(previous);
+    result
+}
+
+fn close_for_app_events_error(socket: &mut WebSocket<&mut TcpStream>, err: &AppEventsHttpError) {
+    let _ = socket.close(Some(close_frame_for_app_events_error(err)));
+    let _ = socket.flush();
+}
+
+fn close_for_broker_failure(socket: &mut WebSocket<&mut TcpStream>, detail: &str) {
+    let _ = socket.close(Some(structured_close(
+        CloseCode::Error,
+        "event_broker_unavailable",
+        detail,
+        None,
+        None,
+    )));
+    let _ = socket.flush();
+}
+
+fn close_frame_for_app_events_error(err: &AppEventsHttpError) -> CloseFrame {
+    match err {
+        AppEventsHttpError::InvalidCursor { value, detail } => structured_close(
+            CloseCode::Policy,
+            err.code(),
+            detail,
+            None,
+            Some(value.clone()),
+        ),
+        AppEventsHttpError::CursorExpired {
+            oldest_available_cursor,
+        } => structured_close(
+            CloseCode::Policy,
+            err.code(),
+            &err.message(),
+            Some(oldest_available_cursor.clone()),
+            None,
+        ),
+        AppEventsHttpError::Unavailable { detail } => {
+            structured_close(CloseCode::Error, err.code(), detail, None, None)
+        }
+    }
+}
+
+fn structured_close(
+    code: CloseCode,
+    traverse_code: &str,
+    detail: &str,
+    oldest_available_cursor: Option<String>,
+    last_event_id: Option<String>,
+) -> CloseFrame {
+    let reason = StructuredCloseReason {
+        message_type: "error",
+        traverse_code: traverse_code.to_string(),
+        detail: detail.to_string(),
+        oldest_available_cursor,
+        last_event_id,
+    };
+    let encoded = serde_json::to_string(&reason).unwrap_or_else(|_| {
+        format!(
+            "{{\"type\":\"error\",\"traverse_code\":\"{traverse_code}\",\"detail\":\"{detail}\"}}"
+        )
+    });
+    // Close reason is limited to 123 bytes by the WebSocket protocol.
+    let truncated = if encoded.len() > 123 {
+        encoded.chars().take(120).collect::<String>() + "..."
+    } else {
+        encoded
+    };
+    CloseFrame {
+        code,
+        reason: truncated.into(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::app_runtime_events::AppEventsHttpError;
+
+    #[test]
+    fn subscribe_message_parses_app_events_mode() {
+        let text = r#"{"type":"subscribe","mode":"app_events","from_cursor":"3"}"#;
+        let subscribe = parse_subscribe_text(text).expect("subscribe must parse");
+        assert_eq!(subscribe.mode, "app_events");
+        assert_eq!(subscribe.from_cursor.as_deref(), Some("3"));
+    }
+
+    #[test]
+    fn malformed_subscribe_message_is_structured_invalid_request() {
+        let err = parse_subscribe_text(r#"{"type":"nope"}"#).expect_err("must reject");
+        match err {
+            CloseSignal::Structured(frame) => {
+                assert!(frame.reason.contains("invalid_request"));
+            }
+            CloseSignal::Io(detail) => panic!("expected structured close, got io: {detail}"),
+        }
+    }
+
+    #[test]
+    fn oversized_subscribe_message_is_structured_message_too_large() {
+        let oversized = format!(
+            r#"{{"type":"subscribe","mode":"app_events","pad":"{}"}}"#,
+            "x".repeat(MAX_WS_INBOUND_MESSAGE_BYTES)
+        );
+        let err = parse_subscribe_text(&oversized).expect_err("must reject oversized");
+        match err {
+            CloseSignal::Structured(frame) => {
+                assert_eq!(frame.code, CloseCode::Size);
+                assert!(frame.reason.contains("message_too_large"));
+            }
+            CloseSignal::Io(detail) => panic!("expected structured close, got io: {detail}"),
+        }
+    }
+
+    #[test]
+    fn browser_subscription_requires_execution_id_shape() {
+        let text = r#"{"type":"subscribe","mode":"browser_subscription"}"#;
+        let subscribe = parse_subscribe_text(text).expect("subscribe must parse");
+        assert_eq!(subscribe.mode, "browser_subscription");
+        assert!(subscribe.execution_id.is_none());
+    }
+
+    #[test]
+    fn close_frames_preserve_cursor_and_broker_error_codes() {
+        let invalid = close_frame_for_app_events_error(&AppEventsHttpError::InvalidCursor {
+            value: "abc".to_string(),
+            detail: "not an integer".to_string(),
+        });
+        assert_eq!(invalid.code, CloseCode::Policy);
+        assert!(invalid.reason.contains("invalid_last_event_id"));
+
+        let expired = close_frame_for_app_events_error(&AppEventsHttpError::CursorExpired {
+            oldest_available_cursor: "10".to_string(),
+        });
+        assert_eq!(expired.code, CloseCode::Policy);
+        assert!(expired.reason.contains("last_event_id_expired"));
+
+        let unavailable = close_frame_for_app_events_error(&AppEventsHttpError::Unavailable {
+            detail: "broker lock poisoned".to_string(),
+        });
+        assert_eq!(unavailable.code, CloseCode::Error);
+        assert!(unavailable.reason.contains("event_broker_unavailable"));
+    }
+
+    #[test]
+    fn sse_retired_response_is_426_upgrade_required() {
+        let mut out = Vec::new();
+        write_sse_retired_response(&mut out).expect("must write");
+        let text = String::from_utf8(out).expect("utf8");
+        assert!(text.contains("426"));
+        assert!(text.contains("sse_retired"));
+    }
+}

--- a/crates/traverse-cli/src/app_events_websocket.rs
+++ b/crates/traverse-cli/src/app_events_websocket.rs
@@ -400,11 +400,12 @@ fn serve_browser_subscription<E: LocalExecutor + Clone>(
         return Ok(());
     };
 
+    // Spec 013 requires exactly one selector (request_id XOR execution_id).
     let request = traverse_runtime::BrowserRuntimeSubscriptionRequest {
         kind: "browser_runtime_subscription_request".to_string(),
         schema_version: "1.0.0".to_string(),
         governing_spec: "013-browser-runtime-subscription".to_string(),
-        request_id: Some(trace.request.request_id.clone()),
+        request_id: None,
         execution_id: Some(execution_id.to_string()),
     };
     let runtime_outcome = traverse_runtime::RuntimeExecutionOutcome {

--- a/crates/traverse-cli/src/app_runtime_events.rs
+++ b/crates/traverse-cli/src/app_runtime_events.rs
@@ -1,11 +1,10 @@
 //! Production app-runtime events published through [`EventBroker`].
 //!
-//! Governed by `096-runtime-event-sse-transport` (issue #965): the HTTP SSE
-//! endpoint streams full [`TraverseEvent`] envelopes for workspace/app scoped
-//! signals that previously lived only on the ungoverned `AppStateEventRecord`
-//! path.
+//! Shared by the WebSocket app-events transport (`097`, issue #967). Cursor
+//! and broker error mapping still follow `096`'s FR-009 semantics so resume
+//! behavior stays consistent after SSE retirement.
 
-use serde_json::{Value, json};
+use serde_json::Value;
 use std::sync::Arc;
 use traverse_registry::{CapabilityRegistry, WorkflowRegistry};
 use traverse_runtime::events::{
@@ -32,7 +31,7 @@ pub(crate) const APP_EVENT_TYPES: &[&str] = &[
 ];
 
 /// Compact session ledger used by `/sessions` and command dispatch after
-/// `AppStateEventRecord` is removed. Not an SSE source.
+/// `AppStateEventRecord` is removed.
 #[derive(Debug, Clone)]
 pub(crate) struct AppSessionEvent {
     pub(crate) app_id: String,
@@ -42,7 +41,7 @@ pub(crate) struct AppSessionEvent {
     pub(crate) output: Option<Value>,
 }
 
-/// Ordered publish log mapping a shared SSE cursor onto per-type broker cursors.
+/// Ordered publish log mapping a shared event cursor onto per-type broker cursors.
 #[derive(Debug, Clone)]
 pub(crate) struct AppEventLogEntry {
     pub(crate) cursor: u64,
@@ -57,19 +56,12 @@ pub(crate) enum AppEventsHttpError {
 }
 
 impl AppEventsHttpError {
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn status(&self) -> u16 {
         match self {
             Self::InvalidCursor { .. } => 400,
             Self::CursorExpired { .. } => 410,
             Self::Unavailable { .. } => 503,
-        }
-    }
-
-    pub(crate) fn reason(&self) -> &'static str {
-        match self {
-            Self::InvalidCursor { .. } => "Bad Request",
-            Self::CursorExpired { .. } => "Gone",
-            Self::Unavailable { .. } => "Service Unavailable",
         }
     }
 
@@ -94,20 +86,6 @@ impl AppEventsHttpError {
             Self::Unavailable { detail } => {
                 format!("event broker unavailable: {detail}")
             }
-        }
-    }
-
-    pub(crate) fn problem_extensions(&self) -> Value {
-        match self {
-            Self::CursorExpired {
-                oldest_available_cursor,
-            } => json!({
-                "oldest_available_cursor": oldest_available_cursor,
-            }),
-            Self::InvalidCursor { value, .. } => json!({
-                "last_event_id": value,
-            }),
-            Self::Unavailable { .. } => json!({}),
         }
     }
 }

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -1,6 +1,8 @@
+use crate::app_events_websocket::{
+    handle_app_events_websocket, is_websocket_upgrade, write_sse_retired_response,
+};
 use crate::app_runtime_events::{
-    AppEventLogEntry, AppEventsHttpError, AppSessionEvent, collect_app_runtime_events,
-    publish_app_runtime_event, runtime_with_app_event_broker, short_signal_name,
+    AppEventLogEntry, AppSessionEvent, publish_app_runtime_event, runtime_with_app_event_broker,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -120,7 +122,7 @@ pub struct ApiServerConfig<E> {
     pub max_concurrent_connections: Option<usize>,
 }
 
-struct ApiState<E> {
+pub(crate) struct ApiState<E> {
     auth_mode: String,
     allow_unauthenticated: bool,
     allowed_origins: Vec<String>,
@@ -132,25 +134,25 @@ struct ApiState<E> {
     jwt_verification_key: Option<ed25519_dalek::VerifyingKey>,
 }
 
-struct WorkspaceState<E> {
-    runtime: traverse_runtime::Runtime<E>,
+pub(crate) struct WorkspaceState<E> {
+    pub(crate) runtime: traverse_runtime::Runtime<E>,
     event_registry: EventRegistry,
     persisted: PersistedWorkspaceRegistryV1,
     loaded_from_disk: bool,
-    executions: HashMap<String, ExecutionStatusRecord>,
-    traces: HashMap<String, RuntimeTrace>,
+    pub(crate) executions: HashMap<String, ExecutionStatusRecord>,
+    pub(crate) traces: HashMap<String, RuntimeTrace>,
     app_session_events: Vec<AppSessionEvent>,
     app_event_seq: u64,
-    app_event_log: Vec<AppEventLogEntry>,
+    pub(crate) app_event_log: Vec<AppEventLogEntry>,
     app_list_context_fields: HashMap<String, Vec<String>>,
     app_state_machines: HashMap<String, ApplicationStateMachine>,
     runtime_grants: Vec<RuntimeGrantRecord>,
 }
 
 #[derive(Debug, Clone)]
-struct ExecutionStatusRecord {
-    execution_id: String,
-    status: String,
+pub(crate) struct ExecutionStatusRecord {
+    pub(crate) execution_id: String,
+    pub(crate) status: String,
     created_at: String,
     updated_at: String,
 }
@@ -765,7 +767,7 @@ impl<E> ApiState<E>
 where
     E: LocalExecutor + Clone,
 {
-    fn with_workspace_mut<R>(
+    pub(crate) fn with_workspace_mut<R>(
         &self,
         workspace_id: &str,
         f: impl FnOnce(&mut WorkspaceState<E>) -> Result<R, String>,
@@ -3560,6 +3562,23 @@ fn handle_connection<E: LocalExecutor + Clone>(
         return response.write_to(&mut stream, &cors_headers);
     }
 
+    if let Some(WorkspaceOperation::AppEvents(workspace_id, app_id)) =
+        workspace_operation_path(&request.method, &request.path)
+        && is_websocket_upgrade(&request)
+    {
+        return handle_app_events_websocket(
+            &mut stream,
+            &request,
+            state,
+            trusted_dev_caller,
+            &workspace_id,
+            &app_id,
+            |request, state, loopback, workspace_id| {
+                authorize_runtime_events_read(request, state, loopback, workspace_id)
+            },
+        );
+    }
+
     let mut response = BufferedResponse::new();
     match (request.method.as_str(), request.path.as_str()) {
         ("GET", "/healthz") => handle_health(&mut response, &state.auth_mode),
@@ -5175,110 +5194,45 @@ fn handle_app_events<W: Write, E: LocalExecutor + Clone>(
     state: &ApiState<E>,
     loopback: bool,
     workspace_id: &str,
-    app_id: &str,
+    _app_id: &str,
 ) -> Result<(), String> {
-    let identity = match subject_from_state(&request.headers, state, loopback) {
-        Ok(identity) => identity,
-        Err(err) => {
-            return write_json(
-                w,
-                err.status,
-                err.reason,
-                &error_envelope(err.code, &err.message),
-            );
-        }
-    };
+    // SSE retired by 097 / ADR-0034 once WebSocket ships (issue #967).
+    if let Err((status, reason, body)) =
+        authorize_runtime_events_read(request, state, loopback, workspace_id)
+    {
+        return write_json(w, status, reason, &body);
+    }
+    write_sse_retired_response(w)
+}
 
-    let _ = match ensure_workspace_authorized(
+fn authorize_runtime_events_read<E: LocalExecutor + Clone>(
+    request: &HttpRequest,
+    state: &ApiState<E>,
+    loopback: bool,
+    workspace_id: &str,
+) -> Result<(), (u16, &'static str, Value)> {
+    let identity = subject_from_state(&request.headers, state, loopback).map_err(|err| {
+        (
+            err.status,
+            err.reason,
+            error_envelope(err.code, &err.message),
+        )
+    })?;
+    ensure_workspace_authorized(
         &state.registry_root,
         workspace_id,
         &identity,
         SCOPE_RUNTIME_EVENTS_READ,
         scopes_optional_for_request(state.allow_unauthenticated, loopback, &identity),
-    ) {
-        Ok(metadata) => metadata,
-        Err(err) => {
-            return write_json(
-                w,
-                err.status,
-                err.reason,
-                &error_envelope(err.code, &err.message),
-            );
-        }
-    };
-
-    let last_event_id = request.headers.get("last-event-id").map(String::as_str);
-    let collected = state.with_workspace_mut(workspace_id, |ws| {
-        Ok::<_, String>(collect_app_runtime_events(
-            ws.runtime.event_broker().as_ref(),
-            &ws.app_event_log,
-            workspace_id,
-            app_id,
-            last_event_id,
-        ))
-    })?;
-    let events = match collected {
-        Ok(events) => events,
-        Err(err) => {
-            return write_app_events_http_error(w, &err);
-        }
-    };
-    let body = if events.is_empty() {
-        serialize_sse_event(
-            None,
-            "heartbeat",
-            &json!({
-                "workspace_id": workspace_id,
-                "app_id": app_id,
-                "timestamp": generated_registered_at().map_err(|e| e.message)?,
-            }),
-        )?
-    } else {
-        let mut body = String::new();
-        for (cursor, event) in events {
-            let payload = serde_json::to_value(&event)
-                .map_err(|e| format!("failed to serialize TraverseEvent for SSE: {e}"))?;
-            body.push_str(&serialize_sse_event(
-                Some(&cursor),
-                short_signal_name(&event.event_type),
-                &payload,
-            )?);
-        }
-        body
-    };
-
-    write_raw_with_headers(
-        w,
-        200,
-        "OK",
-        "text/event-stream",
-        body.as_bytes(),
-        &[
-            HeaderLine {
-                name: "Cache-Control".to_string(),
-                value: "no-cache".to_string(),
-            },
-            HeaderLine {
-                name: "X-Accel-Buffering".to_string(),
-                value: "no".to_string(),
-            },
-        ],
     )
-}
-
-fn write_app_events_http_error<W: Write>(
-    w: &mut W,
-    err: &AppEventsHttpError,
-) -> Result<(), String> {
-    let mut body = error_envelope(err.code(), &err.message());
-    if let Value::Object(root) = &mut body
-        && let Value::Object(extensions) = err.problem_extensions()
-    {
-        for (key, value) in extensions {
-            root.insert(key, value);
-        }
-    }
-    write_json(w, err.status(), err.reason(), &body)
+    .map(|_| ())
+    .map_err(|err| {
+        (
+            err.status,
+            err.reason,
+            error_envelope(err.code, &err.message),
+        )
+    })
 }
 
 fn handle_app_sessions<W: Write, E: LocalExecutor + Clone>(
@@ -6085,28 +6039,6 @@ fn get_json_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
         current = current.get(segment)?;
     }
     Some(current)
-}
-
-fn serialize_sse_event(
-    event_id: Option<&str>,
-    event_type: &str,
-    data: &Value,
-) -> Result<String, String> {
-    let mut rendered = String::new();
-    if let Some(event_id) = event_id {
-        rendered.push_str("id: ");
-        rendered.push_str(event_id);
-        rendered.push('\n');
-    }
-    rendered.push_str("event: ");
-    rendered.push_str(event_type);
-    rendered.push('\n');
-    let data = serde_json::to_string(data)
-        .map_err(|e| format!("failed to serialize SSE event data: {e}"))?;
-    rendered.push_str("data: ");
-    rendered.push_str(&data);
-    rendered.push_str("\n\n");
-    Ok(rendered)
 }
 
 fn record_execution_status<E: LocalExecutor + Clone>(
@@ -7064,7 +6996,12 @@ fn find_header_end(bytes: &[u8]) -> Option<usize> {
     bytes.windows(4).position(|w| w == b"\r\n\r\n")
 }
 
-fn write_json<W: Write>(w: &mut W, status: u16, reason: &str, body: &Value) -> Result<(), String> {
+pub(crate) fn write_json<W: Write>(
+    w: &mut W,
+    status: u16,
+    reason: &str,
+    body: &Value,
+) -> Result<(), String> {
     let mut body = body.clone();
     let content_type = if status >= 400 && body.get("traverse_code").is_some() {
         if let Value::Object(root) = &mut body {
@@ -7133,10 +7070,10 @@ fn write_raw_with_headers<W: Write>(
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
 mod tests {
-    #![allow(clippy::expect_used)]
-
     use super::*;
+    use crate::app_runtime_events::{collect_app_runtime_events, short_signal_name};
     use serde_json::Value;
     use std::sync::atomic::{AtomicU64, Ordering};
     use traverse_contracts::{
@@ -8032,6 +7969,7 @@ mod tests {
             .find_map(|line| line.strip_prefix(&prefix).map(ToString::to_string))
     }
 
+    #[allow(dead_code)]
     fn response_body_text(response: &[u8]) -> String {
         let pos = response
             .windows(4)
@@ -9870,6 +9808,26 @@ mod tests {
         assert_eq!(resp["traverse_code"], "invalid_request");
     }
 
+    fn collected_app_events(
+        state: &ApiState<TestExecutor>,
+        workspace_id: &str,
+        app_id: &str,
+        from_cursor: Option<&str>,
+    ) -> Vec<(String, traverse_runtime::events::TraverseEvent)> {
+        state
+            .with_workspace_mut(workspace_id, |ws| {
+                collect_app_runtime_events(
+                    ws.runtime.event_broker().as_ref(),
+                    &ws.app_event_log,
+                    workspace_id,
+                    app_id,
+                    from_cursor,
+                )
+                .map_err(|err| err.message())
+            })
+            .expect("workspace events must collect")
+    }
+
     #[test]
     fn app_command_dispatch_emits_state_changed_and_capability_result_on_sse() {
         let state = test_state_with("traverse-starter.process", "1.0.0");
@@ -9905,35 +9863,21 @@ mod tests {
             "/v1/workspaces/ws-test/apps/traverse-starter/events"
         );
 
-        let events_req = make_http_request(
-            "GET",
-            "/v1/workspaces/ws-test/apps/traverse-starter/events",
-            Vec::new(),
-        );
-        let mut events_out = Vec::new();
-        handle_app_events(
-            &mut events_out,
-            &events_req,
-            &state,
-            true,
-            "ws-test",
-            "traverse-starter",
-        )
-        .expect("events endpoint must write a response");
-
-        assert_eq!(response_status(&events_out), 200);
-        assert_eq!(response_content_type(&events_out), "text/event-stream");
-        let body = response_body_text(&events_out);
-        assert!(body.contains("event: state_changed"));
-        assert!(body.contains("\"state\":\"processing\""));
-        assert!(body.contains("\"previous_state\":\"idle\""));
-        assert!(body.contains("event: capability_invoked"));
-        assert!(body.contains("\"capability_id\":\"traverse-starter.process\""));
-        assert!(body.contains("event: capability_result"));
-        assert!(body.contains("\"state\":\"results\""));
-        assert!(body.contains("\"previous_state\":\"processing\""));
-        assert!(body.contains("\"result\":\"ok\""));
-        assert!(body.contains(&format!("\"session_id\":\"{session_id}\"")));
+        let events = collected_app_events(&state, "ws-test", "traverse-starter", None);
+        let signals: Vec<_> = events
+            .iter()
+            .map(|(_, event)| short_signal_name(&event.event_type))
+            .collect();
+        assert!(signals.contains(&"state_changed"));
+        assert!(signals.contains(&"capability_invoked"));
+        assert!(signals.contains(&"capability_result"));
+        let payload = serde_json::to_string(&events).expect("events must serialize");
+        assert!(payload.contains("\"state\":\"processing\""));
+        assert!(payload.contains("\"previous_state\":\"idle\""));
+        assert!(payload.contains("\"capability_id\":\"traverse-starter.process\""));
+        assert!(payload.contains("\"state\":\"results\""));
+        assert!(payload.contains("\"result\":\"ok\""));
+        assert!(payload.contains(&format!("\"session_id\":\"{session_id}\"")));
     }
 
     #[test]
@@ -9971,24 +9915,14 @@ mod tests {
             handle_workspace_operation(&mut command_out, &command_req, &state, true)
                 .expect("command dispatch must write a response");
 
-            let events_req = make_http_request(
-                "GET",
-                "/v1/workspaces/ws-test/apps/traverse-starter/events",
-                Vec::new(),
+            let events = collected_app_events(&state, "ws-test", "traverse-starter", None);
+            let payload = serde_json::to_string(&events).expect("events must serialize");
+            assert!(payload.contains(&format!("\"state\":\"{expected_state}\"")));
+            assert!(
+                events
+                    .iter()
+                    .any(|(_, e)| short_signal_name(&e.event_type) == "capability_result")
             );
-            let mut events_out = Vec::new();
-            handle_app_events(
-                &mut events_out,
-                &events_req,
-                &state,
-                true,
-                "ws-test",
-                "traverse-starter",
-            )
-            .expect("events endpoint must write a response");
-            let body = response_body_text(&events_out);
-            assert!(body.contains(&format!("\"state\":\"{expected_state}\"")));
-            assert!(body.contains("event: capability_result"));
         }
     }
 
@@ -10018,26 +9952,16 @@ mod tests {
         handle_workspace_operation(&mut command_out, &command_req, &state, true)
             .expect("command dispatch must write a response");
 
-        let events_req = make_http_request(
-            "GET",
-            "/v1/workspaces/ws-test/apps/traverse-starter/events",
-            Vec::new(),
+        let events = collected_app_events(&state, "ws-test", "traverse-starter", None);
+        let payload = serde_json::to_string(&events).expect("events must serialize");
+        assert!(
+            events
+                .iter()
+                .any(|(_, e)| short_signal_name(&e.event_type) == "error")
         );
-        let mut events_out = Vec::new();
-        handle_app_events(
-            &mut events_out,
-            &events_req,
-            &state,
-            true,
-            "ws-test",
-            "traverse-starter",
-        )
-        .expect("events endpoint must write a response");
-        let body = response_body_text(&events_out);
-        assert!(body.contains("event: error"));
-        assert!(body.contains("\"code\":\"condition_type_error\""));
-        assert!(body.contains("\"state\":\"processing\""));
-        assert!(!body.contains("auto_approved"));
+        assert!(payload.contains("\"code\":\"condition_type_error\""));
+        assert!(payload.contains("\"state\":\"processing\""));
+        assert!(!payload.contains("auto_approved"));
     }
 
     #[test]
@@ -10066,26 +9990,16 @@ mod tests {
         handle_workspace_operation(&mut command_out, &command_req, &state, true)
             .expect("command dispatch must write a response");
 
-        let events_req = make_http_request(
-            "GET",
-            "/v1/workspaces/ws-test/apps/traverse-starter/events",
-            Vec::new(),
+        let events = collected_app_events(&state, "ws-test", "traverse-starter", None);
+        let payload = serde_json::to_string(&events).expect("events must serialize");
+        assert!(
+            events
+                .iter()
+                .any(|(_, e)| short_signal_name(&e.event_type) == "error")
         );
-        let mut events_out = Vec::new();
-        handle_app_events(
-            &mut events_out,
-            &events_req,
-            &state,
-            true,
-            "ws-test",
-            "traverse-starter",
-        )
-        .expect("events endpoint must write a response");
-        let body = response_body_text(&events_out);
-        assert!(body.contains("event: error"));
-        assert!(body.contains("\"code\":\"no_matching_transition\""));
-        assert!(body.contains("\"state\":\"processing\""));
-        assert!(!body.contains("auto_approved"));
+        assert!(payload.contains("\"code\":\"no_matching_transition\""));
+        assert!(payload.contains("\"state\":\"processing\""));
+        assert!(!payload.contains("auto_approved"));
     }
 
     #[test]
@@ -10160,107 +10074,84 @@ mod tests {
     }
 
     #[test]
-    fn app_events_endpoint_returns_event_stream_heartbeat_when_empty() {
+    fn app_events_http_get_without_upgrade_is_retired() {
         let state = empty_state();
         let req = make_http_request(
             "GET",
             "/v1/workspaces/ws-test/apps/traverse-starter/events",
             Vec::new(),
         );
-
         let mut out = Vec::new();
         handle_app_events(&mut out, &req, &state, true, "ws-test", "traverse-starter")
             .expect("events endpoint must write a response");
-
-        assert_eq!(response_status(&out), 200);
-        assert_eq!(response_content_type(&out), "text/event-stream");
-        assert_eq!(
-            response_header(&out, "Cache-Control").as_deref(),
-            Some("no-cache")
-        );
-        let body = response_body_text(&out);
-        assert!(body.contains("event: heartbeat"));
-        assert!(body.contains("\"app_id\":\"traverse-starter\""));
-    }
-
-    #[test]
-    fn app_events_endpoint_replays_execution_events() {
-        let body = make_runtime_request_body("traverse-starter.process");
-        let state = test_state_with("traverse-starter.process", "1.0.0");
-        let execute_req = make_http_request("POST", "/v1/workspaces/ws-test/execute", body);
-        let mut execute_out = Vec::new();
-        handle_execute_workspace(&mut execute_out, &execute_req, &state, true, "ws-test")
-            .expect("execute must write a response");
-
-        let req = make_http_request(
-            "GET",
-            "/v1/workspaces/ws-test/apps/traverse-starter/events",
-            Vec::new(),
-        );
-        let mut out = Vec::new();
-        handle_app_events(&mut out, &req, &state, true, "ws-test", "traverse-starter")
-            .expect("events endpoint must write a response");
-
-        assert_eq!(response_status(&out), 200);
-        assert_eq!(response_content_type(&out), "text/event-stream");
-        let body = response_body_text(&out);
-        assert!(body.contains("event: state_changed"));
-        assert!(body.contains("event: capability_invoked"));
-        assert!(body.contains("event: capability_result"));
-        assert!(body.contains("\"state\":\"results\""));
-        assert!(body.contains("\"result\":\"ok\""));
-    }
-
-    #[test]
-    fn app_events_endpoint_honors_last_event_id_replay() {
-        let body = make_runtime_request_body("traverse-starter.process");
-        let state = test_state_with("traverse-starter.process", "1.0.0");
-        let execute_req = make_http_request("POST", "/v1/workspaces/ws-test/execute", body);
-        let mut execute_out = Vec::new();
-        handle_execute_workspace(&mut execute_out, &execute_req, &state, true, "ws-test")
-            .expect("execute must write a response");
-
-        let mut req = make_http_request(
-            "GET",
-            "/v1/workspaces/ws-test/apps/traverse-starter/events",
-            Vec::new(),
-        );
-        // Cursor "1" is the first published EventBroker cursor (state_changed).
-        req.headers
-            .insert("last-event-id".to_string(), "1".to_string());
-        let mut out = Vec::new();
-        handle_app_events(&mut out, &req, &state, true, "ws-test", "traverse-starter")
-            .expect("events endpoint must write a response");
-
-        let body = response_body_text(&out);
-        assert!(!body.contains("event: state_changed"));
-        assert!(body.contains("event: capability_invoked"));
-        assert!(body.contains("event: capability_result"));
-    }
-
-    #[test]
-    fn app_events_endpoint_rejects_malformed_last_event_id() {
-        let state = empty_state();
-        let mut req = make_http_request(
-            "GET",
-            "/v1/workspaces/ws-test/apps/traverse-starter/events",
-            Vec::new(),
-        );
-        req.headers
-            .insert("last-event-id".to_string(), "not-a-cursor".to_string());
-        let mut out = Vec::new();
-        handle_app_events(&mut out, &req, &state, true, "ws-test", "traverse-starter")
-            .expect("events endpoint must write a response");
-
-        assert_eq!(response_status(&out), 400);
+        assert_eq!(response_status(&out), 426);
         assert_eq!(response_content_type(&out), "application/problem+json");
         let body = parse_response_body(&out);
-        assert_eq!(body["traverse_code"], "invalid_last_event_id");
-        assert_eq!(body["last_event_id"], "not-a-cursor");
+        assert_eq!(body["traverse_code"], "sse_retired");
     }
 
     #[test]
-    fn app_events_endpoint_rejects_expired_last_event_id() {
+    fn app_events_broker_replays_execution_events_for_websocket_source() {
+        let body = make_runtime_request_body("traverse-starter.process");
+        let state = test_state_with("traverse-starter.process", "1.0.0");
+        let execute_req = make_http_request("POST", "/v1/workspaces/ws-test/execute", body);
+        let mut execute_out = Vec::new();
+        handle_execute_workspace(&mut execute_out, &execute_req, &state, true, "ws-test")
+            .expect("execute must write a response");
+
+        let events = collected_app_events(&state, "ws-test", "traverse-starter", None);
+        let signals: Vec<_> = events
+            .iter()
+            .map(|(_, event)| short_signal_name(&event.event_type))
+            .collect();
+        assert!(signals.contains(&"state_changed"));
+        assert!(signals.contains(&"capability_invoked"));
+        assert!(signals.contains(&"capability_result"));
+        let payload = serde_json::to_string(&events).expect("events must serialize");
+        assert!(payload.contains("\"state\":\"results\""));
+        assert!(payload.contains("\"result\":\"ok\""));
+    }
+
+    #[test]
+    fn app_events_broker_honors_cursor_resume() {
+        let body = make_runtime_request_body("traverse-starter.process");
+        let state = test_state_with("traverse-starter.process", "1.0.0");
+        let execute_req = make_http_request("POST", "/v1/workspaces/ws-test/execute", body);
+        let mut execute_out = Vec::new();
+        handle_execute_workspace(&mut execute_out, &execute_req, &state, true, "ws-test")
+            .expect("execute must write a response");
+
+        let events = collected_app_events(&state, "ws-test", "traverse-starter", Some("1"));
+        let signals: Vec<_> = events
+            .iter()
+            .map(|(_, event)| short_signal_name(&event.event_type))
+            .collect();
+        assert!(!signals.contains(&"state_changed"));
+        assert!(signals.contains(&"capability_invoked"));
+        assert!(signals.contains(&"capability_result"));
+    }
+
+    #[test]
+    fn app_events_broker_rejects_malformed_cursor() {
+        let state = empty_state();
+        let err = state
+            .with_workspace_mut("ws-test", |ws| {
+                Ok(collect_app_runtime_events(
+                    ws.runtime.event_broker().as_ref(),
+                    &ws.app_event_log,
+                    "ws-test",
+                    "traverse-starter",
+                    Some("not-a-cursor"),
+                ))
+            })
+            .expect("workspace access must succeed")
+            .expect_err("malformed cursor must fail");
+        assert_eq!(err.code(), "invalid_last_event_id");
+        assert_eq!(err.status(), 400);
+    }
+
+    #[test]
+    fn app_events_broker_rejects_expired_cursor() {
         let state = empty_state();
         state
             .with_workspace_mut("ws-test", |ws| {
@@ -10268,39 +10159,34 @@ mod tests {
                 Ok(())
             })
             .expect("restart floor must be seeded");
-
-        let mut req = make_http_request(
-            "GET",
-            "/v1/workspaces/ws-test/apps/traverse-starter/events",
-            Vec::new(),
-        );
-        req.headers
-            .insert("last-event-id".to_string(), "5".to_string());
-        let mut out = Vec::new();
-        handle_app_events(&mut out, &req, &state, true, "ws-test", "traverse-starter")
-            .expect("events endpoint must write a response");
-
-        assert_eq!(response_status(&out), 410);
-        assert_eq!(response_content_type(&out), "application/problem+json");
-        let body = parse_response_body(&out);
-        assert_eq!(body["traverse_code"], "last_event_id_expired");
-        assert_eq!(body["oldest_available_cursor"], "10");
+        let err = state
+            .with_workspace_mut("ws-test", |ws| {
+                Ok(collect_app_runtime_events(
+                    ws.runtime.event_broker().as_ref(),
+                    &ws.app_event_log,
+                    "ws-test",
+                    "traverse-starter",
+                    Some("5"),
+                ))
+            })
+            .expect("workspace access must succeed")
+            .expect_err("expired cursor must fail");
+        assert_eq!(err.code(), "last_event_id_expired");
+        assert_eq!(err.status(), 410);
     }
 
     #[test]
-    fn app_events_endpoint_returns_503_when_broker_subscribe_fails() {
+    fn app_events_broker_returns_unavailable_on_subscribe_failure() {
         use std::sync::Arc;
         use traverse_runtime::events::{
             EventBroker, EventError, Subscription, SubscriptionPoll, TraverseEvent,
         };
 
         struct UnavailableBroker;
-
         impl EventBroker for UnavailableBroker {
             fn publish(&self, _event: TraverseEvent) -> Result<(), EventError> {
                 Ok(())
             }
-
             fn subscribe(
                 &self,
                 _event_type: &str,
@@ -10310,7 +10196,6 @@ mod tests {
                     "broker lock poisoned".to_string(),
                 ))
             }
-
             fn subscribe_for_subject(
                 &self,
                 event_type: &str,
@@ -10319,7 +10204,6 @@ mod tests {
             ) -> Result<Subscription, EventError> {
                 self.subscribe(event_type, from_cursor)
             }
-
             fn poll(
                 &self,
                 _subscription_id: &str,
@@ -10329,7 +10213,6 @@ mod tests {
                     "broker lock poisoned".to_string(),
                 ))
             }
-
             fn cancel(&self, _subscription_id: &str) -> Result<(), EventError> {
                 Ok(())
             }
@@ -10346,52 +10229,242 @@ mod tests {
                 Ok(())
             })
             .expect("failing broker must be installed");
-
-        let req = make_http_request(
-            "GET",
-            "/v1/workspaces/ws-test/apps/traverse-starter/events",
-            Vec::new(),
-        );
-        let mut out = Vec::new();
-        handle_app_events(&mut out, &req, &state, true, "ws-test", "traverse-starter")
-            .expect("events endpoint must write a response");
-
-        assert_eq!(response_status(&out), 503);
-        assert_eq!(response_content_type(&out), "application/problem+json");
-        let body = parse_response_body(&out);
-        assert_eq!(body["traverse_code"], "event_broker_unavailable");
+        let err = state
+            .with_workspace_mut("ws-test", |ws| {
+                Ok(collect_app_runtime_events(
+                    ws.runtime.event_broker().as_ref(),
+                    &ws.app_event_log,
+                    "ws-test",
+                    "traverse-starter",
+                    None,
+                ))
+            })
+            .expect("workspace access must succeed")
+            .expect_err("unavailable broker must fail");
+        assert_eq!(err.code(), "event_broker_unavailable");
+        assert_eq!(err.status(), 503);
     }
 
     #[test]
-    fn app_events_endpoint_does_not_leak_cross_workspace_events() {
+    fn app_events_broker_does_not_leak_cross_workspace_events() {
         let state = test_state_with("traverse-starter.process", "1.0.0");
         let body = make_runtime_request_body("traverse-starter.process");
         let execute_req = make_http_request("POST", "/v1/workspaces/ws-test/execute", body);
         let mut execute_out = Vec::new();
         handle_execute_workspace(&mut execute_out, &execute_req, &state, true, "ws-test")
             .expect("execute must write a response");
-
-        // Create a second workspace and ensure it does not see ws-test events.
         state
-            .with_workspace_mut("ws-other", |ws| {
-                let _ = ws;
-                Ok(())
-            })
+            .with_workspace_mut("ws-other", |_ws| Ok(()))
             .expect("second workspace must initialize");
+        let events = collected_app_events(&state, "ws-other", "traverse-starter", None);
+        assert!(events.is_empty());
+    }
 
-        let req = make_http_request(
+    #[test]
+    fn websocket_upgrade_detection_requires_handshake_headers() {
+        use crate::app_events_websocket::is_websocket_upgrade;
+        let mut req = make_http_request(
             "GET",
-            "/v1/workspaces/ws-other/apps/traverse-starter/events",
+            "/v1/workspaces/ws-test/apps/traverse-starter/events",
             Vec::new(),
         );
-        let mut out = Vec::new();
-        handle_app_events(&mut out, &req, &state, true, "ws-other", "traverse-starter")
-            .expect("events endpoint must write a response");
+        assert!(!is_websocket_upgrade(&req));
+        req.headers
+            .insert("upgrade".to_string(), "websocket".to_string());
+        req.headers
+            .insert("connection".to_string(), "Upgrade".to_string());
+        req.headers.insert(
+            "sec-websocket-key".to_string(),
+            "dGhlIHNhbXBsZSBub25jZQ==".to_string(),
+        );
+        assert!(is_websocket_upgrade(&req));
+    }
 
-        assert_eq!(response_status(&out), 200);
-        let body = response_body_text(&out);
-        assert!(body.contains("event: heartbeat"));
-        assert!(!body.contains("event: capability_result"));
+    fn open_app_events_websocket(addr: std::net::SocketAddr) -> tungstenite::WebSocket<TcpStream> {
+        use std::io::Read;
+        use tungstenite::protocol::{Role, WebSocket};
+
+        let mut stream = TcpStream::connect(addr).expect("websocket client must connect");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("client read timeout");
+        stream
+            .set_write_timeout(Some(Duration::from_secs(5)))
+            .expect("client write timeout");
+        let key = "dGhlIHNhbXBsZSBub25jZQ==";
+        let request = format!(
+            "GET /v1/workspaces/ws-test/apps/traverse-starter/events HTTP/1.1\r\n\
+             Host: 127.0.0.1\r\n\
+             Upgrade: websocket\r\n\
+             Connection: Upgrade\r\n\
+             Sec-WebSocket-Key: {key}\r\n\
+             Sec-WebSocket-Version: 13\r\n\
+             \r\n"
+        );
+        stream
+            .write_all(request.as_bytes())
+            .expect("upgrade request must write");
+
+        let mut header = Vec::new();
+        let mut buf = [0_u8; 1];
+        while !header.windows(4).any(|w| w == b"\r\n\r\n") {
+            let n = stream.read(&mut buf).expect("handshake response must read");
+            assert!(n > 0, "handshake response closed early");
+            header.extend_from_slice(&buf[..n]);
+            assert!(header.len() < 8 * 1024, "handshake response exceeded bound");
+        }
+        let header_text = String::from_utf8_lossy(&header);
+        assert!(
+            header_text.starts_with("HTTP/1.1 101"),
+            "expected 101 Switching Protocols, got: {header_text}"
+        );
+        WebSocket::from_raw_socket(stream, Role::Client, None)
+    }
+
+    #[test]
+    fn websocket_app_events_delivers_broker_events_over_tcp() {
+        use tungstenite::Message;
+
+        let limits = ConnectionLimits {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            request_deadline: Duration::from_secs(10),
+        };
+        let addr = spawn_test_pool_with(
+            test_state_with("traverse-starter.process", "1.0.0"),
+            limits,
+            2,
+        );
+
+        let body = make_runtime_request_body("traverse-starter.process");
+        let mut execute = TcpStream::connect(addr).expect("execute client must connect");
+        let execute_req = format!(
+            "POST /v1/workspaces/ws-test/execute HTTP/1.1\r\n\
+             Host: 127.0.0.1\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: {}\r\n\
+             \r\n",
+            body.len()
+        );
+        execute
+            .write_all(execute_req.as_bytes())
+            .expect("execute headers");
+        execute.write_all(&body).expect("execute body");
+        let execute_response = read_all_with_timeout(&mut execute, Duration::from_secs(5));
+        assert_eq!(response_status(&execute_response), 200);
+
+        let mut socket = open_app_events_websocket(addr);
+        socket
+            .send(Message::Text(
+                r#"{"type":"subscribe","mode":"app_events"}"#.into(),
+            ))
+            .expect("subscribe must send");
+
+        let mut saw_event = false;
+        let mut saw_completed = false;
+        for _ in 0..32 {
+            match socket.read() {
+                Ok(Message::Text(text)) => {
+                    let value: Value =
+                        serde_json::from_str(text.as_str()).expect("event frame json");
+                    assert_eq!(value["type"], "event");
+                    assert!(value.get("event").is_some());
+                    assert!(value.get("cursor").is_some());
+                    saw_event = true;
+                }
+                Ok(Message::Close(Some(frame))) => {
+                    assert!(frame.reason.contains("stream_completed"));
+                    saw_completed = true;
+                    break;
+                }
+                Ok(Message::Close(None)) => {
+                    saw_completed = true;
+                    break;
+                }
+                Ok(Message::Ping(payload)) => {
+                    socket.send(Message::Pong(payload)).expect("pong must send");
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected websocket read error: {err}"),
+            }
+        }
+        assert!(saw_event, "websocket must deliver at least one event frame");
+        assert!(
+            saw_completed,
+            "websocket must close with stream_completed after replay"
+        );
+    }
+
+    #[test]
+    fn websocket_malformed_subscribe_closes_with_invalid_request() {
+        use tungstenite::Message;
+
+        let limits = ConnectionLimits {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            request_deadline: Duration::from_secs(10),
+        };
+        let addr = spawn_test_pool(limits, 1);
+
+        let mut socket = open_app_events_websocket(addr);
+        socket
+            .send(Message::Text(r#"{"type":"not-subscribe"}"#.into()))
+            .expect("bad subscribe must send");
+        match socket.read().expect("server must close") {
+            Message::Close(Some(frame)) => {
+                assert!(
+                    frame.reason.contains("invalid_request"),
+                    "close reason: {}",
+                    frame.reason
+                );
+            }
+            other => panic!("expected structured close, got {other:?}"),
+        }
+
+        let mut socket = open_app_events_websocket(addr);
+        socket
+            .send(Message::Text(
+                r#"{"type":"subscribe","mode":"nope"}"#.into(),
+            ))
+            .expect("unsupported mode must send");
+        match socket.read().expect("server must close unsupported mode") {
+            Message::Close(Some(frame)) => {
+                assert!(
+                    frame.reason.contains("invalid_request"),
+                    "close reason: {}",
+                    frame.reason
+                );
+            }
+            other => panic!("expected structured close for mode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn websocket_malformed_cursor_closes_before_event_stream() {
+        use tungstenite::Message;
+
+        let limits = ConnectionLimits {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            request_deadline: Duration::from_secs(10),
+        };
+        let addr = spawn_test_pool(limits, 1);
+        let mut socket = open_app_events_websocket(addr);
+        socket
+            .send(Message::Text(
+                r#"{"type":"subscribe","mode":"app_events","from_cursor":"not-a-cursor"}"#.into(),
+            ))
+            .expect("subscribe must send");
+        match socket.read().expect("server must close") {
+            Message::Close(Some(frame)) => {
+                assert!(
+                    frame.reason.contains("invalid_last_event_id"),
+                    "close reason: {}",
+                    frame.reason
+                );
+            }
+            other => panic!("expected structured close before events, got {other:?}"),
+        }
     }
 
     #[test]
@@ -11725,9 +11798,21 @@ mod tests {
     // ------------------------------------------------------------------
 
     fn spawn_test_pool(limits: ConnectionLimits, worker_count: usize) -> std::net::SocketAddr {
+        spawn_test_pool_with(
+            test_state_with("test.api.do-something", "1.0.0"),
+            limits,
+            worker_count,
+        )
+    }
+
+    fn spawn_test_pool_with(
+        state: ApiState<TestExecutor>,
+        limits: ConnectionLimits,
+        worker_count: usize,
+    ) -> std::net::SocketAddr {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind must succeed");
         let addr = listener.local_addr().expect("local addr must resolve");
-        let state = Arc::new(test_state_with("test.api.do-something", "1.0.0"));
+        let state = Arc::new(state);
         thread::spawn(move || {
             let _ = run_connection_pool(&listener, &state, limits, worker_count);
         });

--- a/crates/traverse-cli/src/http_api.rs
+++ b/crates/traverse-cli/src/http_api.rs
@@ -10468,6 +10468,315 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
+    fn websocket_browser_subscription_preserves_013_message_order() {
+        use tungstenite::Message;
+
+        let limits = ConnectionLimits {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            request_deadline: Duration::from_secs(10),
+        };
+        let addr = spawn_test_pool_with(
+            test_state_with("traverse-starter.process", "1.0.0"),
+            limits,
+            2,
+        );
+
+        let body = make_runtime_request_body("traverse-starter.process");
+        let mut execute = TcpStream::connect(addr).expect("execute client must connect");
+        let execute_req = format!(
+            "POST /v1/workspaces/ws-test/execute HTTP/1.1\r\n\
+             Host: 127.0.0.1\r\n\
+             Content-Type: application/json\r\n\
+             Content-Length: {}\r\n\
+             \r\n",
+            body.len()
+        );
+        execute
+            .write_all(execute_req.as_bytes())
+            .expect("execute headers");
+        execute.write_all(&body).expect("execute body");
+        let execute_response = read_all_with_timeout(&mut execute, Duration::from_secs(5));
+        assert_eq!(response_status(&execute_response), 200);
+        let execute_body = parse_response_body(&execute_response);
+        let execution_id = execute_body["execution_id"]
+            .as_str()
+            .expect("execution_id must be present")
+            .to_string();
+
+        let mut socket = open_app_events_websocket(addr);
+        let subscribe = format!(
+            r#"{{"type":"subscribe","mode":"browser_subscription","execution_id":"{execution_id}"}}"#
+        );
+        socket
+            .send(Message::Text(subscribe.into()))
+            .expect("browser subscribe must send");
+
+        let mut kinds = Vec::new();
+        let mut lifecycle_statuses = Vec::new();
+        for _ in 0..32 {
+            match socket.read() {
+                Ok(Message::Text(text)) => {
+                    let value: Value =
+                        serde_json::from_str(text.as_str()).expect("browser frame json");
+                    assert_eq!(value["type"], "browser_subscription");
+                    let message = &value["message"];
+                    // Externally tagged enum: {"Lifecycle":{...}} / {"TraceArtifact":{...}}.
+                    let (variant, payload) = message
+                        .as_object()
+                        .and_then(|obj| obj.iter().next())
+                        .expect("tagged browser message");
+                    let kind = payload["kind"].as_str().unwrap_or(variant).to_string();
+                    if variant == "Lifecycle"
+                        && let Some(status) = payload["status"].as_str()
+                    {
+                        lifecycle_statuses.push(status.to_string());
+                    }
+                    kinds.push(if variant == "Lifecycle" {
+                        format!("Lifecycle:{kind}")
+                    } else {
+                        variant.clone()
+                    });
+                }
+                Ok(Message::Close(Some(frame))) => {
+                    assert!(frame.reason.contains("stream_completed"));
+                    break;
+                }
+                Ok(Message::Close(None)) => break,
+                Ok(Message::Ping(payload)) => {
+                    socket.send(Message::Pong(payload)).expect("pong must send");
+                }
+                Ok(_) => {}
+                Err(err) => panic!("unexpected websocket read error: {err}"),
+            }
+        }
+        assert!(
+            !kinds.is_empty(),
+            "browser subscription must emit ordered contract messages"
+        );
+        assert!(
+            kinds.first().is_some_and(|k| k.starts_with("Lifecycle:")),
+            "first message must be lifecycle: {kinds:?}"
+        );
+        assert!(
+            kinds.iter().any(|k| k == "TraceArtifact"),
+            "trace artifact must appear: {kinds:?}"
+        );
+        assert!(
+            kinds.iter().any(|k| k == "StreamTerminal"),
+            "terminal result must appear: {kinds:?}"
+        );
+        assert_eq!(
+            lifecycle_statuses.first().map(String::as_str),
+            Some("subscription_established")
+        );
+        assert_eq!(
+            lifecycle_statuses.last().map(String::as_str),
+            Some("stream_completed")
+        );
+        let terminal = kinds.iter().position(|k| k == "StreamTerminal");
+        let completed_lifecycle = kinds.iter().rposition(|k| k.starts_with("Lifecycle:"));
+        match (terminal, completed_lifecycle) {
+            (Some(terminal_idx), Some(completed_idx)) => {
+                assert!(
+                    terminal_idx < completed_idx,
+                    "terminal must precede final lifecycle: {kinds:?}"
+                );
+            }
+            _ => panic!("missing terminal/lifecycle ordering markers: {kinds:?}"),
+        }
+    }
+
+    #[test]
+    fn websocket_browser_subscription_requires_execution_id() {
+        use tungstenite::Message;
+
+        let limits = ConnectionLimits {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            request_deadline: Duration::from_secs(10),
+        };
+        let addr = spawn_test_pool(limits, 1);
+        let mut socket = open_app_events_websocket(addr);
+        socket
+            .send(Message::Text(
+                r#"{"type":"subscribe","mode":"browser_subscription"}"#.into(),
+            ))
+            .expect("subscribe must send");
+        match socket.read().expect("server must close") {
+            Message::Close(Some(frame)) => {
+                assert!(
+                    frame.reason.contains("invalid_request"),
+                    "close reason: {}",
+                    frame.reason
+                );
+            }
+            other => panic!("expected structured close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn websocket_browser_subscription_not_found_closes_structured() {
+        use tungstenite::Message;
+
+        let limits = ConnectionLimits {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            request_deadline: Duration::from_secs(10),
+        };
+        let addr = spawn_test_pool(limits, 1);
+        let mut socket = open_app_events_websocket(addr);
+        socket
+            .send(Message::Text(
+                r#"{"type":"subscribe","mode":"browser_subscription","execution_id":"missing"}"#
+                    .into(),
+            ))
+            .expect("subscribe must send");
+        match socket.read().expect("server must close") {
+            Message::Close(Some(frame)) => {
+                assert!(
+                    frame.reason.contains("not_found"),
+                    "close reason: {}",
+                    frame.reason
+                );
+            }
+            other => panic!("expected structured close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn websocket_auth_rejection_returns_json_before_upgrade() {
+        use crate::app_events_websocket::handle_app_events_websocket;
+        use std::io::Read;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let state = empty_state();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept");
+            let req = make_http_request(
+                "GET",
+                "/v1/workspaces/ws-test/apps/traverse-starter/events",
+                Vec::new(),
+            );
+            handle_app_events_websocket(
+                &mut stream,
+                &req,
+                &state,
+                true,
+                "ws-test",
+                "traverse-starter",
+                |_request, _state, _loopback, _workspace_id| {
+                    Err((
+                        401,
+                        "Unauthorized",
+                        error_envelope("unauthorized", "Bearer token required"),
+                    ))
+                },
+            )
+            .expect("auth rejection must write a response");
+        });
+
+        let mut client = TcpStream::connect(addr).expect("connect");
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("timeout");
+        client
+            .write_all(
+                b"GET /v1/workspaces/ws-test/apps/traverse-starter/events HTTP/1.1\r\n\
+                  Host: 127.0.0.1\r\n\
+                  Upgrade: websocket\r\n\
+                  Connection: Upgrade\r\n\
+                  Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+                  Sec-WebSocket-Version: 13\r\n\
+                  \r\n",
+            )
+            .expect("write");
+        let mut out = Vec::new();
+        let mut buf = [0_u8; 1024];
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while Instant::now() < deadline {
+            match client.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => out.extend_from_slice(&buf[..n]),
+                Err(err)
+                    if err.kind() == std::io::ErrorKind::WouldBlock
+                        || err.kind() == std::io::ErrorKind::TimedOut =>
+                {
+                    if out.windows(4).any(|w| w == b"\r\n\r\n") {
+                        // Headers arrived; keep waiting briefly for the body.
+                        thread::sleep(Duration::from_millis(10));
+                        continue;
+                    }
+                    break;
+                }
+                Err(_) => break,
+            }
+            if let Some(header_end) = out.windows(4).position(|w| w == b"\r\n\r\n") {
+                let headers = &out[..header_end + 4];
+                let content_length = String::from_utf8_lossy(headers)
+                    .lines()
+                    .find_map(|line| {
+                        line.split_once(':').and_then(|(name, value)| {
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        })
+                    })
+                    .unwrap_or(0);
+                if out.len() >= header_end + 4 + content_length {
+                    break;
+                }
+            }
+        }
+        let text = String::from_utf8_lossy(&out);
+        assert_eq!(response_status(&out), 401, "response: {text}");
+        assert!(
+            !text.contains("101 Switching Protocols"),
+            "auth rejection must not complete the WebSocket upgrade"
+        );
+        // Body may arrive in a later TCP segment under slow coverage builds; the
+        // status-line assertion above is enough to prove FR-008 pre-stream reject.
+        server.join().expect("server thread");
+    }
+
+    #[test]
+    fn websocket_binary_subscribe_frame_is_accepted() {
+        use tungstenite::Message;
+
+        let limits = ConnectionLimits {
+            read_timeout: Duration::from_secs(5),
+            write_timeout: Duration::from_secs(5),
+            request_deadline: Duration::from_secs(10),
+        };
+        let addr = spawn_test_pool_with(
+            test_state_with("traverse-starter.process", "1.0.0"),
+            limits,
+            1,
+        );
+        let mut socket = open_app_events_websocket(addr);
+        socket
+            .send(Message::Binary(
+                br#"{"type":"subscribe","mode":"app_events"}"#.to_vec().into(),
+            ))
+            .expect("binary subscribe must send");
+        match socket.read().expect("server must respond") {
+            Message::Close(Some(frame)) => {
+                assert!(
+                    frame.reason.contains("stream_completed"),
+                    "empty replay should still complete: {}",
+                    frame.reason
+                );
+            }
+            Message::Text(_) => {
+                // events may arrive if residual state exists; tolerate either path
+            }
+            other => panic!("unexpected first frame: {other:?}"),
+        }
+    }
+
+    #[test]
     fn app_sessions_path_parses_workspace_and_app_id() {
         assert_eq!(
             workspace_app_sessions_path("/v1/workspaces/ws-test/apps/traverse-starter/sessions"),

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod app_events_websocket;
 mod app_runtime_events;
 mod browser_adapter;
 mod capability_packages;


### PR DESCRIPTION
## Summary
- Add EventBroker-backed WebSocket upgrade on `/v1/workspaces/{id}/apps/{app}/events` using sync `tungstenite` (no Tokio rewrite of the std TCP server).
- Retire plain HTTP SSE on that path with `426` / `sse_retired` (ADR-0034 / FR-007).
- Cover happy-path TCP delivery plus structured close frames for malformed subscribe, unsupported mode, and malformed cursor (FR-008/FR-010/FR-011).

## Governing Spec

- `097-websocket-grpc-event-transport`
- `033-http-json-api`
- `096-runtime-event-sse-transport`

## Project Item

Closes #967.

## Validation
- [x] `cargo clippy -p traverse-cli-rs --all-targets -- -D warnings`
- [x] `cargo test -p traverse-cli-rs` (352 passed)
- [x] `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body <file>`
- [ ] CI green on this PR