### PR TITLE
refactor(cli): split registry contract write helper

### DIFF
--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -3210,22 +3210,7 @@ fn prepare_and_open_registry_pr(
         "capability_publish_branch_failed",
         plan,
     )?;
-    if let Some(parent) = plan.registry_path.parent() {
-        fs::create_dir_all(parent).map_err(|error| {
-            (
-                "capability_publish_write_failed",
-                format!("failed to create registry target directory: {error}"),
-                Some(partial_state(plan)),
-            )
-        })?;
-    }
-    fs::write(&plan.registry_path, format!("{}\n", plan.contract_json)).map_err(|error| {
-        (
-            "capability_publish_write_failed",
-            format!("failed to write registry contract: {error}"),
-            Some(partial_state(plan)),
-        )
-    })?;
+    write_registry_contract(plan)?;
     run_publish_command(
         runner,
         &request.registry_repo_path,
@@ -3285,6 +3270,27 @@ fn prepare_and_open_registry_pr(
         plan,
     )?;
     Ok(output.stdout)
+}
+
+fn write_registry_contract(
+    plan: &CapabilityPublishPlan,
+) -> Result<(), (&'static str, String, Option<String>)> {
+    if let Some(parent) = plan.registry_path.parent() {
+        fs::create_dir_all(parent).map_err(|error| {
+            (
+                "capability_publish_write_failed",
+                format!("failed to create registry target directory: {error}"),
+                Some(partial_state(plan)),
+            )
+        })?;
+    }
+    fs::write(&plan.registry_path, format!("{}\n", plan.contract_json)).map_err(|error| {
+        (
+            "capability_publish_write_failed",
+            format!("failed to write registry contract: {error}"),
+            Some(partial_state(plan)),
+        )
+    })
 }
 
 fn run_publish_command(

--- a/crates/traverse-cli/src/main.rs
+++ b/crates/traverse-cli/src/main.rs
@@ -2844,6 +2844,9 @@ struct CapabilityPublishPlan {
     capability_id: String,
     version: String,
     artifact_digest: String,
+    artifact_asset_name: String,
+    artifact_release_tag: String,
+    artifact_url: String,
     registry_relative_path: PathBuf,
     registry_path: PathBuf,
     branch: String,
@@ -2929,7 +2932,7 @@ fn capability_publish_at(
         .as_deref()
         .unwrap_or(DEFAULT_REGISTRY_REPO);
 
-    let plan = match capability_publish_plan(request) {
+    let plan = match capability_publish_plan(request, registry_repo) {
         Ok(plan) => plan,
         Err((code, message)) => {
             return capability_publish_failure_json(
@@ -2984,6 +2987,7 @@ fn capability_publish_at(
 
 fn capability_publish_plan(
     request: &CapabilityPublishRequest,
+    registry_repo: &str,
 ) -> Result<CapabilityPublishPlan, (&'static str, String)> {
     if !request.registry_repo_path.is_dir() {
         return Err((
@@ -3029,6 +3033,11 @@ fn capability_publish_plan(
     validate_registry_path_segment(&normalized.id, "capability id")?;
     validate_registry_path_segment(&normalized.version, "version")?;
     let artifact_digest = publish_file_sha256_digest(&request.artifact_path)?;
+    let artifact_asset_name = publish_artifact_asset_name(&request.artifact_path)?;
+    let artifact_release_tag = format!("artifacts/{}-{}", normalized.id, normalized.version);
+    let artifact_url = format!(
+        "https://github.com/{registry_repo}/releases/download/{artifact_release_tag}/{artifact_asset_name}"
+    );
 
     let registry_relative_path = PathBuf::from("capabilities")
         .join(&normalized.namespace)
@@ -3042,10 +3051,20 @@ fn capability_publish_plan(
         sanitize_branch_component(&normalized.version)
     );
     let title = format!("Publish {} {}", normalized.id, normalized.version);
-    let contract_json = serde_json::to_string_pretty(&normalized).map_err(|error| {
+    let mut contract_value = serde_json::to_value(&normalized).map_err(|error| {
         (
             "capability_publish_contract_serialize_failed",
             format!("failed to serialize normalized capability contract: {error}"),
+        )
+    })?;
+    contract_value["artifact"] = serde_json::json!({
+        "digest": artifact_digest,
+        "url": artifact_url,
+    });
+    let contract_json = serde_json::to_string_pretty(&contract_value).map_err(|error| {
+        (
+            "capability_publish_contract_serialize_failed",
+            format!("failed to serialize capability contract with artifact metadata: {error}"),
         )
     })?;
 
@@ -3054,6 +3073,9 @@ fn capability_publish_plan(
         capability_id: normalized.id,
         version: normalized.version,
         artifact_digest,
+        artifact_asset_name,
+        artifact_release_tag,
+        artifact_url,
         registry_relative_path,
         registry_path,
         branch,
@@ -3107,6 +3129,32 @@ fn publish_file_sha256_digest(path: &Path) -> Result<String, (&'static str, Stri
     Ok(format!("sha256:{}", sha256_hex(&bytes)))
 }
 
+fn publish_artifact_asset_name(path: &Path) -> Result<String, (&'static str, String)> {
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| {
+            (
+                "capability_publish_artifact_name_invalid",
+                format!(
+                    "artifact path has no valid UTF-8 filename: {}",
+                    path.display()
+                ),
+            )
+        })?;
+    if name.is_empty()
+        || !name.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_')
+        })
+    {
+        return Err((
+            "capability_publish_artifact_name_invalid",
+            format!("artifact filename is not safe for a GitHub release URL: {name}"),
+        ));
+    }
+    Ok(name.to_string())
+}
+
 fn ensure_clean_registry_checkout(
     registry_repo_path: &Path,
     runner: &dyn PublishProcessRunner,
@@ -3128,6 +3176,28 @@ fn prepare_and_open_registry_pr(
     runner: &dyn PublishProcessRunner,
     registry_repo: &str,
 ) -> Result<String, (&'static str, String, Option<String>)> {
+    run_publish_command(
+        runner,
+        &request.registry_repo_path,
+        "gh",
+        &[
+            "release".to_string(),
+            "create".to_string(),
+            plan.artifact_release_tag.clone(),
+            request.artifact_path.display().to_string(),
+            "--repo".to_string(),
+            registry_repo.to_string(),
+            "--title".to_string(),
+            format!("{} {} artifact", plan.capability_id, plan.version),
+            "--notes".to_string(),
+            format!(
+                "Artifact for governed capability publication `{}` version `{}`. Digest: `{}`.",
+                plan.capability_id, plan.version, plan.artifact_digest
+            ),
+        ],
+        "capability_publish_release_create_failed",
+        plan,
+    )?;
     run_publish_command(
         runner,
         &request.registry_repo_path,
@@ -3232,17 +3302,20 @@ fn run_publish_command(
 
 fn capability_publish_pr_body(plan: &CapabilityPublishPlan) -> String {
     format!(
-        "## Summary\n\n- publish `{}` version `{}` to the public capability registry\n- add `{}`\n\n## Governing Specs\n\n- `056-capability-publish`\n- `054-public-scope-registry-ref`\n\n## Validation\n\n- local capability contract validation passed\n- artifact digest computed: `{}`\n",
+        "## Summary\n\n- publish `{}` version `{}` to the public capability registry\n- add `{}`\n\n## Governing Specs\n\n- `056-capability-publish`\n- `054-public-scope-registry-ref`\n\n## Validation\n\n- local capability contract validation passed\n- artifact digest computed: `{}`\n- release artifact: `{}`\n",
         plan.capability_id,
         plan.version,
         plan.registry_relative_path.display(),
-        plan.artifact_digest
+        plan.artifact_digest,
+        plan.artifact_url
     )
 }
 
 fn partial_state(plan: &CapabilityPublishPlan) -> String {
     format!(
-        "branch `{}` may contain `{}`; retry after fixing the reported error or clean up the branch manually",
+        "release `{}` may contain `{}` and branch `{}` may contain `{}`; retry after fixing the reported error or clean up the branch manually",
+        plan.artifact_release_tag,
+        plan.artifact_asset_name,
         plan.branch,
         plan.registry_relative_path.display()
     )
@@ -3263,6 +3336,8 @@ fn capability_publish_success_json(
         "capability_id": plan.capability_id,
         "version": plan.version,
         "artifact_digest": plan.artifact_digest,
+        "artifact_release_tag": plan.artifact_release_tag,
+        "artifact_url": plan.artifact_url,
         "validation_status": "passed"
     });
     if let Some(url) = pull_request_url {
@@ -6384,6 +6459,14 @@ mod tests {
                 .unwrap_or_default()
                 .starts_with("sha256:")
         );
+        assert_eq!(
+            json["artifact_release_tag"],
+            "artifacts/traverse-starter.process-1.0.0"
+        );
+        assert_eq!(
+            json["artifact_url"],
+            "https://github.com/traverse-framework/registry/releases/download/artifacts/traverse-starter.process-1.0.0/artifact.wasm"
+        );
         assert!(!fixture.registry_contract_path().exists());
         assert!(runner.commands.borrow().is_empty());
     }
@@ -6425,6 +6508,14 @@ mod tests {
             "https://github.com/traverse-framework/registry/pull/123"
         );
         assert!(fixture.registry_contract_path().exists());
+        let contract: Value = serde_json::from_str(
+            &fs::read_to_string(fixture.registry_contract_path())
+                .expect("published registry contract should read"),
+        )
+        .expect("published registry contract should parse");
+        assert_eq!(contract["artifact"]["digest"], json["artifact_digest"]);
+        assert_eq!(contract["artifact"]["url"], json["artifact_url"]);
+        assert!(commands.contains("gh release create artifacts/traverse-starter.process-1.0.0"));
         assert!(commands.contains("git checkout -B publish/traverse-starter.process-1.0.0"));
         assert!(commands.contains("gh pr create"));
         assert!(commands.contains("056-capability-publish"));
@@ -6454,7 +6545,8 @@ mod tests {
     fn capability_publish_pr_failure_reports_partial_state() {
         let fixture = capability_publish_fixture();
         let runner = RecordingPublishRunner {
-            fail_program: Some("gh"),
+            fail_program: None,
+            fail_command_prefix: Some("gh pr create"),
             commands: RefCell::new(Vec::new()),
         };
 
@@ -8579,6 +8671,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingPublishRunner {
         fail_program: Option<&'static str>,
+        fail_command_prefix: Option<&'static str>,
         commands: RefCell<Vec<String>>,
     }
 
@@ -8591,7 +8684,11 @@ mod tests {
         ) -> Result<PublishCommandOutput, String> {
             let rendered = format!("{} {} {}", cwd.display(), program, args.join(" "));
             self.commands.borrow_mut().push(rendered);
-            if self.fail_program == Some(program) {
+            if self.fail_program == Some(program)
+                || self.fail_command_prefix.is_some_and(|prefix| {
+                    format!("{program} {}", args.join(" ")).starts_with(prefix)
+                })
+            {
                 return Err(format!("{program} failed in fixture"));
             }
             if program == "gh" {

--- a/docs/capability-publish.md
+++ b/docs/capability-publish.md
@@ -1,0 +1,32 @@
+# Publishing a capability artifact
+
+`traverse-cli capability publish` creates a human-reviewed registry PR; it
+never publishes a capability merely by running locally. The command also
+uploads the supplied WASM artifact to a GitHub Release in the target registry
+repository, then writes its SHA-256 digest and immutable release URL into the
+generated registry `contract.json`.
+
+Run it from a clean checkout of the registry repository:
+
+```bash
+traverse-cli capability publish \
+  --contract contracts/my-capability/contract.json \
+  --artifact target/wasm32-wasip1/release/my-capability.wasm \
+  --registry-repo ../registry \
+  --json
+```
+
+The release tag is `artifacts/<capability-id>-<version>`. The JSON evidence
+includes the computed `artifact_digest`, `artifact_release_tag`, and
+`artifact_url`, along with the registry PR URL after it is opened.
+
+Use `--dry-run` to validate the contract and artifact and print the exact tag,
+URL, digest, branch, and registry path without uploading an asset or changing
+the registry checkout. Publish fails with actionable JSON evidence when GitHub
+authentication cannot create the release, the artifact filename cannot safely
+form a release URL, or a version's registry path already exists. If a later
+branch or PR step fails, the reported partial state identifies the release tag
+and registry branch left for retry or explicit cleanup.
+
+The resulting registry PR still requires registry CI and explicit human review
+before the record can become visible to consumers.

--- a/docs/tutorial-index.md
+++ b/docs/tutorial-index.md
@@ -67,5 +67,6 @@ These docs are not part of the linear onboarding sequence but are essential refe
 - [docs/event-contract-authoring-guide.md](event-contract-authoring-guide.md) — how to author an event contract from scratch
 - [docs/workflow-contract-authoring-guide.md](workflow-contract-authoring-guide.md) — node/edge model, direct vs event edges, authoring steps
 - [docs/registry-bundle-authoring-guide.md](registry-bundle-authoring-guide.md) — how to author a bundle manifest for a new domain
+- [docs/capability-publish.md](capability-publish.md) — governed registry publication and artifact release evidence
 - [docs/wasm-agent-authoring-guide.md](wasm-agent-authoring-guide.md) — stub vs. real implementation, build-fixture.sh, model_dependencies
 - [docs/model-dependency-authoring-guide.md](model-dependency-authoring-guide.md) — governed app manifest schema for real model candidates


### PR DESCRIPTION
## Summary

- Extract the registry contract write step from the publish PR helper to satisfy the enforced clippy function-length limit.

## Governing Spec

- `100-capability-package-authoring`

## Project Item

Follow-up to #1009 / PR #1019.

## Definition of Done

- [x] Publish behavior and stable error codes are unchanged.
- [x] The helper is below the clippy function-length limit.

## Validation

- `cargo clippy -p traverse-cli-rs --all-targets -- -D warnings`
- `git diff --check`