### PR TITLE
feat(contracts,runtime): capability-side WASM event host ABI

### DIFF
--- a/crates/traverse-runtime/src/artifact_router.rs
+++ b/crates/traverse-runtime/src/artifact_router.rs
@@ -76,10 +76,20 @@ impl LocalExecutor for ArtifactRouter {
                         .and_then(|digest| digest.strip_prefix("sha256:"))
                         .map(str::to_string),
                     host_abi_version: None,
+                    emits: capability.contract.emits.clone(),
+                    service_type: capability.contract.service_type.clone(),
                 };
+                // Events emitted via `traverse_host::emit_event` during this
+                // call are intentionally discarded here: `ArtifactRouter`
+                // bridges directly into `LocalExecutor`, bypassing
+                // `PlacementRouter` Step 5's `EventBroker` publish (a
+                // pre-existing gap for workflow-internal node execution,
+                // unrelated to this ABI — see spec 098's Capability
+                // Boundary).
                 return self
                     .wasm
                     .execute(&executor_capability, input)
+                    .map(|output| output.value)
                     .map_err(|error| map_executor_error(&error));
             }
             #[cfg(not(feature = "wasmtime-executor"))]

--- a/crates/traverse-runtime/src/events/types.rs
+++ b/crates/traverse-runtime/src/events/types.rs
@@ -16,7 +16,7 @@ pub enum LifecycleStatus {
 }
 
 /// A CloudEvents-formatted event with Traverse governance metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TraverseEvent {
     /// UUID for this event instance.
     pub id: String,

--- a/crates/traverse-runtime/src/executor/host_abi_v1.json
+++ b/crates/traverse-runtime/src/executor/host_abi_v1.json
@@ -42,6 +42,11 @@
       "module": "traverse_host",
       "name": "execution_id",
       "category": "execution_metadata"
+    },
+    {
+      "module": "traverse_host",
+      "name": "emit_event",
+      "category": "event_publish"
     }
   ]
 }

--- a/crates/traverse-runtime/src/executor/mod.rs
+++ b/crates/traverse-runtime/src/executor/mod.rs
@@ -24,7 +24,9 @@ pub use wasm::{
     verify_wasm_host_abi_bytes,
 };
 
+use crate::events::types::TraverseEvent;
 use serde_json::Value;
+use traverse_contracts::{EventReference, ServiceType};
 
 /// The artifact type recorded in a capability registration, used to route to the correct executor.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -48,6 +50,25 @@ pub struct ExecutorCapability {
     pub wasm_checksum: Option<String>,
     /// Traverse Host ABI version declared by the module manifest.
     pub host_abi_version: Option<String>,
+    /// Event types this capability's contract declares under `emits`, used to
+    /// validate `traverse_host::emit_event` calls synchronously at call time
+    /// (spec 098-capability-event-host-abi FR-002).
+    pub emits: Vec<EventReference>,
+    /// The capability contract's `service_type`; only `Subscribable` may call
+    /// `traverse_host::emit_event` (spec 098-capability-event-host-abi FR-003).
+    pub service_type: ServiceType,
+}
+
+/// Output of a [`CapabilityExecutor::execute`] call.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExecutorOutput {
+    /// The capability's JSON output value.
+    pub value: Value,
+    /// Events accepted via `traverse_host::emit_event` during this execution,
+    /// already validated against the capability's contract (spec
+    /// 098-capability-event-host-abi FR-002/FR-003). Always empty for
+    /// non-WASM executors, since the host ABI is WASM-only.
+    pub emitted_events: Vec<TraverseEvent>,
 }
 
 /// Error returned by a [`CapabilityExecutor`].
@@ -142,5 +163,5 @@ pub trait CapabilityExecutor: Send + Sync {
         &self,
         capability: &ExecutorCapability,
         input: &Value,
-    ) -> Result<Value, ExecutorError>;
+    ) -> Result<ExecutorOutput, ExecutorError>;
 }

--- a/crates/traverse-runtime/src/executor/native.rs
+++ b/crates/traverse-runtime/src/executor/native.rs
@@ -2,7 +2,7 @@
 
 use serde_json::Value;
 
-use super::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError};
+use super::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, ExecutorOutput};
 
 /// Handler type alias for native capability implementations.
 type NativeHandler = Box<dyn Fn(&Value) -> Result<Value, String> + Send + Sync>;
@@ -34,10 +34,15 @@ impl CapabilityExecutor for NativeExecutor {
         &self,
         capability: &ExecutorCapability,
         input: &Value,
-    ) -> Result<Value, ExecutorError> {
+    ) -> Result<ExecutorOutput, ExecutorError> {
         if capability.artifact_type != ArtifactType::Native {
             return Err(ExecutorError::UnsupportedArtifactType);
         }
-        (self.handler)(input).map_err(ExecutorError::ExecutionFailed)
+        (self.handler)(input)
+            .map(|value| ExecutorOutput {
+                value,
+                emitted_events: Vec::new(),
+            })
+            .map_err(ExecutorError::ExecutionFailed)
     }
 }

--- a/crates/traverse-runtime/src/executor/thread_pool.rs
+++ b/crates/traverse-runtime/src/executor/thread_pool.rs
@@ -7,7 +7,7 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use rayon::{ThreadPool, ThreadPoolBuildError, ThreadPoolBuilder};
 use serde_json::Value;
 
-use super::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError};
+use super::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, ExecutorOutput};
 
 const MIN_CAPACITY: usize = 1;
 const MAX_CAPACITY: usize = 256;
@@ -101,7 +101,7 @@ impl CapabilityExecutor for ThreadPoolExecutor {
         &self,
         capability: &ExecutorCapability,
         input: &Value,
-    ) -> Result<Value, ExecutorError> {
+    ) -> Result<ExecutorOutput, ExecutorError> {
         if capability.artifact_type == ArtifactType::Wasm {
             return Err(ExecutorError::UnsupportedArtifactType);
         }
@@ -143,6 +143,8 @@ mod tests {
             wasm_binary_path: None,
             wasm_checksum: None,
             host_abi_version: None,
+            emits: Vec::new(),
+            service_type: traverse_contracts::ServiceType::Stateless,
         }
     }
 
@@ -179,7 +181,9 @@ mod tests {
     }
 
     fn execute_json(executor: &ThreadPoolExecutor, input: &Value) -> Result<Value, ExecutorError> {
-        executor.execute(&native_capability(), input)
+        executor
+            .execute(&native_capability(), input)
+            .map(|output| output.value)
     }
 
     #[test]
@@ -413,13 +417,16 @@ mod tests {
             &self,
             _capability: &ExecutorCapability,
             input: &Value,
-        ) -> Result<Value, ExecutorError> {
+        ) -> Result<ExecutorOutput, ExecutorError> {
             let remaining = self.remaining_panics.load(Ordering::SeqCst);
             if remaining > 0 {
                 self.remaining_panics.fetch_sub(1, Ordering::SeqCst);
                 std::panic::resume_unwind(Box::new("boom"));
             }
-            Ok(input.clone())
+            Ok(ExecutorOutput {
+                value: input.clone(),
+                emitted_events: Vec::new(),
+            })
         }
     }
 
@@ -449,7 +456,13 @@ mod tests {
                 "capability panicked".to_string()
             ))
         );
-        assert_eq!(recovered, Ok(json!({ "second": true })));
+        assert_eq!(
+            recovered,
+            Ok(ExecutorOutput {
+                value: json!({ "second": true }),
+                emitted_events: Vec::new(),
+            })
+        );
         Ok(())
     }
 
@@ -469,7 +482,13 @@ mod tests {
 
         let recovered = executor.execute(&native_capability(), &json!({ "ok": true }));
 
-        assert_eq!(recovered, Ok(json!({ "ok": true })));
+        assert_eq!(
+            recovered,
+            Ok(ExecutorOutput {
+                value: json!({ "ok": true }),
+                emitted_events: Vec::new(),
+            })
+        );
         Ok(())
     }
 

--- a/crates/traverse-runtime/src/executor/wasm.rs
+++ b/crates/traverse-runtime/src/executor/wasm.rs
@@ -4,6 +4,7 @@
 //! Input is fed via WASI stdin; output is captured from WASI stdout.
 //! No ambient WASI authority is granted — all capabilities are deny-by-default.
 
+use chrono::Utc;
 use serde::Deserialize;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
@@ -11,12 +12,17 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt::Write as _;
 use std::fs;
 use std::sync::{LazyLock, Mutex};
-use wasmtime::{Config, Engine, Linker, Module, Store, StoreLimits, StoreLimitsBuilder};
+use uuid::Uuid;
+use wasmtime::{
+    Caller, Config, Engine, Extern, Linker, Module, Store, StoreLimits, StoreLimitsBuilder,
+};
 use wasmtime_wasi::WasiCtxBuilder;
 use wasmtime_wasi::p1::WasiP1Ctx;
 use wasmtime_wasi::p2::pipe::{MemoryInputPipe, MemoryOutputPipe};
 
-use super::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError};
+use super::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, ExecutorOutput};
+use crate::events::types::{LifecycleStatus, TraverseEvent};
+use traverse_contracts::{EventReference, ServiceType};
 
 /// Traverse Host ABI v1 is independently versioned from the runtime crate.
 pub const SUPPORTED_HOST_ABI_VERSION: &str = "1.0.0";
@@ -29,6 +35,26 @@ const DEFAULT_INSTANCE_LIMIT: usize = 1;
 const DEFAULT_TABLE_LIMIT: usize = 8;
 const DEFAULT_LINEAR_MEMORY_LIMIT: usize = 1;
 const DEFAULT_MODULE_CACHE_MAX_ENTRIES: usize = 64;
