### PR TITLE
Document guest-enforced fields for structured deny use cases

### DIFF
--- a/docs/capability-contract-authoring-guide.md
+++ b/docs/capability-contract-authoring-guide.md
@@ -195,6 +195,7 @@ Governed by Spec `102-contract-surface-coverage` / ADR-0038.
 - Declaring side effects implicitly but forgetting to declare `side_effects` and event edges (`emits` / `consumes`).
 - Using `host_api_access: exception_required` without adding an exception reference in `provenance.exception_refs`.
 - Treating `preconditions` / `postconditions` as executable policy. They are documentation, not runtime code.
+- Putting a guest-denied field in JSON Schema `required`, then wondering why smoke never sees the guest `reason_code` (see Guest-enforced fields above).
 
 ## Validation
 
@@ -324,6 +325,32 @@ These fields hold assertions about the state of the world before and after capab
 ```
 
 **These are not enforced by the runtime in v0.x.** The runtime does not evaluate preconditions before execution or postconditions after. They are purely documentation — useful for human review, spec coverage, and future tooling. State this explicitly to consumers of your contract.
+
+### Guest-enforced fields (host schema vs guest denials)
+
+Host JSON Schema validation runs before the WASM guest. If a field is listed in
+JSON Schema `required`, unhappy-path use cases that omit it never reach the
+guest — the host rejects them first — so the guest cannot return a structured
+`reason_code` for that precondition.
+
+When a denial must be guest-authored (for example `reason_code:
+invalid_principal`), keep that field **schema-optional** and enforce it in the
+guest instead. Document the choice so it is not mistaken for accidental
+weakening:
+
+1. Omit the field from the nearest JSON Schema `required` array.
+2. State in the property (or parent object) `description` that the guest
+   enforces the field and name the covering use case / `reason_code`.
+3. Cover the omission with an explicit `use_cases[]` entry and a package smoke
+   fixture that reaches the guest.
+
+Default host validation for normal requests stays fail-closed: other required
+fields remain required, and guests must still reject empty/invalid optional
+values they claim to enforce. Do not use a global “skip input schema” escape
+hatch for production execute paths.
+
+Working example: `examples/core-authorize` UC-09 — `principal.id` is
+guest-enforced and schema-optional; the guest returns `invalid_principal`.
 
 ---
 

--- a/docs/wasm-agent-authoring-guide.md
+++ b/docs/wasm-agent-authoring-guide.md
@@ -31,6 +31,13 @@ This generates `capabilities/acme.ml.my-classifier/` with a real, loadable `kind
 
 Do not skip the contract edit. The runtime validates inputs and outputs against the schema before executing. A permissive schema (`additionalProperties: true`) will pass validation but defeat governance.
 
+If a use case must return a structured guest denial for a missing field, keep
+that field schema-optional and enforce it in the guest — host `required` will
+otherwise reject the request before the guest runs. Document the field as
+guest-enforced and cover it with a use case (see
+[`docs/capability-contract-authoring-guide.md`](capability-contract-authoring-guide.md)
+“Guest-enforced fields”; example: `examples/core-authorize` UC-09).
+
 ## Start From a Governed Package
 
 Begin with the executable capability package template, then specialize it for the new agent:

--- a/examples/core-authorize/NOTES.md
+++ b/examples/core-authorize/NOTES.md
@@ -28,4 +28,13 @@ bash scripts/ci/core_authorize_example_smoke.sh
 | UC-08 | `uc08-break-glass-allow.json` | `break_glass_override` |
 | UC-09 | `uc09-invalid-principal-deny.json` | `invalid_principal` |
 
+## Guest-enforced fields
+
+`principal.id` is intentionally omitted from `inputs.schema.properties.principal.required`
+so UC-09 can reach the WASM guest. Host JSON Schema would otherwise reject the
+omission before execution. The guest returns `reason_code: invalid_principal`.
+This follows the guest-enforced fields convention in
+`docs/capability-contract-authoring-guide.md` — it is not a silent weakening of
+default fail-closed host validation for other required fields.
+
 Registry: publish `capabilities/core/core.authorize/1.1.0/` with a real artifact release after this package lands.

--- a/examples/core-authorize/contract.json
+++ b/examples/core-authorize/contract.json
@@ -613,11 +613,12 @@
       "properties": {
         "principal": {
           "type": "object",
-          "description": "Caller identity. Missing or empty id is not schema-rejected so the guest can return reason_code invalid_principal (UC-09).",
+          "description": "Caller identity. principal.id is guest-enforced (schema-optional) so UC-09 can return reason_code invalid_principal; see docs/capability-contract-authoring-guide.md Guest-enforced fields.",
           "properties": {
             "id": {
               "type": "string",
-              "minLength": 1
+              "minLength": 1,
+              "description": "Guest-enforced non-empty principal id. Omitted from principal.required so missing/empty id reaches the guest (UC-09 → invalid_principal)."
             },
             "roles": {
               "type": "array",


### PR DESCRIPTION
## Summary

- Document the guest-enforced fields convention: keep fields that must produce guest `reason_code`s schema-optional, describe them explicitly, and cover them with use cases/smoke.
- Clarify `examples/core-authorize` UC-09 (`principal.id` / `invalid_principal`) as the working example of that convention.
- Keep default host validation fail-closed for other required fields; no skip-schema escape hatch.

## Governing Spec

- `100-capability-package-authoring`
- `102-contract-surface-coverage`
- `065-sigstore-bundle-verification`
- `516-agent-artifact-execution`

## Project Item

Closes #1007.

## Definition of Done

- [x] Chosen approach documented (schema-optional guest-enforced convention)
- [x] `examples/core-authorize` UC-09 exercises the path without silent weakening
- [x] CI smoke remains green (`core_authorize_example_smoke.sh`)
- [x] No silent weakening of default fail-closed host validation for normal requests

## Validation

- [x] `bash scripts/ci/core_authorize_example_smoke.sh`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)