### PR TITLE
docs: govern standalone executable capability packages

### DIFF
--- a/docs/adr/0040-standalone-capability-packages-and-activation-resolution.md
+++ b/docs/adr/0040-standalone-capability-packages-and-activation-resolution.md
@@ -1,0 +1,47 @@
+# ADR-0040: Standalone Capability Packages and Activation-Time Artifact Resolution
+
+- Status: Accepted
+- Governing specs: `105-standalone-capability-packages`, `106-activation-artifact-resolution`
+- Related issues: #1057, #1058, #1059, #1060, #1061
+
+## Context
+
+The capability-package validator requires a package to declare an approved
+workflow reference. That reverses the intended dependency: a workflow composes
+capability contracts, while a package is one portable executable implementation
+of a capability. It blocks independently useful packages and encourages
+synthetic workflow references. In addition, workflow registration proves that a
+contract exists, but cannot truthfully prove that a specific host can execute it.
+
+## Decision
+
+Capability packages may be standalone. `known_compositions` is optional,
+advisory metadata; it is never an execution prerequisite. Schema v1 accepts
+`workflow_refs` as a deprecated alias for one supported minor release. Different
+values in both fields are invalid, and schema v2 removes the alias.
+
+Workflows continue to reference capability contracts, not package identities.
+At host activation, each required contract resolves to a compatible active,
+verified executable package. An exact package pin wins; otherwise the resolver
+selects the highest compatible active version and then package id. The immutable
+activation record contains the selected identity, digest, resolver version, and
+eligibility evidence. Execution consumes that record and fails closed on drift.
+
+## Consequences
+
+Standalone packages are inspectable and executable without application knowledge.
+Portable workflow registration remains independent of host inventory. Hosts gain
+deterministic, auditable eligibility checks before traffic reaches execution.
+Existing manifests remain valid for the defined migration window.
+
+## Alternatives Considered
+
+- Keep mandatory workflow references: rejected because it creates reverse
+  coupling and false composition metadata.
+- Remove workflow metadata immediately: rejected as an unnecessary breaking
+  change that loses useful discovery information.
+- Resolve a package during workflow registration: rejected because registry
+  portability would depend on one host installation.
+- Resolve at every execution: rejected because selection could drift silently.
+- Require a package pin in every application: rejected because applications
+  should remain portable; pins remain an optional strict-reproducibility choice.

--- a/specs/105-standalone-capability-packages/spec.md
+++ b/specs/105-standalone-capability-packages/spec.md
@@ -1,0 +1,60 @@
+# Feature Specification: Standalone Executable Capability Packages
+
+**Status**: Approved
+**Canonical governing ID**: `105-standalone-capability-packages`
+**Version**: 1.0.0
+**Extends**: `017-ai-agent-packaging`, `100-capability-package-authoring`
+**Input**: #1057, #1058, #1059; ADR-0040.
+
+## Purpose
+
+Allow one governed executable package to implement and directly execute one
+capability contract without knowing an application workflow. This preserves
+contract, digest, ABI, constraint, fixture, and sandbox governance.
+
+## Requirements
+
+- **FR-001**: A package manifest MUST declare one valid capability contract
+  reference and executable artifact; it MUST NOT require a workflow reference.
+- **FR-002**: `known_compositions` MAY be omitted or empty. When present, it
+  records advisory known/tested workflow compositions only.
+- **FR-003**: Schema v1 MUST accept `workflow_refs` as the deprecated alias for
+  `known_compositions` for one supported minor release.
+- **FR-004**: If both fields occur with different normalized values, validation
+  MUST fail with `conflicting_composition_metadata`.
+- **FR-005**: Schema v2 MUST reject `workflow_refs` and require the canonical
+  field where composition metadata is supplied.
+- **FR-006**: `capability-package inspect` and `capability-package execute`
+  MUST accept a valid standalone package through the ordinary verified-artifact
+  path.
+- **FR-007**: Composition metadata MUST NOT grant authority, determine package
+  execution eligibility, or become a registry `requires` dependency.
+- **FR-008**: Existing validation for contracts, source/binary paths, digests,
+  ABI, host access, network/filesystem policy, runtime fixtures, lifecycle, and
+  execution evidence MUST remain unchanged.
+- **FR-009**: Inspect output and documentation MUST distinguish a standalone
+  package from advisory known compositions without implying a prerequisite.
+
+## Acceptance Scenarios
+
+1. A valid package with omitted or empty `known_compositions` inspects and
+   executes successfully from its runtime request fixture.
+2. A package using only legacy `workflow_refs` remains valid in schema v1 and
+   emits deterministic migration guidance.
+3. A package containing conflicting canonical and legacy values fails before
+   artifact execution with `conflicting_composition_metadata`.
+4. Existing non-empty workflow-reference packages remain valid without edits.
+5. Invalid contract, digest, ABI, or sandbox declarations remain rejected even
+   when the package is standalone.
+
+## Quality Gates
+
+- Unit and CLI tests cover omitted, empty, canonical, alias, equal dual-field,
+  conflicting dual-field, and existing workflow-reference manifests.
+- Regression tests prove direct execution uses the verified artifact router.
+- Documentation specifies the v1 migration window and v2 removal behavior.
+
+## Out of Scope
+
+Workflow creation, dynamic traversal-time discovery, host connector bindings,
+remote package loading, and changes to executable sandbox authority.

