### PR TITLE
docs(governance): author spec 101 + ADR-0037 for LocalExecutor event emission

### DIFF
--- a/docs/adr/0037-local-executor-event-emission.md
+++ b/docs/adr/0037-local-executor-event-emission.md
@@ -1,0 +1,157 @@
+# ADR-0037: Extend `LocalExecutor` to Carry Emitted Events
+
+- Status: Accepted
+- Governing spec: `101-local-executor-event-emission`
+
+## Context
+
+`098-capability-event-host-abi` (issue #969) defined `traverse_host::emit_event`,
+a WASM host function letting a capability imperatively publish an event
+during execution, validated synchronously against the capability's contract
+`emits` list and `service_type`. Issue #970 implemented it end to end for
+`CapabilityExecutor::execute() -> Result<ExecutorOutput, ExecutorError>`:
+`WasmExecutor` populates `ExecutorOutput.emitted_events` from validated host
+calls, and `PlacementRouter` Step 5 publishes them to `EventBroker` for
+`Subscribable` capabilities.
+
+That implementation only reaches `CapabilityExecutor`. A separate, older
+trait, `LocalExecutor::execute() -> Result<Value, LocalExecutionFailure>`
+(`crates/traverse-runtime/src/lib.rs`), has no event channel at all, and two
+real production paths use it:
+
+- `BoundLocalExecutor` bridges a host-provided native `LocalExecutor`
+  closure into `CapabilityExecutor` for `Runtime::execute()`'s live
+  single-capability path. It always returns an empty `emitted_events`,
+  regardless of what the underlying closure does — there is structurally no
+  ABI for a native closure to call, since `traverse_host::emit_event` is a
+  WASM guest/host import.
+- `ArtifactRouter` implements `LocalExecutor` directly and is the executor
+  used for workflow-internal node execution (`workflows.rs`). For WASM
+  capabilities it calls `WasmExecutor::execute` internally — which *does*
+  produce real, ABI-validated `ExecutorOutput.emitted_events` — but discards
+  them (`.map(|output| output.value)`) before returning.
+
+`traverse-cli`'s production wiring (`main.rs`) constructs
+`Runtime::new(registry, ArtifactRouter::new()?)`, so `ArtifactRouter` is the
+same executor instance backing both paths: workflow-internal node execution
+(direct call, bypassing `PlacementRouter`) and the live single-capability
+path (wrapped in `BoundLocalExecutor`, routed through `PlacementRouter`).
+
+A second, related gap: `098` FR-004 required removing the old output-JSON
+`emitted_events` convention (a capability embedding an `emitted_events`
+array in its own JSON output) "once this ABI exists — not kept as a second
+supported path." `workflows.rs`'s `emitted_events(&output: &Value)`
+JSON-parsing helper is still in use, because it was — until now — the only
+event-emission mechanism available to native (non-WASM) capabilities inside
+a workflow. It is also narrower than `EventBroker`-backed emission: it only
+ever satisfies waiting edges within the *same* workflow execution, never
+reaching `EventBroker` for other workflows, capabilities, or external
+subscribers.
+
+Traverse has no production capabilities depending on `LocalExecutor`'s
+current signature today (`docs/decision-log.md` Decision 48).
+
+## Decision
+
+Extend `LocalExecutor::execute()`'s return type to carry emitted events
+alongside its value output, mirroring `ExecutorOutput`:
+
+```rust
+pub struct LocalExecutionOutput {
+    pub value: Value,
+    pub emitted_events: Vec<TraverseEvent>,
+}
+
+pub trait LocalExecutor: Send + Sync {
+    fn execute(
+        &self,
+        capability: &ResolvedCapability,
+        input: &Value,
+    ) -> Result<LocalExecutionOutput, LocalExecutionFailure>;
+}
+```
+
+This is a breaking change to a public, embedder-facing trait (roughly a
+dozen implementors/call sites across `traverse-runtime`, `traverse-cli`, and
+`traverse-mcp`), accepted because it is the only shape that gives native
+`LocalExecutor` implementors — host-provided closures, `ArtifactRouter`'s
+native handlers — an actual, structural channel to emit events at all. A
+narrower fix scoped only to `ArtifactRouter`'s WASM path would leave native
+capabilities with no channel; collapsing `LocalExecutor` into
+`CapabilityExecutor` entirely was considered and rejected as disproportionate
+to this gap (see Alternatives).
+
+`BoundLocalExecutor` threads `LocalExecutionOutput.emitted_events` into
+`ExecutorOutput.emitted_events`, so `PlacementRouter` Step 5 publishes them
+for the live `Runtime::execute()` path with no further changes to `Step 5`
+itself. `ArtifactRouter` returns real `WasmExecutor`-sourced events for WASM
+capabilities instead of discarding them, and native handlers may populate
+`emitted_events` directly.
+
+`ArtifactRouter` itself does not hold an `EventBroker` reference and does
+not publish internally — it is used both directly by `workflows.rs` and,
+via `BoundLocalExecutor`, by `PlacementRouter` Step 5, and publishing from
+within `ArtifactRouter` would double-publish on the live path.
+`workflows.rs::execute_workflow_capability` gains its own publish step,
+structurally analogous to `PlacementRouter` Step 5 (same `Subscribable`
+gate, same best-effort publish semantics), since workflow-internal node
+execution bypasses `PlacementRouter` entirely.
+
+The old output-JSON `emitted_events` convention in `workflows.rs` is
+removed. Pass-1 event-driven edge matching reads from the new structured
+`LocalExecutionOutput.emitted_events` field instead of parsing the node's
+JSON output — completing `098` FR-004 across the codebase, not just the
+`executor`/`router` slice it originally covered.
+
+Because native `LocalExecutor` implementors are unsandboxed host code (unlike
+WASM, which is validated synchronously inside the host function at call
+time), natively-populated events are validated against the capability
+contract's `emits` list and `service_type == Subscribable` before publish —
+after the closure has already returned, since there is no way to reject
+mid-call the way the WASM host function can. An undeclared or invalid native
+event fails the whole capability/node execution, matching the severity of a
+WASM ABI rejection, so "emitted events are always declared" remains a real
+guarantee on the native path too.
+
+## Consequences
+
+`LocalExecutor` implementors across the workspace (test doubles in
+`workflows.rs` and router tests, `traverse-cli/src/main.rs`,
+`traverse-cli/src/http_api.rs`, `traverse-mcp/src/lib.rs`,
+`traverse-mcp/src/stdio_server.rs`,
+`examples/load_workspace_app_state.rs`) must migrate to the new return
+type. Existing tests that document the gap as expected behavior
+(`bound_local_executor_never_publishes_events_through_placement_router` in
+`lib.rs`, `live_native_execution_completes_and_writes_trace_without_publishing_events`
+in `tests/placement_router_live_wiring.rs`) must be rewritten to assert the
+corrected behavior. `workflows.rs` gains a new validation-and-publish
+responsibility it did not previously have, and its trace evidence
+(`WorkflowTraversalEvidence.emitted_events`) is sourced from the structured
+field rather than JSON parsing. Downstream embedders implementing
+`LocalExecutor` directly against this crate must update their
+implementations at the next version bump — acceptable per Decision 48 given
+no production capabilities exist yet.
+
+## Alternatives Considered
+
+- Narrow fix scoped to `ArtifactRouter` only (inject an `EventBroker`
+  reference directly, publish from within `ArtifactRouter`, no trait
+  signature change) — smaller and non-breaking, and was the initially
+  recommended option. Rejected because it leaves native `LocalExecutor`
+  implementors with no event-emission channel at all, and because
+  publishing from within `ArtifactRouter` itself would double-publish on
+  the live `Runtime::execute()` path once `ArtifactRouter` is also wrapped
+  by `BoundLocalExecutor`/`PlacementRouter` Step 5.
+- Collapse `LocalExecutor` into `CapabilityExecutor` entirely, removing the
+  dual-trait split at its root — rejected as disproportionate: it would
+  rewrite `BoundLocalExecutor`'s role, `ArtifactRouter`'s trait impl, every
+  workflow test double, and both embedders' integration simultaneously, for
+  a gap this ADR closes with a narrower, additive-field change.
+- Keep the output-JSON `emitted_events` convention in `workflows.rs` as a
+  documented fallback alongside the new structured field — rejected: keeps
+  a second supported path indefinitely, directly contradicting `098` FR-004
+  and Decision 48's no-back-compat-tax principle.
+- Drop invalid native-emitted events with a warning instead of failing
+  execution — rejected: weakens "emitted events are always declared" to
+  something easy to silently miss, inconsistent with the WASM ABI's
+  synchronous-rejection guarantee.

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -1892,3 +1892,143 @@ boundary. Guest constraints remain governed by `091` / `090`.
 - `#986` / `#987` remain independently Ready under existing specs.
 - Decision 48 (no pre-production backward-compatibility tax) applies: do not
   maintain a long dual-scaffold era.
+
+## Decision 55: New Spec + ADR for `LocalExecutor` Event Emission, Extending `LocalExecutor`'s Trait Signature Rather Than Patching Around It
+
+- **Date**: 2026-08-07
+- **Status**: Accepted
+- **Governing specs**: [ADR-0037](adr/0037-local-executor-event-emission.md) + `101-local-executor-event-emission` (authored in #995), extends `098-capability-event-host-abi`, `207-event-broker`; touches but does not amend `099-workflow-event-broker-unification` (that spec's boundary explicitly excludes "how a capability emits an event")
+- **Related issues**: follows up on `#970` (098's implementation); `#995` (spec, complete), `#996` (implementation, Ready)
+- **Origin**: `/brainstorm` session auditing `#970`'s follow-through
+
+### Context
+
+`#970` implemented spec `098`'s `traverse_host::emit_event` WASM ABI and
+threaded it through `CapabilityExecutor::execute() -> ExecutorOutput` and
+`PlacementRouter` Step 5, but only for the `CapabilityExecutor` trait. A
+separate, older trait, `LocalExecutor::execute() -> Result<Value,
+LocalExecutionFailure>` (`crates/traverse-runtime/src/lib.rs`), has no
+event channel at all and is used by two real production paths:
+`BoundLocalExecutor` (bridges a host-provided native `LocalExecutor` into
+`Runtime::execute()`'s live path) and `ArtifactRouter` (the `LocalExecutor`
+used for workflow-internal node execution in `workflows.rs`, and — since
+`traverse-cli`'s `main.rs` constructs `Runtime::new(registry,
+ArtifactRouter::new()?)` — the *same* underlying executor as the live path).
+`ArtifactRouter` calls `WasmExecutor` internally for WASM capabilities and
+already receives real, ABI-validated `ExecutorOutput.emitted_events`, but
+discards them (`.map(|output| output.value)`) before returning. Both gaps
+were already flagged in-repo as known issues (tests documenting the drop in
+`lib.rs` and `tests/placement_router_live_wiring.rs`).
+
+A related, closely coupled gap surfaced during investigation: spec `098`'s
+FR-004 required removing the old output-JSON `emitted_events` convention
+"once this ABI exists — not kept as a second supported path," but
+`workflows.rs`'s `emitted_events(&output: &Value)` JSON-parsing convention
+is still the only event-emission mechanism available to native
+(non-WASM) capabilities inside workflows, and was therefore never actually
+removed. It's also narrower than `EventBroker`-backed emission: a
+workflow node's emitted events today only ever satisfy waiting edges
+within the *same* workflow execution — they never reach `EventBroker` for
+other workflows, capabilities, or external subscribers.
+
+### Decision
+
+Six sub-decisions, worked through in sequence:
+
+1. **Fix shape**: extend `LocalExecutor::execute()`'s return type (e.g. a
+   new `LocalExecutionOutput { value: Value, emitted_events:
+   Vec<TraverseEvent> }`, mirroring `ExecutorOutput`) rather than a
+   narrower fix scoped to `ArtifactRouter` alone. Accepted as a breaking
+   change to a public, embedder-facing trait (~12 call sites across
+   `traverse-runtime`, `traverse-cli`, `traverse-mcp`) because it's the
+   only shape that gives native `LocalExecutor` implementors (host
+   closures, `ArtifactRouter`'s native handlers) an actual, structural way
+   to emit events at all — a narrower `ArtifactRouter`-only fix would have
+   left native capabilities with no channel, and full unification into
+   `CapabilityExecutor` was rejected as disproportionate to this bug.
+2. **Old JSON convention**: removed outright, migrating `workflows.rs`'s
+   node-execution and Pass-1 event-driven edge matching onto the new
+   structured `emitted_events` field. This finally satisfies `098`'s
+   FR-004 across the full codebase (it previously only covered the
+   `executor`/`router` slice), consistent with Decision 48 (no
+   back-compat tax pre-production).
+3. **External publish**: a workflow node's emitted events now also publish
+   to `EventBroker` (in addition to satisfying same-execution waiting
+   edges), closing the "workflow events are invisible outside their own
+   execution" gap while the same code path is already being touched.
+4. **Governance vehicle**: a new ADR + spec, not an amendment to `098`.
+   `098`'s capability boundary explicitly scoped itself to
+   `executor`/`router`/`traverse-contracts`/`traverse-native-bridge`, and
+   this is a materially different mechanism (a trait signature change,
+   not a WASM host import) serving a related but distinct purpose —
+   matching the Decision 51 precedent of one ADR+spec per distinct
+   capability boundary.
+5. **Native event validation**: events populated directly by native
+   `LocalExecutor` implementors must be validated against the capability
+   contract's `emits` list and `service_type == Subscribable` before
+   publish, mirroring the WASM ABI's FR-002/FR-003 synchronous validation.
+   Without this, native code (unsandboxed, unlike WASM) could emit
+   undeclared events straight to `EventBroker`, since the existing
+   `PlacementRouter` Step 5 check only gates on `service_type`, not on
+   `emits` content.
+6. **Failure mode on invalid native event**: an undeclared/invalid native
+   event fails the whole capability/node execution (same severity as a
+   WASM ABI rejection), even though native validation necessarily happens
+   *after* the closure has already returned (it can't be rejected
+   mid-call the way the synchronous WASM host function can). Chosen over
+   silently dropping the event with a warning, to keep "emitted events are
+   always declared" a real guarantee on the native path too, not just WASM.
+
+An architectural consequence of (1) that isn't a preference but a forced
+correctness constraint: `ArtifactRouter` must not hold its own
+`EventBroker` reference or publish internally, since it is used both
+directly by `workflows.rs` (bypassing `PlacementRouter`) and, wrapped in
+`BoundLocalExecutor`, by `PlacementRouter` Step 5 for the live
+`Runtime::execute()` path. Publishing from within `ArtifactRouter` itself
+would double-publish on the live path. The single publish point per path
+stays `PlacementRouter` Step 5 (already correct once `BoundLocalExecutor`
+threads real `emitted_events` through) for the live path, plus a new,
+analogous publish step inside `workflows.rs`'s
+`execute_workflow_capability` for the workflow-internal path.
+
+### Alternatives Considered
+
+- Narrow fix scoped to `ArtifactRouter` only (inject `EventBroker`
+  directly, no trait signature change) — smaller and non-breaking, but
+  leaves native `LocalExecutor` implementors with no event-emission
+  channel at all, and would have needed reverting once decision 5's native
+  closures could populate real events. Not chosen.
+- Collapse `LocalExecutor` into `CapabilityExecutor` entirely — removes
+  the dual-trait split at its root, but rewrites `BoundLocalExecutor`,
+  `ArtifactRouter`'s trait impl, every workflow test double, and both
+  embedders (`traverse-cli`, `traverse-mcp`) simultaneously; disproportionate
+  to this bug. Not chosen.
+- Keep the old JSON `emitted_events` convention as a documented fallback
+  alongside the new structured field — less migration work, but directly
+  contradicts `098` FR-004 and Decision 48's no-back-compat-tax principle.
+  Not chosen.
+- Drop invalid native-emitted events with a warning instead of failing
+  execution — avoids punishing an otherwise-successful capability result
+  for an unrelated event-declaration bug, but weakens the "emitted events
+  are always declared" guarantee to something easy to silently miss. Not
+  chosen.
+
+### Outcome
+
+Two tickets, following the repo's spec-then-implement convention: `#995`
+authored ADR-0037 + spec `101-local-executor-event-emission` v1.0.0
+(extending `098`'s emission model to the `LocalExecutor` surface,
+including the `workflows.rs` publish step and native-event
+validation/failure semantics) directly in-session, registered `approved`
+in `specs/governance/approved-specs.json` per the auto-approval policy
+(aligned with this decision log entry); `#996` tracks the implementation —
+the trait signature change and all ~12 call-site migrations, the
+`workflows.rs` JSON-convention removal and structured-field migration, and
+updates to the tests that currently document the gap as expected behavior
+(`lib.rs`'s `bound_local_executor_never_publishes_events_through_placement_router`,
+`tests/placement_router_live_wiring.rs`'s
+`live_native_execution_completes_and_writes_trace_without_publishing_events`).
+Both filed on org Project 1 (`#995` In Progress pending PR merge, `#996`
+Ready). Spec canonical id renumbered from `100` to `101` during this
+session's rebase after discovering `origin/main` had concurrently claimed
+`100-capability-package-authoring` (Decision 54, #989).

--- a/specs/995-local-executor-event-emission/spec.md
+++ b/specs/995-local-executor-event-emission/spec.md
@@ -1,0 +1,144 @@
+# Feature Specification: `LocalExecutor` Event Emission
+
+**Status**: Approved
+**Canonical governing ID**: `101-local-executor-event-emission`
+**Version**: 1.0.0
+**Extends**: `098-capability-event-host-abi`, `207-event-broker`
+**Input**: Issue #995; ADR-0037; `/brainstorm` session recorded as Decision 53 in `docs/decision-log.md`.
+
+## Purpose
+
+Close a gap left by `098-capability-event-host-abi`'s implementation
+(issue #970): the new `traverse_host::emit_event` WASM ABI only reaches
+capabilities executed through `CapabilityExecutor`. A separate,
+older trait, `LocalExecutor` (`crates/traverse-runtime/src/lib.rs`), backs
+two real production paths — `BoundLocalExecutor` (the live
+`Runtime::execute()` single-capability path) and `ArtifactRouter`
+(workflow-internal node execution in `workflows.rs`) — and has no channel
+to carry emitted events at all. This spec extends `LocalExecutor`'s return
+type to carry emitted events, threads them through both paths to
+`EventBroker`, and completes `098` FR-004's removal of the output-JSON
+`emitted_events` convention, which is still alive in `workflows.rs` because
+it was, until now, the only event-emission mechanism available to native
+`LocalExecutor` capabilities.
+
+## Capability Boundary
+
+This spec governs `crates/traverse-runtime/src/lib.rs` (the `LocalExecutor`
+trait and `BoundLocalExecutor`), `crates/traverse-runtime/src/artifact_router.rs`
+(`ArtifactRouter`'s `LocalExecutor` implementation), and
+`crates/traverse-runtime/src/workflows.rs` (workflow-internal node
+execution, event-driven edge matching, and the new workflow-node event
+publish step). It does not change `traverse_host::emit_event`'s WASM ABI
+signature or synchronous validation behavior (`098`, unchanged), does not
+change `CapabilityExecutor`/`ExecutorOutput` or `PlacementRouter` Step 5's
+existing publish logic (both already correct per `098`/#970 and reused
+as-is once `BoundLocalExecutor` threads real events through them), and does
+not change how a waiting workflow edge subscribes to or consumes
+`EventBroker` events (`099-workflow-event-broker-unification`'s domain,
+unchanged).
+
+## Requirements
+
+- **FR-001**: `LocalExecutor::execute()` MUST return a value carrying both
+  the capability's JSON output and any events it emitted (e.g. a
+  `LocalExecutionOutput { value: Value, emitted_events: Vec<TraverseEvent> }`
+  struct), replacing the current bare `Result<Value, LocalExecutionFailure>`.
+- **FR-002**: `BoundLocalExecutor` MUST thread `LocalExecutionOutput.emitted_events`
+  into `ExecutorOutput.emitted_events` when bridging a `LocalExecutor` into
+  `CapabilityExecutor`, so `PlacementRouter` Step 5 publishes them for
+  `Subscribable` capabilities on the live `Runtime::execute()` path with no
+  change to Step 5 itself.
+- **FR-003**: `ArtifactRouter::execute` MUST return the real,
+  ABI-validated `emitted_events` produced by `WasmExecutor::execute` for
+  WASM capabilities, instead of discarding them.
+- **FR-004**: `ArtifactRouter` MUST NOT hold an `EventBroker` reference or
+  publish events internally. It is used both directly by `workflows.rs`
+  (bypassing `PlacementRouter`) and, wrapped in `BoundLocalExecutor`, by
+  `PlacementRouter` Step 5 for the live path; publishing from within
+  `ArtifactRouter` would double-publish on the live path.
+- **FR-005**: `workflows.rs::execute_workflow_capability` MUST publish a
+  workflow node's `emitted_events` to `EventBroker` when the executing
+  capability's `service_type == Subscribable`, structurally analogous to
+  `PlacementRouter` Step 5 (same gate, same best-effort semantics: a
+  publish error is recorded but does not fail the workflow step). This
+  closes the gap where workflow-node-emitted events previously satisfied
+  only same-execution waiting edges and never reached `EventBroker`.
+- **FR-006**: The output-JSON `emitted_events` convention in `workflows.rs`
+  (`emitted_events(output: &Value)`, parsing an `emitted_events` array out
+  of a capability's own JSON output) MUST be removed. Workflow-internal
+  Pass-1 event-driven edge matching MUST read from the structured
+  `LocalExecutionOutput.emitted_events` field instead.
+- **FR-007**: An event populated directly by a native `LocalExecutor`
+  implementor (a host closure, or one of `ArtifactRouter`'s registered
+  native handlers) MUST be validated against the executing capability
+  contract's `emits` list (`event_id` + `version`) and
+  `service_type == Subscribable` before publish, mirroring `098`
+  FR-002/FR-003's synchronous WASM-boundary validation. This check
+  necessarily runs after the native closure has already returned (there is
+  no host-function call boundary to reject mid-call, unlike WASM), but MUST
+  still run before any publish to `EventBroker`.
+- **FR-008**: A native-emitted event that fails FR-007's validation MUST
+  fail the whole capability/node execution (the same severity as a WASM ABI
+  synchronous rejection under `098` FR-002), not be silently dropped with
+  only a warning.
+- **FR-009**: All existing `LocalExecutor` implementors and call sites in
+  this workspace (test doubles in `workflows.rs` and router tests,
+  `traverse-cli/src/main.rs`, `traverse-cli/src/http_api.rs`,
+  `traverse-mcp/src/lib.rs`, `traverse-mcp/src/stdio_server.rs`,
+  `examples/load_workspace_app_state.rs`) MUST be migrated to the new
+  `LocalExecutionOutput` return type.
+- **FR-010**: Tests that currently document the gap this spec closes as
+  expected behavior — `lib.rs`'s
+  `bound_local_executor_never_publishes_events_through_placement_router`
+  and `tests/placement_router_live_wiring.rs`'s
+  `live_native_execution_completes_and_writes_trace_without_publishing_events`
+  — MUST be rewritten to assert the corrected behavior (events do publish).
+
+## Acceptance Scenarios
+
+1. Given a `Subscribable` WASM capability invoked via `Runtime::execute()`'s
+   live path (backed by `ArtifactRouter` wrapped in `BoundLocalExecutor`)
+   that calls `traverse_host::emit_event` with a declared event, when
+   execution completes, then the event is published to `EventBroker`.
+2. Given a `Subscribable` WASM capability inside a workflow node that calls
+   `traverse_host::emit_event` with a declared event, when the node
+   completes, then the event both satisfies same-execution waiting edges
+   (if a matching edge exists) and is published to `EventBroker` for
+   external consumers.
+3. Given a native `LocalExecutor` capability (a host closure, or an
+   `ArtifactRouter` native handler) whose `service_type` is `Subscribable`
+   and that populates `LocalExecutionOutput.emitted_events` with an event
+   declared in its contract's `emits` list, when execution completes, then
+   the event is published to `EventBroker`.
+4. Given a native `LocalExecutor` capability that populates
+   `LocalExecutionOutput.emitted_events` with an event NOT declared in its
+   contract's `emits` list, when execution completes, then the capability's
+   execution result is a failure and no event reaches `EventBroker`.
+5. Given a native `LocalExecutor` capability whose `service_type` is not
+   `Subscribable` that populates `LocalExecutionOutput.emitted_events` with
+   any event, when execution completes, then the capability's execution
+   result is a failure and no event reaches `EventBroker`.
+6. Given a workflow node capability with no emitted events, when the node
+   completes, then no publish call is made and existing traversal behavior
+   is unchanged.
+7. Given `EventBroker` is unreachable when `workflows.rs` attempts to
+   publish a workflow node's emitted event, when the publish is attempted,
+   then the error is recorded (matching `PlacementRouter` Step 5's
+   best-effort semantics) and the workflow step still completes
+   successfully — a broker outage does not fail workflow traversal.
+
+## Out of Scope
+
+- Changes to `traverse_host::emit_event`'s WASM ABI signature or
+  synchronous validation behavior (`098-capability-event-host-abi`).
+- Changes to `CapabilityExecutor`, `ExecutorOutput`, or `PlacementRouter`
+  Step 5's existing publish logic.
+- Changes to how a waiting workflow edge subscribes to or consumes
+  `EventBroker` events (`099-workflow-event-broker-unification`).
+- Collapsing `LocalExecutor` into `CapabilityExecutor` (considered and
+  rejected in ADR-0037 as disproportionate to this gap).
+- A native-side host-callback API giving `BoundLocalExecutor`'s
+  host-provided closures a richer, ABI-validated event-emission mechanism
+  beyond directly populating `LocalExecutionOutput.emitted_events` —
+  deferred as a distinct future problem if ever needed.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1322,7 +1322,8 @@
         "crates/traverse-runtime/src/artifact_router.rs",
         "crates/traverse-runtime/src/workflows.rs",
         "docs/adr/0037-local-executor-event-emission.md",
-        "specs/995-local-executor-event-emission/"
+        "specs/995-local-executor-event-emission/",
+        "docs/decision-log.md"
       ]
     }
   ]

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1310,6 +1310,20 @@
         "specs/100-capability-package-authoring/",
         "docs/decision-log.md"
       ]
+    },
+    {
+      "id": "101-local-executor-event-emission",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/995-local-executor-event-emission/spec.md",
+      "governs": [
+        "crates/traverse-runtime/src/lib.rs",
+        "crates/traverse-runtime/src/artifact_router.rs",
+        "crates/traverse-runtime/src/workflows.rs",
+        "docs/adr/0037-local-executor-event-emission.md",
+        "specs/995-local-executor-event-emission/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Governing Spec

- 101-local-executor-event-emission
- 004-spec-alignment-gate

## Project Item

Closes #995

## Validation

- `bash scripts/ci/spec_alignment_check.sh` passes against this diff.
- `jq . specs/governance/approved-specs.json` validates.
- Spec/ADR content reviewed against `docs/decision-log.md` Decision 55, generated via `/brainstorm` per the repo's spec-approval policy.

## Summary

Authors ADR-0037 + spec `101-local-executor-event-emission` v1.0.0, closing
the follow-up gap from #970 (098's implementation): `LocalExecutor`
(`BoundLocalExecutor`, `ArtifactRouter`) silently drops events emitted via
`traverse_host::emit_event`, and `workflows.rs`'s pre-098 output-JSON
`emitted_events` convention was never actually removed. This PR only adds
governance artifacts (decision log, ADR, spec, approved-specs.json entry) —
implementation is tracked separately in #996.
