### PR TITLE
fix(cli): package protobuf source for v0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-cli-rs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-contracts"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "semver",
  "serde",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-embedder"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "semver",
  "serde",
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-expedition-wasm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-mcp"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-native-bridge"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "sha2 0.11.0",
  "wat",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-runtime"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes-gcm",
  "chrono",
@@ -2728,7 +2728,7 @@ dependencies = [
 
 [[package]]
 name = "traverse-swift-host"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde_json",
  "sha2 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/traverse-framework/traverse"
 rust-version = "1.94"
-version = "0.9.0"
+version = "0.9.1"
 
 [workspace.dependencies]
-traverse-contracts = { path = "crates/traverse-contracts", version = "0.9.0" }
+traverse-contracts = { path = "crates/traverse-contracts", version = "0.9.1" }
 traverse-registry = { version = "=0.12.0" }
-traverse-runtime = { path = "crates/traverse-runtime", version = "0.9.0" }
+traverse-runtime = { path = "crates/traverse-runtime", version = "0.9.1" }
 
 # The published registry crate pins the current contracts release.  During
 # Traverse development, resolve that transitive dependency to this workspace's

--- a/crates/traverse-cli/Cargo.toml
+++ b/crates/traverse-cli/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "Command-line interface for Traverse — register, list, validate, and run governed capabilities"
+include = ["src/**", "templates/**", "proto/**", "build.rs", "Cargo.toml"]
 
 [[bin]]
 name = "traverse-cli"

--- a/crates/traverse-cli/build.rs
+++ b/crates/traverse-cli/build.rs
@@ -1,13 +1,13 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-changed=../../contracts/proto/traverse/runtime/v1/events.proto");
+    println!("cargo:rerun-if-changed=proto/traverse/runtime/v1/events.proto");
     let mut prost_config = prost_build::Config::new();
     prost_config.protoc_executable(protoc_bin_vendored::protoc_bin_path()?);
     tonic_prost_build::configure()
         .build_server(true)
         .compile_with_config(
             prost_config,
-            &["../../contracts/proto/traverse/runtime/v1/events.proto"],
-            &["../../contracts/proto"],
+            &["proto/traverse/runtime/v1/events.proto"],
+            &["proto"],
         )?;
     Ok(())
 }

--- a/crates/traverse-cli/proto/traverse/runtime/v1/events.proto
+++ b/crates/traverse-cli/proto/traverse/runtime/v1/events.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+
+package traverse.runtime.v1;
+
+// CloudEvents fields plus the Traverse governance metadata carried by every
+// EventBroker-delivered TraverseEvent.
+message GovernanceMetadata {
+  string owner = 1;
+  string version = 2;
+  string lifecycle_status = 3;
+  optional string deduplication_id = 4;
+  optional string ordering_scope = 5;
+  optional string correlation_id = 6;
+  optional string causation_id = 7;
+  optional string subject_id = 8;
+  optional string actor_id = 9;
+}
+
+message Event {
+  string specversion = 1;
+  string id = 2;
+  string source = 3;
+  string type = 4;
+  string time = 5;
+  string data_json = 6;
+  string datacontenttype = 7;
+  GovernanceMetadata governance = 8;
+  string cursor = 9;
+}
+
+message StreamEventsRequest {
+  string workspace_id = 1;
+  string app_id = 2;
+  repeated string event_types = 3;
+  optional string cursor = 4;
+}
+
+service EventService {
+  rpc StreamEvents(StreamEventsRequest) returns (stream Event);
+}


### PR DESCRIPTION
## Summary

Packages the CLI protobuf source so traverse-cli-rs can verify from its crate tarball, then bumps the workspace to v0.9.1 after the partial v0.9.0 publication.

## Governing Spec

- 048-semver-publishing-pipeline

## Project Item

https://github.com/traverse-framework/traverse/issues/1035

## Validation

- cargo test -p traverse-cli-rs --quiet
- Cargo package verification at v0.9.0 passed with the fixed tarball.
- Required repository-check subflows, including app ownership validation.