--- a/specs/106-activation-artifact-resolution/spec.md
+++ b/specs/106-activation-artifact-resolution/spec.md
@@ -1,0 +1,64 @@
+# Feature Specification: Activation-Time Executable Artifact Resolution
+
+**Status**: Approved
+**Canonical governing ID**: `106-activation-artifact-resolution`
+**Version**: 1.0.0
+**Extends**: `041-workflow-composition-api`, `044-application-bundle-manifest`, `103-application-connector-binding`
+**Input**: #1057, #1058, #1060, #1061; ADR-0040.
+
+## Purpose
+
+Make host activation prove that every capability contract required by an
+application or workflow has a compatible, active, verified executable package
+in that host environment, while retaining portable workflow registration.
+
+## Requirements
+
+- **FR-001**: Workflow registration MUST continue to validate its graph and
+  capability contract references without requiring host package inventory.
+- **FR-002**: Host activation MUST resolve every required contract to an active
+  executable package whose version, digest, ABI, placement, lifecycle, and
+  declared execution constraints are compatible.
+- **FR-003**: An explicit application package id/version pin MUST be honored.
+- **FR-004**: Without a pin, the resolver MUST select the highest compatible
+  active package version and then lexicographically lowest package id as a
+  stable tie-break.
+- **FR-005**: Activation MUST validate applicable connector and model
+  requirements without exposing secrets or host-private configuration.
+- **FR-006**: Successful activation MUST persist immutable non-secret evidence:
+  contract reference, selected package id/version/digest, resolver version,
+  eligibility decisions, and configuration references.
+- **FR-007**: Missing, incompatible, inactive, invalid, unsatisfied, or drifted
+  artifacts MUST fail closed with stable structured errors and evidence.
+- **FR-008**: Execution MUST consume the activation record and MUST NOT silently
+  re-resolve an artifact. A changed digest, lifecycle, ABI, placement, or
+  constraint MUST produce an activation-drift failure.
+- **FR-009**: Advisory package composition metadata MUST NOT influence artifact
+  eligibility, selection, or authorization.
+
+## Acceptance Scenarios
+
+1. A portable workflow registers where its contracts exist but no local package
+   is installed; host activation then fails with `executable_artifact_unavailable`.
+2. Activation selects one eligible package and records its digest; execution
+   succeeds only using that record.
+3. An exact pin selects the requested compatible package; an invalid pin fails
+   without falling back to another package.
+4. Multiple eligible packages resolve by highest compatible version and stable
+   package-id tie-break.
+5. Artifact or lifecycle drift after activation causes execution to fail closed
+   with `activation_artifact_drift`.
+
+## Quality Gates
+
+- Unit, integration, activation, trace, and drift tests cover zero, one, and
+  multiple candidates; pins; ties; constraints; connector/model requirements;
+  and all stable failure classes.
+- Activation evidence is deterministic, non-secret, and inspectable.
+- Spec-alignment validation covers registry, application host, runtime, CLI,
+  MCP discovery metadata, and ADR-0040 paths.
+
+## Out of Scope
+
+Automatic workflow creation, traversal-time package selection, remote loading,
+secret storage, and connector invocation ABI implementation.

--- a/specs/governance/approved-specs.json
+++ b/specs/governance/approved-specs.json
@@ -1367,6 +1367,35 @@
         "docs/adr/0039-connector-binding-and-mediated-host-integration.md",
         "specs/104-mediated-connector-invocation/"
       ]
+    },
+    {
+      "id": "105-standalone-capability-packages",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/105-standalone-capability-packages/spec.md",
+      "governs": [
+        "crates/traverse-cli/src/capability_packages.rs",
+        "crates/traverse-cli/src/main.rs",
+        "crates/traverse-runtime/",
+        "docs/adr/0040-standalone-capability-packages-and-activation-resolution.md",
+        "specs/105-standalone-capability-packages/"
+      ]
+    },
+    {
+      "id": "106-activation-artifact-resolution",
+      "version": "1.0.0",
+      "status": "approved",
+      "immutable": true,
+      "path": "specs/106-activation-artifact-resolution/spec.md",
+      "governs": [
+        "crates/traverse-registry/",
+        "crates/traverse-runtime/",
+        "crates/traverse-cli/",
+        "crates/traverse-mcp/",
+        "docs/adr/0040-standalone-capability-packages-and-activation-resolution.md",
+        "specs/106-activation-artifact-resolution/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds ADR-0040 and approved Specs 105 and 106 for standalone executable
capability packages and activation-time artifact resolution.

## Governing Spec

- `004-spec-alignment-gate`
- `105-standalone-capability-packages`
- `106-activation-artifact-resolution`

## Project Item

#1058

## Validation

- `jq empty specs/governance/approved-specs.json`
- `bash scripts/ci/spec_alignment_check.sh /private/tmp/issue-1058-pr-body.md`
- `git diff --check`
