### PR TITLE
feat(cli): implement capability new, retire component new + scaffold script

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -100,6 +100,9 @@ enum Command {
     ComponentNew {
         component_id: String,
     },
+    CapabilityNew {
+        capability_id: String,
+    },
     CapabilityPackageInspect {
         manifest_path: PathBuf,
     },
@@ -262,6 +265,7 @@ fn main() -> ExitCode {
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn run_command(command: Command) -> Result<String, CliError> {
     match command {
         Command::BundleInspect {
@@ -306,6 +310,7 @@ fn run_command(command: Command) -> Result<String, CliError> {
             dry_run,
         ),
         Command::ComponentNew { component_id } => component_new(&component_id),
+        Command::CapabilityNew { capability_id } => capability_new(&capability_id),
         Command::Serve { .. } => Err(CliError::UsageError(usage())),
         Command::CapabilityPackageInspect { manifest_path } => {
             inspect_capability_package(&manifest_path)
@@ -438,6 +443,7 @@ fn parse_command(args: &[String]) -> Result<Command, String> {
         (Some("registry"), Some("list")) => parse_registry_list_command(args),
         (Some("registry"), Some("search")) => parse_registry_search_command(args),
         (Some("component"), Some("new")) => parse_component_new_command(args),
+        (Some("capability"), Some("new")) => parse_capability_new_command(args),
         (Some("federation"), Some(_)) => parse_federation_command(args),
         (Some("capability-package"), Some("execute")) => {
             parse_capability_package_execute_command(args)
@@ -485,6 +491,7 @@ fn subcommand_help(family: Option<&str>, subcommand: Option<&str>) -> String {
         (Some("workflow"), _) => help_workflow(),
         (Some("expedition"), Some("execute")) => help_expedition_execute(),
         (Some("expedition"), _) => help_expedition(),
+        (Some("capability"), Some("new")) => help_capability_new(),
         (Some("capability"), Some("inspect")) => help_capability_inspect(),
         (Some("capability"), Some("discover")) => help_capability_discover(),
         (Some("capability"), Some("publish")) => help_capability_publish(),
@@ -768,20 +775,14 @@ fn help_capability_publish() -> String {
 fn help_component_new() -> String {
     "traverse-cli component new <component-id>
 
-  Purpose:
-    Create a governed WASM component package directory under
-    components/<component-id>. The scaffold contains a schema-valid component
-    manifest, draft capability contract, Rust package shell, source directory,
-    and artifact directory. It does not create an executable WASM artifact.
+  Retired (spec 100-capability-package-authoring FR-008):
+    This command no longer scaffolds a package. It exits non-zero and
+    directs you to the real create path.
 
-  Required arguments:
-    <component-id>   Component and capability id to scaffold.
+  Use instead:
+    traverse-cli capability new <capability-id>
 
-  Optional flags:
-    --help           Print this help text.
-
-  Example:
-    traverse-cli component new knowledge.retrieve"
+  Run `traverse-cli capability new --help` for details."
         .to_string()
 }
 
@@ -789,9 +790,9 @@ fn help_component() -> String {
     "traverse-cli component <subcommand> [options]
 
   Subcommands:
-    new <component-id>   Create a governed WASM component package scaffold.
+    new <component-id>   Retired — redirects to `capability new` (spec 100).
 
-  Run `traverse-cli component new --help` for subcommand-specific help."
+  Run `traverse-cli capability new --help` for the real create path."
         .to_string()
 }
 
@@ -1126,10 +1127,35 @@ fn help_capability_discover() -> String {
         .to_string()
 }
 
+fn help_capability_new() -> String {
+    "traverse-cli capability new <capability-id>
+
+  Purpose:
+    Create a governed WASM capability package directory under
+    capabilities/<capability-id> (spec 100-capability-package-authoring).
+    The scaffold is a real `kind: capability_package` — the same shape
+    `capability-package inspect`/`execute` load in production — with a
+    contract carrying authorable input/output fields (not empty
+    placeholders) and a #![no_std] WASI guest stub. It does not claim to be
+    executable yet: no wasm artifact exists until you build one.
+
+  Required arguments:
+    <capability-id>   Capability id to scaffold (dot-separated, e.g.
+                       example.domain.my-cap).
+
+  Optional flags:
+    --help            Print this help text.
+
+  Example:
+    traverse-cli capability new example.domain.my-cap"
+        .to_string()
+}
+
 fn help_capability() -> String {
     "traverse-cli capability <subcommand> [options]
 
   Subcommands:
+    new <capability-id>             Scaffold a governed WASM capability package.
     inspect <contract-path>         Parse and validate a capability contract.
     discover <manifest-path>        List capabilities from a registry bundle.
     publish --contract <path>       Open a governed registry publication PR.
@@ -1348,6 +1374,15 @@ fn parse_component_new_command(args: &[String]) -> Result<Command, String> {
     match args {
         [_, _, _, component_id] => Ok(Command::ComponentNew {
             component_id: component_id.clone(),
+        }),
+        _ => Err(usage()),
+    }
+}
+
+fn parse_capability_new_command(args: &[String]) -> Result<Command, String> {
+    match args {
+        [_, _, _, capability_id] => Ok(Command::CapabilityNew {
+            capability_id: capability_id.clone(),
         }),
         _ => Err(usage()),
     }
@@ -1867,24 +1902,38 @@ fn app_new_at(
     Ok(lines.join("\n"))
 }
 
-fn component_new(component_id: &str) -> Result<String, CliError> {
-    let base_dir = env::current_dir()
-        .map_err(|e| CliError::IoError(format!("failed to resolve current directory: {e}")))?;
-    component_new_at(&base_dir, component_id)
+/// Spec `100-capability-package-authoring` FR-008: `component new` no longer
+/// emits the pre-Spec-100 empty, non-loadable scaffold. It redirects authors
+/// to the real `capability new` create path instead.
+fn component_new(_component_id: &str) -> Result<String, CliError> {
+    Err(CliError::UsageError(
+        "`traverse-cli component new` has been retired in favor of `traverse-cli capability new \
+         <capability-id>`, which scaffolds a real, inspectable `kind: capability_package` \
+         (spec 100-capability-package-authoring). Run `traverse-cli capability new --help` for \
+         details."
+            .to_string(),
+    ))
 }
 
-fn component_new_at(base_dir: &Path, component_id: &str) -> Result<String, CliError> {
-    validate_scaffold_id(component_id, "component id")?;
-    let component_dir = base_dir.join("components").join(component_id);
-    if component_dir.exists() {
+fn capability_new(capability_id: &str) -> Result<String, CliError> {
+    let base_dir = env::current_dir()
+        .map_err(|e| CliError::IoError(format!("failed to resolve current directory: {e}")))?;
+    capability_new_at(&base_dir, capability_id)
+}
+
+fn capability_new_at(base_dir: &Path, capability_id: &str) -> Result<String, CliError> {
+    validate_scaffold_id(capability_id, "capability id")?;
+    let capability_dir = base_dir.join("capabilities").join(capability_id);
+    if capability_dir.exists() {
         return Err(CliError::IoError(format!(
-            "component scaffold target already exists: {}",
-            component_dir.display()
+            "capability scaffold target already exists: {}",
+            capability_dir.display()
         )));
     }
 
-    let src_dir = component_dir.join("src");
-    let artifacts_dir = component_dir.join("artifacts");
+    let src_dir = capability_dir.join("src");
+    let artifacts_dir = capability_dir.join("artifacts");
+    let runtime_requests_dir = capability_dir.join("runtime-requests");
     fs::create_dir_all(&src_dir).map_err(|e| {
         CliError::IoError(format!(
             "failed to create source directory {}: {e}",
@@ -1897,62 +1946,273 @@ fn component_new_at(base_dir: &Path, component_id: &str) -> Result<String, CliEr
             artifacts_dir.display()
         ))
     })?;
+    fs::create_dir_all(&runtime_requests_dir).map_err(|e| {
+        CliError::IoError(format!(
+            "failed to create runtime-requests directory {}: {e}",
+            runtime_requests_dir.display()
+        ))
+    })?;
 
-    let component_name = scaffold_leaf_name(component_id);
-    let wasm_name = format!("{component_name}.wasm");
-    let package_name = component_id.replace('.', "-");
-    write_new_file(
-        &component_dir.join("Cargo.toml"),
-        &format!(
-            "[package]\nname = \"{package_name}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[lib]\ncrate-type = [\"cdylib\"]\npath = \"src/lib.rs\"\n"
-        ),
-    )?;
-    write_new_file(&src_dir.join("lib.rs"), "")?;
+    let leaf_name = scaffold_leaf_name(capability_id);
+    let wasm_name = format!("{leaf_name}.wasm");
+
+    write_new_file(&src_dir.join("agent.rs"), &capability_guest_stub_source())?;
     write_new_file(
         &artifacts_dir.join("README.md"),
-        "Place the compiled WASM artifact here after the component implementation is built.\n",
+        "Place the compiled WASM artifact here after running build-fixture.sh. \
+         `capability-package inspect`/`execute` refuse to treat this package as executable \
+         until a real artifact exists here and its digest matches manifest.json's \
+         binary.expected_digest.\n",
+    )?;
+    write_new_file(
+        &capability_dir.join("build-fixture.sh"),
+        &capability_build_fixture_script(&wasm_name),
     )?;
     write_pretty_json(
-        &component_dir.join("contract.json"),
-        &component_contract_json(component_id, &component_name),
+        &capability_dir.join("contract.json"),
+        &capability_contract_json(capability_id, &leaf_name),
     )?;
     write_pretty_json(
-        &component_dir.join("manifest.json"),
-        &serde_json::json!({
-            "component_id": component_id,
+        &capability_dir.join("manifest.json"),
+        &capability_package_manifest_json(capability_id, &wasm_name),
+    )?;
+    write_pretty_json(
+        &runtime_requests_dir.join(format!("{leaf_name}.json")),
+        &capability_sample_runtime_request_json(capability_id, &leaf_name),
+    )?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let build_script = capability_dir.join("build-fixture.sh");
+        if let Ok(metadata) = fs::metadata(&build_script) {
+            let mut permissions = metadata.permissions();
+            permissions.set_mode(0o755);
+            let _ = fs::set_permissions(&build_script, permissions);
+        }
+    }
+
+    let manifest_path = capability_dir.join("manifest.json");
+    let request_path = runtime_requests_dir.join(format!("{leaf_name}.json"));
+    Ok([
+        format!("created_capability: {capability_id}"),
+        format!("capability_dir: {}", capability_dir.display()),
+        format!("manifest: {}", manifest_path.display()),
+        format!(
+            "contract: {}",
+            capability_dir.join("contract.json").display()
+        ),
+        format!("source: {}", src_dir.join("agent.rs").display()),
+        format!("sample_request: {}", request_path.display()),
+        "next_steps:".to_string(),
+        "  1. Implement real input/output fields and business logic in src/agent.rs \
+             and contract.json (this scaffold is a placeholder, not executable yet)."
+            .to_string(),
+        format!(
+            "  2. Build the WASM artifact: bash {}",
+            capability_dir.join("build-fixture.sh").display()
+        ),
+        format!(
+            "  3. Run `traverse-cli capability-package inspect {}` — if binary.expected_digest \
+             doesn't match yet, the error reports the real digest to paste into manifest.json.",
+            manifest_path.display()
+        ),
+        format!(
+            "  4. Once inspect succeeds, run `traverse-cli capability-package execute {} {}`.",
+            manifest_path.display(),
+            request_path.display()
+        ),
+    ]
+    .join("\n"))
+}
+
+fn capability_package_manifest_json(capability_id: &str, wasm_name: &str) -> Value {
+    serde_json::json!({
+        "kind": "capability_package",
+        "schema_version": "1.0.0",
+        "package_id": capability_id,
+        "version": "1.0.0",
+        "summary": format!("Governed capability package for {capability_id}."),
+        "capability_ref": {
+            "id": capability_id,
             "version": "1.0.0",
-            "schema_version": "1.0.0",
-            "capability_id": component_id,
-            "capability_version": "1.0.0",
-            "contract_path": "contract.json",
-            "wasm_binary_path": format!("artifacts/{wasm_name}"),
-            "wasm_digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-            "runtime_constraints": {
+            "contract_path": "contract.json"
+        },
+        "workflow_refs": [
+            {
+                "workflow_id": capability_id,
+                "workflow_version": "1.0.0"
+            }
+        ],
+        "source": {
+            "path": "src/agent.rs",
+            "language": "rust",
+            "entry": "run"
+        },
+        "binary": {
+            "path": format!("artifacts/{wasm_name}"),
+            "format": "wasm",
+            "expected_digest": "fnv1a64:0000000000000000",
+            "abi_version": SUPPORTED_HOST_ABI_VERSION
+        },
+        "constraints": {
+            "host_api_access": "none",
+            "network_access": "forbidden",
+            "filesystem_access": "none"
+        }
+    })
+}
+
+fn capability_contract_json(capability_id: &str, name: &str) -> Value {
+    let namespace = component_namespace(capability_id);
+    serde_json::json!({
+        "kind": "capability_contract",
+        "schema_version": "1.0.0",
+        "id": capability_id,
+        "namespace": namespace,
+        "name": name,
+        "version": "1.0.0",
+        "lifecycle": "active",
+        "owner": {
+            "team": "local-author",
+            "contact": "local-author"
+        },
+        "summary": format!("Governed capability contract for {capability_id}."),
+        "description": format!("Draft Traverse capability contract for the real WASM capability {capability_id}."),
+        "inputs": {
+            "schema": {
+                "type": "object",
+                "required": ["input_value"],
+                "additionalProperties": false,
+                "properties": {
+                    "input_value": {
+                        "type": "string",
+                        "description": "Placeholder input field. Replace with this capability's real input fields."
+                    }
+                }
+            }
+        },
+        "outputs": {
+            "schema": {
+                "type": "object",
+                "required": ["output_value"],
+                "additionalProperties": false,
+                "properties": {
+                    "output_value": {
+                        "type": "string",
+                        "description": "Placeholder output field. Replace with this capability's real output fields."
+                    }
+                }
+            }
+        },
+        "preconditions": [],
+        "postconditions": [],
+        "side_effects": [
+            {
+                "kind": "memory_only",
+                "description": "No external side effects are declared for this draft capability contract."
+            }
+        ],
+        "emits": [],
+        "consumes": [],
+        "permissions": [
+            {
+                "id": capability_id
+            }
+        ],
+        "execution": {
+            "binary_format": "wasm",
+            "entrypoint": {
+                "kind": "wasi-command",
+                "command": "run"
+            },
+            "preferred_targets": ["local"],
+            "constraints": {
                 "host_api_access": "none",
                 "network_access": "forbidden",
                 "filesystem_access": "none"
-            },
-            "permitted_targets": ["local"],
-            "dependencies": [],
-            "connector_requirements": [],
-            "validation_evidence": []
-        }),
-    )?;
+            }
+        },
+        "policies": [
+            {
+                "id": "manual-approval-required"
+            }
+        ],
+        "dependencies": [],
+        "provenance": {
+            "source": "greenfield",
+            "author": "traverse-cli",
+            "created_at": "capability-scaffold",
+            "spec_ref": "100-capability-package-authoring@1.0.0",
+            "adr_refs": [],
+            "exception_refs": []
+        },
+        "evidence": [],
+        "service_type": "stateless",
+        "permitted_targets": ["local"],
+        "artifact_type": "native"
+    })
+}
 
-    Ok([
-        format!("created_component: {component_id}"),
-        format!("component_dir: {}", component_dir.display()),
-        format!(
-            "manifest: {}",
-            component_dir.join("manifest.json").display()
-        ),
-        format!(
-            "contract: {}",
-            component_dir.join("contract.json").display()
-        ),
-        format!("source: {}", src_dir.join("lib.rs").display()),
-    ]
-    .join("\n"))
+fn capability_sample_runtime_request_json(capability_id: &str, leaf_name: &str) -> Value {
+    serde_json::json!({
+        "kind": "runtime_request",
+        "schema_version": "1.0.0",
+        "request_id": format!("{leaf_name}-scaffold-001"),
+        "intent": {
+            "capability_id": capability_id,
+            "capability_version": "1.0.0"
+        },
+        "input": {
+            "input_value": "example value"
+        },
+        "lookup": {
+            "scope": "prefer_private",
+            "allow_ambiguity": false
+        },
+        "context": {
+            "requested_target": "local",
+            "caller": "capability-scaffold"
+        },
+        "governing_spec": "006-runtime-request-execution"
+    })
+}
+
+/// A `#![no_std]` WASI guest stub matching the no-std guest profile
+/// (`091-no-std-wasi-guest-profile`): it imports only
+/// `wasi_snapshot_preview1::fd_write` (never `environ_get`) and emits a
+/// static placeholder that matches `capability_contract_json`'s output
+/// schema. It is an honest placeholder, not fake business logic (`044`
+/// QG-004) — the author must implement real input handling and logic here.
+/// The template's own source keeps `unsafe` syntax, as any real
+/// `#![no_std]` WASI guest must (spec `091-no-std-wasi-guest-profile`
+/// FR-004's raw host-import boundary). It lives in a `.rs.template` data
+/// file rather than a `.rs` string literal here specifically so
+/// `scripts/ci/scoped_unsafe_boundary_check.sh`'s repo-wide `unsafe` grep
+/// (scoped to files this crate itself compiles as Rust) does not mistake
+/// *generated scaffold text* for unsafe code in `traverse-cli` itself.
+fn capability_guest_stub_source() -> String {
+    include_str!("../templates/capability_guest_stub.rs.template").to_string()
+}
+
+fn capability_build_fixture_script(wasm_name: &str) -> String {
+    format!(
+        "#!/usr/bin/env bash\n\
+         \n\
+         set -euo pipefail\n\
+         \n\
+         script_dir=\"$(cd \"$(dirname \"${{BASH_SOURCE[0]}}\")\" && pwd)\"\n\
+         artifact_dir=\"$script_dir/artifacts\"\n\
+         artifact_path=\"$artifact_dir/{wasm_name}\"\n\
+         \n\
+         mkdir -p \"$artifact_dir\"\n\
+         \n\
+         rustup run \"$(rustup show active-toolchain | awk '{{print $1}}')\" rustc \"$script_dir/src/agent.rs\" \\\n  \
+             --target wasm32-unknown-unknown --crate-type cdylib -O -C panic=abort -C strip=symbols \\\n  \
+             --remap-path-prefix \"$script_dir=/traverse-repo/agent\" -o \"$artifact_path\"\n\
+         \n\
+         printf 'built %s\\n' \"$artifact_path\"\n"
+    )
 }
 
 fn register_generated_app_bundle(
@@ -3702,85 +3962,6 @@ fn validate_non_placeholder_sha256(
         });
     }
     None
-}
-
-fn component_contract_json(component_id: &str, name: &str) -> Value {
-    let namespace = component_namespace(component_id);
-    serde_json::json!({
-        "kind": "capability_contract",
-        "schema_version": "1.0.0",
-        "id": component_id,
-        "namespace": namespace,
-        "name": name,
-        "version": "1.0.0",
-        "lifecycle": "draft",
-        "owner": {
-            "team": "local-author",
-            "contact": "local-author"
-        },
-        "summary": format!("Governed capability contract for {component_id}."),
-        "description": format!("Draft Traverse capability contract for the real WASM component {component_id}."),
-        "inputs": {
-            "schema": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {}
-            }
-        },
-        "outputs": {
-            "schema": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {}
-            }
-        },
-        "preconditions": [],
-        "postconditions": [],
-        "side_effects": [
-            {
-                "kind": "memory_only",
-                "description": "No external side effects are declared for this draft component contract."
-            }
-        ],
-        "emits": [],
-        "consumes": [],
-        "permissions": [
-            {
-                "id": component_id
-            }
-        ],
-        "execution": {
-            "binary_format": "wasm",
-            "entrypoint": {
-                "kind": "wasi-command",
-                "command": "run"
-            },
-            "preferred_targets": ["local"],
-            "constraints": {
-                "host_api_access": "none",
-                "network_access": "forbidden",
-                "filesystem_access": "none"
-            }
-        },
-        "policies": [
-            {
-                "id": "manual-approval-required"
-            }
-        ],
-        "dependencies": [],
-        "provenance": {
-            "source": "greenfield",
-            "author": "traverse-cli",
-            "created_at": "app-scaffold",
-            "spec_ref": "044-application-bundle-manifest@1.0.0",
-            "adr_refs": [],
-            "exception_refs": []
-        },
-        "evidence": [],
-        "service_type": "stateless",
-        "permitted_targets": ["local"],
-        "artifact_type": "native"
-    })
 }
 
 fn component_namespace(component_id: &str) -> String {
@@ -5684,10 +5865,10 @@ mod tests {
         ArtifactRouter, CapabilityPublishRequest, CapabilityRegistry, CliError, Command,
         DEFAULT_PUBLIC_REGISTRY_SOURCE, ExpeditionExampleExecutor, FetchedRegistryIndex,
         PublishCommandOutput, PublishProcessRunner, RealPublishProcessRunner, RegistryIndexFetcher,
-        RegistrySyncError, Runtime, RuntimeResultStatus, app_new_at, app_register_at,
-        app_registration_state_path, app_validate, app_validate_at,
-        canonical_expedition_bundle_path, capability_publish_at, component_new_at, curl_text,
-        ensure_clean_registry_checkout, execute_capability_package, execute_expedition,
+        RegistrySyncError, Runtime, RuntimeResultStatus, SUPPORTED_HOST_ABI_VERSION, app_new_at,
+        app_register_at, app_registration_state_path, app_validate, app_validate_at,
+        canonical_expedition_bundle_path, capability_new_at, capability_publish_at, component_new,
+        curl_text, ensure_clean_registry_checkout, execute_capability_package, execute_expedition,
         execute_traverse_starter_process, execute_traverse_starter_summarize,
         execute_traverse_starter_validate, format_capability_package_execution_summary,
         help_expedition_execute, help_serve, inspect_bundle, inspect_capability,
@@ -6863,35 +7044,88 @@ mod tests {
     }
 
     #[test]
-    fn component_new_generates_manifest_contract_and_non_executable_package() {
+    fn component_new_redirects_to_capability_new() {
+        let error = component_new("knowledge.retrieve").expect_err("component new must fail");
+        assert!(matches!(error, CliError::UsageError(_)));
+        assert!(error.message().contains("capability new"));
+        assert!(error.message().contains("retired"));
+    }
+
+    #[test]
+    fn capability_new_generates_loadable_capability_package() {
         let temp_dir = unique_temp_dir();
 
-        let output = component_new_at(&temp_dir, "knowledge.retrieve")
-            .expect("component scaffold should be created");
+        let output = capability_new_at(&temp_dir, "knowledge.retrieve")
+            .expect("capability scaffold should be created");
 
-        let component_dir = temp_dir.join("components/knowledge.retrieve");
-        assert!(output.contains("created_component: knowledge.retrieve"));
-        assert!(component_dir.join("manifest.json").is_file());
-        assert!(component_dir.join("contract.json").is_file());
-        assert!(component_dir.join("Cargo.toml").is_file());
-        assert!(component_dir.join("src/lib.rs").is_file());
-        assert!(!component_dir.join("artifacts/retrieve.wasm").exists());
+        let capability_dir = temp_dir.join("capabilities/knowledge.retrieve");
+        assert!(output.contains("created_capability: knowledge.retrieve"));
+        assert!(capability_dir.join("manifest.json").is_file());
+        assert!(capability_dir.join("contract.json").is_file());
+        assert!(capability_dir.join("src/agent.rs").is_file());
+        assert!(capability_dir.join("build-fixture.sh").is_file());
+        assert!(capability_dir.join("artifacts/README.md").is_file());
+        assert!(
+            capability_dir
+                .join("runtime-requests/retrieve.json")
+                .is_file()
+        );
+        assert!(!capability_dir.join("artifacts/retrieve.wasm").exists());
 
         let manifest = serde_json::from_str::<serde_json::Value>(
-            &fs::read_to_string(component_dir.join("manifest.json"))
-                .expect("component manifest should read"),
+            &fs::read_to_string(capability_dir.join("manifest.json"))
+                .expect("capability manifest should read"),
         )
-        .expect("component manifest should parse as JSON");
-        assert_eq!(manifest["component_id"], "knowledge.retrieve");
-        assert_eq!(manifest["capability_id"], "knowledge.retrieve");
-        assert_eq!(manifest["wasm_binary_path"], "artifacts/retrieve.wasm");
+        .expect("capability manifest should parse as JSON");
+        assert_eq!(manifest["kind"], "capability_package");
+        assert_eq!(manifest["package_id"], "knowledge.retrieve");
+        assert_eq!(manifest["capability_ref"]["id"], "knowledge.retrieve");
+        assert_eq!(manifest["capability_ref"]["contract_path"], "contract.json");
+        assert_eq!(manifest["binary"]["path"], "artifacts/retrieve.wasm");
+        assert_eq!(
+            manifest["binary"]["abi_version"],
+            SUPPORTED_HOST_ABI_VERSION
+        );
+        assert!(
+            manifest["workflow_refs"]
+                .as_array()
+                .is_some_and(|refs| !refs.is_empty())
+        );
 
         let contract_contents =
-            fs::read_to_string(component_dir.join("contract.json")).expect("contract should read");
+            fs::read_to_string(capability_dir.join("contract.json")).expect("contract should read");
         let contract = parse_contract(&contract_contents).expect("contract should parse");
         assert_eq!(contract.id, "knowledge.retrieve");
-        assert_eq!(contract.lifecycle, traverse_contracts::Lifecycle::Draft);
-        assert!(!read_tree(&component_dir).contains("TODO"));
+        assert_eq!(contract.lifecycle, traverse_contracts::Lifecycle::Active);
+        assert!(!read_tree(&capability_dir).contains("TODO"));
+
+        let request = serde_json::from_str::<serde_json::Value>(
+            &fs::read_to_string(capability_dir.join("runtime-requests/retrieve.json"))
+                .expect("sample request should read"),
+        )
+        .expect("sample request should parse as JSON");
+        assert_eq!(request["intent"]["capability_id"], "knowledge.retrieve");
+    }
+
+    #[test]
+    fn capability_new_rejects_invalid_id_without_writing_files() {
+        let temp_dir = unique_temp_dir();
+
+        let error =
+            capability_new_at(&temp_dir, "../escape").expect_err("invalid id must be rejected");
+        assert!(matches!(error, CliError::UsageError(_)));
+        assert!(!temp_dir.join("capabilities").exists());
+    }
+
+    #[test]
+    fn capability_new_refuses_to_overwrite_existing_target() {
+        let temp_dir = unique_temp_dir();
+        capability_new_at(&temp_dir, "knowledge.retrieve")
+            .expect("first scaffold should be created");
+
+        let error = capability_new_at(&temp_dir, "knowledge.retrieve")
+            .expect_err("second scaffold must be rejected");
+        assert!(matches!(error, CliError::IoError(message) if message.contains("already exists")));
     }
 
     #[test]
@@ -8811,6 +9045,7 @@ mod tests {
             ("workflow", None),
             ("expedition", Some("execute")),
             ("expedition", None),
+            ("capability", Some("new")),
             ("capability", Some("inspect")),
             ("capability", Some("discover")),
             ("capability", Some("publish")),

--- a/crates/traverse-cli/templates/capability_guest_stub.rs.template
+++ b/crates/traverse-cli/templates/capability_guest_stub.rs.template
@@ -1,0 +1,35 @@
+#![no_std]
+#![no_main]
+
+#[repr(C)]
+struct IoVec {
+    buffer: *const u8,
+    length: usize,
+}
+
+#[link(wasm_import_module = "wasi_snapshot_preview1")]
+unsafe extern "C" {
+    fn fd_write(fd: u32, vectors: *const IoVec, count: usize, written: *mut usize) -> u32;
+}
+
+// Placeholder output matching contract.json's outputs.schema. Replace
+// this whole function with real request parsing and business logic —
+// see docs/wasm-agent-authoring-guide.md.
+static OUTPUT: &[u8] = br#"{"output_value":"replace with real capability output"}"#;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() {
+    let vector = IoVec {
+        buffer: OUTPUT.as_ptr(),
+        length: OUTPUT.len(),
+    };
+    let mut written = 0;
+    unsafe {
+        let _ = fd_write(1, &vector, 1, &mut written);
+    }
+}
+
+#[panic_handler]
+fn panic(_: &core::panic::PanicInfo<'_>) -> ! {
+    loop {}
+}

--- a/scripts/ci/new_capability_scaffold_smoke.sh
+++ b/scripts/ci/new_capability_scaffold_smoke.sh
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# scripts/scaffold/new-capability.sh is retired (spec
+# 100-capability-package-authoring FR-009): it must now fail loudly and
+# redirect authors to `traverse-cli capability new` rather than silently
+# emitting the stale, non-loadable scaffold shape it used to produce.
+
 REPO_ROOT="${TRAVERSE_REPO_ROOT:-$(pwd)}"
-OUT="/tmp/scaffold-smoke-$$"
 
-bash "$REPO_ROOT/scripts/scaffold/new-capability.sh" \
-  --name smoke-test \
-  --namespace ci.smoke \
-  --output-dir "$OUT"
+set +e
+OUTPUT="$(bash "$REPO_ROOT/scripts/scaffold/new-capability.sh" --name smoke-test --namespace ci.smoke 2>&1)"
+STATUS=$?
+set -e
 
-for f in contract.json Cargo.toml src/main.rs build-fixture.sh runtime-request.json; do
-  [[ -f "$OUT/$f" ]] || { echo "MISSING: $OUT/$f" >&2; exit 1; }
-done
+if [[ "$STATUS" -eq 0 ]]; then
+  echo "expected scripts/scaffold/new-capability.sh to exit non-zero (retired script)" >&2
+  exit 1
+fi
 
-ID=$(python3 -c "import json; d=json.load(open('$OUT/contract.json')); print(d['id'])")
-[[ "$ID" == "ci.smoke.smoke-test" ]] || { echo "Wrong id: $ID" >&2; exit 1; }
+if [[ "$OUTPUT" != *"traverse-cli capability new"* ]]; then
+  echo "expected retirement message to redirect to 'traverse-cli capability new':" >&2
+  echo "$OUTPUT" >&2
+  exit 1
+fi
 
-echo "Scaffold smoke: PASS"
-rm -rf "$OUT"
+echo "Scaffold retirement smoke: PASS"

--- a/scripts/scaffold/new-capability.sh
+++ b/scripts/scaffold/new-capability.sh
@@ -1,194 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-NAME=""
-NAMESPACE=""
-OUTPUT_DIR=""
+# Retired (spec 100-capability-package-authoring FR-009). This script used to
+# emit a stale scaffold shape (flat "input_schema"/"output_schema" contract
+# keys, no manifest.json, a std-linked cargo build) that cannot be loaded by
+# `traverse-cli capability-package inspect`/`execute`. It now fails loudly
+# and points authors at the real, governed create path instead of silently
+# producing a broken scaffold.
 
-usage() {
-  echo "Usage: $0 --name <name> --namespace <namespace> [--output-dir <dir>]" >&2
-  exit 1
-}
+cat >&2 <<'MSG'
+scripts/scaffold/new-capability.sh has been retired (spec 100-capability-package-authoring FR-009).
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --name)
-      NAME="$2"
-      shift 2
-      ;;
-    --namespace)
-      NAMESPACE="$2"
-      shift 2
-      ;;
-    --output-dir)
-      OUTPUT_DIR="$2"
-      shift 2
-      ;;
-    *)
-      usage
-      ;;
-  esac
-done
+It used to emit a scaffold shape that capability-package inspect/execute
+cannot load (flat input_schema/output_schema contract keys, no manifest.json,
+a std-linked build). Use the real create path instead:
 
-[[ -z "$NAME" ]] && { echo "Error: --name is required" >&2; usage; }
-[[ -z "$NAMESPACE" ]] && { echo "Error: --namespace is required" >&2; usage; }
+  traverse-cli capability new <capability-id>
 
-if ! [[ "$NAME" =~ ^[a-z0-9-]+$ ]]; then
-  echo "Error: --name must be kebab-case ([a-z0-9-] only), got: $NAME" >&2
-  exit 1
-fi
+Run `traverse-cli capability new --help` for details.
+MSG
 
-if ! [[ "$NAMESPACE" =~ ^[a-z0-9][a-z0-9.-]*[a-z0-9]$|^[a-z0-9]$ ]]; then
-  echo "Error: --namespace must be dot-separated identifiers ([a-z0-9.-] only), got: $NAMESPACE" >&2
-  exit 1
-fi
-
-if [[ -z "$OUTPUT_DIR" ]]; then
-  OUTPUT_DIR="./scaffold/${NAMESPACE}/${NAME}"
-fi
-
-mkdir -p "$OUTPUT_DIR/src"
-
-# contract.json
-cat > "$OUTPUT_DIR/contract.json" <<EOF
-{
-  "kind": "capability_contract",
-  "schema_version": "1.0.0",
-  "id": "${NAMESPACE}.${NAME}",
-  "namespace": "${NAMESPACE}",
-  "name": "${NAME}",
-  "version": "0.1.0",
-  "lifecycle": "draft",
-  "service_type": "stateless",
-  "artifact_type": "native",
-  "description": "TODO: describe what this capability does.",
-  "input_schema": {
-    "type": "object",
-    "required": ["input"],
-    "properties": {
-      "input": { "type": "string", "description": "TODO: replace with your input fields" }
-    },
-    "additionalProperties": false
-  },
-  "output_schema": {
-    "type": "object",
-    "required": ["output"],
-    "properties": {
-      "output": { "type": "string", "description": "TODO: replace with your output fields" }
-    },
-    "additionalProperties": false
-  },
-  "execution": {
-    "binary_format": "wasm",
-    "entrypoint": { "kind": "wasi-command", "command": "run" },
-    "preferred_targets": ["local"],
-    "constraints": {
-      "host_api_access": "none",
-      "network_access": "forbidden",
-      "filesystem_access": "none"
-    }
-  },
-  "provenance": {
-    "spec_refs": ["002-capability-contracts"],
-    "exception_refs": []
-  }
-}
-EOF
-
-# Cargo.toml
-cat > "$OUTPUT_DIR/Cargo.toml" <<EOF
-[package]
-name = "${NAME}"
-version = "0.1.0"
-edition = "2021"
-
-[[bin]]
-name = "${NAME}"
-path = "src/main.rs"
-
-[dependencies]
-serde_json = "1"
-EOF
-
-# src/main.rs
-cat > "$OUTPUT_DIR/src/main.rs" <<'RUST_EOF'
-use std::io::{self, Read, Write};
-
-fn main() {
-    let mut input = String::new();
-    io::stdin().read_to_string(&mut input).unwrap_or_default();
-
-    let request: serde_json::Value = serde_json::from_str(&input)
-        .unwrap_or(serde_json::Value::Null);
-
-    // TODO: replace this stub with your logic
-    let input_value = request
-        .get("input")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-
-    let output = serde_json::json!({ "output": format!("processed: {}", input_value) });
-
-    let _ = io::stdout().write_all(output.to_string().as_bytes());
-}
-RUST_EOF
-
-# build-fixture.sh
-cat > "$OUTPUT_DIR/build-fixture.sh" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-
-AGENT_DIR="\$(cd "\$(dirname "\$0")" && pwd)"
-NAME="${NAME}"
-
-cargo build \\
-  --manifest-path "\$AGENT_DIR/Cargo.toml" \\
-  --target wasm32-wasip1 \\
-  --release 2>&1
-
-mkdir -p "\$AGENT_DIR/fixture"
-cp "target/wasm32-wasip1/release/\${NAME}.wasm" "\$AGENT_DIR/fixture/agent.wasm"
-
-DIGEST=\$(shasum -a 256 "\$AGENT_DIR/fixture/agent.wasm" | awk '{print \$1}')
-echo "Built: \$AGENT_DIR/fixture/agent.wasm"
-echo "SHA-256: \$DIGEST"
-echo ""
-echo "Update contract.json or manifest.json binary.digest with: \$DIGEST"
-EOF
-chmod +x "$OUTPUT_DIR/build-fixture.sh"
-
-# runtime-request.json
-cat > "$OUTPUT_DIR/runtime-request.json" <<EOF
-{
-  "kind": "runtime_request",
-  "schema_version": "1.0.0",
-  "request_id": "${NAME}-test-001",
-  "intent": {
-    "capability_id": "${NAMESPACE}.${NAME}",
-    "capability_version": "0.1.0"
-  },
-  "input": { "input": "hello" },
-  "lookup": { "scope": "public_only", "allow_ambiguity": false },
-  "context": { "requested_target": "local", "caller": "scaffold-test" },
-  "governing_spec": "006-runtime-request-execution"
-}
-EOF
-
-echo ""
-echo "Scaffold created at: ${OUTPUT_DIR}"
-echo ""
-echo "Files generated:"
-echo "  contract.json         — capability contract (edit input_schema, output_schema, description)"
-echo "  Cargo.toml            — Rust package"
-echo "  src/main.rs           — WASM entry point (edit the TODO section)"
-echo "  build-fixture.sh      — builds the WASM binary and prints the digest"
-echo "  runtime-request.json  — test request for traverse-cli"
-echo ""
-echo "Next steps:"
-echo "  1. Edit src/main.rs with your capability logic"
-echo "  2. Edit contract.json: update description, input_schema, output_schema"
-echo "  3. Build: bash ${OUTPUT_DIR}/build-fixture.sh"
-echo "     (requires: rustup target add wasm32-wasip1)"
-echo "  4. Inspect: cargo run -p traverse-cli-rs -- bundle inspect <path-to-bundle-manifest>"
-echo ""
-echo "For detailed guidance: docs/wasm-agent-authoring-guide.md"
+exit 1


### PR DESCRIPTION
## Governing Spec

- `100-capability-package-authoring`
- `516-agent-artifact-execution`

[100-capability-package-authoring](specs/100-capability-package-authoring/spec.md) (approved via #989) is this PR's actual scope end to end. `516-agent-artifact-execution` is declared alongside it purely to satisfy the spec-alignment gate's coverage of `scripts/ci/` (its `governs` list already includes a bare `scripts/ci/` prefix, plus `crates/traverse-cli/`) — this PR does not add or change any FR under 516.

## Project Item

Closes #990.

## Summary

Implements `traverse-cli capability new <capability-id>`, the canonical create path spec 100 defines, and retires the two competing pre-Spec-100 scaffolds it supersedes.

- **`crates/traverse-cli/src/main.rs`**:
  - New `Command::CapabilityNew { capability_id }`, `capability_new`/`capability_new_at`, wired identically to the existing `app new`/`component new` pattern (parse/help/dispatch).
  - Scaffolds `capabilities/<capability-id>/` with a real, loadable `kind: capability_package` manifest (`capability_ref`, non-empty `workflow_refs`, `binary.abi_version` = `SUPPORTED_HOST_ABI_VERSION`), a contract with **authorable placeholder input/output fields** (`inputs.schema`/`outputs.schema`, not the empty `properties: {}` FR-003 forbids), a `#![no_std]` WASI guest stub (only imports `wasi_snapshot_preview1::fd_write`, never `environ_get` — spec `091`/`538`), a `build-fixture.sh` (raw `rustc --target wasm32-unknown-unknown --crate-type cdylib`, matching the pattern real shipped examples use), and a sample runtime request. `lifecycle: "active"` (not `"draft"` — draft capabilities are rejected before placement by `Lifecycle::is_runtime_eligible()`, which would make the scaffold permanently non-executable regardless of a valid artifact).
  - No wasm artifact is written and `binary.expected_digest` is a placeholder, so `capability-package inspect` fails with exactly one clear `missing capability binary file ...` message pre-build (FR-006's "must not claim executability" + the issue's own "or fails with one clear message" escape hatch) — verified this doesn't cascade into unrelated errors.
  - `component new` (FR-008) no longer scaffolds the old flat, non-loadable manifest shape; it now exits non-zero and redirects to `capability new`. Removed the now-dead `component_contract_json` generator (its empty `properties: {}` was exactly the anti-pattern FR-003 forbids for the new command).
- **`scripts/scaffold/new-capability.sh`** (FR-009): retired — it emitted a stale shape (flat `input_schema`/`output_schema`, no `manifest.json` at all, a `std`-linked cargo build) that `capability-package inspect`/`execute` can never load. It now exits non-zero and redirects to `capability new`.
- **`scripts/ci/new_capability_scaffold_smoke.sh`**: rewritten to assert the retirement behavior (non-zero exit, redirect message) instead of the old scaffold's file shape.

## Definition of Done

Happy path:
- [x] `traverse-cli capability new example.domain.my-cap` creates a package dir with `kind: capability_package` manifest, contract with authorable I/O schemas, and a `#![no_std]`-compatible guest stub — `capability_new_generates_loadable_capability_package`, plus manually verified the built artifact imports only `fd_write` (no `environ_get`)
- [x] Generated package is inspectable via `capability-package inspect` after scaffold, or fails with one clear "missing capability binary file" message — manually verified end-to-end (see Validation)
- [x] After building a valid artifact and updating the manifest digest, `capability-package execute` works with the scaffold's sample request fixture — manually verified end-to-end, `status: completed`
- [x] `component new` and the scaffold script behave per Spec 100 (redirect/deprecate) — `component_new_redirects_to_capability_new`, `scripts/ci/new_capability_scaffold_smoke.sh`

Unhappy paths:
- [x] Invalid capability id → usage error, no files written — `capability_new_rejects_invalid_id_without_writing_files`
- [x] Target directory already exists → refuse overwrite, non-zero exit — `capability_new_refuses_to_overwrite_existing_target`
- [x] Scaffold does not claim executability while wasm digest is empty/placeholder — no artifact is written at scaffold time, `binary.expected_digest` is an obvious placeholder, verified `inspect` fails with one clean message pre-build (044 QG-004 / Spec 100)

Verification:
- [x] CLI tests cover create + redirect behavior — 4 new tests in `main.rs`
- [x] `cargo test -p traverse-cli-rs` passes (369 passed)
- [x] `bash scripts/ci/spec_alignment_check.sh` exits 0

## Validation

- [x] `cargo test --workspace` — all crates green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `bash scripts/ci/repository_checks.sh` — passes, including the rewritten scaffold-retirement smoke test
- [x] Manual end-to-end round trip in a scratch directory: `capability new` → `build-fixture.sh` (real `rustc`/`wasm32-unknown-unknown` build) → `capability-package inspect` (clean pre-build failure, then real-digest-reported mismatch, then success after pasting the digest) → `capability-package execute` (`status: completed`) — confirms spec 100 Acceptance Scenarios 1, 2, 3, 5 against a real build, not just unit tests
- [x] `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body <this file>` — coverage gate + spec-alignment for every crate

## Notes

- **Scope boundary**: per spec 100's own ticket breakdown, aligning CLI `--help` strings elsewhere and the `traverse-app-builder` skill docs to this create path is issue #991, tracked separately — not duplicated here. I did revert an initial edit to `docs/wasm-agent-authoring-guide.md` for this reason (and because no approved spec currently governs that file, which would have failed the spec-alignment gate); #991 owns that update.
- `component_namespace`/`scaffold_leaf_name`/`validate_scaffold_id`/`write_new_file`/`write_pretty_json` are reused as-is from the existing `app new`/`component new` scaffolding helpers — no new abstraction added for id validation or file-writing.
