### PR TITLE
docs: align cli-reference and wasm-agent-authoring-guide with capability new

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,7 +35,7 @@ traverse-cli bundle register --help
 traverse-cli app new --help
 traverse-cli app validate --help
 traverse-cli app register --help
-traverse-cli component new --help
+traverse-cli capability new --help
 traverse-cli capability-package inspect --help
 traverse-cli capability-package execute --help
 traverse-cli workflow inspect --help
@@ -56,7 +56,7 @@ consistent with error output behaviour across the CLI.
 | `app new <app-id> [--register --workspace <workspace-id>]` | Create a governed Traverse app bundle scaffold under `apps/<app-id>`. | `cargo run -p traverse-cli-rs -- app new youaskm3` | Creates `manifest.json`, `workspace.config.json`, component/workflow directories, and a bundle README. `--register` rejects the initial incomplete scaffold until real components and workflows are present. |
 | `app validate --manifest <path> --json` | Validate a downstream app manifest and emit stable setup evidence without writing workspace state. | `cargo run -p traverse-cli-rs -- app validate --manifest examples/applications/expedition-readiness/app.manifest.json --json` | Prints JSON with `status: validated`, app identity, component/workflow ids, verified WASM digests, public surfaces, model readiness, and runtime references. |
 | `app register --manifest <path> --workspace <workspace-id> --json` | Validate a downstream app manifest and atomically persist local workspace registration state. | `cargo run -p traverse-cli-rs -- app register --manifest examples/applications/expedition-readiness/app.manifest.json --workspace local --json` | Prints JSON with `status: registered` or `status: already_registered`, app identity, workspace id, `state_scope: workspace_persisted`, `state_path`, digest evidence, and runtime references. |
-| `component new <component-id>` | Create a governed WASM component package scaffold under `components/<component-id>`. | `cargo run -p traverse-cli-rs -- component new knowledge.retrieve` | Creates a component `manifest.json`, draft capability `contract.json`, Rust package shell, source directory, and artifact directory without creating executable WASM behavior. |
+| `capability new <capability-id>` | Create a governed WASM capability package scaffold under `capabilities/<capability-id>`. | `cargo run -p traverse-cli-rs -- capability new knowledge.retrieve` | Creates a loadable `kind: capability_package` manifest, contract with authorable input/output fields, `#![no_std]` WASI guest stub, and sample runtime request. `component new` is retired and redirects here. |
 | `capability-package inspect <manifest-path>` | Load and summarize a governed WASM capability package manifest. | `cargo run -p traverse-cli-rs -- capability-package inspect examples/capabilities/expedition-intent-agent/manifest.json` | Prints `path`, `package_id`, `package_version`, `capability_id`, binary location, digest, and model/workflow references. |
 | `capability-package execute <manifest-path> <request-path>` | Load a governed WASM capability package and execute it against a runtime request. | `cargo run -p traverse-cli-rs -- capability-package execute examples/capabilities/expedition-intent-agent/manifest.json examples/capabilities/runtime-requests/interpret-expedition-intent.json` | Prints `request_id`, `execution_id`, `package_id`, `capability_id`, `trace_ref`, `status`, and capability-specific result fields. |
 | `event inspect <contract-path>` | Parse and validate an event contract. | `cargo run -p traverse-cli-rs -- event inspect contracts/examples/expedition/events/expedition-objective-captured/contract.json` | Prints `path`, `id`, `version`, lifecycle, classification, publisher/subscriber counts, and publisher/subscriber ids. |
@@ -73,7 +73,7 @@ The following command families are intended to be the public documented surface 
 - `app new`
 - `app validate`
 - `app register`
-- `component new`
+- `capability new`
 - `capability-package inspect`
 - `capability-package execute`
 - `event inspect`
@@ -188,7 +188,7 @@ This reference was checked against the live CLI behavior with:
 - `cargo run -p traverse-cli-rs -- app new --help`
 - `cargo run -p traverse-cli-rs -- app validate --help`
 - `cargo run -p traverse-cli-rs -- app register --help`
-- `cargo run -p traverse-cli-rs -- component new --help`
+- `cargo run -p traverse-cli-rs -- capability new --help`
 - `cargo run -p traverse-cli-rs -- capability-package inspect --help`
 - `cargo run -p traverse-cli-rs -- capability-package execute --help`
 - `cargo run -p traverse-cli-rs -- workflow inspect --help`

--- a/docs/wasm-agent-authoring-guide.md
+++ b/docs/wasm-agent-authoring-guide.md
@@ -16,19 +16,16 @@ If you've completed the zero-to-hero path, you have a working `say-hello` agent.
 ### Generate a capability scaffold
 
 ```bash
-bash scripts/scaffold/new-capability.sh \
-  --name my-classifier \
-  --namespace acme.ml \
-  --output-dir ./my-classifier
+traverse-cli capability new acme.ml.my-classifier
 ```
 
-This generates a complete directory with a valid contract stub, compilable Rust source, and a test request. You only need to fill in the TODOs.
+This generates `capabilities/acme.ml.my-classifier/` with a real, loadable `kind: capability_package` manifest, a contract with authorable placeholder input/output fields, a `#![no_std]` WASI guest stub, and a sample runtime request — the same shape `traverse-cli capability-package inspect`/`traverse-cli capability-package execute` load in production. `scripts/scaffold/new-capability.sh` is retired (spec `100-capability-package-authoring` FR-009); it now exits non-zero and points here. `component new` is retired too (FR-008): it redirects to `capability new`.
 
 ### What to change
 