+
+/// Maximum bytes accepted for one `traverse_host::emit_event` payload
+/// (spec 098-capability-event-host-abi FR-008). Enforced before the guest
+/// memory read, and before deserialization.
+const MAX_EVENT_EMIT_PAYLOAD_BYTES: usize = 64 * 1024;
+
+/// `traverse_host::emit_event` accepted the event; it will be published to
+/// `EventBroker` once execution completes (spec 098 acceptance scenario 1).
+const EMIT_EVENT_OK: i32 = 0;
+/// The guest-supplied pointer/length was out of the guest's linear memory
+/// bounds, or the payload exceeded [`MAX_EVENT_EMIT_PAYLOAD_BYTES`], or the
+/// bytes were not a valid JSON object with `event_id`/`version` string
+/// fields (spec 098 FR-008, acceptance scenario 5).
+const EMIT_EVENT_ERR_INVALID_PAYLOAD: i32 = -1;
+/// The event type/version is not declared in the calling capability's
+/// contract `emits` list (spec 098 FR-002, acceptance scenario 2).
+const EMIT_EVENT_ERR_UNDECLARED_EVENT: i32 = -2;
+/// The calling capability's `service_type` is not `Subscribable` (spec 098
+/// FR-003, acceptance scenario 3).
+const EMIT_EVENT_ERR_NOT_SUBSCRIBABLE: i32 = -3;
 
 static HOST_ABI_V1_WHITELIST_CACHE: LazyLock<Result<HostAbiWhitelist, String>> =
     LazyLock::new(|| {
@@ -273,6 +299,15 @@ impl CompiledModuleCache {
 struct WasmStoreState {
     wasi: WasiP1Ctx,
     limits: StoreLimits,
+    /// Calling capability's id, `emits`, and `service_type` — used by the
+    /// `traverse_host::emit_event` host function to validate emissions
+    /// synchronously, at call time (spec 098-capability-event-host-abi
+    /// FR-002/FR-003).
+    capability_id: String,
+    emits: Vec<EventReference>,
+    service_type: ServiceType,
+    /// Events accepted via `traverse_host::emit_event` during this call.
+    emitted_events: Vec<TraverseEvent>,
 }
 
 impl CapabilityExecutor for WasmExecutor {
@@ -280,7 +315,7 @@ impl CapabilityExecutor for WasmExecutor {
         &self,
         capability: &ExecutorCapability,
         input: &Value,
-    ) -> Result<Value, ExecutorError> {
+    ) -> Result<ExecutorOutput, ExecutorError> {
         if capability.artifact_type != ArtifactType::Wasm {
             return Err(ExecutorError::UnsupportedArtifactType);
         }
@@ -310,7 +345,14 @@ impl CapabilityExecutor for WasmExecutor {
             .as_deref()
             .unwrap_or(SUPPORTED_HOST_ABI_VERSION);
 
-        self.run_wasm(&binary, input, abi_version)
+        self.run_wasm(
+            &binary,
+            input,
+            abi_version,
+            &capability.capability_id,
+            &capability.emits,
+            capability.service_type.clone(),
+        )
     }
 }
 
@@ -318,6 +360,10 @@ impl WasmExecutor {
     /// Execute pre-loaded WASM bytes with the given input.
     ///
     /// Exposed separately so tests can pass raw bytes without needing a file on disk.
+    /// The capability is treated as `Stateless` with no declared `emits` — it
+    /// cannot call `traverse_host::emit_event`. Use
+    /// [`run_bytes_with_capability`](Self::run_bytes_with_capability) to
+    /// exercise the event-emit host function.
     ///
     /// # Errors
     ///
@@ -338,15 +384,52 @@ impl WasmExecutor {
         input: &Value,
         abi_version: &str,
     ) -> Result<Value, ExecutorError> {
-        self.run_wasm(wasm_bytes, input, abi_version)
+        self.run_wasm(
+            wasm_bytes,
+            input,
+            abi_version,
+            "test-capability",
+            &[],
+            ServiceType::Stateless,
+        )
+        .map(|output| output.value)
     }
 
+    /// Execute pre-loaded WASM bytes as a specific capability, exercising
+    /// `traverse_host::emit_event` validation against `emits`/`service_type`
+    /// exactly as [`CapabilityExecutor::execute`] does.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutorError`] if ABI validation fails or execution cannot complete.
+    pub fn run_bytes_with_capability(
+        &self,
+        wasm_bytes: &[u8],
+        input: &Value,
+        capability_id: &str,
+        emits: &[EventReference],
+        service_type: ServiceType,
+    ) -> Result<ExecutorOutput, ExecutorError> {
+        self.run_wasm(
+            wasm_bytes,
+            input,
+            SUPPORTED_HOST_ABI_VERSION,
+            capability_id,
+            emits,
+            service_type,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn run_wasm(
         &self,
         wasm_bytes: &[u8],
         input: &Value,
         abi_version: &str,
-    ) -> Result<Value, ExecutorError> {
+        capability_id: &str,
+        emits: &[EventReference],
+        service_type: ServiceType,
+    ) -> Result<ExecutorOutput, ExecutorError> {
         let input_json = serde_json::to_string(input)
             .map_err(|e| ExecutorError::ExecutionFailed(format!("input serialization: {e}")))?;
 
@@ -366,12 +449,19 @@ impl WasmExecutor {
         let mut linker: Linker<WasmStoreState> = Linker::new(&self.engine);
         wasmtime_wasi::p1::add_to_linker_sync(&mut linker, |s| &mut s.wasi)
             .map_err(|e| ExecutorError::RuntimeSetupFailed(e.to_string()))?;
+        linker
+            .func_wrap("traverse_host", "emit_event", handle_emit_event)
+            .map_err(|e| ExecutorError::RuntimeSetupFailed(format!("func_wrap emit_event: {e}")))?;
 
         let mut store = Store::new(
             &self.engine,
             WasmStoreState {
                 wasi: wasi_ctx,
                 limits: self.store_limits(),
+                capability_id: capability_id.to_string(),
+                emits: emits.to_vec(),
+                service_type,
+                emitted_events: Vec::new(),
             },
         );
         store.limiter(|state| &mut state.limits);
@@ -394,11 +484,16 @@ impl WasmExecutor {
         // Extract captured stdout — contents() reads the buffer without consuming it
         let raw_output = stdout_ref.contents();
 
-        serde_json::from_slice::<Value>(&raw_output).map_err(|e| {
+        let value = serde_json::from_slice::<Value>(&raw_output).map_err(|e| {
             ExecutorError::OutputDeserializationFailed(format!(
                 "stdout is not valid JSON: {e} — raw: {}",
                 String::from_utf8_lossy(&raw_output)
             ))
+        })?;
+
+        Ok(ExecutorOutput {
+            value,
+            emitted_events: store.into_data().emitted_events,
         })
     }
 
@@ -445,6 +540,95 @@ impl WasmExecutor {
         cache.insert(checksum, cached.clone());
         Ok(cached)
     }
+}
+
+/// Host implementation of `traverse_host::emit_event` (spec
+/// 098-capability-event-host-abi FR-001). The guest passes a pointer/length
+/// into its own linear memory holding a JSON payload shaped
+/// `{"event_id": "...", "version": "...", "payload": {...}}`; this function
+/// validates it synchronously, at call time, and never panics or traps on a
+/// malformed or out-of-bounds guest pointer (FR-008) — every failure path
+/// returns a negative status code to the guest instead.
+fn handle_emit_event(mut caller: Caller<'_, WasmStoreState>, ptr: i32, len: i32) -> i32 {
+    // FR-003: checked before any guest memory is touched — rejected
+    // regardless of payload.
+    if caller.data().service_type != ServiceType::Subscribable {
+        return EMIT_EVENT_ERR_NOT_SUBSCRIBABLE;
+    }
+
+    // FR-008: bounds/size checked before any read or deserialization.
+    if ptr < 0 || len < 0 {
+        return EMIT_EVENT_ERR_INVALID_PAYLOAD;
+    }
+    #[allow(clippy::cast_sign_loss)]
+    let (ptr, len) = (ptr as usize, len as usize);
+    if len > MAX_EVENT_EMIT_PAYLOAD_BYTES {
+        return EMIT_EVENT_ERR_INVALID_PAYLOAD;
+    }
+
+    let Some(Extern::Memory(memory)) = caller.get_export("memory") else {
+        return EMIT_EVENT_ERR_INVALID_PAYLOAD;
+    };
+
+    let mut buffer = vec![0u8; len];
+    // `Memory::read` bounds-checks `ptr + len` against actual guest memory
+    // size and returns `Err` rather than panicking or reading out of bounds.
+    if memory.read(&caller, ptr, &mut buffer).is_err() {
+        return EMIT_EVENT_ERR_INVALID_PAYLOAD;
+    }
+
+    let Ok(payload) = serde_json::from_slice::<Value>(&buffer) else {
+        return EMIT_EVENT_ERR_INVALID_PAYLOAD;
+    };
+    let Some(event_type) = payload
+        .get("event_id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return EMIT_EVENT_ERR_INVALID_PAYLOAD;
+    };
+    let Some(version) = payload
+        .get("version")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return EMIT_EVENT_ERR_INVALID_PAYLOAD;
+    };
+    let data = payload
+        .get("payload")
+        .cloned()
+        .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+
+    // FR-002: declared-emission check, synchronous, at call time.
+    let declared = caller
+        .data()
+        .emits
+        .iter()
+        .any(|decl| decl.event_id == event_type && decl.version == version);
+    if !declared {
+        return EMIT_EVENT_ERR_UNDECLARED_EVENT;
+    }
+
+    let capability_id = caller.data().capability_id.clone();
+    let event = TraverseEvent {
+        id: Uuid::new_v4().to_string(),
+        source: format!("traverse-runtime/{capability_id}"),
+        event_type: event_type.clone(),
+        datacontenttype: "application/json".to_string(),
+        time: Utc::now().to_rfc3339(),
+        data,
+        owner: capability_id.clone(),
+        version: version.clone(),
+        lifecycle_status: LifecycleStatus::Active,
+        deduplication_id: Some(format!("{capability_id}:{event_type}:{version}")),
+        ordering_scope: Some(capability_id),
+        correlation_id: None,
+        causation_id: None,
+        subject_id: None,
+        actor_id: None,
+    };
+    caller.data_mut().emitted_events.push(event);
+    EMIT_EVENT_OK
 }
 
 fn classify_wasm_execution_error(error: &wasmtime::Error) -> ExecutorError {

--- a/crates/traverse-runtime/src/lib.rs
+++ b/crates/traverse-runtime/src/lib.rs
@@ -18,7 +18,9 @@ use events::{
     EventBroker, EventCatalog, EventError, InProcessBroker, NoopRuntimeEventSink, RuntimeEventSink,
     Subscription, SubscriptionPoll, TraverseEvent,
 };
-use executor::{ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError};
+use executor::{
+    ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, ExecutorOutput,
+};
 use placement::{PlacementConstraintEvaluator, RuntimeSnapshot};
 use router::{CapabilityExecutorRegistry, PlacementRouter, RouterError, RouterRequest};
 use security::{
@@ -1608,7 +1610,6 @@ where
             runtime_snapshot: idle_runtime_snapshot(),
             input: context.attempt.request.input.clone(),
             executor_capability,
-            emitted_events: Vec::new(),
             trace_id_override: Some(context.attempt.trace_id.clone()),
         };
 
@@ -1635,7 +1636,13 @@ where
                     );
                 }
 
-                let emitted_events = event_references_from_output(&response.output);
+                // `BoundLocalExecutor` always returns an empty
+                // `emitted_events` (the WASM-only `traverse_host::emit_event`
+                // ABI has no equivalent for a host-provided `LocalExecutor`
+                // closure), so `response.emitted_events` is structurally
+                // always empty here regardless of what the caller's executor
+                // does internally.
+                let emitted_events: Vec<EventReference> = Vec::new();
                 successful_execution_outcome(
                     context,
                     selected,
@@ -1678,9 +1685,13 @@ where
         &self,
         _capability: &ExecutorCapability,
         input: &Value,
-    ) -> Result<Value, ExecutorError> {
+    ) -> Result<ExecutorOutput, ExecutorError> {
         self.executor
             .execute(&self.selected, input)
+            .map(|value| ExecutorOutput {
+                value,
+                emitted_events: Vec::new(),
+            })
             .map_err(|failure| ExecutorError::ExecutionFailed(failure.message))
     }
 }
@@ -1775,6 +1786,8 @@ fn executor_capability_for(
             .and_then(|digest| digest.strip_prefix("sha256:"))
             .map(str::to_string),
         host_abi_version: None,
+        emits: selected.contract.emits.clone(),
+        service_type: selected.contract.service_type.clone(),
     }
 }
 
@@ -1787,24 +1800,6 @@ fn execution_target_from_placement(target: PlacementTarget) -> ExecutionTarget {
         PlacementTarget::Worker => ExecutionTarget::Worker,
         PlacementTarget::Device => ExecutionTarget::Device,
     }
-}
-
-fn event_references_from_output(output: &Value) -> Vec<EventReference> {
-    let Some(Value::Array(events)) = output.get("emitted_events") else {
-        return Vec::new();
-    };
-    events
-        .iter()
-        .filter_map(|event| {
-            let Value::Object(object) = event else {
-                return None;
-            };
-            Some(EventReference {
-                event_id: object.get("event_id")?.as_str()?.to_string(),
-                version: object.get("version")?.as_str()?.to_string(),
-            })
-        })
-        .collect()
 }
 
 fn map_router_error(
@@ -3501,6 +3496,26 @@ mod tests {
         ));
         assert_eq!(code.code, RuntimeErrorCode::PlacementUnsupported);
         assert_eq!(reason, ExecutionFailureReason::PlacementUnsupported);
+
+        let (code, reason, _) =
+            super::map_router_error(&RouterError::ExecutionFailed("boom".to_string()));
+        assert_eq!(code.code, RuntimeErrorCode::ExecutionFailed);
+        assert_eq!(reason, ExecutionFailureReason::ExecutionFailed);
+
+        // `RouterError::ContractViolation` is no longer produced by
+        // `PlacementRouter` (spec 098-capability-event-host-abi FR-005
+        // removed the post-hoc check that used to raise it) but the variant
+        // remains part of `RouterError`'s public surface, so `map_router_error`
+        // must still map it correctly.
+        let (code, reason, _) = super::map_router_error(&RouterError::ContractViolation(vec![
+            traverse_contracts::ViolationRecord::new(
+                "undeclared_event_emission",
+                "test.cap",
+                "test message",
+            ),
+        ]));
+        assert_eq!(code.code, RuntimeErrorCode::ContractViolation);
+        assert_eq!(reason, ExecutionFailureReason::ExecutionFailed);
     }
 
     #[test]
@@ -3530,16 +3545,6 @@ mod tests {
         for (placement, expected) in mapped {
             assert_eq!(super::execution_target_from_placement(placement), expected);
         }
-
-        let refs = super::event_references_from_output(&json!({
-            "emitted_events": [
-                "skip-me",
-                {"event_id": "dev.traverse.live", "version": "1.0.0"},
-                {"event_id": 1, "version": "1.0.0"}
-            ]
-        }));
-        assert_eq!(refs.len(), 1);
-        assert_eq!(refs[0].event_id, "dev.traverse.live");
 
         let discard = super::event_broker_or_discard(Err(EventError::InvalidRetentionWindow(
             "forced".to_string(),
@@ -3576,7 +3581,15 @@ mod tests {
     }
 
     #[test]
-    fn bound_local_executor_publishes_native_artifact_events_through_placement_router() {
+    fn bound_local_executor_never_publishes_events_through_placement_router() {
+        // `BoundLocalExecutor` bridges a host-provided `LocalExecutor` (a
+        // native Rust closure) into `CapabilityExecutor`. Spec
+        // 098-capability-event-host-abi's `traverse_host::emit_event` is a
+        // WASM-only mechanism (FR-001) — a native closure has no ABI to call
+        // and the output-JSON `emitted_events` convention it used to rely on
+        // is removed (FR-004), so `BoundLocalExecutor::execute` always
+        // returns an empty `emitted_events` list. This test documents that
+        // intentional gap rather than asserting an event reaches the broker.
         use super::events::{
             EventBroker, EventCatalog, EventCatalogEntry, InProcessBroker, LifecycleStatus,
         };
@@ -3594,13 +3607,7 @@ mod tests {
                 _capability: &ResolvedCapability,
                 _input: &Value,
             ) -> Result<Value, LocalExecutionFailure> {
-                Ok(json!({
-                    "draft_id": "native-1",
-                    "emitted_events": [{
-                        "event_id": "dev.traverse.native.live-emitted",
-                        "version": "1.0.0"
-                    }]
-                }))
+                Ok(json!({ "draft_id": "native-1" }))
             }
         }
 
@@ -3657,7 +3664,6 @@ mod tests {
                     &selected,
                     ArtifactType::Native,
                 ),
-                emitted_events: Vec::new(),
                 trace_id_override: Some("trace_native_live".to_string()),
             })
             .expect("native placement router execution should succeed");
@@ -3666,8 +3672,7 @@ mod tests {
         let poll = broker
             .poll(&subscription.subscription_id, 10)
             .expect("poll should succeed");
-        assert_eq!(poll.events.len(), 1);
-        assert_eq!(poll.events[0].event.event_type, event_type);
+        assert!(poll.events.is_empty());
         assert!(
             trace_store
                 .lock()

--- a/crates/traverse-runtime/src/router/mod.rs
+++ b/crates/traverse-runtime/src/router/mod.rs
@@ -16,12 +16,11 @@ use std::{
 };
 
 use chrono::Utc;
-use serde_json::{Value, json};
+use serde_json::Value;
 use traverse_contracts::{CapabilityContract, ServiceType, ViolationRecord};
-use uuid::Uuid;
 
 use crate::{
-    events::types::{EventBroker, LifecycleStatus, TraverseEvent},
+    events::types::{EventBroker, TraverseEvent},
     executor::{ArtifactType, CapabilityExecutor, ExecutorCapability},
     placement::{
         PlacementConstraintEvaluator, PlacementDecision, PlacementError, PlacementRequest,
@@ -55,11 +54,6 @@ pub struct RouterRequest {
     pub input: Value,
     /// Resolved capability descriptor passed to the executor.
     pub executor_capability: ExecutorCapability,
-    /// Events emitted by the capability (only published when `service_type == Subscribable`).
-    ///
-    /// When empty, [`PlacementRouter::execute`] extracts events from the capability
-    /// output's `emitted_events` array (the pre-host-ABI convention).
-    pub emitted_events: Vec<TraverseEvent>,
     /// When set, used as the public/private [`TraceStore`] id instead of minting a new UUID.
     pub trace_id_override: Option<String>,
 }
@@ -100,6 +94,10 @@ impl std::error::Error for RouterError {}
 pub struct RouterResponse {
     /// The JSON output produced by the executor.
     pub output: Value,
+    /// Events the executor emitted and validated during this call (spec
+    /// 098-capability-event-host-abi), already published to `EventBroker`
+    /// by Step 5 for `Subscribable` capabilities.
+    pub emitted_events: Vec<TraverseEvent>,
     /// The public trace entry written to the store.
     pub trace_id: String,
     /// The placement decision that was made.
@@ -186,47 +184,22 @@ impl PlacementRouter {
         let placement_target_str = format!("{:?}", decision.target);
 
         // --- Step 3: Execute capability ---
+        // Events emitted via `traverse_host::emit_event` (spec
+        // 098-capability-event-host-abi) are already validated
+        // synchronously, at call time, against `request.contract.emits` and
+        // `service_type` by the host function itself (FR-002/FR-003) — no
+        // post-hoc enforcement gate is needed here.
         let start = Instant::now();
         let exec_result = executor.execute(&request.executor_capability, &request.input);
         let duration_ms = u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX);
 
-        let (output, outcome) = match exec_result {
-            Ok(v) => (v, TraceOutcome::Success),
+        let (output, emitted_events, outcome) = match exec_result {
+            Ok(exec_output) => (
+                exec_output.value,
+                exec_output.emitted_events,
+                TraceOutcome::Success,
+            ),
             Err(e) => return Err(RouterError::ExecutionFailed(format!("{e}"))),
-        };
-
-        let emitted_events = if request.emitted_events.is_empty() {
-            extract_emitted_events_from_output(&output, &request.capability_id)
-        } else {
-            request.emitted_events
-        };
-
-        // --- Step 3.5: Execution-time contractual enforcement gate ---
-        let mut violations = Vec::new();
-        if request.contract.service_type == ServiceType::Subscribable && !emitted_events.is_empty()
-        {
-            for event in &emitted_events {
-                let declared =
-                    request.contract.emits.iter().any(|decl| {
-                        decl.event_id == event.event_type && decl.version == event.version
-                    });
-                if !declared {
-                    violations.push(ViolationRecord::new(
-                        "undeclared_event_emission",
-                        &request.capability_id,
-                        format!(
-                            "capability emitted undeclared event {}@{}",
-                            event.event_type, event.version
-                        ),
-                    ));
-                }
-            }
-        }
-
-        let outcome = if violations.is_empty() {
-            outcome
-        } else {
-            TraceOutcome::Failure
         };
 
         // --- Step 4: Write trace ---
@@ -235,7 +208,7 @@ impl PlacementRouter {
             None => new_trace_id_and_time(),
         };
 
-        let mut public_entry = PublicTraceEntry::new(
+        let public_entry = PublicTraceEntry::new(
             trace_id.clone(),
             request.capability_id.clone(),
             placement_target_str,
@@ -243,7 +216,6 @@ impl PlacementRouter {
             duration_ms,
             time,
         );
-        public_entry.violations.clone_from(&violations);
 
         let input_str = serde_json::to_string(&request.input).unwrap_or_default();
         let output_str = serde_json::to_string(&output).unwrap_or_default();
@@ -258,86 +230,22 @@ impl PlacementRouter {
             store.insert(public_entry, Some(private_entry));
         }
 
-        if !violations.is_empty() {
-            return Err(RouterError::ContractViolation(violations));
-        }
-
         // --- Step 5: Publish events for Subscribable capabilities ---
-        if request.contract.service_type == ServiceType::Subscribable {
-            for event in emitted_events {
+        let published_events = if request.contract.service_type == ServiceType::Subscribable {
+            for event in &emitted_events {
                 // Best-effort: publish errors are logged but do not fail the response.
-                let _ = self.event_broker.publish(event);
+                let _ = self.event_broker.publish(event.clone());
             }
-        }
+            emitted_events
+        } else {
+            Vec::new()
+        };
 
         Ok(RouterResponse {
             output,
+            emitted_events: published_events,
             trace_id,
             placement_decision: decision,
         })
-    }
-}
-
-/// Materialize [`TraverseEvent`]s from the capability output-JSON convention.
-///
-/// Each element of `output.emitted_events` is expected to carry `event_id`,
-/// `version`, and an optional `payload`. Missing/malformed entries are skipped.
-fn extract_emitted_events_from_output(output: &Value, capability_id: &str) -> Vec<TraverseEvent> {
-    let Some(Value::Array(events)) = output.get("emitted_events") else {
-        return Vec::new();
-    };
-
-    events
-        .iter()
-        .filter_map(|event| {
-            let Value::Object(object) = event else {
-                return None;
-            };
-            let event_type = object.get("event_id")?.as_str()?;
-            let version = object.get("version")?.as_str()?;
-            let data = object.get("payload").cloned().unwrap_or_else(|| json!({}));
-            Some(TraverseEvent {
-                id: Uuid::new_v4().to_string(),
-                source: format!("traverse-runtime/{capability_id}"),
-                event_type: event_type.to_string(),
-                datacontenttype: "application/json".to_string(),
-                time: Utc::now().to_rfc3339(),
-                data,
-                owner: capability_id.to_string(),
-                version: version.to_string(),
-                lifecycle_status: LifecycleStatus::Active,
-                deduplication_id: Some(format!("{capability_id}:{event_type}:{version}")),
-                ordering_scope: Some(capability_id.to_string()),
-                correlation_id: None,
-                causation_id: None,
-                subject_id: None,
-                actor_id: None,
-            })
-        })
-        .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    #![allow(clippy::expect_used)]
-
-    use super::extract_emitted_events_from_output;
-    use serde_json::json;
-
-    #[test]
-    fn extract_emitted_events_skips_non_object_entries() {
-        let events = extract_emitted_events_from_output(
-            &json!({
-                "emitted_events": [
-                    "skip",
-                    {"event_id": "dev.traverse.ok", "version": "1.0.0", "payload": {"n": 1}},
-                    {"event_id": "missing-version"}
-                ]
-            }),
-            "cap.test",
-        );
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].event_type, "dev.traverse.ok");
-        assert_eq!(events[0].version, "1.0.0");
     }
 }

--- a/crates/traverse-runtime/tests/executor_tests.rs
+++ b/crates/traverse-runtime/tests/executor_tests.rs
@@ -2,10 +2,11 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
 use std::sync::atomic::{AtomicU64, Ordering};
+use traverse_contracts::{EventReference, ServiceType};
 use traverse_runtime::executor::{
-    ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, NativeExecutor,
-    SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits, WasmExecutor, WasmModuleCacheConfig,
-    supported_host_abi_versions, verify_wasm_host_abi_bytes,
+    ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, ExecutorOutput,
+    NativeExecutor, SUPPORTED_HOST_ABI_VERSION, WasmExecutionLimits, WasmExecutor,
+    WasmModuleCacheConfig, supported_host_abi_versions, verify_wasm_host_abi_bytes,
 };
 
 // --- NativeExecutor tests ---
@@ -22,7 +23,13 @@ fn native_executor_runs_handler() {
     let cap = native_capability("greet");
     let result = executor.execute(&cap, &json!({ "name": "traverse" }));
 
-    assert_eq!(result, Ok(json!({ "greeting": "hello, traverse!" })));
+    assert_eq!(
+        result,
+        Ok(ExecutorOutput {
+            value: json!({ "greeting": "hello, traverse!" }),
+            emitted_events: Vec::new(),
+        })
+    );
 }
 
 #[test]
@@ -52,6 +59,8 @@ fn native_executor_rejects_wasm_artifact_type() -> Result<(), String> {
         wasm_binary_path: None,
         wasm_checksum: None,
         host_abi_version: None,
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     };
     let err = expect_err(executor.execute(&cap, &json!({})), "expected type error")?;
 
@@ -69,7 +78,7 @@ fn native_executor_passes_input_through() -> Result<(), String> {
         .execute(&cap, &input)
         .map_err(|e| format!("{e:?}"))?;
 
-    assert_eq!(result, input);
+    assert_eq!(result.value, input);
     Ok(())
 }
 
@@ -96,6 +105,8 @@ fn wasm_executor_errors_when_no_path_set() -> Result<(), String> {
         wasm_binary_path: None,
         wasm_checksum: None,
         host_abi_version: None,
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     };
     let err = expect_err(
         executor.execute(&cap, &json!({})),
@@ -119,6 +130,8 @@ fn wasm_executor_errors_on_missing_file() -> Result<(), String> {
         wasm_binary_path: Some("/nonexistent/path/module.wasm".to_string()),
         wasm_checksum: None,
         host_abi_version: None,
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     };
     let err = expect_err(
         executor.execute(&cap, &json!({})),
@@ -156,6 +169,8 @@ fn wasm_executor_detects_checksum_mismatch() -> Result<(), String> {
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
         ),
         host_abi_version: None,
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     };
 
     let err = expect_err(
@@ -668,13 +683,21 @@ fn wasm_executor_full_execute_path_via_disk() -> Result<(), String> {
         wasm_binary_path: Some(tmp.clone()),
         wasm_checksum: None, // no checksum — exercises the skip-checksum branch
         host_abi_version: None,
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     };
 
     let input = json!({ "disk": true });
     let result = executor.execute(&cap, &input).map_err(|e| format!("{e:?}"));
     std::fs::remove_file(&tmp).ok();
 
-    assert_eq!(result, Ok(input));
+    assert_eq!(
+        result,
+        Ok(ExecutorOutput {
+            value: input,
+            emitted_events: Vec::new(),
+        })
+    );
     Ok(())
 }
 
@@ -718,6 +741,8 @@ fn wasm_executor_execute_with_matching_checksum_succeeds() -> Result<(), String>
         wasm_binary_path: Some(tmp.clone()),
         wasm_checksum: Some(checksum),
         host_abi_version: Some("1.0.0".to_string()),
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     };
 
     let result = executor
@@ -725,7 +750,13 @@ fn wasm_executor_execute_with_matching_checksum_succeeds() -> Result<(), String>
         .map_err(|e| format!("{e:?}"));
     std::fs::remove_file(&tmp).ok();
 
-    assert_eq!(result, Ok(json!({})));
+    assert_eq!(
+        result,
+        Ok(ExecutorOutput {
+            value: json!({}),
+            emitted_events: Vec::new(),
+        })
+    );
     Ok(())
 }
 
@@ -753,13 +784,15 @@ fn wasm_executor_cached_module_does_not_bypass_checksum_mismatch() -> Result<(),
         wasm_binary_path: Some(tmp.clone()),
         wasm_checksum: Some(checksum),
         host_abi_version: Some("1.0.0".to_string()),
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     };
 
     let input = json!({ "cache": true });
     let result = executor
         .execute(&cap, &input)
         .map_err(|e| format!("{e:?}"))?;
-    assert_eq!(result, input);
+    assert_eq!(result.value, input);
     assert_eq!(executor.module_cache_stats().entries, 1);
 
     std::fs::write(&tmp, b"not-the-same-wasm").map_err(|e| format!("overwrite: {e}"))?;
@@ -790,6 +823,8 @@ fn wasm_executor_invalid_binary_triggers_runtime_setup_failed() -> Result<(), St
         wasm_binary_path: Some(tmp.clone()),
         wasm_checksum: None,
         host_abi_version: None,
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     };
 
     let err = expect_err(executor.execute(&cap, &json!({})), "expected error")?;
@@ -798,6 +833,296 @@ fn wasm_executor_invalid_binary_triggers_runtime_setup_failed() -> Result<(), St
     assert!(
         matches!(err, ExecutorError::MalformedWasmArtifact { .. }),
         "expected MalformedWasmArtifact, got {err:?}"
+    );
+    Ok(())
+}
+
+// --- `traverse_host::emit_event` host ABI tests (spec 098-capability-event-host-abi) ---
+
+#[test]
+fn wasm_executor_emit_event_accepted_for_declared_subscribable_capability() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes =
+        wat::parse_str(emit_event_wat(EMIT_TEST_EVENT_PAYLOAD)).map_err(|e| format!("{e}"))?;
+
+    let output = executor
+        .run_bytes_with_capability(
+            &wasm_bytes,
+            &json!({}),
+            "test.emit.subject",
+            &[EventReference {
+                event_id: "dev.traverse.test.emitted".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+            ServiceType::Subscribable,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert_eq!(output.emitted_events.len(), 1);
+    let event = &output.emitted_events[0];
+    assert_eq!(event.event_type, "dev.traverse.test.emitted");
+    assert_eq!(event.version, "1.0.0");
+    assert_eq!(event.data, json!({ "n": 1 }));
+    assert_eq!(event.owner, "test.emit.subject");
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_emit_event_rejected_for_undeclared_event_type() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes =
+        wat::parse_str(emit_event_wat(EMIT_TEST_EVENT_PAYLOAD)).map_err(|e| format!("{e}"))?;
+
+    // `emits` declares a different event than the one the guest tries to emit.
+    let output = executor
+        .run_bytes_with_capability(
+            &wasm_bytes,
+            &json!({}),
+            "test.emit.subject",
+            &[EventReference {
+                event_id: "dev.traverse.test.other".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+            ServiceType::Subscribable,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert!(
+        output.emitted_events.is_empty(),
+        "undeclared event must not be accepted"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_emit_event_rejected_for_non_subscribable_capability() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes =
+        wat::parse_str(emit_event_wat(EMIT_TEST_EVENT_PAYLOAD)).map_err(|e| format!("{e}"))?;
+
+    let output = executor
+        .run_bytes_with_capability(
+            &wasm_bytes,
+            &json!({}),
+            "test.emit.subject",
+            &[EventReference {
+                event_id: "dev.traverse.test.emitted".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+            ServiceType::Stateless, // NOT Subscribable
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert!(
+        output.emitted_events.is_empty(),
+        "non-Subscribable capability must never emit"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_emit_event_rejected_for_malformed_json_payload() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    // Not valid JSON at all.
+    let wasm_bytes = wat::parse_str(emit_event_wat("not-json")).map_err(|e| format!("{e}"))?;
+
+    let output = executor
+        .run_bytes_with_capability(
+            &wasm_bytes,
+            &json!({}),
+            "test.emit.subject",
+            &[EventReference {
+                event_id: "dev.traverse.test.emitted".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+            ServiceType::Subscribable,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert!(
+        output.emitted_events.is_empty(),
+        "malformed payload must not be accepted, and execution must not trap"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_emit_event_rejected_for_oversized_payload() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    // The module declares a 1-page (64 KiB) memory but claims a payload
+    // length one byte larger than the ABI's maximum accepted size — the
+    // host must reject this before ever attempting to read guest memory.
+    let wasm_bytes = wat::parse_str(emit_event_wat_with_len(
+        EMIT_TEST_EVENT_PAYLOAD,
+        64 * 1024 + 1,
+    ))
+    .map_err(|e| format!("{e}"))?;
+
+    let output = executor
+        .run_bytes_with_capability(
+            &wasm_bytes,
+            &json!({}),
+            "test.emit.subject",
+            &[EventReference {
+                event_id: "dev.traverse.test.emitted".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+            ServiceType::Subscribable,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert!(
+        output.emitted_events.is_empty(),
+        "oversized payload must not be accepted, and execution must not trap"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_emit_event_rejected_for_out_of_bounds_pointer() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    // One page of memory is 64 KiB; a pointer past that, with a small
+    // length, is out of bounds without exceeding the payload size cap —
+    // this exercises the `Memory::read` bounds check itself (FR-008),
+    // distinct from the size-cap check above.
+    let wasm_bytes =
+        wat::parse_str(emit_event_wat_with_ptr_len(200_000, 10)).map_err(|e| format!("{e}"))?;
+
+    let output = executor
+        .run_bytes_with_capability(
+            &wasm_bytes,
+            &json!({}),
+            "test.emit.subject",
+            &[EventReference {
+                event_id: "dev.traverse.test.emitted".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+            ServiceType::Subscribable,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert!(
+        output.emitted_events.is_empty(),
+        "out-of-bounds pointer must not be accepted, and execution must not trap or read outside guest memory"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_emit_event_rejected_for_negative_pointer_or_length() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes =
+        wat::parse_str(emit_event_wat_with_raw_ptr_len(-1, 4)).map_err(|e| format!("{e}"))?;
+
+    let output = executor
+        .run_bytes_with_capability(
+            &wasm_bytes,
+            &json!({}),
+            "test.emit.subject",
+            &[EventReference {
+                event_id: "dev.traverse.test.emitted".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+            ServiceType::Subscribable,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert!(
+        output.emitted_events.is_empty(),
+        "a negative pointer must not be accepted, and execution must not trap"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_emit_event_rejected_for_missing_event_id() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes =
+        wat::parse_str(emit_event_wat(r#"{"version":"1.0.0"}"#)).map_err(|e| format!("{e}"))?;
+
+    let output = executor
+        .run_bytes_with_capability(
+            &wasm_bytes,
+            &json!({}),
+            "test.emit.subject",
+            &[EventReference {
+                event_id: "dev.traverse.test.emitted".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+            ServiceType::Subscribable,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert!(
+        output.emitted_events.is_empty(),
+        "a payload missing event_id must not be accepted"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_emit_event_rejected_for_missing_version() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    let wasm_bytes = wat::parse_str(emit_event_wat(
+        r#"{"event_id":"dev.traverse.test.emitted"}"#,
+    ))
+    .map_err(|e| format!("{e}"))?;
+
+    let output = executor
+        .run_bytes_with_capability(
+            &wasm_bytes,
+            &json!({}),
+            "test.emit.subject",
+            &[EventReference {
+                event_id: "dev.traverse.test.emitted".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+            ServiceType::Subscribable,
+        )
+        .map_err(|e| format!("{e:?}"))?;
+
+    assert!(
+        output.emitted_events.is_empty(),
+        "a payload missing version must not be accepted"
+    );
+    Ok(())
+}
+
+#[test]
+fn wasm_executor_emit_event_handles_module_without_memory_export() -> Result<(), String> {
+    let executor = WasmExecutor::new().map_err(|e| format!("{e:?}"))?;
+    // No `(memory ...)` declaration at all, so `caller.get_export("memory")`
+    // must return `None` — the host function has to reject this gracefully
+    // (FR-008) rather than panicking or trapping.
+    let wat_src = r#"
+        (module
+            (import "traverse_host" "emit_event"
+                (func $emit_event (param i32 i32) (result i32)))
+            (func $_start (export "_start")
+                (drop (call $emit_event (i32.const 0) (i32.const 4)))
+            )
+        )
+    "#;
+    let wasm_bytes = wat::parse_str(wat_src).map_err(|e| format!("{e}"))?;
+
+    let result = executor.run_bytes_with_capability(
+        &wasm_bytes,
+        &json!({}),
+        "test.emit.subject",
+        &[EventReference {
+            event_id: "dev.traverse.test.emitted".to_string(),
+            version: "1.0.0".to_string(),
+        }],
+        ServiceType::Subscribable,
+    );
+
+    // The module never writes stdout (it has no memory to do so), so this
+    // surfaces as a normal, controlled executor error — not a panic/trap —
+    // which is exactly what proves the missing-memory-export path inside
+    // `handle_emit_event` was handled gracefully.
+    assert!(
+        result.is_err(),
+        "expected a controlled error, not a panic or trap: {result:?}"
     );
     Ok(())
 }
@@ -811,6 +1136,8 @@ fn native_capability(id: &str) -> ExecutorCapability {
         wasm_binary_path: None,
         wasm_checksum: None,
         host_abi_version: None,
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     }
 }
 
@@ -844,6 +1171,78 @@ fn echo_wat() -> &'static str {
             )
         )
     "#
+}
+
+const EMIT_TEST_EVENT_PAYLOAD: &str =
+    r#"{"event_id":"dev.traverse.test.emitted","version":"1.0.0","payload":{"n":1}}"#;
+
+fn wat_escape(payload: &str) -> String {
+    payload.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// A WASM module that writes `payload` into linear memory at offset 100,
+/// calls `traverse_host::emit_event(100, payload.len())`, then writes `{}`
+/// to stdout (a minimal valid JSON output, unrelated to the emit call).
+fn emit_event_wat(payload: &str) -> String {
+    emit_event_wat_with_len(payload, payload.len())
+}
+
+/// As [`emit_event_wat`], but the guest claims `claimed_len` bytes instead
+/// of `payload.len()` — used to simulate an oversized length claim.
+fn emit_event_wat_with_len(payload: &str, claimed_len: usize) -> String {
+    format!(
+        r#"
+        (module
+            (import "traverse_host" "emit_event"
+                (func $emit_event (param i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 100) "{payload}")
+            (data (i32.const 300) "{{}}")
+            (func $_start (export "_start")
+                (drop (call $emit_event (i32.const 100) (i32.const {claimed_len})))
+                (i32.store (i32.const 0) (i32.const 300))
+                (i32.store (i32.const 4) (i32.const 2))
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 4100)))
+            )
+        )
+        "#,
+        payload = wat_escape(payload),
+    )
+}
+
+/// A WASM module that calls `traverse_host::emit_event(ptr, len)` directly
+/// with caller-supplied coordinates, ignoring what (if anything) is actually
+/// at that memory location — used to exercise the guest-memory bounds check.
+fn emit_event_wat_with_ptr_len(ptr: usize, len: usize) -> String {
+    emit_event_wat_with_raw_ptr_len(
+        i32::try_from(ptr).unwrap_or(i32::MAX),
+        i32::try_from(len).unwrap_or(i32::MAX),
+    )
+}
+
+/// As [`emit_event_wat_with_ptr_len`], but accepts raw `i32` coordinates
+/// directly — used to exercise a negative pointer or length.
+fn emit_event_wat_with_raw_ptr_len(ptr: i32, len: i32) -> String {
+    format!(
+        r#"
+        (module
+            (import "traverse_host" "emit_event"
+                (func $emit_event (param i32 i32) (result i32)))
+            (import "wasi_snapshot_preview1" "fd_write"
+                (func $fd_write (param i32 i32 i32 i32) (result i32)))
+            (memory (export "memory") 1)
+            (data (i32.const 300) "{{}}")
+            (func $_start (export "_start")
+                (drop (call $emit_event (i32.const {ptr}) (i32.const {len})))
+                (i32.store (i32.const 0) (i32.const 300))
+                (i32.store (i32.const 4) (i32.const 2))
+                (drop (call $fd_write (i32.const 1) (i32.const 0) (i32.const 1) (i32.const 4100)))
+            )
+        )
+        "#,
+    )
 }
 
 /// Assert that `result` is `Err`, returning the error value or a descriptive `String` failure.

--- a/crates/traverse-runtime/tests/expedition_wasm_tests.rs
+++ b/crates/traverse-runtime/tests/expedition_wasm_tests.rs
@@ -278,8 +278,9 @@ fn expedition_wasm_execution_writes_trace() -> Result<(), String> {
             wasm_binary_path: Some(tmp_path.clone()),
             wasm_checksum: None,
             host_abi_version: None,
+            emits: Vec::new(),
+            service_type: ServiceType::Stateless,
         },
-        emitted_events: Vec::new(),
         trace_id_override: None,
     };
 
@@ -398,8 +399,9 @@ fn run_expedition_via_router(wasm_bytes: &[u8], tmp_path: &str) -> Result<Router
             wasm_binary_path: Some(tmp_path.to_string()),
             wasm_checksum: None,
             host_abi_version: None,
+            emits: Vec::new(),
+            service_type: ServiceType::Stateless,
         },
-        emitted_events: Vec::new(),
         trace_id_override: None,
     };
 

--- a/crates/traverse-runtime/tests/placement_router_live_wiring.rs
+++ b/crates/traverse-runtime/tests/placement_router_live_wiring.rs
@@ -56,57 +56,7 @@ impl LocalExecutor for EmittingNativeExecutor {
         _capability: &traverse_registry::ResolvedCapability,
         _input: &Value,
     ) -> Result<Value, LocalExecutionFailure> {
-        Ok(json!({
-            "draft_id": "draft-live-001",
-            "emitted_events": [
-                {
-                    "event_id": "dev.traverse.live.draft-created",
-                    "version": "1.0.0",
-                    "payload": {"draft_id": "draft-live-001"}
-                }
-            ]
-        }))
-    }
-}
-
-struct EmittingWasmExecutor;
-
-impl LocalExecutor for EmittingWasmExecutor {
-    fn execute(
-        &self,
-        _capability: &traverse_registry::ResolvedCapability,
-        _input: &Value,
-    ) -> Result<Value, LocalExecutionFailure> {
-        Ok(json!({
-            "draft_id": "draft-wasm-001",
-            "emitted_events": [
-                {
-                    "event_id": "dev.traverse.live.wasm-draft-created",
-                    "version": "1.0.0",
-                    "payload": {"draft_id": "draft-wasm-001"}
-                }
-            ]
-        }))
-    }
-}
-
-struct UndeclaredEventExecutor;
-
-impl LocalExecutor for UndeclaredEventExecutor {
-    fn execute(
-        &self,
-        _capability: &traverse_registry::ResolvedCapability,
-        _input: &Value,
-    ) -> Result<Value, LocalExecutionFailure> {
-        Ok(json!({
-            "draft_id": "draft-bad-001",
-            "emitted_events": [
-                {
-                    "event_id": "dev.traverse.live.undeclared",
-                    "version": "1.0.0"
-                }
-            ]
-        }))
+        Ok(json!({ "draft_id": "draft-live-001" }))
     }
 }
 
@@ -154,15 +104,6 @@ fn native_registration(event_id: &str) -> CapabilityRegistration {
     base_registration(
         "live.wiring",
         "native-subject",
-        event_id,
-        ServiceType::Subscribable,
-    )
-}
-
-fn wasm_registration(event_id: &str) -> CapabilityRegistration {
-    base_registration(
-        "live.wiring",
-        "wasm-subject",
         event_id,
         ServiceType::Subscribable,
     )
@@ -343,7 +284,16 @@ fn exact_request(capability_id: &str) -> RuntimeRequest {
 }
 
 #[test]
-fn live_native_subscribable_events_reach_event_broker_and_trace_store() {
+fn live_native_execution_completes_and_writes_trace_without_publishing_events() {
+    // `Runtime::execute`'s live path bridges the host-provided `LocalExecutor`
+    // through `BoundLocalExecutor` into `PlacementRouter`. Spec
+    // 098-capability-event-host-abi's `traverse_host::emit_event` is a
+    // WASM-only mechanism (FR-001) that a native `LocalExecutor` closure has
+    // no way to call, and the output-JSON `emitted_events` convention it
+    // used to rely on is removed (FR-004) — so a native capability can no
+    // longer emit events at all through this path. This test documents that
+    // intentional gap: execution and trace recording still succeed, but no
+    // event reaches `EventBroker` or the trace's `emitted_events`.
     let event_type = "dev.traverse.live.draft-created";
     let broker = broker_with_event(event_type);
     let subscription = broker
@@ -363,19 +313,12 @@ fn live_native_subscribable_events_reach_event_broker_and_trace_store() {
 
     let outcome = runtime.execute(exact_request("live.wiring.native-subject"));
     assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
-    assert_eq!(
-        outcome.trace.emitted_events,
-        vec![EventReference {
-            event_id: event_type.to_string(),
-            version: "1.0.0".to_string(),
-        }]
-    );
+    assert!(outcome.trace.emitted_events.is_empty());
 
     let poll = broker
         .poll(&subscription.subscription_id, 10)
         .expect("poll should succeed");
-    assert_eq!(poll.events.len(), 1);
-    assert_eq!(poll.events[0].event.event_type, event_type);
+    assert!(poll.events.is_empty());
 
     let store = trace_store.lock().expect("trace store lock");
     let entries = store.list_public(Some("live.wiring.native-subject"));
@@ -389,31 +332,6 @@ fn live_native_subscribable_events_reach_event_broker_and_trace_store() {
         lifecycle[0].event_type,
         "dev.traverse.runtime.execution.completed"
     );
-}
-
-#[test]
-fn live_wasm_subscribable_events_reach_event_broker() {
-    let event_type = "dev.traverse.live.wasm-draft-created";
-    let broker = broker_with_event(event_type);
-    let subscription = broker
-        .subscribe(event_type, "0")
-        .expect("subscribe should succeed");
-
-    let runtime = Runtime::new(
-        registry_with(wasm_registration(event_type)),
-        EmittingWasmExecutor,
-    )
-    .with_security_config(RuntimeSecurityConfig::development())
-    .with_event_broker(broker.clone());
-
-    let outcome = runtime.execute(exact_request("live.wiring.wasm-subject"));
-    assert_eq!(outcome.result.status, RuntimeResultStatus::Completed);
-
-    let poll = broker
-        .poll(&subscription.subscription_id, 10)
-        .expect("poll should succeed");
-    assert_eq!(poll.events.len(), 1);
-    assert_eq!(poll.events[0].event.event_type, event_type);
 }
 
 #[test]
@@ -462,41 +380,6 @@ fn live_executor_failure_surfaces_through_runtime() {
     assert_eq!(
         outcome.trace.execution.failure_reason,
         Some(ExecutionFailureReason::ExecutionFailed)
-    );
-}
-
-#[test]
-fn live_undeclared_event_emission_fails_and_records_trace_violation() {
-    let event_type = "dev.traverse.live.undeclared";
-    let broker = broker_with_event(event_type);
-    let trace_store = Arc::new(Mutex::new(TraceStore::new()));
-    let mut registration = native_registration("dev.traverse.live.declared-only");
-    registration.contract.emits = vec![EventReference {
-        event_id: "dev.traverse.live.declared-only".to_string(),
-        version: "1.0.0".to_string(),
-    }];
-
-    let runtime = Runtime::new(registry_with(registration), UndeclaredEventExecutor)
-        .with_security_config(RuntimeSecurityConfig::development())
-        .with_event_broker(broker)
-        .with_trace_store(Arc::clone(&trace_store));
-
-    let outcome = runtime.execute(exact_request("live.wiring.native-subject"));
-    assert_eq!(outcome.result.status, RuntimeResultStatus::Error);
-    assert_eq!(
-        outcome.result.error.as_ref().map(|error| error.code),
-        Some(RuntimeErrorCode::ContractViolation)
-    );
-
-    let store = trace_store.lock().expect("trace store lock");
-    let entries = store.list_public(Some("live.wiring.native-subject"));
-    assert_eq!(entries.len(), 1);
-    assert_eq!(entries[0].outcome, TraceOutcome::Failure);
-    assert!(
-        entries[0]
-            .violations
-            .iter()
-            .any(|violation| violation.violation_code == "undeclared_event_emission")
     );
 }
 

--- a/crates/traverse-runtime/tests/router_tests.rs
+++ b/crates/traverse-runtime/tests/router_tests.rs
@@ -16,7 +16,10 @@ use traverse_runtime::{
         EventBroker, EventCatalog, EventCatalogEntry, InProcessBroker, LifecycleStatus,
         TraverseEvent,
     },
-    executor::{ArtifactType, ExecutorCapability, NativeExecutor},
+    executor::{
+        ArtifactType, CapabilityExecutor, ExecutorCapability, ExecutorError, ExecutorOutput,
+        NativeExecutor,
+    },
     placement::{PlacementConstraintEvaluator, PlacementError, RuntimeSnapshot},
     router::{CapabilityExecutorRegistry, PlacementRouter, RouterError, RouterRequest},
     trace::TraceStore,
@@ -117,7 +120,54 @@ fn native_executor_capability(capability_id: &str) -> ExecutorCapability {
         wasm_binary_path: None,
         wasm_checksum: None,
         host_abi_version: None,
+        // Inert for these tests: `NativeExecutor` never calls the WASM-only
+        // `traverse_host::emit_event` ABI, so `emits`/`service_type` here
+        // are never consulted for validation (only `WasmExecutor` does).
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     }
+}
+
+/// A [`CapabilityExecutor`] test double that always returns pre-built
+/// `emitted_events`, standing in for events a real `WasmExecutor` would have
+/// validated and returned via `traverse_host::emit_event`
+/// (spec 098-capability-event-host-abi). Used to test `PlacementRouter`
+/// Step 5's own publish-gating logic in isolation from the ABI itself.
+struct EventEmittingExecutor {
+    output: Value,
+    emitted_events: Vec<TraverseEvent>,
+}
+
+impl CapabilityExecutor for EventEmittingExecutor {
+    fn execute(
+        &self,
+        _capability: &ExecutorCapability,
+        _input: &Value,
+    ) -> Result<ExecutorOutput, ExecutorError> {
+        Ok(ExecutorOutput {
+            value: self.output.clone(),
+            emitted_events: self.emitted_events.clone(),
+        })
+    }
+}
+
+/// Build a router with a single executor that returns `output` and
+/// `emitted_events` (already ABI-validated, per spec 098).
+fn make_router_with_emitting_executor(
+    output: Value,
+    emitted_events: Vec<TraverseEvent>,
+    trace_store: Arc<Mutex<TraceStore>>,
+    broker: Arc<dyn EventBroker>,
+) -> PlacementRouter {
+    let mut registry: CapabilityExecutorRegistry = CapabilityExecutorRegistry::new();
+    registry.insert(
+        ArtifactType::Native,
+        Box::new(EventEmittingExecutor {
+            output,
+            emitted_events,
+        }),
+    );
+    PlacementRouter::new(PlacementConstraintEvaluator, registry, trace_store, broker)
 }
 
 /// Build a minimal broker with one active event type.
@@ -192,7 +242,6 @@ fn native_capability_executes_and_writes_trace() -> Result<(), String> {
         runtime_snapshot: idle_snapshot(),
         input: json!({ "key": "value" }),
         executor_capability: native_executor_capability("router.tests.subject"),
-        emitted_events: Vec::new(),
         trace_id_override: None,
     };
 
@@ -244,7 +293,6 @@ fn placement_failure_returns_error_and_no_trace() -> Result<(), String> {
         },
         input: json!({}),
         executor_capability: native_executor_capability("router.tests.subject"),
-        emitted_events: Vec::new(),
         trace_id_override: None,
     };
 
@@ -291,7 +339,6 @@ fn missing_executor_returns_not_found_error() -> Result<(), String> {
         runtime_snapshot: idle_snapshot(),
         input: json!({}),
         executor_capability: native_executor_capability("router.tests.subject"),
-        emitted_events: Vec::new(),
         trace_id_override: None,
     };
 
@@ -307,66 +354,16 @@ fn missing_executor_returns_not_found_error() -> Result<(), String> {
 
 // ---------------------------------------------------------------------------
 // Test: Subscribable capability publishes emitted events
+//
+// The output-JSON `emitted_events` convention and PlacementRouter's
+// post-hoc `undeclared_event_emission` check are both removed (spec
+// 098-capability-event-host-abi FR-004/FR-005) — declared-emission
+// validation now happens synchronously, inside `WasmExecutor`'s
+// `traverse_host::emit_event` host function (see `executor::wasm` tests),
+// not here. These tests cover what remains PlacementRouter's own
+// responsibility: Step 5 publishes whatever `emitted_events` the executor
+// returns, gated only on `service_type == Subscribable`.
 // ---------------------------------------------------------------------------
-
-#[test]
-fn subscribable_capability_publishes_events_from_output_json() -> Result<(), String> {
-    let trace_store = Arc::new(Mutex::new(TraceStore::new()));
-    let event_type = "dev.traverse.router.test.output-emitted";
-    let broker = broker_with_event(event_type)?;
-    let sub = broker
-        .subscribe(event_type, "0")
-        .map_err(|e| e.to_string())?;
-    let broker_arc: Arc<dyn EventBroker> = broker;
-
-    let router = make_router_with_native(
-        json!({
-            "done": true,
-            "emitted_events": [
-                {
-                    "event_id": event_type,
-                    "version": "1.0.0",
-                    "payload": {"ok": true}
-                }
-            ]
-        }),
-        Arc::clone(&trace_store),
-        Arc::clone(&broker_arc),
-    );
-
-    let mut contract = base_contract(ServiceType::Subscribable);
-    contract.event_trigger = Some("dev.traverse.router.test.triggered".to_string());
-    contract.emits = vec![EventReference {
-        event_id: event_type.to_string(),
-        version: "1.0.0".to_string(),
-    }];
-
-    let request = RouterRequest {
-        capability_id: "router.tests.subject".to_string(),
-        artifact_type: ArtifactType::Native,
-        contract,
-        target_hint: Some(ExecutionTarget::Local),
-        runtime_snapshot: idle_snapshot(),
-        input: json!({}),
-        executor_capability: native_executor_capability("router.tests.subject"),
-        emitted_events: Vec::new(),
-        trace_id_override: None,
-    };
-
-    router.execute(request).map_err(|e| e.to_string())?;
-
-    let poll = broker_arc
-        .poll(&sub.subscription_id, 10)
-        .map_err(|e| e.to_string())?;
-    assert_eq!(
-        poll.events.len(),
-        1,
-        "one event must be delivered from output JSON"
-    );
-    assert_eq!(poll.events[0].event.event_type, event_type);
-
-    Ok(())
-}
 
 #[test]
 fn subscribable_capability_publishes_events() -> Result<(), String> {
@@ -380,8 +377,9 @@ fn subscribable_capability_publishes_events() -> Result<(), String> {
 
     let broker_arc: Arc<dyn EventBroker> = broker;
 
-    let router = make_router_with_native(
+    let router = make_router_with_emitting_executor(
         json!({ "done": true }),
+        vec![sample_event(event_type)],
         Arc::clone(&trace_store),
         Arc::clone(&broker_arc),
     );
@@ -402,7 +400,6 @@ fn subscribable_capability_publishes_events() -> Result<(), String> {
         runtime_snapshot: idle_snapshot(),
         input: json!({}),
         executor_capability: native_executor_capability("router.tests.subject"),
-        emitted_events: vec![sample_event(event_type)],
         trace_id_override: None,
     };
 
@@ -417,61 +414,9 @@ fn subscribable_capability_publishes_events() -> Result<(), String> {
     Ok(())
 }
 
-#[test]
-fn undeclared_event_emission_fails_execution_and_is_recorded() -> Result<(), String> {
-    let trace_store = Arc::new(Mutex::new(TraceStore::new()));
-    let event_type = "dev.traverse.router.test.undeclared";
-    let broker = broker_with_event(event_type)?;
-    let broker_arc: Arc<dyn EventBroker> = broker;
-
-    let router = make_router_with_native(
-        json!({ "done": true }),
-        Arc::clone(&trace_store),
-        Arc::clone(&broker_arc),
-    );
-
-    let mut contract = base_contract(ServiceType::Subscribable);
-    contract.event_trigger = Some("dev.traverse.router.test.triggered".to_string());
-    contract.emits = Vec::new();
-
-    let request = RouterRequest {
-        capability_id: "router.tests.subject".to_string(),
-        artifact_type: ArtifactType::Native,
-        contract,
-        target_hint: Some(ExecutionTarget::Local),
-        runtime_snapshot: idle_snapshot(),
-        input: json!({}),
-        executor_capability: native_executor_capability("router.tests.subject"),
-        emitted_events: vec![sample_event(event_type)],
-        trace_id_override: None,
-    };
-
-    let err = must_err(router.execute(request), "expected contract violation")?;
-    assert!(
-        matches!(err, RouterError::ContractViolation(_)),
-        "expected ContractViolation, got {err:?}"
-    );
-
-    let store = trace_store
-        .lock()
-        .map_err(|_| "trace store lock poisoned".to_string())?;
-    let traces = store.list_public(Some("router.tests.subject"));
-    assert!(
-        traces.iter().any(|trace| {
-            trace.outcome == traverse_runtime::trace::TraceOutcome::Failure
-                && trace
-                    .violations
-                    .iter()
-                    .any(|v| v.violation_code == "undeclared_event_emission")
-        }),
-        "expected a failure trace entry with undeclared_event_emission"
-    );
-
-    Ok(())
-}
-
 // ---------------------------------------------------------------------------
-// Test: Stateless capability does NOT publish events even if emitted_events is non-empty
+// Test: Stateless capability does NOT publish events even if the executor
+// returned some
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -486,8 +431,12 @@ fn stateless_capability_does_not_publish_events() -> Result<(), String> {
 
     let broker_arc: Arc<dyn EventBroker> = broker;
 
-    let router =
-        make_router_with_native(json!({}), Arc::clone(&trace_store), Arc::clone(&broker_arc));
+    let router = make_router_with_emitting_executor(
+        json!({}),
+        vec![sample_event(event_type)], // returned by the executor but must not be published
+        Arc::clone(&trace_store),
+        Arc::clone(&broker_arc),
+    );
 
     let request = RouterRequest {
         capability_id: "router.tests.subject".to_string(),
@@ -497,7 +446,6 @@ fn stateless_capability_does_not_publish_events() -> Result<(), String> {
         runtime_snapshot: idle_snapshot(),
         input: json!({}),
         executor_capability: native_executor_capability("router.tests.subject"),
-        emitted_events: vec![sample_event(event_type)], // provided but must not be published
         trace_id_override: None,
     };
 
@@ -573,7 +521,6 @@ fn executor_error_returns_execution_failed() -> Result<(), String> {
         runtime_snapshot: idle_snapshot(),
         input: json!({}),
         executor_capability: native_executor_capability("router.tests.subject"),
-        emitted_events: Vec::new(),
         trace_id_override: None,
     };
 

--- a/crates/traverse-runtime/tests/thread_pool_integration.rs
+++ b/crates/traverse-runtime/tests/thread_pool_integration.rs
@@ -122,6 +122,8 @@ fn executor_cap(artifact_type: ArtifactType) -> ExecutorCapability {
         wasm_binary_path: None,
         wasm_checksum: None,
         host_abi_version: None,
+        emits: Vec::new(),
+        service_type: ServiceType::Stateless,
     }
 }
 
@@ -157,7 +159,6 @@ fn make_request(input: Value) -> RouterRequest {
         runtime_snapshot: idle_snapshot(),
         input,
         executor_capability: executor_cap(ArtifactType::Native),
-        emitted_events: Vec::new(),
         trace_id_override: None,
     }
 }

--- a/crates/traverse-runtime/tests/thread_pool_stress.rs
+++ b/crates/traverse-runtime/tests/thread_pool_stress.rs
@@ -26,6 +26,8 @@ fn native_capability() -> ExecutorCapability {
         wasm_binary_path: None,
         wasm_checksum: None,
         host_abi_version: None,
+        emits: Vec::new(),
+        service_type: traverse_contracts::ServiceType::Stateless,
     }
 }
 
@@ -40,7 +42,9 @@ fn executor(
 }
 
 fn execute(executor: &ThreadPoolExecutor, input: &Value) -> Result<Value, ExecutorError> {
-    executor.execute(&native_capability(), input)
+    executor
+        .execute(&native_capability(), input)
+        .map(|output| output.value)
 }
 
 fn lock_errors(errors: &Mutex<Vec<String>>) -> std::sync::MutexGuard<'_, Vec<String>> {

--- a/docs/capability-contract-authoring-guide.md
+++ b/docs/capability-contract-authoring-guide.md
@@ -286,7 +286,7 @@ The following is the smallest valid `contract.json` you can author. Every field 
 
 ### `emits` and `consumes` — connecting to event contracts
 
-The `emits` array declares which events this capability may publish via `broker.publish()` at runtime. The runtime validates that the emitted event type is declared here; publishing an undeclared event type causes an `EventError::PolicyViolation`.
+The `emits` array declares which events this capability may publish at runtime via the `traverse_host::emit_event` WASM host function (spec `098-capability-event-host-abi`). The host validates the emitted `event_id`/`version` against this list synchronously, at call time — an undeclared emission is rejected immediately, before execution completes, not discovered afterward. Only capabilities whose `service_type` is `Subscribable` may call the host function at all; any other `service_type` is rejected regardless of payload.
 
 ```json
 "emits": ["examples.hello-world.greeted"],

--- a/docs/event-contract-authoring-guide.md
+++ b/docs/event-contract-authoring-guide.md
@@ -257,22 +257,19 @@ The capability contract at `contracts/examples/expedition/capabilities/capture-e
     "version": "1.0.0"
   }
 ]
-The `emits` declaration in the capability contract is authoritative. The runtime broker constrains what `broker.publish()` may emit: **if an event type is not registered in the catalog as `Active`, `broker.publish` returns `EventError::LifecycleViolation` and the event is not delivered.**
+The `emits` declaration in the capability contract is authoritative. The host validates a capability's emissions against it synchronously, at call time (spec `098-capability-event-host-abi` FR-002) — an undeclared emission is rejected immediately, not discovered after execution completes.
 ### 2. Runtime emission
-The emitting capability registers the event type in an `EventCatalog` with `LifecycleStatus::Active`, then publishes through the `InProcessBroker`:
+The capability itself never calls `broker.publish()` directly — that is host-owned infrastructure (`PlacementRouter` Step 5). Instead, a `Subscribable` capability calls the `traverse_host::emit_event` WASM host function during its own execution, passing a pointer/length into its own linear memory holding a JSON payload shaped `{"event_id": "...", "version": "...", "payload": {...}}`:
 ```rust
-catalog.register(EventCatalogEntry {
-    event_type: "expedition.planning.expedition-objective-captured".to_owned(),
-    owner: "expedition.planning.capture-expedition-objective".to_owned(),
-    version: "1.0.0".to_owned(),
-    lifecycle_status: LifecycleStatus::Active,
-    consumer_count: 0,
-})?;
-let broker = InProcessBroker::new(catalog);
-broker.publish(TraverseEvent {
-    event_type: "expedition.planning.expedition-objective-captured".to_owned(),
-    // ... other fields matching the contract payload schema
-})?;
+// Guest-side (compiled to wasm32-wasip1): write the payload into linear
+// memory, then call the host import.
+let payload = br#"{"event_id":"expedition.planning.expedition-objective-captured","version":"1.0.0","payload":{"objective_id":"obj-1"}}"#;
+let status = unsafe { traverse_host::emit_event(payload.as_ptr() as i32, payload.len() as i32) };
+// status == 0 on acceptance; a negative code identifies why the host
+// rejected the call (undeclared event type, non-Subscribable service_type,
+// or a malformed/oversized/out-of-bounds payload).
+```
+The host validates the call (declared-emission check, `service_type == Subscribable`, and guest-memory bounds), and only accepted events are later published to `EventBroker`. The event type must still be registered in the `EventCatalog` as `Active` — the host's internal `EventBroker::publish` call at the end of execution returns `EventError::LifecycleViolation` for a type that is not.
 ### 3. Subscriber registration
 A downstream capability subscribes before the event is emitted:
 ```rust

--- a/docs/event-publishing-tutorial.md
+++ b/docs/event-publishing-tutorial.md
@@ -164,55 +164,43 @@ Use one catalog instance per runtime session and share it through `Arc<EventCata
 
 ## Step 3: Emit an event from a capability
 
-Once the catalog is set up, create an `InProcessBroker` and publish from the emitting capability.
+A capability never calls `broker.publish()` directly — publishing is host-owned infrastructure (`PlacementRouter` Step 5). Instead, a `Subscribable` capability calls the `traverse_host::emit_event` WASM host function during its own execution (spec `098-capability-event-host-abi`), passing a pointer/length into its own linear memory holding a JSON payload:
 
 ```rust
-use serde_json::json;
-use traverse_runtime::events::{
-    EventBroker, InProcessBroker, LifecycleStatus, TraverseEvent,
-};
-
-fn emit_objective_captured(
-    broker: &impl EventBroker,
-    objective_id: &str,
-) -> Result<(), traverse_runtime::events::EventError> {
-    let event = TraverseEvent {
-        id: uuid::Uuid::new_v4().to_string(),
-        source: "traverse-runtime/expedition.planning.capture-expedition-objective".to_owned(),
-        event_type: "expedition.planning.expedition-objective-captured".to_owned(),
-        datacontenttype: "application/json".to_owned(),
-        time: chrono::Utc::now().to_rfc3339(),
-        data: json!({
-            "objective_id": objective_id,
-            "destination": "Mont Blanc",
-            "target_window": {
-                "start": "2026-07-01T00:00:00Z",
-                "end": "2026-07-14T00:00:00Z"
-            },
-            "preferences": {
-                "style": "alpine",
-                "risk_tolerance": "moderate",
-                "priority": "summit"
-            },
-            "notes": "acclimatization days required"
-        }),
-        owner: "expedition.planning.capture-expedition-objective".to_owned(),
-        version: "1.0.0".to_owned(),
-        lifecycle_status: LifecycleStatus::Active,
-    };
-
-    broker.publish(event)
-}
+// Guest-side (compiled to wasm32-wasip1)
+let payload = serde_json::json!({
+    "event_id": "expedition.planning.expedition-objective-captured",
+    "version": "1.0.0",
+    "payload": {
+        "objective_id": objective_id,
+        "destination": "Mont Blanc",
+        "target_window": {
+            "start": "2026-07-01T00:00:00Z",
+            "end": "2026-07-14T00:00:00Z"
+        },
+        "preferences": {
+            "style": "alpine",
+            "risk_tolerance": "moderate",
+            "priority": "summit"
+        },
+        "notes": "acclimatization days required"
+    }
+});
+let bytes = serde_json::to_vec(&payload).expect("payload must serialize");
+let status = unsafe { traverse_host::emit_event(bytes.as_ptr() as i32, bytes.len() as i32) };
 ```
 
-What happens inside `InProcessBroker::publish`:
+What the host does inside `traverse_host::emit_event`, synchronously, before returning a status code to the guest:
 
-1. The broker looks up `event_type` in the catalog. If the type is not registered, it returns `EventError::UnregisteredEventType`.
-2. If the catalog entry is `Draft` or `Deprecated`, it returns `EventError::LifecycleViolation`.
-3. If the entry is `Active`, the broker calls every registered subscriber handler synchronously on the caller's thread.
-4. Returns `Ok(())` when all handlers have been called.
+1. Rejects the call if the capability's `service_type` is not `Subscribable` — checked before any guest memory is read (FR-003).
+2. Validates the guest-supplied pointer/length against guest linear memory bounds and a maximum payload size, rejecting an out-of-bounds or oversized claim without ever panicking, trapping, or reading past guest memory (FR-008).
+3. Parses the payload as JSON and rejects it if `event_id`/`version` are missing or the bytes aren't valid JSON.
+4. Rejects the call if `event_id`/`version` is not declared in the capability contract's `emits` list (FR-002).
+5. Otherwise accepts the event, to be published to `EventBroker` by `PlacementRouter` Step 5 once execution completes.
 
-The payload in `data` must conform to the `payload.schema` in the contract. The broker does not re-validate the schema at runtime, but downstream registry and CI tools do.
+`EventBroker::publish` (called internally by Step 5, not by capability code) still enforces catalog lifecycle: an event type that is not registered as `Active` returns `EventError::UnregisteredEventType`/`EventError::LifecycleViolation` and the event is not delivered — this is a best-effort publish, so a broker error here does not fail the capability's own execution.
+
+The payload in `data` must conform to the `payload.schema` in the contract. The host does not re-validate the schema at runtime, but downstream registry and CI tools do.
 
 ---
 
@@ -378,16 +366,17 @@ The `emits` and `consumes` fields in a capability contract are the governance br
 ```
 This declares that this capability _may_ publish the `examples.hello-world.greeted` event. It is a promise to the registry.
 
-**2. Runtime emission** — inside the WASM binary or native executor:
+**2. Runtime emission** — inside the WASM binary, via the `traverse_host::emit_event` host function (spec `098-capability-event-host-abi`), never by calling `broker.publish()` directly:
 ```rust
-let event = TraverseEvent {
-    event_type: "examples.hello-world.greeted".to_string(),
-    payload: serde_json::json!({ "subject": "Alice", "greeting": "Hello, Alice!" }),
-    // ...
-};
-broker.publish(event)?;
+let payload = serde_json::json!({
+    "event_id": "examples.hello-world.greeted",
+    "version": "1.0.0",
+    "payload": { "subject": "Alice", "greeting": "Hello, Alice!" }
+});
+let bytes = serde_json::to_vec(&payload).expect("payload must serialize");
+let status = unsafe { traverse_host::emit_event(bytes.as_ptr() as i32, bytes.len() as i32) };
 ```
-At runtime, `broker.publish()` checks the active event catalog. If `examples.hello-world.greeted` is not registered in the catalog, it returns `EventError::UnknownEventType`. If it _is_ registered but the capability contract does not declare it in `emits`, it returns `EventError::PolicyViolation`.
+The host validates this call synchronously, at call time: the capability's `service_type` must be `Subscribable`, the guest pointer/length must be in bounds and under the payload size cap, the bytes must parse as JSON with `event_id`/`version`, and `event_id`/`version` must appear in the capability contract's `emits` list — an undeclared emission is rejected immediately (a negative status code), not discovered afterward. Only accepted events are later published to `EventBroker` by `PlacementRouter` Step 5, where catalog lifecycle is enforced (an unregistered or non-`Active` type is dropped there, logged, not delivered).
 
 **3. Subscriber registration** — a downstream capability or handler:
 ```rust
@@ -403,9 +392,10 @@ Subscribers are registered before execution begins. The runtime delivers publish
 |-------|------------|
 | Bundle registration | `emits` event IDs must exist in the event catalog |
 | Contract parse | `emits` and `consumes` must be valid event contract ID strings |
-| `broker.publish()` | Event type must be in catalog AND declared in capability's `emits` |
+| `traverse_host::emit_event` | `service_type == Subscribable`, guest-memory bounds, payload size, and declared `emits` — all synchronous, at call time |
+| `EventBroker::publish` (Step 5) | Event type must be registered in the catalog as `Active`; failures are logged, not fatal to the capability |
 | Subscription | No validation — subscribers are registered independently |
 
-### Common mistake: publishing without declaring
+### Common mistake: emitting without declaring
 
-If your capability calls `broker.publish("my.event")` but the contract does not list `"my.event"` in `emits`, the runtime returns `EventError::PolicyViolation`. Always keep `emits` in the contract in sync with `broker.publish()` calls in the implementation.
+If your capability calls `traverse_host::emit_event` for an event type the contract does not list in `emits`, the host rejects the call with a negative status code before the event ever reaches `EventBroker`. Always keep `emits` in the contract in sync with the event types your capability's WASM binary actually emits.


### PR DESCRIPTION
## Governing Spec

- `098-capability-event-host-abi`
- `006-runtime-request-execution`
- `070-runtime-event-sink-boundary`

[098-capability-event-host-abi](specs/969-capability-event-host-abi/spec.md) v1.1.0 (authored in #969, ADR-0035), extending `002-capability-contracts`, `003-event-contracts`, `207-event-broker`. `006-runtime-request-execution` and `070-runtime-event-sink-boundary` are declared alongside it purely to satisfy the spec-alignment gate's blanket coverage of `crates/traverse-runtime/` and `docs/` respectively — this PR's actual scope is 098 end to end; the other two are broad umbrella specs, not additional requirements this PR implements.

## Project Item

Closes #970.

## Summary

Implements a WASM host-function ABI (`traverse_host::emit_event`) that lets a `Subscribable` capability imperatively publish an event during its own execution, replacing the output-JSON `emitted_events` convention and `PlacementRouter` Step 3.5's post-hoc validation.

- **`crates/traverse-runtime/src/executor/wasm.rs`**: new `traverse_host::emit_event(ptr, len) -> i32` host function, registered via `wasmtime::Linker::func_wrap` (the first host-function implementation in this crate's wasmtime linker). Validates, in order: `service_type == Subscribable` (before touching guest memory), guest-memory bounds + a 64 KiB payload cap via `wasmtime::Memory::read` (`Result`-based, never panics/traps), JSON parse + `event_id`/`version` presence, then the declared-`emits` check — returning a negative status code to the guest on any rejection, `0` on acceptance.
- **`CapabilityExecutor::execute`** (`executor/mod.rs`) now returns a new `ExecutorOutput { value, emitted_events }` instead of a bare `Value`, so ABI-validated events flow out of `WasmExecutor` to `PlacementRouter` as structured data instead of embedded JSON. `NativeExecutor`/`ThreadPoolExecutor` always return an empty `emitted_events` — the ABI is WASM-only.
- **`PlacementRouter`** (`router/mod.rs`): Step 3.5's `undeclared_event_emission` check and `extract_emitted_events_from_output` are removed; Step 5 now publishes directly from the executor's `ExecutorOutput.emitted_events`. `RouterResponse` gained an `emitted_events` field so callers (e.g. `Runtime::execute`'s trace recording) no longer need to re-parse the output JSON either — removed the third, now-redundant `event_references_from_output` parser in `lib.rs`.
- **`ExecutorCapability`** gained `emits`/`service_type` fields so `WasmExecutor` has what it needs to validate synchronously, at call time.
- **`host_abi_v1.json`**: added the `traverse_host::emit_event` whitelist entry (category `event_publish`).

## Definition of Done

Happy path:
- [x] New host-function import, whitelisted like existing `traverse_*` bridge functions (FR-001) — `host_abi_v1.json`
- [x] Undeclared emission rejected synchronously, at call time (FR-002) — `wasm_executor_emit_event_rejected_for_undeclared_event_type`
- [x] Non-`Subscribable` capability rejected regardless of payload (FR-003) — `wasm_executor_emit_event_rejected_for_non_subscribable_capability`
- [x] Output-JSON `emitted_events` convention removed, not kept as a second path (FR-004) — all three parsers deleted (`router/mod.rs`, `lib.rs`, and workflow-internal usage is untouched/out of scope, see Notes)
- [x] `PlacementRouter` Step 3.5 removed; Step 5 still publishes (FR-005) — `router/mod.rs`
- [x] Existing fixtures/tests migrated off the output-JSON convention (FR-006) — `router_tests.rs`, `placement_router_live_wiring.rs`, `expedition_wasm_tests.rs`, `thread_pool_integration.rs`, `thread_pool_stress.rs`, `executor_tests.rs`
- [x] Whitelist entry documented alongside existing ABI entries (FR-007) — `host_abi_v1.json` + doc comment on `handle_emit_event`

Unhappy paths (spec v1.1.0 FR-002/FR-003/FR-008):
- [x] Undeclared event type/version rejected synchronously (FR-002) — see above
- [x] Non-`Subscribable` `service_type` rejected regardless of payload (FR-003) — see above
- [x] Out-of-bounds/oversized guest pointer rejected without panic/trap/OOB read (FR-008) — `wasm_executor_emit_event_rejected_for_oversized_payload`, `wasm_executor_emit_event_rejected_for_out_of_bounds_pointer`, `wasm_executor_emit_event_rejected_for_malformed_json_payload`

## Validation

- [x] `cargo test --workspace` — all crates green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body <this file>` — coverage gate + spec-alignment for every crate

## Notes

- **Scope boundary**: this ticket is WASM-only per spec 098's Capability Boundary. Two pre-existing execution paths bridge through the `LocalExecutor` trait (`ArtifactRouter`, used by workflow-internal node execution; and `BoundLocalExecutor`, used by `Runtime::execute`'s live wiring for host-provided native closures) — neither can surface `ExecutorOutput.emitted_events` today, since `LocalExecutor::execute` only returns a bare `Value`. This is a real, pre-existing gap distinct from what this ticket changes (before this PR, the same paths only "worked" for native capabilities by accident, because the old JSON convention rode along inside the output value itself, transparent to any bridge). Extending `LocalExecutor` to close this gap is a much larger, separate architectural change and is out of scope here; three tests (`bound_local_executor_never_publishes_events_through_placement_router` in `lib.rs`, `live_native_execution_completes_and_writes_trace_without_publishing_events` in `placement_router_live_wiring.rs`) now explicitly document the gap rather than silently regressing coverage. Flagging as a follow-up.
- Rebased onto `main` after #977 (SSE→EventBroker migration, unrelated files) merged mid-implementation — clean, no conflicts.
