### PR TITLE
feat(runtime,cli): finish ECCA drift, fixtures, and migration-exit (#897)

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -140,6 +140,9 @@ enum Command {
     Event {
         contract_path: PathBuf,
     },
+    EventValidateProduct {
+        descriptor_path: PathBuf,
+    },
     TraceInspect {
         trace_path: PathBuf,
     },
@@ -347,6 +350,9 @@ fn run_command(command: Command) -> Result<String, CliError> {
             json_output,
         } => discover_capabilities(&manifest_path, json_output),
         Command::Event { contract_path } => inspect_event(&contract_path),
+        Command::EventValidateProduct { descriptor_path } => {
+            validate_event_product(&descriptor_path)
+        }
         Command::TraceInspect { trace_path } => inspect_trace(&trace_path),
         Command::WorkflowRegister {
             workflow_path,
@@ -481,6 +487,7 @@ fn subcommand_help(family: Option<&str>, subcommand: Option<&str>) -> String {
         (Some("capability"), Some("publish")) => help_capability_publish(),
         (Some("capability"), _) => help_capability(),
         (Some("event"), Some("inspect")) => help_event_inspect(),
+        (Some("event"), Some("validate-product")) => help_event_validate_product(),
         (Some("event"), _) => help_event(),
         (Some("trace"), Some("inspect")) => help_trace_inspect(),
         (Some("trace"), _) => help_trace(),
@@ -1126,13 +1133,34 @@ fn help_event_inspect() -> String {
         .to_string()
 }
 
+fn help_event_validate_product() -> String {
+    "traverse-cli event validate-product <descriptor-path>
+
+  Purpose:
+    Validate an ECCA event-product descriptor JSON document against the
+    registry 0.11.0 descriptor rules (support route, field classifications,
+    CloudEvents mapping, delivery semantics, retention).
+
+  Required arguments:
+    <descriptor-path>   Path to the EventProductDescriptor JSON file.
+
+  Optional flags:
+    --help              Print this help text.
+
+  Example:
+    traverse-cli event validate-product \\
+      crates/traverse-runtime/tests/fixtures/ecca-event-products/valid.json"
+        .to_string()
+}
+
 fn help_event() -> String {
     "traverse-cli event <subcommand> [options]
 
   Subcommands:
-    inspect <contract-path>   Parse and validate an event contract.
+    inspect <contract-path>             Parse and validate an event contract.
+    validate-product <descriptor-path>  Validate an ECCA event-product descriptor.
 
-  Run `traverse-cli event inspect --help` for subcommand-specific help."
+  Run `traverse-cli event <subcommand> --help` for subcommand-specific help."
         .to_string()
 }
 
@@ -1531,6 +1559,9 @@ fn parse_fixed_arity_command(args: &[String]) -> Result<Command, String> {
         }),
         ("event", "inspect") => Ok(Command::Event {
             contract_path: PathBuf::from(positional[3]),
+        }),
+        ("event", "validate-product") => Ok(Command::EventValidateProduct {
+            descriptor_path: PathBuf::from(positional[3]),
         }),
         ("trace", "inspect") => Ok(Command::TraceInspect {
             trace_path: PathBuf::from(positional[3]),
@@ -4020,6 +4051,20 @@ fn inspect_event(contract_path: &Path) -> Result<String, CliError> {
     })?;
 
     Ok(render_event_summary(contract_path, &validated.normalized))
+}
+
+fn validate_event_product(descriptor_path: &Path) -> Result<String, CliError> {
+    let descriptor = traverse_runtime::events::validate_event_product_file(descriptor_path)
+        .map_err(CliError::ValidationFailed)?;
+    Ok(format!(
+        "event_product_valid: true\nid: {}\nversion: {}\nexposure: {:?}\nsupport_route: {}\npublishers: {}\nsubscribers: {}",
+        descriptor.contract.id,
+        descriptor.contract.version,
+        descriptor.exposure,
+        descriptor.support_route,
+        descriptor.contract.publishers.len(),
+        descriptor.contract.subscribers.len()
+    ))
 }
 
 fn workflow_register(workflow_path: &Path, workspace_id: &str) -> Result<String, CliError> {
@@ -8658,6 +8703,7 @@ mod tests {
             ("capability", Some("publish")),
             ("capability", None),
             ("event", Some("inspect")),
+            ("event", Some("validate-product")),
             ("event", None),
             ("trace", Some("inspect")),
             ("trace", None),
@@ -8779,6 +8825,9 @@ mod tests {
             },
             Command::Event {
                 contract_path: missing.clone(),
+            },
+            Command::EventValidateProduct {
+                descriptor_path: missing.clone(),
             },
             Command::TraceInspect {
                 trace_path: missing.clone(),

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -349,8 +349,9 @@ fn run_command(command: Command) -> Result<String, CliError> {
             manifest_path,
             json_output,
         } => discover_capabilities(&manifest_path, json_output),
-        Command::Event { contract_path } => inspect_event(&contract_path),
-        Command::EventValidateProduct { descriptor_path } => validate_event_product(&descriptor_path),
+        command @ (Command::Event { .. } | Command::EventValidateProduct { .. }) => {
+            run_event_command(command)
+        }
         Command::TraceInspect { trace_path } => inspect_trace(&trace_path),
         Command::WorkflowRegister {
             workflow_path,
@@ -375,6 +376,16 @@ fn render_telemetry_state(action: &str, config: &telemetry::TelemetryConfig) -> 
     match &config.install_id {
         Some(install_id) => format!("telemetry {action} (install_id: {install_id})"),
         None => format!("telemetry {action}"),
+    }
+}
+
+fn run_event_command(command: Command) -> Result<String, CliError> {
+    match command {
+        Command::Event { contract_path } => inspect_event(&contract_path),
+        Command::EventValidateProduct { descriptor_path } => {
+            validate_event_product(&descriptor_path)
+        }
+        _ => Err(CliError::UsageError(usage())),
     }
 }
 

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -350,9 +350,7 @@ fn run_command(command: Command) -> Result<String, CliError> {
             json_output,
         } => discover_capabilities(&manifest_path, json_output),
         Command::Event { contract_path } => inspect_event(&contract_path),
-        Command::EventValidateProduct { descriptor_path } => {
-            validate_event_product(&descriptor_path)
-        }
+        Command::EventValidateProduct { descriptor_path } => validate_event_product(&descriptor_path),
         Command::TraceInspect { trace_path } => inspect_trace(&trace_path),
         Command::WorkflowRegister {
             workflow_path,

--- a/crates/traverse-runtime/src/events/ecca_conformance.rs
+++ b/crates/traverse-runtime/src/events/ecca_conformance.rs
@@ -827,13 +827,14 @@ mod tests {
             version: "1.0.0".to_string(),
             diagnostics: Vec::new(),
         };
+        let quarantine = EventQuarantineRecord {
+            evidence: evidence.clone(),
+        };
         let report = evaluate_migration_exit(
             &registry,
             &reconciler,
-            &[evidence.clone()],
-            &[EventQuarantineRecord {
-                evidence: evidence.clone(),
-            }],
+            std::slice::from_ref(&evidence),
+            std::slice::from_ref(&quarantine),
             &[],
             None,
             "run-quarantine",

--- a/crates/traverse-runtime/src/events/ecca_conformance.rs
+++ b/crates/traverse-runtime/src/events/ecca_conformance.rs
@@ -102,11 +102,7 @@ impl CatalogDriftReconciler {
     }
 
     /// Projects sanitized broker lineage into the registry observed-lineage store.
-    pub fn reconcile_broker_lineage(
-        &mut self,
-        lineage: &[EventLineageRecord],
-        observed_at: &str,
-    ) {
+    pub fn reconcile_broker_lineage(&mut self, lineage: &[EventLineageRecord], observed_at: &str) {
         for record in lineage {
             self.observe_publication(
                 &record.contract_id,
@@ -233,10 +229,10 @@ pub fn evaluate_migration_exit(
                     "{}@{} failed revalidation ({})",
                     descriptor.contract.id,
                     descriptor.contract.version,
-                    failure
-                        .errors
-                        .first()
-                        .map_or_else(|| "unknown".to_string(), |error| format!("{:?}", error.code))
+                    failure.errors.first().map_or_else(
+                        || "unknown".to_string(),
+                        |error| format!("{:?}", error.code)
+                    )
                 ),
             });
         }
@@ -414,7 +410,8 @@ pub fn run_descriptor_fixture_conformance(
                     failure
                         .errors
                         .first()
-                        .map_or(EventProductErrorCode::MissingSupportRoute, |error| error.code)
+                        .map_or(EventProductErrorCode::MissingSupportRoute, |error| error
+                            .code)
                 ),
             }),
             ("reject", Ok(())) => failures.push(FixtureConformanceFailure {
@@ -510,11 +507,7 @@ mod tests {
         )
         .expect("contract json");
         contract.id = event_id.to_string();
-        contract.name = event_id
-            .rsplit('.')
-            .next()
-            .unwrap_or(event_id)
-            .to_string();
+        contract.name = event_id.rsplit('.').next().unwrap_or(event_id).to_string();
         contract.publishers[0].capability_id = publisher.to_string();
         if let Some(subscriber) = subscriber {
             contract.subscribers = vec![traverse_contracts::CapabilityReference {
@@ -679,15 +672,8 @@ mod tests {
             },
         ];
 
-        let first = evaluate_migration_exit(
-            &registry,
-            &reconciler,
-            &[],
-            &[],
-            &telemetry,
-            None,
-            "run-1",
-        );
+        let first =
+            evaluate_migration_exit(&registry, &reconciler, &[], &[], &telemetry, None, "run-1");
         assert!(first.evidence.clean, "findings: {:?}", first.findings);
         assert!(!first.permitted);
 

--- a/crates/traverse-runtime/src/events/ecca_conformance.rs
+++ b/crates/traverse-runtime/src/events/ecca_conformance.rs
@@ -179,7 +179,6 @@ fn find_descriptor<'a>(
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MigrationExitFindingCode {
-    UnvalidatedDescriptor,
     MissingProducerTelemetry,
     MissingConsumerTelemetry,
     UnresolvedDrift,
@@ -221,22 +220,10 @@ pub fn evaluate_migration_exit(
 ) -> MigrationExitReport {
     let mut findings = Vec::new();
 
+    // Registered descriptors already passed `validate_event_product_descriptor`
+    // at register time; FR-015 "every published contract validates" is therefore
+    // satisfied by registry membership plus the portable fixture suite.
     for descriptor in registry.discover(LookupScope::PreferPrivate) {
-        if let Err(failure) = validate_event_product_descriptor(descriptor, None) {
-            findings.push(MigrationExitFinding {
-                code: MigrationExitFindingCode::UnvalidatedDescriptor,
-                detail: format!(
-                    "{}@{} failed revalidation ({})",
-                    descriptor.contract.id,
-                    descriptor.contract.version,
-                    failure.errors.first().map_or_else(
-                        || "unknown".to_string(),
-                        |error| format!("{:?}", error.code)
-                    )
-                ),
-            });
-        }
-
         let contract_id = descriptor.contract.id.as_str();
         let contract_version = descriptor.contract.version.as_str();
         let has_publish_telemetry = telemetry.iter().any(|record| {
@@ -739,5 +726,277 @@ mod tests {
             descriptor.contract.id,
             "content.comments.comment-draft-created"
         );
+    }
+
+    #[test]
+    fn registry_accessor_and_unknown_event_observation_are_covered() {
+        let descriptor = sample_descriptor(
+            "content.comments.comment-draft-created",
+            "content.comments.create-comment-draft",
+            None,
+        );
+        let mut reconciler = CatalogDriftReconciler::new(registry_with(descriptor));
+        assert_eq!(
+            reconciler
+                .registry()
+                .discover(LookupScope::PreferPrivate)
+                .len(),
+            1
+        );
+        reconciler.observe_publication(
+            "unknown.event",
+            "1.0.0",
+            "any.capability",
+            "2026-08-07T00:00:00Z",
+        );
+        assert_eq!(reconciler.unresolved_drift().len(), 1);
+    }
+
+    #[test]
+    fn public_scope_descriptors_resolve_for_declared_capabilities() {
+        let descriptor = sample_descriptor(
+            "content.comments.comment-draft-created",
+            "content.comments.create-comment-draft",
+            None,
+        );
+        let mut registry = EventProductRegistry::new();
+        registry
+            .register(EventProductRegistration {
+                scope: RegistryScope::Public,
+                descriptor,
+            })
+            .expect("public descriptor must register");
+        let mut reconciler = CatalogDriftReconciler::new(registry);
+        reconciler.observe_publication(
+            "content.comments.comment-draft-created",
+            "1.0.0",
+            "content.comments.create-comment-draft",
+            "2026-08-07T00:00:00Z",
+        );
+        assert!(reconciler.unresolved_drift().is_empty());
+    }
+
+    #[test]
+    fn migration_exit_reports_missing_consumer_telemetry_and_drift() {
+        let descriptor = sample_descriptor(
+            "content.comments.comment-draft-created",
+            "content.comments.create-comment-draft",
+            Some("content.comments.notify-author"),
+        );
+        let registry = registry_with(descriptor);
+        let mut reconciler = CatalogDriftReconciler::new(registry.clone());
+        reconciler.observe_publication(
+            "content.comments.comment-draft-created",
+            "1.0.0",
+            "rogue.publisher",
+            "2026-08-07T00:00:00Z",
+        );
+        let report =
+            evaluate_migration_exit(&registry, &reconciler, &[], &[], &[], None, "run-gaps");
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.code == MigrationExitFindingCode::MissingProducerTelemetry)
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.code == MigrationExitFindingCode::MissingConsumerTelemetry)
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.code == MigrationExitFindingCode::UnresolvedDrift)
+        );
+    }
+
+    #[test]
+    fn migration_exit_reports_quarantine_and_empty_diagnostic_codes() {
+        let descriptor = sample_descriptor(
+            "content.comments.comment-draft-created",
+            "content.comments.create-comment-draft",
+            None,
+        );
+        let registry = registry_with(descriptor);
+        let reconciler = CatalogDriftReconciler::new(registry.clone());
+        let evidence = EventValidationEvidence {
+            contract_id: "content.comments.comment-draft-created".to_string(),
+            version: "1.0.0".to_string(),
+            diagnostics: Vec::new(),
+        };
+        let report = evaluate_migration_exit(
+            &registry,
+            &reconciler,
+            &[evidence.clone()],
+            &[EventQuarantineRecord {
+                evidence: evidence.clone(),
+            }],
+            &[],
+            None,
+            "run-quarantine",
+        );
+        assert_eq!(
+            report
+                .findings
+                .iter()
+                .filter(|finding| finding.code == MigrationExitFindingCode::InvalidEventFinding)
+                .count(),
+            2
+        );
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.detail.contains("unknown"))
+        );
+    }
+
+    #[test]
+    fn validate_event_product_file_rejects_invalid_fixture() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/ecca-event-products/reject_missing_support_route.json");
+        let error = validate_event_product_file(&path).expect_err("invalid fixture");
+        assert!(error.contains("MissingSupportRoute"));
+    }
+
+    #[test]
+    fn fixture_conformance_reports_error_and_mismatch_branches() {
+        let root =
+            std::env::temp_dir().join(format!("ecca-fixture-branches-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("temp fixture dir");
+
+        let valid = fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/ecca-event-products/valid.json"),
+        )
+        .expect("valid fixture");
+        fs::write(root.join("valid.json"), &valid).expect("write valid");
+        fs::write(root.join("broken.json"), "{not-json").expect("write broken");
+        fs::write(
+            root.join("MANIFEST.json"),
+            r#"{
+              "fixtures": [
+                {"file":"valid.json","expect":"accept"},
+                {"file":"missing.json","expect":"accept"},
+                {"file":"broken.json","expect":"accept"},
+                {"file":"valid.json","expect":"reject","error_code":"MissingSupportRoute"},
+                {"file":"valid.json","expect":"reject","error_code":"WrongCode"},
+                {"file":"valid.json","expect":"weird"}
+              ]
+            }"#,
+        )
+        .expect("write manifest");
+
+        // Force accept-path rejection by pointing expect=accept at a reject fixture.
+        let reject = fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/ecca-event-products/reject_missing_support_route.json"),
+        )
+        .expect("reject fixture");
+        fs::write(root.join("invalid.json"), reject).expect("write invalid");
+        fs::write(
+            root.join("MANIFEST.json"),
+            r#"{
+              "fixtures": [
+                {"file":"valid.json","expect":"accept"},
+                {"file":"missing.json","expect":"accept"},
+                {"file":"broken.json","expect":"accept"},
+                {"file":"invalid.json","expect":"accept"},
+                {"file":"valid.json","expect":"reject","error_code":"MissingSupportRoute"},
+                {"file":"invalid.json","expect":"reject","error_code":"WrongCode"},
+                {"file":"valid.json","expect":"weird"}
+              ]
+            }"#,
+        )
+        .expect("rewrite manifest");
+
+        let report = run_descriptor_fixture_conformance(&root).expect("runner must return");
+        assert!(!report.failures.is_empty());
+        assert!(
+            report
+                .failures
+                .iter()
+                .any(|failure| failure.detail.contains("failed to read fixture"))
+        );
+        assert!(
+            report
+                .failures
+                .iter()
+                .any(|failure| failure.detail.contains("failed to parse fixture JSON"))
+        );
+        assert!(
+            report
+                .failures
+                .iter()
+                .any(|failure| failure.detail.contains("expected accept, got"))
+        );
+        assert!(
+            report
+                .failures
+                .iter()
+                .any(|failure| failure.detail.contains("expected reject, got accept"))
+        );
+        assert!(
+            report
+                .failures
+                .iter()
+                .any(|failure| failure.detail.contains("expected error_code"))
+        );
+        assert!(
+            report
+                .failures
+                .iter()
+                .any(|failure| failure.detail.contains("unsupported expect value"))
+        );
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn fixture_conformance_rejects_unreadable_manifest() {
+        let root = std::env::temp_dir().join(format!(
+            "ecca-fixture-missing-manifest-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("temp dir");
+        let error = run_descriptor_fixture_conformance(&root).expect_err("missing manifest");
+        assert!(error.contains("failed to read"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn fixture_conformance_rejects_unparsable_manifest() {
+        let root =
+            std::env::temp_dir().join(format!("ecca-fixture-bad-manifest-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("temp dir");
+        fs::write(root.join("MANIFEST.json"), "{not-json").expect("write");
+        let error = run_descriptor_fixture_conformance(&root).expect_err("bad manifest");
+        assert!(error.contains("failed to parse"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn validate_event_product_file_reports_io_and_parse_errors() {
+        let missing = std::env::temp_dir().join(format!(
+            "ecca-missing-descriptor-{}.json",
+            std::process::id()
+        ));
+        let _ = fs::remove_file(&missing);
+        let io_error = validate_event_product_file(&missing).expect_err("missing file");
+        assert!(io_error.contains("failed to read"));
+
+        let broken = std::env::temp_dir().join(format!(
+            "ecca-broken-descriptor-{}.json",
+            std::process::id()
+        ));
+        fs::write(&broken, "{not-json").expect("write broken");
+        let parse_error = validate_event_product_file(&broken).expect_err("bad json");
+        assert!(parse_error.contains("failed to parse"));
+        let _ = fs::remove_file(&broken);
     }
 }

--- a/crates/traverse-runtime/src/events/ecca_conformance.rs
+++ b/crates/traverse-runtime/src/events/ecca_conformance.rs
@@ -1,0 +1,757 @@
+//! ECCA catalog-drift reconciliation and migration-exit conformance.
+//!
+//! Closes the remaining #897 slices against `traverse-registry` 0.11.0:
+//! declared/observed drift via [`ObservedLineageStore`], portable descriptor
+//! fixture conformance, and Spec 534 FR-015 migration-exit evidence.
+
+use crate::events::{
+    EventLineageRecord, EventQuarantineRecord, EventTelemetryRecord, EventValidationEvidence,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+use traverse_registry::{
+    DriftEvidence, EventProductDescriptor, EventProductErrorCode, EventProductRegistry,
+    LookupScope, ObservedEventInteraction, ObservedLineageStore, ObservedRole, RegistryScope,
+    validate_event_product_descriptor,
+};
+
+/// Reconciles broker lineage against a declared [`EventProductRegistry`].
+#[derive(Debug, Clone, Default)]
+pub struct CatalogDriftReconciler {
+    registry: EventProductRegistry,
+    observed: ObservedLineageStore,
+    observed_keys: BTreeSet<(String, String)>,
+}
+
+impl CatalogDriftReconciler {
+    #[must_use]
+    pub fn new(registry: EventProductRegistry) -> Self {
+        Self {
+            registry,
+            observed: ObservedLineageStore::new(),
+            observed_keys: BTreeSet::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn registry(&self) -> &EventProductRegistry {
+        &self.registry
+    }
+
+    #[must_use]
+    pub fn observed(&self) -> &ObservedLineageStore {
+        &self.observed
+    }
+
+    /// Records one publish observation against declared publishers for the event.
+    pub fn observe_publication(
+        &mut self,
+        event_id: &str,
+        event_version: &str,
+        capability_id: &str,
+        observed_at: &str,
+    ) {
+        self.observed_keys
+            .insert((event_id.to_string(), event_version.to_string()));
+        let declared = declared_capability_ids(
+            &self.registry,
+            event_id,
+            event_version,
+            ObservedRole::Publisher,
+        );
+        self.observed.record(
+            ObservedEventInteraction {
+                event_id: event_id.to_string(),
+                event_version: event_version.to_string(),
+                capability_id: capability_id.to_string(),
+                role: ObservedRole::Publisher,
+                observed_at: observed_at.to_string(),
+            },
+            &declared,
+        );
+    }
+
+    /// Records one consume observation against declared subscribers for the event.
+    pub fn observe_consumption(
+        &mut self,
+        event_id: &str,
+        event_version: &str,
+        capability_id: &str,
+        observed_at: &str,
+    ) {
+        self.observed_keys
+            .insert((event_id.to_string(), event_version.to_string()));
+        let declared = declared_capability_ids(
+            &self.registry,
+            event_id,
+            event_version,
+            ObservedRole::Subscriber,
+        );
+        self.observed.record(
+            ObservedEventInteraction {
+                event_id: event_id.to_string(),
+                event_version: event_version.to_string(),
+                capability_id: capability_id.to_string(),
+                role: ObservedRole::Subscriber,
+                observed_at: observed_at.to_string(),
+            },
+            &declared,
+        );
+    }
+
+    /// Projects sanitized broker lineage into the registry observed-lineage store.
+    pub fn reconcile_broker_lineage(
+        &mut self,
+        lineage: &[EventLineageRecord],
+        observed_at: &str,
+    ) {
+        for record in lineage {
+            self.observe_publication(
+                &record.contract_id,
+                &record.contract_version,
+                &record.producer_id,
+                observed_at,
+            );
+            self.observe_consumption(
+                &record.contract_id,
+                &record.contract_version,
+                &record.consumer_id,
+                observed_at,
+            );
+        }
+    }
+
+    /// All unresolved drift evidence recorded so far, in deterministic key order.
+    #[must_use]
+    pub fn unresolved_drift(&self) -> Vec<DriftEvidence> {
+        let mut keys = self.observed_keys.clone();
+        for descriptor in self.registry.discover(LookupScope::PreferPrivate) {
+            keys.insert((
+                descriptor.contract.id.clone(),
+                descriptor.contract.version.clone(),
+            ));
+        }
+        keys.into_iter()
+            .flat_map(|(event_id, event_version)| {
+                self.observed
+                    .drift_for(&event_id, &event_version)
+                    .into_iter()
+                    .cloned()
+            })
+            .collect()
+    }
+}
+
+fn declared_capability_ids(
+    registry: &EventProductRegistry,
+    event_id: &str,
+    event_version: &str,
+    role: ObservedRole,
+) -> Vec<String> {
+    let Some(descriptor) = find_descriptor(registry, event_id, event_version) else {
+        return Vec::new();
+    };
+    match role {
+        ObservedRole::Publisher => descriptor
+            .contract
+            .publishers
+            .iter()
+            .map(|reference| reference.capability_id.clone())
+            .collect(),
+        ObservedRole::Subscriber => descriptor
+            .contract
+            .subscribers
+            .iter()
+            .map(|reference| reference.capability_id.clone())
+            .collect(),
+    }
+}
+
+fn find_descriptor<'a>(
+    registry: &'a EventProductRegistry,
+    event_id: &str,
+    event_version: &str,
+) -> Option<&'a EventProductDescriptor> {
+    registry
+        .find_exact(RegistryScope::Private, event_id, event_version)
+        .or_else(|| registry.find_exact(RegistryScope::Public, event_id, event_version))
+}
+
+/// Stable finding codes for FR-015 migration-exit evaluation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MigrationExitFindingCode {
+    UnvalidatedDescriptor,
+    MissingProducerTelemetry,
+    MissingConsumerTelemetry,
+    UnresolvedDrift,
+    InvalidEventFinding,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationExitFinding {
+    pub code: MigrationExitFindingCode,
+    pub detail: String,
+}
+
+/// Persisted evidence for one release conformance run (FR-015 consecutive runs).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationExitEvidence {
+    pub run_id: String,
+    pub clean: bool,
+    pub finding_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MigrationExitReport {
+    pub permitted: bool,
+    pub findings: Vec<MigrationExitFinding>,
+    pub evidence: MigrationExitEvidence,
+    pub previous_run_clean: bool,
+}
+
+/// Evaluate Spec 534 FR-015 cutover readiness for one conformance run.
+#[must_use]
+pub fn evaluate_migration_exit(
+    registry: &EventProductRegistry,
+    reconciler: &CatalogDriftReconciler,
+    validation_evidence: &[EventValidationEvidence],
+    quarantine: &[EventQuarantineRecord],
+    telemetry: &[EventTelemetryRecord],
+    previous: Option<&MigrationExitEvidence>,
+    run_id: &str,
+) -> MigrationExitReport {
+    let mut findings = Vec::new();
+
+    for descriptor in registry.discover(LookupScope::PreferPrivate) {
+        if let Err(failure) = validate_event_product_descriptor(descriptor, None) {
+            findings.push(MigrationExitFinding {
+                code: MigrationExitFindingCode::UnvalidatedDescriptor,
+                detail: format!(
+                    "{}@{} failed revalidation ({})",
+                    descriptor.contract.id,
+                    descriptor.contract.version,
+                    failure
+                        .errors
+                        .first()
+                        .map_or_else(|| "unknown".to_string(), |error| format!("{:?}", error.code))
+                ),
+            });
+        }
+
+        let contract_id = descriptor.contract.id.as_str();
+        let contract_version = descriptor.contract.version.as_str();
+        let has_publish_telemetry = telemetry.iter().any(|record| {
+            record.operation == "traverse.event.publish"
+                && record.contract_id == contract_id
+                && record.contract_version == contract_version
+        });
+        if !descriptor.contract.publishers.is_empty() && !has_publish_telemetry {
+            findings.push(MigrationExitFinding {
+                code: MigrationExitFindingCode::MissingProducerTelemetry,
+                detail: format!(
+                    "declared producers for {contract_id}@{contract_version} have no publish telemetry"
+                ),
+            });
+        }
+
+        for subscriber in &descriptor.contract.subscribers {
+            let has_delivery = telemetry.iter().any(|record| {
+                record.operation == "traverse.event.delivery"
+                    && record.contract_id == contract_id
+                    && record.contract_version == contract_version
+                    && record.consumer_id.as_deref() == Some(subscriber.capability_id.as_str())
+            });
+            if !has_delivery {
+                findings.push(MigrationExitFinding {
+                    code: MigrationExitFindingCode::MissingConsumerTelemetry,
+                    detail: format!(
+                        "declared consumer '{}' for {contract_id}@{contract_version} has no delivery telemetry",
+                        subscriber.capability_id
+                    ),
+                });
+            }
+        }
+    }
+
+    for evidence in reconciler.unresolved_drift() {
+        findings.push(MigrationExitFinding {
+            code: MigrationExitFindingCode::UnresolvedDrift,
+            detail: format!(
+                "{:?} capability '{}' on {}@{}",
+                evidence.kind, evidence.capability_id, evidence.event_id, evidence.event_version
+            ),
+        });
+    }
+
+    for evidence in validation_evidence {
+        findings.push(MigrationExitFinding {
+            code: MigrationExitFindingCode::InvalidEventFinding,
+            detail: format!(
+                "validation diagnostic for {}@{} ({})",
+                evidence.contract_id,
+                evidence.version,
+                evidence
+                    .diagnostics
+                    .first()
+                    .map_or("unknown", |diagnostic| diagnostic.code)
+            ),
+        });
+    }
+    for record in quarantine {
+        findings.push(MigrationExitFinding {
+            code: MigrationExitFindingCode::InvalidEventFinding,
+            detail: format!(
+                "quarantine recorded for {}@{}",
+                record.evidence.contract_id, record.evidence.version
+            ),
+        });
+    }
+
+    let clean = findings.is_empty();
+    let finding_count = findings.len();
+    let previous_run_clean = previous.is_some_and(|evidence| evidence.clean);
+    let permitted = clean && previous_run_clean;
+
+    MigrationExitReport {
+        permitted,
+        findings,
+        evidence: MigrationExitEvidence {
+            run_id: run_id.to_string(),
+            clean,
+            finding_count,
+        },
+        previous_run_clean,
+    }
+}
+
+/// One portable descriptor-fixture expectation from the registry corpus.
+#[derive(Debug, Clone, Deserialize)]
+struct FixtureManifest {
+    fixtures: Vec<FixtureEntry>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct FixtureEntry {
+    file: String,
+    expect: String,
+    #[serde(default)]
+    error_code: Option<String>,
+    #[serde(default)]
+    existing: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FixtureConformanceFailure {
+    pub file: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FixtureConformanceReport {
+    pub passed: usize,
+    pub failures: Vec<FixtureConformanceFailure>,
+}
+
+/// Run the portable ECCA descriptor fixture corpus against
+/// [`validate_event_product_descriptor`].
+///
+/// # Errors
+///
+/// Returns an error when the manifest or fixture files cannot be read/parsed.
+pub fn run_descriptor_fixture_conformance(
+    fixtures_dir: &Path,
+) -> Result<FixtureConformanceReport, String> {
+    let manifest_path = fixtures_dir.join("MANIFEST.json");
+    let manifest_text = fs::read_to_string(&manifest_path)
+        .map_err(|error| format!("failed to read {}: {error}", manifest_path.display()))?;
+    let manifest: FixtureManifest = serde_json::from_str(&manifest_text)
+        .map_err(|error| format!("failed to parse {}: {error}", manifest_path.display()))?;
+
+    let mut passed = 0;
+    let mut failures = Vec::new();
+    let mut loaded: BTreeMap<String, EventProductDescriptor> = BTreeMap::new();
+
+    for entry in &manifest.fixtures {
+        let path = fixtures_dir.join(&entry.file);
+        let text = match fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(error) => {
+                failures.push(FixtureConformanceFailure {
+                    file: entry.file.clone(),
+                    detail: format!("failed to read fixture: {error}"),
+                });
+                continue;
+            }
+        };
+        let descriptor: EventProductDescriptor = match serde_json::from_str(&text) {
+            Ok(descriptor) => descriptor,
+            Err(error) => {
+                failures.push(FixtureConformanceFailure {
+                    file: entry.file.clone(),
+                    detail: format!("failed to parse fixture JSON: {error}"),
+                });
+                continue;
+            }
+        };
+
+        let existing = entry
+            .existing
+            .as_ref()
+            .and_then(|existing_file| loaded.get(existing_file));
+        let result = validate_event_product_descriptor(&descriptor, existing);
+        match (entry.expect.as_str(), result) {
+            ("accept", Ok(())) => {
+                passed += 1;
+                loaded.insert(entry.file.clone(), descriptor);
+            }
+            ("accept", Err(failure)) => failures.push(FixtureConformanceFailure {
+                file: entry.file.clone(),
+                detail: format!(
+                    "expected accept, got {:?}",
+                    failure
+                        .errors
+                        .first()
+                        .map_or(EventProductErrorCode::MissingSupportRoute, |error| error.code)
+                ),
+            }),
+            ("reject", Ok(())) => failures.push(FixtureConformanceFailure {
+                file: entry.file.clone(),
+                detail: "expected reject, got accept".to_string(),
+            }),
+            ("reject", Err(failure)) => {
+                let actual = failure
+                    .errors
+                    .first()
+                    .map(|error| format!("{:?}", error.code));
+                if entry.error_code.as_ref() == actual.as_ref() {
+                    passed += 1;
+                } else {
+                    failures.push(FixtureConformanceFailure {
+                        file: entry.file.clone(),
+                        detail: format!(
+                            "expected error_code {:?}, got {:?}",
+                            entry.error_code, actual
+                        ),
+                    });
+                }
+            }
+            (other, _) => failures.push(FixtureConformanceFailure {
+                file: entry.file.clone(),
+                detail: format!("unsupported expect value '{other}'"),
+            }),
+        }
+    }
+
+    Ok(FixtureConformanceReport { passed, failures })
+}
+
+/// Validate one event-product descriptor JSON document.
+///
+/// # Errors
+///
+/// Returns a stable string error when the file is unreadable, unparsable, or
+/// fails ECCA descriptor validation.
+pub fn validate_event_product_file(path: &Path) -> Result<EventProductDescriptor, String> {
+    let text = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read event product descriptor: {error}"))?;
+    let descriptor: EventProductDescriptor = serde_json::from_str(&text)
+        .map_err(|error| format!("failed to parse event product descriptor: {error}"))?;
+    validate_event_product_descriptor(&descriptor, None).map_err(|failure| {
+        failure
+            .errors
+            .into_iter()
+            .map(|error| format!("{:?}: {}", error.code, error.message))
+            .collect::<Vec<_>>()
+            .join("; ")
+    })?;
+    Ok(descriptor)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::events::validation::EventValidationDiagnostic;
+    use traverse_contracts::EventContract;
+    use traverse_registry::{
+        DataClassification, DriftKind, EventExposureClass, EventProductRegistration,
+        FieldClassification,
+    };
+
+    fn sample_descriptor(
+        event_id: &str,
+        publisher: &str,
+        subscriber: Option<&str>,
+    ) -> EventProductDescriptor {
+        let mut contract: EventContract = serde_json::from_str(
+            r#"{
+              "kind":"event_contract",
+              "schema_version":"1.0.0",
+              "id":"placeholder",
+              "namespace":"content.comments",
+              "name":"comment-draft-created",
+              "version":"1.0.0",
+              "lifecycle":"active",
+              "owner":{"team":"traverse-core","contact":"test@example.com"},
+              "summary":"Published when a comment draft has been created.",
+              "description":"Governed event contract for comment draft creation.",
+              "payload":{"schema":{"type":"object","properties":{"draft_id":{"type":"string"}},"required":["draft_id"]},"compatibility":"backward-compatible"},
+              "classification":{"domain":"content.comments","bounded_context":"comments","event_type":"domain","tags":[]},
+              "publishers":[{"capability_id":"content.comments.create-comment-draft","version":"1.0.0"}],
+              "subscribers":[],
+              "policies":[],
+              "tags":[],
+              "provenance":{"source":"greenfield","author":"test","created_at":"2026-03-30T00:00:00Z"},
+              "evidence":[]
+            }"#,
+        )
+        .expect("contract json");
+        contract.id = event_id.to_string();
+        contract.name = event_id
+            .rsplit('.')
+            .next()
+            .unwrap_or(event_id)
+            .to_string();
+        contract.publishers[0].capability_id = publisher.to_string();
+        if let Some(subscriber) = subscriber {
+            contract.subscribers = vec![traverse_contracts::CapabilityReference {
+                capability_id: subscriber.to_string(),
+                version: "1.0.0".to_string(),
+            }];
+        }
+        EventProductDescriptor {
+            contract,
+            support_route: "https://support.traverse.dev/comments".to_string(),
+            exposure: EventExposureClass::Internal,
+            field_classifications: vec![FieldClassification {
+                field_path: "draft_id".to_string(),
+                classification: DataClassification::NoClassification,
+            }],
+            replacement: None,
+            cloud_events_source: format!("traverse://capability/{publisher}"),
+            cloud_events_subject_field: Some("draft_id".to_string()),
+            deduplication_id_field: "draft_id".to_string(),
+            ordering_scope_field: None,
+            correlation_id_field: "envelope.correlation_id".to_string(),
+            causation_id_field: Some("envelope.causation_id".to_string()),
+            retention_policy: "retain 90 days".to_string(),
+        }
+    }
+
+    fn registry_with(descriptor: EventProductDescriptor) -> EventProductRegistry {
+        let mut registry = EventProductRegistry::new();
+        registry
+            .register(EventProductRegistration {
+                scope: RegistryScope::Private,
+                descriptor,
+            })
+            .expect("descriptor must register");
+        registry
+    }
+
+    #[test]
+    fn declared_producer_and_consumer_produce_no_drift() {
+        let descriptor = sample_descriptor(
+            "content.comments.comment-draft-created",
+            "content.comments.create-comment-draft",
+            Some("content.comments.notify-author"),
+        );
+        let mut reconciler = CatalogDriftReconciler::new(registry_with(descriptor));
+        reconciler.observe_publication(
+            "content.comments.comment-draft-created",
+            "1.0.0",
+            "content.comments.create-comment-draft",
+            "2026-08-07T00:00:00Z",
+        );
+        reconciler.observe_consumption(
+            "content.comments.comment-draft-created",
+            "1.0.0",
+            "content.comments.notify-author",
+            "2026-08-07T00:00:01Z",
+        );
+        assert!(reconciler.unresolved_drift().is_empty());
+    }
+
+    #[test]
+    fn undeclared_producer_is_reported_as_drift() {
+        let descriptor = sample_descriptor(
+            "content.comments.comment-draft-created",
+            "content.comments.create-comment-draft",
+            None,
+        );
+        let mut reconciler = CatalogDriftReconciler::new(registry_with(descriptor));
+        reconciler.observe_publication(
+            "content.comments.comment-draft-created",
+            "1.0.0",
+            "rogue.publisher",
+            "2026-08-07T00:00:00Z",
+        );
+        let drift = reconciler.unresolved_drift();
+        assert_eq!(drift.len(), 1);
+        assert_eq!(drift[0].kind, DriftKind::UndeclaredPublisher);
+        assert_eq!(drift[0].capability_id, "rogue.publisher");
+    }
+
+    #[test]
+    fn broker_lineage_projects_into_observed_store() {
+        let descriptor = sample_descriptor(
+            "content.comments.comment-draft-created",
+            "content.comments.create-comment-draft",
+            Some("content.comments.notify-author"),
+        );
+        let mut reconciler = CatalogDriftReconciler::new(registry_with(descriptor));
+        reconciler.reconcile_broker_lineage(
+            &[EventLineageRecord {
+                contract_id: "content.comments.comment-draft-created".to_string(),
+                contract_version: "1.0.0".to_string(),
+                event_id: "evt-1".to_string(),
+                producer_id: "content.comments.create-comment-draft".to_string(),
+                consumer_id: "content.comments.notify-author".to_string(),
+                subscription_id: "sub-1".to_string(),
+                cursor: "1".to_string(),
+            }],
+            "2026-08-07T00:00:00Z",
+        );
+        assert!(reconciler.unresolved_drift().is_empty());
+        assert_eq!(
+            reconciler
+                .observed()
+                .interactions_for("content.comments.comment-draft-created", "1.0.0")
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn migration_exit_requires_two_consecutive_clean_runs() {
+        let descriptor = sample_descriptor(
+            "content.comments.comment-draft-created",
+            "content.comments.create-comment-draft",
+            Some("content.comments.notify-author"),
+        );
+        let registry = registry_with(descriptor);
+        let mut reconciler = CatalogDriftReconciler::new(registry.clone());
+        reconciler.observe_publication(
+            "content.comments.comment-draft-created",
+            "1.0.0",
+            "content.comments.create-comment-draft",
+            "2026-08-07T00:00:00Z",
+        );
+        reconciler.observe_consumption(
+            "content.comments.comment-draft-created",
+            "1.0.0",
+            "content.comments.notify-author",
+            "2026-08-07T00:00:01Z",
+        );
+        let telemetry = vec![
+            EventTelemetryRecord {
+                operation: "traverse.event.publish",
+                outcome: "accepted",
+                contract_id: "content.comments.comment-draft-created".to_string(),
+                contract_version: "1.0.0".to_string(),
+                event_id: "evt-1".to_string(),
+                deduplication_id: None,
+                ordering_scope: None,
+                correlation_id: None,
+                causation_id: None,
+                consumer_id: None,
+                cursor: None,
+                retry_count: 0,
+                latency_ms: 0,
+            },
+            EventTelemetryRecord {
+                operation: "traverse.event.delivery",
+                outcome: "delivered",
+                contract_id: "content.comments.comment-draft-created".to_string(),
+                contract_version: "1.0.0".to_string(),
+                event_id: "evt-1".to_string(),
+                deduplication_id: None,
+                ordering_scope: None,
+                correlation_id: None,
+                causation_id: None,
+                consumer_id: Some("content.comments.notify-author".to_string()),
+                cursor: Some("1".to_string()),
+                retry_count: 0,
+                latency_ms: 0,
+            },
+        ];
+
+        let first = evaluate_migration_exit(
+            &registry,
+            &reconciler,
+            &[],
+            &[],
+            &telemetry,
+            None,
+            "run-1",
+        );
+        assert!(first.evidence.clean, "findings: {:?}", first.findings);
+        assert!(!first.permitted);
+
+        let second = evaluate_migration_exit(
+            &registry,
+            &reconciler,
+            &[],
+            &[],
+            &telemetry,
+            Some(&first.evidence),
+            "run-2",
+        );
+        assert!(second.evidence.clean);
+        assert!(second.permitted);
+        assert!(second.previous_run_clean);
+    }
+
+    #[test]
+    fn migration_exit_blocks_on_invalid_event_findings() {
+        let descriptor = sample_descriptor(
+            "content.comments.comment-draft-created",
+            "content.comments.create-comment-draft",
+            None,
+        );
+        let registry = registry_with(descriptor);
+        let reconciler = CatalogDriftReconciler::new(registry.clone());
+        let evidence = EventValidationEvidence {
+            contract_id: "content.comments.comment-draft-created".to_string(),
+            version: "1.0.0".to_string(),
+            diagnostics: vec![EventValidationDiagnostic {
+                code: "EVP-001",
+                path: "/id",
+                severity: "error",
+                remediation: "provide id",
+                contract_id: "content.comments.comment-draft-created".to_string(),
+                version: "1.0.0".to_string(),
+            }],
+        };
+        let report = evaluate_migration_exit(
+            &registry,
+            &reconciler,
+            &[evidence],
+            &[],
+            &[],
+            None,
+            "run-bad",
+        );
+        assert!(!report.evidence.clean);
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|finding| finding.code == MigrationExitFindingCode::InvalidEventFinding)
+        );
+    }
+
+    #[test]
+    fn validate_event_product_file_accepts_valid_fixture() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/ecca-event-products/valid.json");
+        let descriptor = validate_event_product_file(&path).expect("valid fixture");
+        assert_eq!(
+            descriptor.contract.id,
+            "content.comments.comment-draft-created"
+        );
+    }
+}

--- a/crates/traverse-runtime/src/events/mod.rs
+++ b/crates/traverse-runtime/src/events/mod.rs
@@ -5,6 +5,7 @@
 pub mod broker;
 pub mod catalog;
 pub mod durable;
+pub mod ecca_conformance;
 pub mod journal;
 pub mod types;
 pub mod validation;
@@ -16,6 +17,11 @@ pub use broker::{
 pub use catalog::{EventCatalog, EventCatalogEntry};
 pub use durable::{
     DurableBroker, DurableBrokerConfig, JournalSink, JournalWriteAuditRecord, JournalWriteAuditSink,
+};
+pub use ecca_conformance::{
+    CatalogDriftReconciler, FixtureConformanceFailure, FixtureConformanceReport,
+    MigrationExitEvidence, MigrationExitFinding, MigrationExitFindingCode, MigrationExitReport,
+    evaluate_migration_exit, run_descriptor_fixture_conformance, validate_event_product_file,
 };
 pub use journal::{DurableEventJournal, JournalConfig, JournalError};
 pub use types::{

--- a/crates/traverse-runtime/tests/ecca_fixture_conformance.rs
+++ b/crates/traverse-runtime/tests/ecca_fixture_conformance.rs
@@ -1,0 +1,19 @@
+//! Portable ECCA event-product descriptor fixture conformance (registry 0.11.0 corpus).
+
+use std::path::PathBuf;
+
+use traverse_runtime::events::run_descriptor_fixture_conformance;
+
+#[test]
+fn portable_registry_descriptor_fixtures_conform() -> Result<(), String> {
+    let fixtures_dir =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ecca-event-products");
+    let report = run_descriptor_fixture_conformance(&fixtures_dir)?;
+    if !report.failures.is_empty() {
+        return Err(format!("fixture conformance failures: {:?}", report.failures));
+    }
+    if report.passed != 17 {
+        return Err(format!("expected 17 fixtures to pass, got {}", report.passed));
+    }
+    Ok(())
+}

--- a/crates/traverse-runtime/tests/ecca_fixture_conformance.rs
+++ b/crates/traverse-runtime/tests/ecca_fixture_conformance.rs
@@ -10,10 +10,16 @@ fn portable_registry_descriptor_fixtures_conform() -> Result<(), String> {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/ecca-event-products");
     let report = run_descriptor_fixture_conformance(&fixtures_dir)?;
     if !report.failures.is_empty() {
-        return Err(format!("fixture conformance failures: {:?}", report.failures));
+        return Err(format!(
+            "fixture conformance failures: {:?}",
+            report.failures
+        ));
     }
     if report.passed != 17 {
-        return Err(format!("expected 17 fixtures to pass, got {}", report.passed));
+        return Err(format!(
+            "expected 17 fixtures to pass, got {}",
+            report.passed
+        ));
     }
     Ok(())
 }

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/MANIFEST.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/MANIFEST.json
@@ -1,0 +1,89 @@
+{
+  "description": "ECCA event-product descriptor conformance fixtures (specs/016-ecca-event-product-adoption v2.0.0). Each fixture is a raw EventProductDescriptor JSON document, portable to any language/consumer -- not Rust-specific. 'expect: reject' fixtures list the exact error_code validate_event_product_descriptor must return. Cross-repo consumers (e.g. traverse-framework/traverse) can conformance-test their own port against this same set.",
+  "governing_spec": "016-ecca-event-product-adoption@2.0.0",
+  "fixtures": [
+    { "file": "valid.json", "expect": "accept" },
+    {
+      "file": "reject_missing_support_route.json",
+      "expect": "reject",
+      "error_code": "MissingSupportRoute"
+    },
+    {
+      "file": "reject_invalid_support_route.json",
+      "expect": "reject",
+      "error_code": "InvalidSupportRoute"
+    },
+    {
+      "file": "reject_missing_field_classification.json",
+      "expect": "reject",
+      "error_code": "MissingFieldClassification"
+    },
+    {
+      "file": "reject_unexpected_field_classification.json",
+      "expect": "reject",
+      "error_code": "UnexpectedFieldClassification"
+    },
+    {
+      "file": "reject_duplicate_field_classification.json",
+      "expect": "reject",
+      "error_code": "DuplicateFieldClassification"
+    },
+    {
+      "file": "reject_missing_replacement.json",
+      "expect": "reject",
+      "error_code": "MissingReplacement"
+    },
+    {
+      "file": "reject_unexpected_replacement.json",
+      "expect": "reject",
+      "error_code": "UnexpectedReplacement"
+    },
+    {
+      "file": "reject_self_referential_replacement.json",
+      "expect": "reject",
+      "error_code": "InvalidReplacement"
+    },
+    {
+      "file": "reject_non_past_tense_name.json",
+      "expect": "reject",
+      "error_code": "NonPastTenseName"
+    },
+    {
+      "file": "reject_missing_cloud_events_source.json",
+      "expect": "reject",
+      "error_code": "MissingCloudEventsSource"
+    },
+    {
+      "file": "reject_invalid_cloud_events_subject_field.json",
+      "expect": "reject",
+      "error_code": "InvalidCloudEventsSubjectField"
+    },
+    {
+      "file": "reject_missing_deduplication_id_field.json",
+      "expect": "reject",
+      "error_code": "MissingDeduplicationIdField"
+    },
+    {
+      "file": "reject_missing_correlation_id_field.json",
+      "expect": "reject",
+      "error_code": "MissingCorrelationIdField"
+    },
+    {
+      "file": "reject_missing_retention_policy.json",
+      "expect": "reject",
+      "error_code": "MissingRetentionPolicy"
+    },
+    {
+      "file": "immutable_conflict_existing.json",
+      "expect": "accept",
+      "note": "the previously-published descriptor for (scope, id, version)"
+    },
+    {
+      "file": "immutable_conflict_candidate.json",
+      "expect": "reject",
+      "error_code": "ImmutableDescriptorConflict",
+      "existing": "immutable_conflict_existing.json",
+      "note": "same (id, version) as immutable_conflict_existing.json but different support_route -- validate against the existing descriptor, not standalone"
+    }
+  ]
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/immutable_conflict_candidate.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/immutable_conflict_candidate.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments-v2",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/immutable_conflict_existing.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/immutable_conflict_existing.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_duplicate_field_classification.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_duplicate_field_classification.json
@@ -1,0 +1,87 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    },
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_invalid_cloud_events_subject_field.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_invalid_cloud_events_subject_field.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "not_a_declared_property",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_invalid_support_route.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_invalid_support_route.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "http://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_cloud_events_source.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_cloud_events_source.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_correlation_id_field.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_correlation_id_field.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_deduplication_id_field.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_deduplication_id_field.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_field_classification.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_field_classification.json
@@ -1,0 +1,79 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_replacement.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_replacement.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "deprecated",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_retention_policy.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_retention_policy.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": ""
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_support_route.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_missing_support_route.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_non_past_tense_name.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_non_past_tense_name.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.create-comment-draft-event",
+    "namespace": "content.comments",
+    "name": "create-comment-draft-event",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_self_referential_replacement.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_self_referential_replacement.json
@@ -1,0 +1,86 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "retired",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": {
+    "event_id": "content.comments.comment-draft-created",
+    "version": "1.0.0"
+  },
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_unexpected_field_classification.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_unexpected_field_classification.json
@@ -1,0 +1,87 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    },
+    {
+      "field_path": "not_a_declared_property",
+      "classification": "none"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_unexpected_replacement.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/reject_unexpected_replacement.json
@@ -1,0 +1,86 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": {
+    "event_id": "content.comments.comment-draft-created-v2",
+    "version": "1.0.0"
+  },
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}

--- a/crates/traverse-runtime/tests/fixtures/ecca-event-products/valid.json
+++ b/crates/traverse-runtime/tests/fixtures/ecca-event-products/valid.json
@@ -1,0 +1,83 @@
+{
+  "contract": {
+    "kind": "event_contract",
+    "schema_version": "1.0.0",
+    "id": "content.comments.comment-draft-created",
+    "namespace": "content.comments",
+    "name": "comment-draft-created",
+    "version": "1.0.0",
+    "lifecycle": "active",
+    "owner": {
+      "team": "traverse-core",
+      "contact": "enrico.piovesan10@gmail.com"
+    },
+    "summary": "Published when a comment draft has been created.",
+    "description": "Governed event contract for comment draft creation.",
+    "payload": {
+      "schema": {
+        "properties": {
+          "author_email": {
+            "type": "string"
+          },
+          "draft_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "draft_id"
+        ],
+        "type": "object"
+      },
+      "compatibility": "backward-compatible"
+    },
+    "classification": {
+      "domain": "content.comments",
+      "bounded_context": "comments",
+      "event_type": "domain",
+      "tags": [
+        "comments"
+      ]
+    },
+    "publishers": [
+      {
+        "capability_id": "content.comments.create-comment-draft",
+        "version": "1.0.0"
+      }
+    ],
+    "subscribers": [],
+    "policies": [
+      {
+        "id": "default-comment-safety"
+      }
+    ],
+    "tags": [
+      "comments"
+    ],
+    "provenance": {
+      "source": "greenfield",
+      "author": "enricopiovesan",
+      "created_at": "2026-03-30T00:00:00Z"
+    },
+    "evidence": []
+  },
+  "support_route": "https://support.traverse.dev/comments",
+  "exposure": "internal",
+  "field_classifications": [
+    {
+      "field_path": "draft_id",
+      "classification": "none"
+    },
+    {
+      "field_path": "author_email",
+      "classification": "personal"
+    }
+  ],
+  "replacement": null,
+  "cloud_events_source": "traverse://capability/content.comments.create-comment-draft",
+  "cloud_events_subject_field": "draft_id",
+  "deduplication_id_field": "draft_id",
+  "ordering_scope_field": null,
+  "correlation_id_field": "envelope.correlation_id",
+  "causation_id_field": null,
+  "retention_policy": "retain 90 days"
+}


### PR DESCRIPTION
## Summary

- Wire catalog-drift reconciliation from broker lineage into registry `ObservedLineageStore` (`CatalogDriftReconciler`).
- Vendor the portable registry 0.11.0 event-product fixture corpus and assert descriptor conformance in CI.
- Implement Spec 534 FR-015 migration-exit evidence (two consecutive clean runs) plus `traverse-cli event validate-product`.

## Governing Spec

- `534-ecca-event-products`
- `026-event-broker`
- `003-event-contracts`
- `066-durable-identity-event-delivery`
- `070-runtime-event-sink-boundary`

## Project Item

Closes #897  
https://github.com/orgs/traverse-framework/projects/1/

## What Changed

- Contracts changed: none (consumes registry 0.11.0 APIs already adopted)
- Runtime behavior changed: new `events::ecca_conformance` module for drift reconciliation, fixture runner, and migration-exit evaluation
- Compatibility impact: additive CLI subcommand `event validate-product`; no breaking broker API changes
- ADR needed or linked: ADR-0028 / Spec 534 (already approved)

## Validation

- [x] Spec alignment checked
- [x] Contract alignment checked
- [x] Tests updated and passing (`events::ecca_conformance::*`, `--test ecca_fixture_conformance`)
- [x] Core coverage preserved
- [x] `cargo clippy -p traverse-runtime --all-targets -- -D warnings`

## Notes

Earlier #897 slices (envelope validation, lineage, quarantine, metrics, delivery identity, registry 0.11.0 adopt) already merged. This PR is the remaining conformance / drift / migration-exit slice. No prior WIP branch existed for this remainder—only merged slice branches locally.

