### PR TITLE
Honesty-bump core.transition-action-status@1.2.0 emits declaration

### DIFF
--- a/examples/core-transition-action-status/DEV-JOURNAL.md
+++ b/examples/core-transition-action-status/DEV-JOURNAL.md
@@ -4,3 +4,5 @@
 - Guest: `#![no_std]` evaluator over inlined `transition_config.allowed_transitions` + `owner_only`.
 - Smoke: `bash scripts/ci/core_transition_action_status_example_smoke.sh`.
 - Ticket: traverse-framework/traverse#1026.
+
+- 1.2.0 honesty bump (#1046): declare `emits`/`event_emission` for governed event `core.action-item.status-transitioned@1.0.0` (already published in registry). Declaration-only — WASM guest still pure memory_only evaluation.

--- a/examples/core-transition-action-status/contract.json
+++ b/examples/core-transition-action-status/contract.json
@@ -4,14 +4,14 @@
   "id": "core.transition-action-status",
   "namespace": "core",
   "name": "transition-action-status",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lifecycle": "active",
   "owner": {
     "team": "loop",
     "contact": "founders@loop.dev"
   },
   "summary": "Deterministic state machine for action item status transitions (open \u2192 in_progress \u2192 blocked \u2192 snoozed \u2192 done / cancelled).",
-  "description": "Pure state-machine for action-item status transitions under a caller-supplied transition_config (allowed_transitions + owner_only).\n\nImplemented and smoke-tested matrix (use_cases):\n- open \u2192 in_progress (ok)\n- done \u2192 open illegal (illegal_transition)\n- open \u2192 snoozed (ok)\n- non-owner denied (not_owner)\n- in_progress \u2192 blocked (ok)\n- in_progress \u2192 done (ok)\n- blocked \u2192 in_progress (ok)\n- snoozed \u2192 open (ok)\n- open \u2192 cancelled (ok)\n- cancelled \u2192 open illegal (covers current_status=cancelled)\n- missing current_status \u2192 invalid_status\n\nKnown limitations (intentional in 1.1.0):\n- Transition graph is entirely caller-supplied; no built-in default policy\n- Does not persist status changes",
+  "description": "Pure state-machine for action-item status transitions under a caller-supplied transition_config (allowed_transitions + owner_only).\n\nImplemented and smoke-tested matrix (use_cases):\n- open \u2192 in_progress (ok)\n- done \u2192 open illegal (illegal_transition)\n- open \u2192 snoozed (ok)\n- non-owner denied (not_owner)\n- in_progress \u2192 blocked (ok)\n- in_progress \u2192 done (ok)\n- blocked \u2192 in_progress (ok)\n- snoozed \u2192 open (ok)\n- open \u2192 cancelled (ok)\n- cancelled \u2192 open illegal (covers current_status=cancelled)\n- missing current_status \u2192 invalid_status\n\nKnown limitations (intentional in 1.2.0):\n- Transition graph is entirely caller-supplied; no built-in default policy\n- Does not persist status changes\n- Declares governed event core.action-item.status-transitioned@1.0.0 on accepted transitions; the WASM guest does not call the host emit ABI (declaration-only honesty with the published event product)",
   "use_cases": [
     {
       "scenario": "As an owner, I want to move an item from open to in_progress, so that active work is reflected accurately.",
@@ -644,9 +644,18 @@
     {
       "kind": "memory_only",
       "description": "Pure state machine evaluation"
+    },
+    {
+      "kind": "event_emission",
+      "description": "Declares domain fact core.action-item.status-transitioned when a transition is accepted (ok)"
     }
   ],
-  "emits": [],
+  "emits": [
+    {
+      "event_id": "core.action-item.status-transitioned",
+      "version": "1.0.0"
+    }
+  ],
   "consumes": [],
   "permissions": [
     {
@@ -680,7 +689,7 @@
     "source": "ai-assisted",
     "author": "loop-founders + traverse-capability-author",
     "created_at": "2026-08-08T06:00:00Z",
-    "spec_ref": "core.transition-action-status@1.1.0",
+    "spec_ref": "core.transition-action-status@1.2.0",
     "adr_refs": [
       "persona-council-review-2026-08-08"
     ],
@@ -688,7 +697,7 @@
   },
   "evidence": [
     {
-      "evidence_id": "core-transition-action-status-1.1.0-contract-validation",
+      "evidence_id": "core-transition-action-status-1.2.0-contract-validation",
       "type": "contract_validation",
       "status": "passed"
     }

--- a/examples/core-transition-action-status/manifest.json
+++ b/examples/core-transition-action-status/manifest.json
@@ -2,17 +2,17 @@
   "kind": "capability_package",
   "schema_version": "1.0.0",
   "package_id": "core.transition-action-status-agent",
-  "version": "1.1.0",
-  "summary": "Capability package for core.transition-action-status@1.1.0.",
+  "version": "1.2.0",
+  "summary": "Capability package for core.transition-action-status@1.2.0.",
   "capability_ref": {
     "id": "core.transition-action-status",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "contract_path": "./contract.json"
   },
   "workflow_refs": [
     {
       "workflow_id": "core.transition-action-status",
-      "workflow_version": "1.1.0"
+      "workflow_version": "1.2.0"
     }
   ],
   "source": {

--- a/examples/core-transition-action-status/runtime-requests/uc01-open-to-in-progress.json
+++ b/examples/core-transition-action-status/runtime-requests/uc01-open-to-in-progress.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-01",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "open",

--- a/examples/core-transition-action-status/runtime-requests/uc02-done-to-open-illegal.json
+++ b/examples/core-transition-action-status/runtime-requests/uc02-done-to-open-illegal.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-02",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "done",

--- a/examples/core-transition-action-status/runtime-requests/uc03-open-to-snoozed.json
+++ b/examples/core-transition-action-status/runtime-requests/uc03-open-to-snoozed.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-03",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "open",

--- a/examples/core-transition-action-status/runtime-requests/uc04-non-owner-denied.json
+++ b/examples/core-transition-action-status/runtime-requests/uc04-non-owner-denied.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-04",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "open",

--- a/examples/core-transition-action-status/runtime-requests/uc05-in-progress-to-blocked.json
+++ b/examples/core-transition-action-status/runtime-requests/uc05-in-progress-to-blocked.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-05",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "in_progress",

--- a/examples/core-transition-action-status/runtime-requests/uc06-in-progress-to-done.json
+++ b/examples/core-transition-action-status/runtime-requests/uc06-in-progress-to-done.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-06",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "in_progress",

--- a/examples/core-transition-action-status/runtime-requests/uc07-blocked-to-in-progress.json
+++ b/examples/core-transition-action-status/runtime-requests/uc07-blocked-to-in-progress.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-07",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "blocked",

--- a/examples/core-transition-action-status/runtime-requests/uc08-snoozed-to-open.json
+++ b/examples/core-transition-action-status/runtime-requests/uc08-snoozed-to-open.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-08",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "snoozed",

--- a/examples/core-transition-action-status/runtime-requests/uc09-open-to-cancelled.json
+++ b/examples/core-transition-action-status/runtime-requests/uc09-open-to-cancelled.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-09",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "open",

--- a/examples/core-transition-action-status/runtime-requests/uc10-cancelled-to-open-illegal.json
+++ b/examples/core-transition-action-status/runtime-requests/uc10-cancelled-to-open-illegal.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-10",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "cancelled",

--- a/examples/core-transition-action-status/runtime-requests/uc11-invalid-status.json
+++ b/examples/core-transition-action-status/runtime-requests/uc11-invalid-status.json
@@ -4,7 +4,7 @@
   "request_id": "core-transition-action-status-11",
   "intent": {
     "capability_id": "core.transition-action-status",
-    "capability_version": "1.1.0"
+    "capability_version": "1.2.0"
   },
   "input": {
     "current_status": "",

--- a/examples/core-transition-action-status/workflows/transition-action-status/workflow.json
+++ b/examples/core-transition-action-status/workflows/transition-action-status/workflow.json
@@ -3,7 +3,7 @@
   "schema_version": "1.0.0",
   "id": "core.transition-action-status",
   "name": "transition-action-status",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lifecycle": "active",
   "owner": {
     "team": "loop",
@@ -37,7 +37,7 @@
     {
       "node_id": "transition",
       "capability_id": "core.transition-action-status",
-      "capability_version": "1.1.0",
+      "capability_version": "1.2.0",
       "input": {
         "from_workflow_input": [
           "current_status",

--- a/scripts/ci/core_transition_action_status_example_smoke.sh
+++ b/scripts/ci/core_transition_action_status_example_smoke.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# End-to-end smoke for examples/core-transition-action-status (core.transition-action-status@1.1.0).
+# End-to-end smoke for examples/core-transition-action-status (core.transition-action-status@1.2.0).
 
 set -euo pipefail
 
@@ -28,7 +28,7 @@ echo "==> capability inspect"
 contract_out="$("${cli[@]}" capability inspect "$pkg/contract.json")"
 printf '%s\n' "$contract_out"
 require_match "$contract_out" "id: core.transition-action-status" "contract inspect id"
-require_match "$contract_out" "version: 1.1.0" "contract inspect version"
+require_match "$contract_out" "version: 1.2.0" "contract inspect version"
 
 echo "==> wasm abi verify"
 abi_out="$("${cli[@]}" wasm abi verify "$pkg/artifacts/core-transition-action-status.wasm")"
@@ -39,7 +39,7 @@ echo "==> capability-package inspect"
 pkg_out="$("${cli[@]}" capability-package inspect "$pkg/manifest.json")"
 printf '%s\n' "$pkg_out"
 require_match "$pkg_out" "package_id: core.transition-action-status-agent" "package_id"
-require_match "$pkg_out" "capability_version: 1.1.0" "capability_version"
+require_match "$pkg_out" "capability_version: 1.2.0" "capability_version"
 
 assert_execute() {
   local request="$1"
@@ -53,7 +53,7 @@ assert_execute() {
   out="$("${cli[@]}" capability-package execute "$pkg/manifest.json" "$request")"
   printf '%s\n' "$out"
   require_match "$out" "status: completed" "$label status"
-  require_match "$out" "capability_version: 1.1.0" "$label capability_version"
+  require_match "$out" "capability_version: 1.2.0" "$label capability_version"
   require_match "$out" "\"allowed\": $allowed" "$label allowed"
   require_match "$out" "\"reason_code\": \"$code\"" "$label reason_code"
   if [[ -n "$extra" ]]; then
@@ -73,4 +73,4 @@ assert_execute "$pkg/runtime-requests/uc09-open-to-cancelled.json" "true" "ok" "
 assert_execute "$pkg/runtime-requests/uc10-cancelled-to-open-illegal.json" "false" "illegal_transition" "UC-10" '"new_status": "cancelled"'
 assert_execute "$pkg/runtime-requests/uc11-invalid-status.json" "false" "invalid_status" "UC-11"
 
-echo "OK: core.transition-action-status 1.1.0 E2E smoke passed"
+echo "OK: core.transition-action-status 1.2.0 E2E smoke passed"


### PR DESCRIPTION
## Summary

- Honesty-bump `core.transition-action-status` 1.1.0 → **1.2.0**
- Declare `emits` for governed event `core.action-item.status-transitioned@1.0.0` and `event_emission` side effect (declaration-only; WASM guest remains pure evaluation)
- Keep UC01–UC11 smoke fixtures working; WASM digest unchanged
- Registry publish: https://github.com/traverse-framework/registry/pull/252

## Governing Spec

- `004-spec-alignment-gate`
- `008-expedition-example-domain`
- `028-schema-alignment-gate-v02`
- `031-supply-chain-hardening`
- `040-contractual-enforcement-gate`
- `054-public-scope-registry-ref`
- `056-capability-publish`
- `057-embeddable-runtime-host`
- `058-workflow-pipeline-execution`
- `087-hosted-datastore-transport`
- `100-capability-package-authoring`
- `102-contract-surface-coverage`
- `516-agent-artifact-execution`
- `534-ecca-event-products`

## Project Item

- Closes #1046

## Validation

- [x] `capability publish --dry-run` validation passed
- [x] UC01–UC11 `capability-package execute` smoke passed
- [x] ABI whitelist verify passed
- [x] Registry release `artifacts/core.transition-action-status-1.2.0` created
