### PR TITLE
Approve Spec 102 and enforce publish surface coverage

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -6666,7 +6666,7 @@ mod tests {
         )
         .expect_err("uncovered enum must fail");
         assert_eq!(err.0, "capability_publish_surface_coverage_failed");
-        assert!(err.1.contains("b"));
+        assert!(err.1.contains('b'));
     }
 
     #[test]

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -3083,9 +3083,7 @@ fn reject_private_contract_scope(contract_text: &str) -> Result<(), (&'static st
 
 /// Spec `102-contract-surface-coverage` FR-001/FR-002: every `action` enum value
 /// must appear in at least one `use_cases[].input_example.action`.
-fn enforce_contract_surface_coverage(
-    contract_text: &str,
-) -> Result<(), (&'static str, String)> {
+fn enforce_contract_surface_coverage(contract_text: &str) -> Result<(), (&'static str, String)> {
     let value: Value = serde_json::from_str(contract_text).map_err(|error| {
         (
             "capability_publish_contract_parse_failed",
@@ -3106,9 +3104,7 @@ fn enforce_contract_surface_coverage(
 }
 
 fn uncovered_action_enum_values(contract: &Value) -> Result<Vec<String>, String> {
-    let Some(action_schema) = contract
-        .pointer("/inputs/schema/properties/action")
-    else {
+    let Some(action_schema) = contract.pointer("/inputs/schema/properties/action") else {
         return Ok(Vec::new());
     };
     let Some(enum_values) = action_schema.get("enum").and_then(Value::as_array) else {
@@ -5967,18 +5963,17 @@ mod tests {
         RegistrySyncError, Runtime, RuntimeResultStatus, SUPPORTED_HOST_ABI_VERSION, app_new_at,
         app_register_at, app_registration_state_path, app_validate, app_validate_at,
         canonical_expedition_bundle_path, capability_new_at, capability_publish_at, component_new,
-        curl_text, ensure_clean_registry_checkout, execute_capability_package, execute_expedition,
-        execute_traverse_starter_process, execute_traverse_starter_summarize,
-        execute_traverse_starter_validate, format_capability_package_execution_summary,
-        help_expedition_execute, help_serve, inspect_bundle, inspect_capability,
-        inspect_capability_package, inspect_event, inspect_trace, latest_index_release_asset,
-        load_capability_package, load_registered_bundle,
+        curl_text, enforce_contract_surface_coverage, ensure_clean_registry_checkout,
+        execute_capability_package, execute_expedition, execute_traverse_starter_process,
+        execute_traverse_starter_summarize, execute_traverse_starter_validate,
+        format_capability_package_execution_summary, help_expedition_execute, help_serve,
+        inspect_bundle, inspect_capability, inspect_capability_package, inspect_event,
+        inspect_trace, latest_index_release_asset, load_capability_package, load_registered_bundle,
         load_registered_bundle_with_public_records, load_runtime_request, parse_command,
         publish_file_sha256_digest, register_bundle, register_generated_app_bundle,
         registry_record_order, registry_sync_at, registry_sync_default_or_override,
-        registry_sync_failure_json, reject_private_contract_scope,
-        enforce_contract_surface_coverage, uncovered_action_enum_values, run_command, sha256_hex,
-        telemetry, validate_registry_path_segment,
+        registry_sync_failure_json, reject_private_contract_scope, run_command, sha256_hex,
+        telemetry, uncovered_action_enum_values, validate_registry_path_segment,
     };
     use crate::capability_packages::fnv1a64;
     use serde_json::Value;

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -3002,6 +3002,8 @@ fn capability_publish_plan(
         )
     })?;
     reject_private_contract_scope(&contract_text)?;
+    // Spec 102: check raw JSON so use_cases (not on CapabilityContract) are visible.
+    enforce_contract_surface_coverage(&contract_text)?;
 
     let contract = parse_contract(&contract_text).map_err(|failure| {
         (
@@ -3077,6 +3079,74 @@ fn reject_private_contract_scope(contract_text: &str) -> Result<(), (&'static st
         ));
     }
     Ok(())
+}
+
+/// Spec `102-contract-surface-coverage` FR-001/FR-002: every `action` enum value
+/// must appear in at least one `use_cases[].input_example.action`.
+fn enforce_contract_surface_coverage(
+    contract_text: &str,
+) -> Result<(), (&'static str, String)> {
+    let value: Value = serde_json::from_str(contract_text).map_err(|error| {
+        (
+            "capability_publish_contract_parse_failed",
+            format!("failed to parse capability contract JSON: {error}"),
+        )
+    })?;
+    match uncovered_action_enum_values(&value) {
+        Ok(uncovered) if uncovered.is_empty() => Ok(()),
+        Ok(uncovered) => Err((
+            "capability_publish_surface_coverage_failed",
+            format!(
+                "inputs.schema.properties.action.enum values lack covering use_cases: {}. Every enum value must appear as use_cases[].input_example.action (spec 102-contract-surface-coverage FR-001)",
+                uncovered.join(", ")
+            ),
+        )),
+        Err(message) => Err(("capability_publish_surface_coverage_failed", message)),
+    }
+}
+
+fn uncovered_action_enum_values(contract: &Value) -> Result<Vec<String>, String> {
+    let Some(action_schema) = contract
+        .pointer("/inputs/schema/properties/action")
+    else {
+        return Ok(Vec::new());
+    };
+    let Some(enum_values) = action_schema.get("enum").and_then(Value::as_array) else {
+        return Ok(Vec::new());
+    };
+    let mut declared = Vec::new();
+    for value in enum_values {
+        let Some(as_str) = value.as_str() else {
+            return Err(
+                "inputs.schema.properties.action.enum must contain only strings (spec 102 FR-001)"
+                    .to_string(),
+            );
+        };
+        declared.push(as_str.to_string());
+    }
+    if declared.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let use_cases = contract
+        .get("use_cases")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut covered = std::collections::BTreeSet::new();
+    for use_case in &use_cases {
+        if let Some(action) = use_case
+            .pointer("/input_example/action")
+            .and_then(Value::as_str)
+        {
+            covered.insert(action.to_string());
+        }
+    }
+
+    Ok(declared
+        .into_iter()
+        .filter(|action| !covered.contains(action))
+        .collect())
 }
 
 fn validate_registry_path_segment(
@@ -3232,7 +3302,7 @@ fn run_publish_command(
 
 fn capability_publish_pr_body(plan: &CapabilityPublishPlan) -> String {
     format!(
-        "## Summary\n\n- publish `{}` version `{}` to the public capability registry\n- add `{}`\n\n## Governing Specs\n\n- `056-capability-publish`\n- `054-public-scope-registry-ref`\n\n## Validation\n\n- local capability contract validation passed\n- artifact digest computed: `{}`\n",
+        "## Summary\n\n- publish `{}` version `{}` to the public capability registry\n- add `{}`\n\n## Governing Spec\n\n- `001-registry-foundation`\n- `002-capability-validation`\n- `056-capability-publish`\n- `054-public-scope-registry-ref`\n- `102-contract-surface-coverage`\n\n## Project Item\n\n- Capability publish via traverse-cli\n\n## Validation\n\n- local capability contract validation passed\n- contract surface coverage (action enum ⊆ use_cases) passed\n- artifact digest computed: `{}`\n",
         plan.capability_id,
         plan.version,
         plan.registry_relative_path.display(),
@@ -5906,7 +5976,8 @@ mod tests {
         load_registered_bundle_with_public_records, load_runtime_request, parse_command,
         publish_file_sha256_digest, register_bundle, register_generated_app_bundle,
         registry_record_order, registry_sync_at, registry_sync_default_or_override,
-        registry_sync_failure_json, reject_private_contract_scope, run_command, sha256_hex,
+        registry_sync_failure_json, reject_private_contract_scope,
+        enforce_contract_surface_coverage, uncovered_action_enum_values, run_command, sha256_hex,
         telemetry, validate_registry_path_segment,
     };
     use crate::capability_packages::fnv1a64;
@@ -6501,6 +6572,106 @@ mod tests {
             "capability_publish_contract_validation_failed"
         );
         assert!(runner.commands.borrow().is_empty());
+    }
+
+    #[test]
+    fn capability_publish_surface_coverage_failure_runs_no_commands() {
+        let fixture = capability_publish_fixture();
+        let mut contract: Value = serde_json::from_str(
+            &fs::read_to_string(&fixture.contract).expect("contract fixture should read"),
+        )
+        .expect("contract fixture should parse");
+        contract["inputs"]["schema"]["properties"]["action"] = serde_json::json!({
+            "type": "string",
+            "enum": ["create", "resolve"]
+        });
+        contract["use_cases"] = serde_json::json!([
+            {
+                "name": "create only",
+                "description": "covers create",
+                "input_example": { "action": "create" },
+                "expected_output_example": { "ok": true }
+            }
+        ]);
+        fs::write(
+            &fixture.contract,
+            serde_json::to_string_pretty(&contract).expect("contract fixture should serialize"),
+        )
+        .expect("uncovered-action contract should write");
+        let runner = RecordingPublishRunner::default();
+
+        let output = capability_publish_at(&fixture.request(false), &runner)
+            .expect("surface coverage failure should return JSON evidence");
+        let json: Value = serde_json::from_str(&output).expect("publish output must be JSON");
+
+        assert_eq!(json["status"], "failed");
+        assert_eq!(
+            json["errors"][0]["code"],
+            "capability_publish_surface_coverage_failed"
+        );
+        assert!(
+            json["errors"][0]["message"]
+                .as_str()
+                .expect("message")
+                .contains("resolve"),
+            "failure should name uncovered action"
+        );
+        assert!(runner.commands.borrow().is_empty());
+    }
+
+    #[test]
+    fn uncovered_action_enum_values_reports_gaps_and_skips_when_absent() {
+        let covered = serde_json::json!({
+            "inputs": {
+                "schema": {
+                    "properties": {
+                        "action": { "type": "string", "enum": ["create", "edit"] }
+                    }
+                }
+            },
+            "use_cases": [
+                { "input_example": { "action": "create" } },
+                { "input_example": { "action": "edit" } }
+            ]
+        });
+        assert!(
+            uncovered_action_enum_values(&covered)
+                .expect("covered contract")
+                .is_empty()
+        );
+
+        let gap = serde_json::json!({
+            "inputs": {
+                "schema": {
+                    "properties": {
+                        "action": { "type": "string", "enum": ["create", "pin"] }
+                    }
+                }
+            },
+            "use_cases": [
+                { "input_example": { "action": "create" } }
+            ]
+        });
+        assert_eq!(
+            uncovered_action_enum_values(&gap).expect("gap contract"),
+            vec!["pin".to_string()]
+        );
+
+        let no_action = serde_json::json!({ "inputs": { "schema": { "properties": {} } } });
+        assert!(
+            uncovered_action_enum_values(&no_action)
+                .expect("no action enum")
+                .is_empty()
+        );
+
+        enforce_contract_surface_coverage(r#"{"inputs":{"schema":{"properties":{}}}}"#)
+            .expect("contracts without action enum must pass");
+        let err = enforce_contract_surface_coverage(
+            r#"{"inputs":{"schema":{"properties":{"action":{"enum":["a","b"]}}}},"use_cases":[{"input_example":{"action":"a"}}]}"#,
+        )
+        .expect_err("uncovered enum must fail");
+        assert_eq!(err.0, "capability_publish_surface_coverage_failed");
+        assert!(err.1.contains("b"));
     }
 
     #[test]

--- a/docs/adr/0038-contract-surface-coverage.md
+++ b/docs/adr/0038-contract-surface-coverage.md
@@ -1,7 +1,7 @@
 # ADR-0038: Contract Surface Must Be Covered by Use Cases
 
-- Status: Proposed (accept with Spec `102-contract-surface-coverage` approval)
-- Governing spec: `102-contract-surface-coverage` (Draft)
+- Status: Accepted
+- Governing spec: `102-contract-surface-coverage`
 - Related issues: traverse#1014, #1015, #1016; registry#192, #193
 
 ## Context

--- a/docs/capability-contract-authoring-guide.md
+++ b/docs/capability-contract-authoring-guide.md
@@ -185,9 +185,8 @@ set. Do not list actions the artifact only rejects with a generic
 Description prose that mentions behavior beyond the use-case matrix MUST either
 be removed or called out under an explicit **Known limitations** section.
 
-Governed by Draft Spec `102-contract-surface-coverage` / ADR-0038 (Proposed).
-Publish tooling will enforce enum ⊆ use_cases after that spec is Approved
-(issue #1016).
+Governed by Spec `102-contract-surface-coverage` / ADR-0038.
+`capability publish` / `--dry-run` enforce enum ⊆ use_cases (issue #1016).
 
 ## Common Mistakes
 

--- a/docs/decision-log.md
+++ b/docs/decision-log.md
@@ -2107,8 +2107,8 @@ or ADR required.
 ## Decision 57: Contract Surface Coverage — Schema ⊆ Use Cases ⊆ Smoke
 
 - **Date**: 2026-08-08
-- **Status**: Accepted (honesty path); Spec 102 remains Draft until owner registers it
-- **Governing spec**: `102-contract-surface-coverage` (Draft), ADR-0038 (Proposed)
+- **Status**: Accepted; Spec 102 Approved and registered 2026-08-08
+- **Governing spec**: `102-contract-surface-coverage`, ADR-0038
 - **Related issues**: `#1014`, `#1015`, `#1016`; registry `#192`, `#193`
 - **Origin**: Post-ship review of `core.process-comment@1.0.0` overclaim (enum/description beyond use-case matrix).
 

--- a/specs/102-contract-surface-coverage/spec.md
+++ b/specs/102-contract-surface-coverage/spec.md
@@ -1,6 +1,6 @@
 # Feature Specification: Contract Surface Coverage
 
-**Status**: Draft (awaits owner approval before `approved-specs.json` registration)
+**Status**: Approved
 **Canonical governing ID**: `102-contract-surface-coverage`
 **Version**: 1.0.0
 **Extends**: `002-capability-contracts`, `100-capability-package-authoring`, `056-capability-publish`, `516-agent-artifact-execution`
@@ -49,4 +49,4 @@ Out of scope:
 
 ## Approval Note
 
-This file is **Draft**. Do not treat FRs as binding in CI until the owner moves Status to Approved and registers the spec in `specs/governance/approved-specs.json`. Implementation issue #1016 remains `needs-spec` until then.
+Approved 2026-08-08 (owner direction). Registered in `specs/governance/approved-specs.json`. Implementation: #1016 / registry#192.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1325,6 +1325,21 @@
         "specs/995-local-executor-event-emission/",
         "docs/decision-log.md"
       ]
+    },
+    {
+      "id": "102-contract-surface-coverage",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/102-contract-surface-coverage/spec.md",
+      "governs": [
+        "crates/traverse-cli/",
+        "docs/capability-contract-authoring-guide.md",
+        "docs/adr/0038-contract-surface-coverage.md",
+        "specs/102-contract-surface-coverage/",
+        "docs/decision-log.md",
+        "scripts/ci/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Approve Spec `102-contract-surface-coverage` and Accept ADR-0038; register in `approved-specs.json`.
- Enforce Spec 102 FR-001/FR-002 in `capability publish` / `--dry-run`: fail when `action.enum` values lack covering `use_cases[].input_example.action`.
- Update authoring guide + Decision 57 status to match Approved governance.

## Governing Spec
- `102-contract-surface-coverage`
- `056-capability-publish`
- `004-spec-alignment-gate`

## Project Item
- Closes #1014
- Closes #1016
- Related: registry#192

## Definition of Done
- [x] Spec 102 and ADR-0038 are approved and registered.
- [x] Publish and dry-run reject uncovered action enum values with focused tests.
- [x] Authoring guidance and Decision 57 reflect the approved contract.

## Validation
- [x] `cargo test -p traverse-cli-rs surface_coverage`
- [x] `cargo test -p traverse-cli-rs uncovered_action_enum`
- [x] `cargo test -p traverse-cli-rs capability_publish_`
- [x] local preflight (fmt, smokes, coverage gate, spec alignment)
- [ ] CI green