### PR TITLE
Fail capability publish on missing personas

### DIFF
--- a/docs/capability-publish.md
+++ b/docs/capability-publish.md
@@ -32,5 +32,11 @@ form a release URL, or a version's registry path already exists. If a later
 branch or PR step fails, the reported partial state identifies the release tag
 and registry branch left for retry or explicit cleanup.
 
+Before either dry-run or real publish proceeds, every non-empty
+`use_cases[].persona_ref` must resolve to a directory under `personas/` in the
+target registry checkout. Missing IDs are reported together with the expected
+`personas/<id>/<version>/persona.json` shape, so authors can add the governed
+persona before opening a registry PR.
+
 The resulting registry PR still requires registry CI and explicit human review
 before the record can become visible to consumers.


### PR DESCRIPTION
## Summary

- Fail capability publish planning when a use-case persona reference is absent from the target registry checkout.
- Return a stable error listing every missing ID and the expected persona record path.
- Document the preflight and add regression coverage proving no command runs.

## Governing Spec

- `056-capability-publish`
- `100-capability-package-authoring`
- `065-sigstore-bundle-verification`

## Project Item

- Closes #1011

## Definition of Done

- [x] Dry-run and real publish validate registry persona references before writes.
- [x] Missing references have actionable JSON evidence.
- [x] Documentation and regression coverage are included.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo test -p traverse-cli-rs capability_publish_`
- [x] `git diff --check`