-1. **`contract.json`** — replace `input_schema` and `output_schema` with your actual fields. The `description` field is required.
-2. **`src/main.rs`** — replace the stub logic with your computation. Read JSON from stdin, write JSON to stdout.
-3. **Build and verify** — `bash my-classifier/build-fixture.sh` compiles to WASM and prints the digest.
+1. **`contract.json`** — replace the placeholder `input_value`/`output_value` fields under `inputs.schema`/`outputs.schema` with your actual fields. The `description` field is required.
+2. **`src/agent.rs`** — replace the static placeholder output with your computation. Read JSON from stdin, write JSON to stdout.
+3. **Build and verify** — `bash capabilities/acme.ml.my-classifier/build-fixture.sh` compiles to WASM; `traverse-cli capability-package inspect <manifest>` reports the real digest to paste into `manifest.json`'s `binary.expected_digest` if it doesn't match yet, then `traverse-cli capability-package execute <manifest> <request>` runs it.
 
 ### Common mistake
 


### PR DESCRIPTION
## Governing Spec

- `100-capability-package-authoring`
- `046-public-cli-app-registration`
- `070-runtime-event-sink-boundary`

[100-capability-package-authoring](specs/100-capability-package-authoring/spec.md) is this PR's actual scope. `046-public-cli-app-registration` and `070-runtime-event-sink-boundary` are declared alongside it purely to satisfy the spec-alignment gate's coverage of the two changed docs — `046` governs `docs/cli-reference.md` specifically, and `070` governs `docs/wasm-agent-authoring-guide.md` via its broad `docs/` prefix — this PR does not add or change any FR under either.

## Project Item

Closes #991.

## Summary

Aligns the remaining in-repo docs with the `capability new` create path #990 shipped, per spec 100's FR-008/FR-009 redirect requirements. `traverse-cli`'s own `--help` strings for `capability`/`capability-package` were already correct as of #990 — this PR closes the two doc gaps that were still teaching the retired paths.

- **`docs/wasm-agent-authoring-guide.md`**: "Generate a capability scaffold" now shows `traverse-cli capability new acme.ml.my-classifier` instead of the retired `bash scripts/scaffold/new-capability.sh` invocation. Updated the field names in "What to change" to match the real contract shape (`inputs.schema`/`outputs.schema`, not `input_schema`/`output_schema`) and the real guest file name (`src/agent.rs`, not `src/main.rs`). Notes both retirements (`new-capability.sh` and `component new`) inline.
- **`docs/cli-reference.md`**: replaced the `component new` row/help-example/subcommand-list entries with `capability new`, describing the real generated shape (loadable manifest, authorable contract fields, `#![no_std]` guest stub) instead of the retired non-executable component layout.

## Definition of Done

Happy path:
- [x] Skill and CLI help both say: `capability new` → build → `capability-package inspect` → `capability-package execute` — CLI help already correct from #990 (verified); `docs/wasm-agent-authoring-guide.md` and `docs/cli-reference.md` now say the same
- [x] Skill still documents Host ABI / no-std constraints as reinforcement of the scaffold, not the only path — `wasm-agent-authoring-guide.md`'s "Start From a Governed Package"/"Minimal Package Shape" sections are unchanged and already frame this correctly
- [x] No primary-path docs still recommend the empty `component new` layout or the stale bash scaffold — verified via a repo-wide grep for `component new`/`new-capability.sh` across `*.md`/`*.rs`/`*.sh`; only remaining hits are the CLI's own (already-correct) redirect messages, the immutable spec `044` FR-015 text spec 100 explicitly supersedes without editing (see Notes), and spec 100's own text

Unhappy / consistency:
- [x] Any remaining mention of `component new` states redirected/deprecated status per Spec 100 — confirmed (CLI help + `cli-reference.md` row both state it)
- [x] Docs do not claim `capability inspect` works until #986 is Done — #986 (and #987) are both already closed/completed, so no caveat needed; verified no doc contains a stale "not yet wired" caveat

Verification:
- [x] Doc/skill review in PR (this PR)
- [x] `bash scripts/ci/spec_alignment_check.sh` exits 0

## Validation

- [x] `cargo test --workspace` — all crates green (no code changes, docs only)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `bash scripts/ci/repository_checks.sh` — passes
- [x] `bash scripts/ci/wasm_agent_authoring_guide_smoke.sh` — passes (all required content strings still present)
- [x] `BASE_SHA=origin/main bash scripts/ci/local_preflight.sh --pr-body <this file>` — coverage gate + spec-alignment for every crate

## Notes

- **`traverse-app-builder` skill**: the issue's scope mentions updating "in-repo skill docs," but `traverse-app-builder` is an external/plugin-level Claude Code skill, not a file checked into this repository (confirmed: no match for it anywhere under this repo's tree; `docs/decision-log.md`'s existing mention is just descriptive, referencing why `#988`'s umbrella exists). There is nothing in-repo to edit for it.
- **Spec `044-application-bundle-manifest` FR-015** still describes the original `component new` behavior and is left untouched deliberately — spec 100 explicitly "does not edit immutable `044` text," it "supersedes the practical create-path authority of FR-015" instead (see spec 100's own "Relationship to Spec 044 FR-015" section). Editing 044 would violate this repo's spec-immutability governance.
- No code changes — docs only, so `cargo test`/clippy/fmt have nothing new to cover; the coverage gate's per-crate thresholds are unaffected by this PR.
